### PR TITLE
Fix critical CDP injection vulnerabilities and cloud state corruption across 9 modules

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -28,6 +28,25 @@ const KNOWN_PATHS = {
 
 export { KNOWN_PATHS };
 
+/**
+ * Sanitize a string for safe interpolation into JavaScript code evaluated via CDP.
+ * Uses JSON.stringify to produce a properly escaped JS string literal (with quotes).
+ * Prevents injection via quotes, backticks, template literals, or control chars.
+ */
+export function safeString(str) {
+  return JSON.stringify(String(str));
+}
+
+/**
+ * Validate that a value is a finite number. Throws if NaN, Infinity, or non-numeric.
+ * Prevents corrupt values from reaching TradingView APIs that persist to cloud state.
+ */
+export function requireFinite(value, name) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw new Error(`${name} must be a finite number, got: ${value}`);
+  return n;
+}
+
 export async function getClient() {
   if (client) {
     try {

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,7 +1,7 @@
 /**
  * Core alert logic.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
 
 export async function create({ condition, price, message }) {
   const opened = await evaluate(`
@@ -28,7 +28,7 @@ export async function create({ condition, price, message }) {
         var label = inputs[i].closest('[class*="row"]')?.querySelector('[class*="label"]');
         if (label && /value|price/i.test(label.textContent)) {
           var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-          nativeSet.call(inputs[i], '${price}');
+          nativeSet.call(inputs[i], ${safeString(String(price))});
           inputs[i].dispatchEvent(new Event('input', { bubbles: true }));
           inputs[i].dispatchEvent(new Event('change', { bubbles: true }));
           return true;
@@ -36,7 +36,7 @@ export async function create({ condition, price, message }) {
       }
       if (inputs.length > 0) {
         var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-        nativeSet.call(inputs[0], '${price}');
+        nativeSet.call(inputs[0], ${safeString(String(price))});
         inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
         return true;
       }

--- a/src/core/batch.js
+++ b/src/core/batch.js
@@ -1,7 +1,7 @@
 /**
  * Core batch execution logic.
  */
-import { evaluate, evaluateAsync, getClient, getChartApi, getChartCollection } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, getChartApi, getChartCollection, safeString } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
@@ -23,12 +23,12 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
     for (const tf of tfs) {
       const combo = { symbol, timeframe: tf };
       try {
-        if (colPath) await evaluate(`${colPath}.setSymbol('${symbol}')`);
-        else if (apiPath) await evaluate(`${apiPath}.setSymbol('${symbol}')`);
+        if (colPath) await evaluate(`${colPath}.setSymbol(${safeString(symbol)})`);
+        else if (apiPath) await evaluate(`${apiPath}.setSymbol(${safeString(symbol)})`);
 
         if (tf) {
-          if (colPath) await evaluate(`${colPath}.setResolution('${tf}')`);
-          else if (apiPath) await evaluate(`${apiPath}.setResolution('${tf}')`);
+          if (colPath) await evaluate(`${colPath}.setResolution(${safeString(tf)})`);
+          else if (apiPath) await evaluate(`${apiPath}.setResolution(${safeString(tf)})`);
         }
 
         await waitForChartReady(symbol);
@@ -40,7 +40,7 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
           const client = await getClient();
           const { data } = await client.Page.captureScreenshot({ format: 'png' });
           const ts = new Date().toISOString().replace(/[:.]/g, '-');
-          const fname = `batch_${symbol}_${tf || 'default'}_${ts}.png`;
+          const fname = `batch_${symbol}_${tf || 'default'}_${ts}`.replace(/[\/\\]/g, '_') + '.png';
           const filePath = join(SCREENSHOT_DIR, fname);
           writeFileSync(filePath, Buffer.from(data, 'base64'));
           actionResult = { file_path: filePath };

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -13,7 +13,7 @@ export async function captureScreenshot({ region, filename, method } = {}) {
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const fname = filename || `tv_${region}_${ts}`;
+  const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_');
   const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
 
   if (method === 'api') {

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -1,7 +1,7 @@
 /**
  * Core chart control logic.
  */
-import { evaluate, evaluateAsync } from '../connection.js';
+import { evaluate, evaluateAsync, safeString, requireFinite } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
@@ -33,7 +33,7 @@ export async function setSymbol({ symbol }) {
     (function() {
       var chart = ${CHART_API};
       return new Promise(function(resolve) {
-        chart.setSymbol('${symbol.replace(/'/g, "\\'")}', {});
+        chart.setSymbol(${safeString(symbol)}, {});
         setTimeout(resolve, 500);
       });
     })()
@@ -46,7 +46,7 @@ export async function setTimeframe({ timeframe }) {
   await evaluate(`
     (function() {
       var chart = ${CHART_API};
-      chart.setResolution('${timeframe.replace(/'/g, "\\'")}', {});
+      chart.setResolution(${safeString(timeframe)}, {});
     })()
   `);
   const ready = await waitForChartReady(null, timeframe);
@@ -60,7 +60,7 @@ export async function setType({ chart_type }) {
     'HeikinAshi': 8, 'HollowCandles': 9,
   };
   const typeNum = typeMap[chart_type] ?? Number(chart_type);
-  if (isNaN(typeNum)) {
+  if (isNaN(typeNum) || typeNum < 0 || typeNum > 9 || !Number.isInteger(typeNum)) {
     throw new Error(`Unknown chart type: ${chart_type}. Use a name (Candles, Line, etc.) or number (0-9).`);
   }
   await evaluate(`
@@ -81,7 +81,7 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
     await evaluate(`
       (function() {
         var chart = ${CHART_API};
-        chart.createStudy('${indicator.replace(/'/g, "\\'")}', false, false, ${JSON.stringify(inputArr)});
+        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputArr)});
       })()
     `);
     await new Promise(r => setTimeout(r, 1500));
@@ -93,7 +93,7 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
     await evaluate(`
       (function() {
         var chart = ${CHART_API};
-        chart.removeEntity('${entity_id.replace(/'/g, "\\'")}');
+        chart.removeEntity(${safeString(entity_id)});
       })()
     `);
     return { success: true, action: 'remove', entity_id };
@@ -113,6 +113,8 @@ export async function getVisibleRange() {
 }
 
 export async function setVisibleRange({ from, to }) {
+  const f = requireFinite(from, 'from');
+  const t = requireFinite(to, 'to');
   await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -124,8 +126,8 @@ export async function setVisibleRange({ from, to }) {
       var fromIdx = startIdx, toIdx = endIdx;
       for (var i = startIdx; i <= endIdx; i++) {
         var v = bars.valueAt(i);
-        if (v && v[0] >= ${from} && fromIdx === startIdx) fromIdx = i;
-        if (v && v[0] <= ${to}) toIdx = i;
+        if (v && v[0] >= ${f} && fromIdx === startIdx) fromIdx = i;
+        if (v && v[0] <= ${t}) toIdx = i;
       }
       ts.zoomToBarsRange(fromIdx, toIdx);
     })()

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -1,7 +1,7 @@
 /**
  * Core data access logic.
  */
-import { evaluate, evaluateAsync, KNOWN_PATHS } from '../connection.js';
+import { evaluate, evaluateAsync, KNOWN_PATHS, safeString } from '../connection.js';
 
 const MAX_OHLCV_BARS = 500;
 const MAX_TRADES = 20;
@@ -15,7 +15,7 @@ function buildGraphicsJS(collectionName, mapKey, filter) {
       var model = chart.model();
       var sources = model.model().dataSources();
       var results = [];
-      var filter = '${filter}';
+      var filter = ${safeString(filter || '')};
       for (var si = 0; si < sources.length; si++) {
         var s = sources[si];
         if (!s.metaInfo) continue;
@@ -110,8 +110,8 @@ export async function getIndicator({ entity_id }) {
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
-      var study = api.getStudyById('${entity_id}');
-      if (!study) return { error: 'Study not found: ${entity_id}' };
+      var study = api.getStudyById(${safeString(entity_id)});
+      if (!study) return { error: 'Study not found: ' + ${safeString(entity_id)} };
       var result = { name: null, inputs: null, visible: null };
       try { result.visible = study.isVisible(); } catch(e) {}
       try { result.inputs = study.getInputValues(); } catch(e) { result.inputs_error = e.message; }
@@ -246,7 +246,7 @@ export async function getQuote({ symbol } = {}) {
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
-      var sym = '${symbol || ''}';
+      var sym = ${safeString(symbol || '')};
       if (!sym) { try { sym = api.symbol(); } catch(e) {} }
       if (!sym) { try { sym = api.symbolExt().symbol; } catch(e) {} }
       var ext = {};

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -1,7 +1,7 @@
 /**
  * Core drawing logic.
  */
-import { evaluate, getChartApi } from '../connection.js';
+import { evaluate, getChartApi, safeString, requireFinite } from '../connection.js';
 
 export async function drawShape({ shape, point, point2, overrides: overridesRaw, text }) {
   const overrides = overridesRaw ? (typeof overridesRaw === 'string' ? JSON.parse(overridesRaw) : overridesRaw) : {};
@@ -9,20 +9,26 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   const overridesStr = JSON.stringify(overrides || {});
   const textStr = text ? JSON.stringify(text) : '""';
 
+  // Validate coordinates — NaN/Infinity would corrupt drawings persisted to cloud layout
+  const p1time = requireFinite(point.time, 'point.time');
+  const p1price = requireFinite(point.price, 'point.price');
+
   const before = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
 
   if (point2) {
+    const p2time = requireFinite(point2.time, 'point2.time');
+    const p2price = requireFinite(point2.price, 'point2.price');
     await evaluate(`
       ${apiPath}.createMultipointShape(
-        [{ time: ${point.time}, price: ${point.price} }, { time: ${point2.time}, price: ${point2.price} }],
-        { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
+        [{ time: ${p1time}, price: ${p1price} }, { time: ${p2time}, price: ${p2price} }],
+        { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
       )
     `);
   } else {
     await evaluate(`
       ${apiPath}.createShape(
-        { time: ${point.time}, price: ${point.price} },
-        { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
+        { time: ${p1time}, price: ${p1price} },
+        { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
       )
     `);
   }
@@ -51,7 +57,7 @@ export async function getProperties({ entity_id }) {
   const result = await evaluate(`
     (function() {
       var api = ${apiPath};
-      var eid = '${entity_id}';
+      var eid = ${safeString(entity_id)};
       var props = { entity_id: eid };
       var shape = api.getShapeById(eid);
       if (!shape) return { error: 'Shape not found: ' + eid };
@@ -80,7 +86,7 @@ export async function removeOne({ entity_id }) {
   const result = await evaluate(`
     (function() {
       var api = ${apiPath};
-      var eid = '${entity_id}';
+      var eid = ${safeString(entity_id)};
       var before = api.getAllShapes();
       var found = false;
       for (var i = 0; i < before.length; i++) { if (before[i].id === eid) { found = true; break; } }

--- a/src/core/indicators.js
+++ b/src/core/indicators.js
@@ -1,7 +1,7 @@
 /**
  * Core indicator settings logic.
  */
-import { evaluate } from '../connection.js';
+import { evaluate, safeString } from '../connection.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 
@@ -12,14 +12,13 @@ export async function setInputs({ entity_id, inputs: inputsRaw }) {
     throw new Error('inputs must be a non-empty object, e.g. { length: 50 }');
   }
 
-  const escapedId = entity_id.replace(/'/g, "\\'");
   const inputsJson = JSON.stringify(inputs);
 
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
-      var study = chart.getStudyById('${escapedId}');
-      if (!study) return { error: 'Study not found: ${escapedId}' };
+      var study = chart.getStudyById(${safeString(entity_id)});
+      if (!study) return { error: 'Study not found: ' + ${safeString(entity_id)} };
       var currentInputs = study.getInputValues();
       var overrides = ${inputsJson};
       var updatedKeys = {};
@@ -42,12 +41,11 @@ export async function toggleVisibility({ entity_id, visible }) {
   if (!entity_id) throw new Error('entity_id is required. Use chart_get_state to find study IDs.');
   if (typeof visible !== 'boolean') throw new Error('visible must be a boolean (true or false)');
 
-  const escapedId = entity_id.replace(/'/g, "\\'");
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
-      var study = chart.getStudyById('${escapedId}');
-      if (!study) return { error: 'Study not found: ${escapedId}' };
+      var study = chart.getStudyById(${safeString(entity_id)});
+      if (!study) return { error: 'Study not found: ' + ${safeString(entity_id)} };
       study.setVisible(${visible});
       var actualVisible = study.isVisible();
       return { visible: actualVisible };

--- a/src/core/pane.js
+++ b/src/core/pane.js
@@ -2,7 +2,7 @@
  * Core pane/layout management logic.
  * Controls multi-chart layouts (split panes) in TradingView.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
 
 const CWC = 'window.TradingViewApi._chartWidgetCollection';
 
@@ -96,7 +96,7 @@ export async function setLayout({ layout }) {
     throw new Error(`Unknown layout "${layout}". Available layouts:\n${available}`);
   }
 
-  await evaluateAsync(`${CWC}.setLayout('${resolved}')`);
+  await evaluateAsync(`${CWC}.setLayout(${safeString(resolved)})`);
   await new Promise(r => setTimeout(r, 500));
 
   const state = await list();
@@ -136,8 +136,6 @@ export async function focus({ index }) {
  */
 export async function setSymbol({ index, symbol }) {
   const idx = Number(index);
-  const escaped = symbol.replace(/'/g, "\\'");
-
   // Focus the target pane first
   await focus({ index: idx });
   await new Promise(r => setTimeout(r, 300));
@@ -147,7 +145,7 @@ export async function setSymbol({ index, symbol }) {
     (function() {
       var chart = window.TradingViewApi._activeChartWidgetWV.value();
       return new Promise(function(resolve) {
-        chart.setSymbol('${escaped}', {});
+        chart.setSymbol(${safeString(symbol)}, {});
         setTimeout(resolve, 500);
       });
     })()

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -3,6 +3,8 @@
  */
 import { evaluate, getReplayApi } from '../connection.js';
 
+const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
@@ -32,9 +34,8 @@ export async function start({ date } = {}) {
   `);
 
   if (toast) {
-    // Stop replay to recover chart
+    // Stop replay to recover chart — do NOT hide toolbar (syncs to cloud account)
     try { await evaluate(`${rp}.stopReplay()`); } catch {}
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     throw new Error(`Replay date unavailable: "${toast}". The requested date has no data for this timeframe. Try a more recent date or switch to a higher timeframe (e.g., Daily).`);
   }
 
@@ -53,10 +54,16 @@ export async function step() {
 }
 
 export async function autoplay({ speed } = {}) {
+  // Validate BEFORE any CDP calls — invalid values corrupt cloud account state permanently
+  if (speed > 0 && !VALID_AUTOPLAY_DELAYS.includes(speed))
+    throw new Error(`Invalid autoplay delay ${speed}ms. Valid values: ${VALID_AUTOPLAY_DELAYS.join(', ')}`);
+
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) throw new Error('Replay is not started. Use replay_start first.');
-  if (speed > 0) await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  if (speed > 0) {
+    await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  }
   await evaluate(`${rp}.toggleAutoplay()`);
   const isAutoplay = await evaluate(wv(`${rp}.isAutoplayStarted()`));
   const currentDelay = await evaluate(wv(`${rp}.autoplayDelay()`));
@@ -67,12 +74,9 @@ export async function stop() {
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) {
-    // Try to hide toolbar even if not started
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     return { success: true, action: 'already_stopped' };
   }
   await evaluate(`${rp}.stopReplay()`);
-  try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
   return { success: true, action: 'replay_stopped' };
 }
 

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -1,7 +1,7 @@
 /**
  * Core replay mode logic.
  */
-import { evaluate, getReplayApi } from '../connection.js';
+import { evaluate, getReplayApi, safeString } from '../connection.js';
 
 const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
 
@@ -17,7 +17,7 @@ export async function start({ date } = {}) {
   await evaluate(`${rp}.showReplayToolbar()`);
   await new Promise(r => setTimeout(r, 500));
 
-  if (date) await evaluate(`${rp}.selectDate(new Date('${date}'))`);
+  if (date) await evaluate(`${rp}.selectDate(new Date(${safeString(date)}))`);
   else await evaluate(`${rp}.selectFirstAvailableDate()`);
   await new Promise(r => setTimeout(r, 1000));
 

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -16,7 +16,7 @@ export function registerReplayTools(server) {
   });
 
   server.tool('replay_autoplay', 'Toggle autoplay in replay mode, optionally set speed', {
-    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Leave empty to just toggle. (default 0)'),
+    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Valid values: 100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000. Leave empty to just toggle.'),
   }, async ({ speed }) => {
     try { return jsonResult(await core.autoplay({ speed })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tests for replay.js — autoplay delay validation and hideReplayToolbar removal.
+ * Covers the fixes for issue #19 (cloud account state corruption).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+// Direct import for autoplay validation test
+import { autoplay } from '../src/core/replay.js';
+
+const VALID_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
+describe('replay autoplay — delay validation', () => {
+  for (const delay of VALID_DELAYS) {
+    it(`accepts valid delay ${delay}ms`, async () => {
+      // autoplay() will throw on CDP connection since TradingView isn't running,
+      // but it should NOT throw the validation error for valid delays.
+      try {
+        await autoplay({ speed: delay });
+      } catch (err) {
+        // Connection errors are expected (no TradingView running).
+        // Validation errors are NOT expected.
+        assert.ok(
+          !err.message.includes('Invalid autoplay delay'),
+          `Valid delay ${delay} was rejected: ${err.message}`,
+        );
+      }
+    });
+  }
+
+  const INVALID_DELAYS = [50, 60000, 99, 101, 500, 750, 1500, 9999, 20000];
+  for (const delay of INVALID_DELAYS) {
+    it(`rejects invalid delay ${delay}ms`, async () => {
+      await assert.rejects(
+        () => autoplay({ speed: delay }),
+        (err) => {
+          assert.ok(err.message.includes('Invalid autoplay delay'));
+          assert.ok(err.message.includes(String(delay)));
+          assert.ok(err.message.includes('Valid values:'));
+          return true;
+        },
+      );
+    });
+  }
+
+  it('skips validation when speed is 0 (just toggle)', async () => {
+    try {
+      await autoplay({ speed: 0 });
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `speed=0 should skip validation: ${err.message}`,
+      );
+    }
+  });
+
+  it('skips validation when speed is omitted', async () => {
+    try {
+      await autoplay({});
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `omitted speed should skip validation: ${err.message}`,
+      );
+    }
+  });
+});
+
+describe('replay — no hideReplayToolbar calls (issue #19)', () => {
+  it('stop() does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    const stopFn = source.slice(source.indexOf('export async function stop('));
+    const stopBody = stopFn.slice(0, stopFn.indexOf('\nexport ') > 0 ? stopFn.indexOf('\nexport ') : stopFn.length);
+    assert.ok(
+      !stopBody.includes('hideReplayToolbar'),
+      'stop() must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('start() error recovery does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    // Check the toast error recovery block specifically
+    const toastBlock = source.slice(source.indexOf('if (toast)'), source.indexOf('const started = await'));
+    assert.ok(
+      !toastBlock.includes('hideReplayToolbar'),
+      'start() error recovery must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('hideReplayToolbar appears nowhere in the file', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    assert.ok(
+      !source.includes('hideReplayToolbar'),
+      'hideReplayToolbar must not appear anywhere in replay.js — it syncs hidden state to cloud account',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Add `safeString()` and `requireFinite()` utilities** to `connection.js` for consistent input sanitization across all CDP `evaluate()` calls
- **Replace all raw string interpolation** in 9 core modules — every `'${var}'` and manual `.replace(/'/g, "\'")`  pattern is now `safeString()`
- **Validate chart type codes** are integers 0–9 before `setChartType()` (invalid codes persist to cloud)
- **Validate drawing coordinates** are finite numbers before `createShape()` (NaN/Infinity persists to layout)
- **Strip path separators** from screenshot filenames to prevent directory traversal writes

### Why this matters

All `evaluate()` calls run JavaScript inside TradingView's Electron renderer via CDP. User input that breaks out of string literals can execute arbitrary code in the authenticated session — access to cookies, localStorage, account APIs, and cloud-synced state.

The existing escaping (`symbol.replace(/'/g, "\'")`) is incomplete — it doesn't handle backslashes, backticks, template literals, newlines, or unicode escapes. `safeString()` uses `JSON.stringify()` which handles all of these correctly.

Several TradingView APIs persist values to the user's cloud account (chart types, drawing coordinates, indicator inputs, autoplay delays). Invalid values that bypass validation corrupt state across all devices and layouts.

### Files changed

| File | What changed |
|------|-------------|
| `connection.js` | Added `safeString()`, `requireFinite()` exports |
| `replay.js` | `safeString(date)` in `selectDate()` |
| `chart.js` | `safeString()` for symbol, timeframe, indicator, entity_id; `requireFinite()` for visible range; chart type 0–9 validation |
| `drawing.js` | `safeString()` for shape name, entity_id; `requireFinite()` for point coordinates |
| `indicators.js` | `safeString()` for entity_id (replaces incomplete `escapedId` pattern) |
| `data.js` | `safeString()` for study_filter, entity_id, symbol |
| `alerts.js` | `safeString()` for price input |
| `batch.js` | `safeString()` for symbol, timeframe; path separator stripping for filenames |
| `pane.js` | `safeString()` for layout code, symbol |
| `capture.js` | Path separator stripping for screenshot filenames |

### Relationship to existing fixes

This builds on the replay autoplay validation from 6ccac64 (issue #19). That commit correctly validated autoplay delays before CDP calls — this PR applies the same principle (validate before evaluate) to all other user-facing parameters across the codebase.

## Test plan

- [ ] Existing tests pass (`npm test` — 16/17, e2e skipped without TV running)
- [ ] Replay delay validation tests pass (23 tests from #19)
- [ ] Manual: `chart_set_symbol` with `AAPL`, `ES1!`, `NYMEX:CL1!` works normally
- [ ] Manual: `draw_shape` with valid coordinates works
- [ ] Manual: `chart_set_type` rejects values outside 0–9

🤖 Generated with [Claude Code](https://claude.com/claude-code)