### PR TITLE
Fix replay_stop and replay_autoplay corrupting account state

### DIFF
--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -3,6 +3,8 @@
  */
 import { evaluate, getReplayApi } from '../connection.js';
 
+const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
@@ -32,9 +34,8 @@ export async function start({ date } = {}) {
   `);
 
   if (toast) {
-    // Stop replay to recover chart
+    // Stop replay to recover chart — do NOT hide toolbar (syncs to cloud account)
     try { await evaluate(`${rp}.stopReplay()`); } catch {}
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     throw new Error(`Replay date unavailable: "${toast}". The requested date has no data for this timeframe. Try a more recent date or switch to a higher timeframe (e.g., Daily).`);
   }
 
@@ -53,10 +54,16 @@ export async function step() {
 }
 
 export async function autoplay({ speed } = {}) {
+  // Validate BEFORE any CDP calls — invalid values corrupt cloud account state permanently
+  if (speed > 0 && !VALID_AUTOPLAY_DELAYS.includes(speed))
+    throw new Error(`Invalid autoplay delay ${speed}ms. Valid values: ${VALID_AUTOPLAY_DELAYS.join(', ')}`);
+
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) throw new Error('Replay is not started. Use replay_start first.');
-  if (speed > 0) await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  if (speed > 0) {
+    await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  }
   await evaluate(`${rp}.toggleAutoplay()`);
   const isAutoplay = await evaluate(wv(`${rp}.isAutoplayStarted()`));
   const currentDelay = await evaluate(wv(`${rp}.autoplayDelay()`));
@@ -67,12 +74,9 @@ export async function stop() {
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) {
-    // Try to hide toolbar even if not started
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     return { success: true, action: 'already_stopped' };
   }
   await evaluate(`${rp}.stopReplay()`);
-  try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
   return { success: true, action: 'replay_stopped' };
 }
 

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -16,7 +16,7 @@ export function registerReplayTools(server) {
   });
 
   server.tool('replay_autoplay', 'Toggle autoplay in replay mode, optionally set speed', {
-    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Leave empty to just toggle. (default 0)'),
+    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Valid values: 100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000. Leave empty to just toggle.'),
   }, async ({ speed }) => {
     try { return jsonResult(await core.autoplay({ speed })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tests for replay.js — autoplay delay validation and hideReplayToolbar removal.
+ * Covers the fixes for issue #19 (cloud account state corruption).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+// Direct import for autoplay validation test
+import { autoplay } from '../src/core/replay.js';
+
+const VALID_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
+describe('replay autoplay — delay validation', () => {
+  for (const delay of VALID_DELAYS) {
+    it(`accepts valid delay ${delay}ms`, async () => {
+      // autoplay() will throw on CDP connection since TradingView isn't running,
+      // but it should NOT throw the validation error for valid delays.
+      try {
+        await autoplay({ speed: delay });
+      } catch (err) {
+        // Connection errors are expected (no TradingView running).
+        // Validation errors are NOT expected.
+        assert.ok(
+          !err.message.includes('Invalid autoplay delay'),
+          `Valid delay ${delay} was rejected: ${err.message}`,
+        );
+      }
+    });
+  }
+
+  const INVALID_DELAYS = [50, 60000, 99, 101, 500, 750, 1500, 9999, 20000];
+  for (const delay of INVALID_DELAYS) {
+    it(`rejects invalid delay ${delay}ms`, async () => {
+      await assert.rejects(
+        () => autoplay({ speed: delay }),
+        (err) => {
+          assert.ok(err.message.includes('Invalid autoplay delay'));
+          assert.ok(err.message.includes(String(delay)));
+          assert.ok(err.message.includes('Valid values:'));
+          return true;
+        },
+      );
+    });
+  }
+
+  it('skips validation when speed is 0 (just toggle)', async () => {
+    try {
+      await autoplay({ speed: 0 });
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `speed=0 should skip validation: ${err.message}`,
+      );
+    }
+  });
+
+  it('skips validation when speed is omitted', async () => {
+    try {
+      await autoplay({});
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `omitted speed should skip validation: ${err.message}`,
+      );
+    }
+  });
+});
+
+describe('replay — no hideReplayToolbar calls (issue #19)', () => {
+  it('stop() does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    const stopFn = source.slice(source.indexOf('export async function stop('));
+    const stopBody = stopFn.slice(0, stopFn.indexOf('\nexport ') > 0 ? stopFn.indexOf('\nexport ') : stopFn.length);
+    assert.ok(
+      !stopBody.includes('hideReplayToolbar'),
+      'stop() must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('start() error recovery does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    // Check the toast error recovery block specifically
+    const toastBlock = source.slice(source.indexOf('if (toast)'), source.indexOf('const started = await'));
+    assert.ok(
+      !toastBlock.includes('hideReplayToolbar'),
+      'start() error recovery must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('hideReplayToolbar appears nowhere in the file', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    assert.ok(
+      !source.includes('hideReplayToolbar'),
+      'hideReplayToolbar must not appear anywhere in replay.js — it syncs hidden state to cloud account',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Remove all `hideReplayToolbar()` calls** from `stop()` and `start()` error recovery — this was syncing hidden-toolbar state to the user's TradingView cloud account, permanently breaking replay controls across all devices
- **Validate autoplay speed** against TradingView's 9 allowed values (`100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000`) BEFORE any CDP call — invalid values corrupt `_autoplayDelay` in cloud state, causing assertion failures on every toolbar render
- **Fail fast** — validation moved before CDP connection so invalid input is rejected instantly with a clear error, no side effects

## Impact

Without this fix, affected users have **permanently broken replay controls** that survive uninstall/reinstall/cache clear (corruption lives in cloud-synced account state). The only recovery is manually patching `_autoplayDelay._value` via browser DevTools.

## Test plan

- [x] 23 new tests pass (9 valid delays accepted, 9 invalid delays rejected, 2 edge cases for speed=0/omitted, 3 source-level checks confirming hideReplayToolbar fully removed)
- [x] 29 existing tests pass (no regressions)
- [ ] Manual: `replay_stop` leaves toolbar visible
- [ ] Manual: `replay_autoplay` with `speed: 60000` returns clear validation error
- [ ] Manual: `replay_autoplay` with `speed: 1000` works normally

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)