### PR TITLE
Feature: Add replay_set_resolution tool and compound CLI with flexible dates

### DIFF
--- a/src/cli/commands/replay.js
+++ b/src/cli/commands/replay.js
@@ -23,6 +23,13 @@ register('replay', {
       description: 'Get current replay state',
       handler: () => core.status(),
     }],
+    ['resolution', {
+      description: 'Set replay update interval (1T=tick, 1S=second, 1=minute, 5=5min, auto)',
+      options: {
+        interval: { type: 'string', short: 'i', description: 'Update interval: 1T, 1S, 1, 5, auto' },
+      },
+      handler: (opts, positionals) => core.setResolution({ interval: opts.interval || positionals[0] }),
+    }],
     ['autoplay', {
       description: 'Toggle autoplay in replay mode',
       options: {

--- a/src/cli/commands/replay.js
+++ b/src/cli/commands/replay.js
@@ -1,6 +1,26 @@
 import { register } from '../router.js';
 import * as core from '../../core/replay.js';
 import * as chartCore from '../../core/chart.js';
+import * as tabCore from '../../core/tab.js';
+
+/**
+ * Switch to a tab matching a symbol, title substring, or chart ID.
+ * Returns the matched tab or null if no match / only one tab.
+ */
+async function switchToChart(name) {
+  if (!name) return null;
+  const { tabs } = await tabCore.list();
+  if (tabs.length <= 1) return null;
+  const q = name.toLowerCase();
+  const match = tabs.find(t =>
+    t.title.toLowerCase().includes(q) ||
+    (t.chart_id && t.chart_id.toLowerCase() === q)
+  );
+  if (!match) throw new Error(`No tab matching "${name}". Open tabs: ${tabs.map(t => t.title).join(', ')}`);
+  await tabCore.switchTab({ index: match.index });
+  await new Promise(r => setTimeout(r, 500));
+  return match;
+}
 
 /**
  * Parse flexible date/time strings into ISO format for TradingView.
@@ -118,8 +138,9 @@ register('replay', {
   description: 'Replay mode controls',
   subcommands: new Map([
     ['start', {
-      description: 'Start replay: tv replay start -d 20250301 -h 0930 -tf 5 -s 3x -i 1s',
+      description: 'Start replay: tv replay start -d 20250301 -h 0930 -tf 5 -s 3x -i 1s [-c ES]',
       options: {
+        chart: { type: 'string', short: 'c', description: 'Switch to tab matching symbol/name (e.g., ES, AAPL, "My Layout")' },
         date: { type: 'string', short: 'd', description: 'Date: 20250301, 3/1, "mar 1", yesterday, -7d' },
         hour: { type: 'string', short: 'h', description: 'Time: 0930, 9:30, 2pm, 14' },
         tf: { type: 'string', description: 'Chart timeframe (5, 15, 60, D)' },
@@ -135,6 +156,11 @@ register('replay', {
         }
         const date = parseFlexDate(dateStr);
         const results = {};
+
+        // Switch to matching tab if requested
+        if (opts.chart) {
+          results.tab = await switchToChart(opts.chart);
+        }
 
         // Set timeframe first if requested
         if (opts.tf) {

--- a/src/cli/commands/replay.js
+++ b/src/cli/commands/replay.js
@@ -13,6 +13,9 @@ function parseFlexDate(input) {
   // Already ISO-like
   if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s;
 
+  // Compact date "20250301" → "2025-03-01"
+  if (/^\d{8}$/.test(s)) return `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`;
+
   // "today", "yesterday"
   const now = new Date();
   if (/^today$/i.test(s)) return now.toISOString().slice(0, 10);
@@ -62,7 +65,7 @@ function parseFlexDate(input) {
 function parseTime(str) {
   if (!str || !str.trim()) return null;
   const s = str.trim();
-  // "14:00", "14:30"
+  // "14:00", "14:30", "9:30"
   const mil = s.match(/^(\d{1,2}):(\d{2})$/);
   if (mil) return `${mil[1].padStart(2, '0')}:${mil[2]}`;
   // "2pm", "2:30pm", "14"
@@ -74,43 +77,82 @@ function parseTime(str) {
     if (ampm[3].toLowerCase() === 'am' && h === 12) h = 0;
     return `${String(h).padStart(2, '0')}:${m}`;
   }
+  // Bare 4-digit time "0930" → "09:30"
+  if (/^\d{4}$/.test(s)) return `${s.slice(0, 2)}:${s.slice(2)}`;
   // Bare hour "14"
   if (/^\d{1,2}$/.test(s)) return `${s.padStart(2, '0')}:00`;
   return null;
+}
+
+/**
+ * Map human-friendly speed multipliers to TradingView autoplay delays.
+ * Lower delay = faster. "1x" is baseline (1000ms).
+ */
+const SPEED_MAP = {
+  '10x': 100, '7x': 143, '5x': 200, '3x': 300,
+  '1x': 1000, '0.5x': 2000, '0.3x': 3000, '0.2x': 5000, '0.1x': 10000,
+};
+
+function parseSpeed(str) {
+  if (!str) return undefined;
+  const s = str.trim().toLowerCase();
+  if (SPEED_MAP[s] !== undefined) return SPEED_MAP[s];
+  const n = Number(s);
+  if (!isNaN(n) && n > 0) return n; // raw ms passthrough
+  const valid = Object.keys(SPEED_MAP).join(', ');
+  throw new Error(`Invalid speed "${str}". Use: ${valid} (or raw ms: 100-10000)`);
+}
+
+/**
+ * Normalize interval input: case-insensitive, accept friendly aliases.
+ */
+function parseInterval(str) {
+  if (!str) return undefined;
+  const s = str.trim().toLowerCase();
+  const aliases = { 'chart': 'auto', 'tick': '1T', '1t': '1T', '1s': '1S' };
+  if (aliases[s]) return aliases[s];
+  return str.trim(); // pass through as-is (runtime validation will catch bad values)
 }
 
 register('replay', {
   description: 'Replay mode controls',
   subcommands: new Map([
     ['start', {
-      description: 'Start replay (accepts --timeframe, --interval, --speed for one-shot setup)',
+      description: 'Start replay: tv replay start -d 20250301 0930 -tf 5 -s 3x -i 1s',
       options: {
-        date: { type: 'string', short: 'd', description: 'Start date: 2025-03-01, 3/1, "mar 1 2pm", yesterday, -7d' },
-        timeframe: { type: 'string', short: 't', description: 'Set chart timeframe before starting (e.g., 5, 15, 60, D)' },
-        interval: { type: 'string', short: 'i', description: 'Replay tick interval: 1T, 1S, 1, 5, auto' },
-        speed: { type: 'string', short: 's', description: 'Autoplay delay in ms (100=fast, 1000=normal, 10000=slow)' },
+        date: { type: 'string', short: 'd', description: 'Date: 20250301, 3/1, "mar 1", yesterday, -7d' },
+        hour: { type: 'string', short: 'h', description: 'Time: 0930, 9:30, 2pm, 14' },
+        tf: { type: 'string', description: 'Chart timeframe (5, 15, 60, D)' },
+        speed: { type: 'string', short: 's', description: 'Speed: 1x, 3x, 5x, 7x, 10x (or raw ms)' },
+        interval: { type: 'string', short: 'i', description: 'Tick interval: 1s, 1t, 1, 5, chart/auto' },
       },
       handler: async (opts, positionals) => {
-        const date = parseFlexDate(opts.date || positionals[0]);
+        // Combine -d and -h, or pick up positionals
+        let dateStr = opts.date || positionals[0];
+        const hourStr = opts.hour || positionals[opts.date ? 0 : 1];
+        if (dateStr && hourStr && parseTime(hourStr)) {
+          dateStr = dateStr + ' ' + hourStr;
+        }
+        const date = parseFlexDate(dateStr);
         const results = {};
 
         // Set timeframe first if requested
-        if (opts.timeframe) {
-          results.timeframe = await chartCore.setTimeframe({ timeframe: opts.timeframe });
+        if (opts.tf) {
+          results.timeframe = await chartCore.setTimeframe({ timeframe: opts.tf });
           await new Promise(r => setTimeout(r, 500));
         }
 
         // Start replay
         results.replay = await core.start({ date });
 
-        // Set resolution if requested
-        if (opts.interval) {
-          results.resolution = await core.setResolution({ interval: opts.interval });
+        // Set speed and start autoplay if requested (before interval — feels right to set pace first)
+        if (opts.speed) {
+          results.autoplay = await core.autoplay({ speed: parseSpeed(opts.speed) });
         }
 
-        // Set speed and start autoplay if requested
-        if (opts.speed) {
-          results.autoplay = await core.autoplay({ speed: Number(opts.speed) });
+        // Set resolution if requested
+        if (opts.interval) {
+          results.resolution = await core.setResolution({ interval: parseInterval(opts.interval) });
         }
 
         return { success: true, ...results };
@@ -129,18 +171,18 @@ register('replay', {
       handler: () => core.status(),
     }],
     ['resolution', {
-      description: 'Set replay update interval (1T=tick, 1S=second, 1=minute, 5=5min, auto)',
+      description: 'Set tick interval: tv replay resolution 1s (1t, 1s, 1, 5, chart/auto)',
       options: {
-        interval: { type: 'string', short: 'i', description: 'Update interval: 1T, 1S, 1, 5, auto' },
+        interval: { type: 'string', short: 'i', description: 'Interval: 1t=tick, 1s=second, 1=min, 5=5min, chart/auto' },
       },
-      handler: (opts, positionals) => core.setResolution({ interval: opts.interval || positionals[0] }),
+      handler: (opts, positionals) => core.setResolution({ interval: parseInterval(opts.interval || positionals[0]) }),
     }],
     ['autoplay', {
-      description: 'Toggle autoplay in replay mode',
+      description: 'Toggle autoplay: tv replay autoplay -s 3x',
       options: {
-        speed: { type: 'string', short: 's', description: 'Autoplay delay in ms (lower = faster)' },
+        speed: { type: 'string', short: 's', description: 'Speed: 1x, 3x, 5x, 7x, 10x (or raw ms)' },
       },
-      handler: (opts) => core.autoplay({ speed: opts.speed ? Number(opts.speed) : undefined }),
+      handler: (opts, positionals) => core.autoplay({ speed: parseSpeed(opts.speed || positionals[0]) }),
     }],
     ['trade', {
       description: 'Execute a trade in replay mode (buy, sell, close)',

--- a/src/cli/commands/replay.js
+++ b/src/cli/commands/replay.js
@@ -1,15 +1,120 @@
 import { register } from '../router.js';
 import * as core from '../../core/replay.js';
+import * as chartCore from '../../core/chart.js';
+
+/**
+ * Parse flexible date/time strings into ISO format for TradingView.
+ * Accepts: "2025-03-01", "2025-03-01 14:00", "3/1", "3/1 2pm", "mar 1 14:00", "yesterday", "today"
+ */
+function parseFlexDate(input) {
+  if (!input) return undefined;
+  const s = input.trim();
+
+  // Already ISO-like
+  if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s;
+
+  // "today", "yesterday"
+  const now = new Date();
+  if (/^today$/i.test(s)) return now.toISOString().slice(0, 10);
+  if (/^yesterday$/i.test(s)) {
+    now.setDate(now.getDate() - 1);
+    return now.toISOString().slice(0, 10);
+  }
+
+  // Relative: "-7d", "-2w", "-1m"
+  const relMatch = s.match(/^-(\d+)([dwm])$/i);
+  if (relMatch) {
+    const n = parseInt(relMatch[1]);
+    const unit = relMatch[2].toLowerCase();
+    if (unit === 'd') now.setDate(now.getDate() - n);
+    else if (unit === 'w') now.setDate(now.getDate() - n * 7);
+    else if (unit === 'm') now.setMonth(now.getMonth() - n);
+    return now.toISOString().slice(0, 10);
+  }
+
+  // "3/1", "3/1 2pm", "3/1 14:00", "03/01/2025 14:00"
+  const slashMatch = s.match(/^(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?\s*(.*)?$/);
+  if (slashMatch) {
+    const month = slashMatch[1].padStart(2, '0');
+    const day = slashMatch[2].padStart(2, '0');
+    const year = slashMatch[3] ? (slashMatch[3].length === 2 ? '20' + slashMatch[3] : slashMatch[3]) : String(now.getFullYear());
+    const time = parseTime(slashMatch[4]);
+    return time ? `${year}-${month}-${day}T${time}` : `${year}-${month}-${day}`;
+  }
+
+  // "mar 1", "mar 1 2pm", "march 1 14:00"
+  const months = { jan: '01', feb: '02', mar: '03', apr: '04', may: '05', jun: '06', jul: '07', aug: '08', sep: '09', oct: '10', nov: '11', dec: '12' };
+  const monMatch = s.match(/^([a-z]+)\s+(\d{1,2})(?:\s+(\d{4}))?\s*(.*)?$/i);
+  if (monMatch) {
+    const mon = months[monMatch[1].toLowerCase().slice(0, 3)];
+    if (mon) {
+      const day = monMatch[2].padStart(2, '0');
+      const year = monMatch[3] || String(now.getFullYear());
+      const time = parseTime(monMatch[4]);
+      return time ? `${year}-${mon}-${day}T${time}` : `${year}-${mon}-${day}`;
+    }
+  }
+
+  // Fallback: pass through as-is (let TradingView/Date parse it)
+  return s;
+}
+
+function parseTime(str) {
+  if (!str || !str.trim()) return null;
+  const s = str.trim();
+  // "14:00", "14:30"
+  const mil = s.match(/^(\d{1,2}):(\d{2})$/);
+  if (mil) return `${mil[1].padStart(2, '0')}:${mil[2]}`;
+  // "2pm", "2:30pm", "14"
+  const ampm = s.match(/^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i);
+  if (ampm) {
+    let h = parseInt(ampm[1]);
+    const m = ampm[2] || '00';
+    if (ampm[3].toLowerCase() === 'pm' && h < 12) h += 12;
+    if (ampm[3].toLowerCase() === 'am' && h === 12) h = 0;
+    return `${String(h).padStart(2, '0')}:${m}`;
+  }
+  // Bare hour "14"
+  if (/^\d{1,2}$/.test(s)) return `${s.padStart(2, '0')}:00`;
+  return null;
+}
 
 register('replay', {
   description: 'Replay mode controls',
   subcommands: new Map([
     ['start', {
-      description: 'Start replay mode',
+      description: 'Start replay (accepts --timeframe, --interval, --speed for one-shot setup)',
       options: {
-        date: { type: 'string', short: 'd', description: 'Start date (YYYY-MM-DD)' },
+        date: { type: 'string', short: 'd', description: 'Start date: 2025-03-01, 3/1, "mar 1 2pm", yesterday, -7d' },
+        timeframe: { type: 'string', short: 't', description: 'Set chart timeframe before starting (e.g., 5, 15, 60, D)' },
+        interval: { type: 'string', short: 'i', description: 'Replay tick interval: 1T, 1S, 1, 5, auto' },
+        speed: { type: 'string', short: 's', description: 'Autoplay delay in ms (100=fast, 1000=normal, 10000=slow)' },
       },
-      handler: (opts) => core.start({ date: opts.date }),
+      handler: async (opts, positionals) => {
+        const date = parseFlexDate(opts.date || positionals[0]);
+        const results = {};
+
+        // Set timeframe first if requested
+        if (opts.timeframe) {
+          results.timeframe = await chartCore.setTimeframe({ timeframe: opts.timeframe });
+          await new Promise(r => setTimeout(r, 500));
+        }
+
+        // Start replay
+        results.replay = await core.start({ date });
+
+        // Set resolution if requested
+        if (opts.interval) {
+          results.resolution = await core.setResolution({ interval: opts.interval });
+        }
+
+        // Set speed and start autoplay if requested
+        if (opts.speed) {
+          results.autoplay = await core.autoplay({ speed: Number(opts.speed) });
+        }
+
+        return { success: true, ...results };
+      },
     }],
     ['step', {
       description: 'Advance one bar in replay',

--- a/src/cli/commands/replay.js
+++ b/src/cli/commands/replay.js
@@ -118,13 +118,13 @@ register('replay', {
   description: 'Replay mode controls',
   subcommands: new Map([
     ['start', {
-      description: 'Start replay: tv replay start -d 20250301 0930 -tf 5 -s 3x -i 1s',
+      description: 'Start replay: tv replay start -d 20250301 -h 0930 -tf 5 -s 3x -i 1s',
       options: {
         date: { type: 'string', short: 'd', description: 'Date: 20250301, 3/1, "mar 1", yesterday, -7d' },
         hour: { type: 'string', short: 'h', description: 'Time: 0930, 9:30, 2pm, 14' },
         tf: { type: 'string', description: 'Chart timeframe (5, 15, 60, D)' },
         speed: { type: 'string', short: 's', description: 'Speed: 1x, 3x, 5x, 7x, 10x (or raw ms)' },
-        interval: { type: 'string', short: 'i', description: 'Tick interval: 1s, 1t, 1, 5, chart/auto' },
+        interval: { type: 'string', short: 'i', description: 'Update interval: 1s, 1t, 1, 5, chart/auto' },
       },
       handler: async (opts, positionals) => {
         // Combine -d and -h, or pick up positionals

--- a/src/connection.js
+++ b/src/connection.js
@@ -141,6 +141,10 @@ export async function getReplayApi() {
   return verifyAndReturn(KNOWN_PATHS.replayApi, 'Replay API');
 }
 
+export async function getReplayUIController() {
+  return verifyAndReturn(KNOWN_PATHS.replayApi + '._replayUIController', 'Replay UI Controller');
+}
+
 export async function getMainSeriesBars() {
   return verifyAndReturn(KNOWN_PATHS.mainSeriesBars, 'Main Series Bars');
 }

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -1,9 +1,19 @@
 /**
  * Core replay mode logic.
  */
-import { evaluate, getReplayApi } from '../connection.js';
+import { evaluate, getReplayApi, getReplayUIController, safeString } from '../connection.js';
 
 const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
+// Replay update interval labels for human-readable output.
+// Valid resolutions are dynamic (depend on chart timeframe) so we query TradingView at runtime.
+// Known values: "1T" = 1 tick, "1S" = 1 second, "1" = 1 minute, "5" = 5 minutes, "10" = 10 minutes, etc.
+const REPLAY_RESOLUTION_LABELS = {
+  '1T': '1 tick', '1S': '1 second',
+  '1': '1 min', '3': '3 min', '5': '5 min', '10': '10 min', '15': '15 min', '30': '30 min',
+  '1H': '1 hour', '2H': '2 hours', '3H': '3 hours', '4H': '4 hours',
+  '1D': '1 day', auto: 'auto',
+};
 
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
@@ -95,6 +105,37 @@ export async function trade({ action }) {
   return { success: true, action, position, realized_pnl: pnl };
 }
 
+export async function setResolution({ interval } = {}) {
+  // Resolve "auto" to null (TradingView's internal representation)
+  const value = (!interval || interval === 'auto') ? null : interval;
+
+  const rp = await getReplayApi();
+  const started = await evaluate(wv(`${rp}.isReplayStarted()`));
+  if (!started) throw new Error('Replay is not started. Use replay_start first.');
+
+  const ctrl = await getReplayUIController();
+
+  // Query valid resolutions from TradingView — these are dynamic (depend on chart timeframe).
+  // Validate BEFORE calling changeReplayResolution to prevent cloud state corruption.
+  const available = await evaluate(wv(`${ctrl}._allReplayResolutions.value()`));
+  if (!Array.isArray(available))
+    throw new Error('Could not retrieve available replay resolutions from TradingView.');
+  if (value !== null && !available.includes(value))
+    throw new Error(`Invalid replay resolution "${interval}". Available for current timeframe: ${available.join(', ')}, auto. Note: 1T and 1S may require a paid TradingView plan.`);
+
+  await evaluate(`${ctrl}.changeReplayResolution(${value === null ? 'null' : safeString(value)})`);
+
+  const current = await evaluate(wv(`${ctrl}._currentReplayResolution.value()`));
+  const auto = await evaluate(wv(`${ctrl}._autoReplayResolution.value()`));
+  const label = resolveLabel(current, auto);
+  return { success: true, resolution: current, resolution_label: label, auto_resolution: auto };
+}
+
+function resolveLabel(current, auto) {
+  if (current === null) return `auto (${REPLAY_RESOLUTION_LABELS[auto] || auto})`;
+  return REPLAY_RESOLUTION_LABELS[current] || current;
+}
+
 export async function status() {
   const rp = await getReplayApi();
   const st = await evaluate(`
@@ -113,5 +154,17 @@ export async function status() {
   `);
   const pos = await evaluate(wv(`${rp}.position()`));
   const pnl = await evaluate(wv(`${rp}.realizedPL()`));
-  return { success: true, ...st, position: pos, realized_pnl: pnl };
+
+  // Include replay resolution info
+  let replay_resolution = null;
+  let replay_resolution_label = null;
+  try {
+    const ctrl = await getReplayUIController();
+    const current = await evaluate(wv(`${ctrl}._currentReplayResolution.value()`));
+    const auto = await evaluate(wv(`${ctrl}._autoReplayResolution.value()`));
+    replay_resolution = current;
+    replay_resolution_label = resolveLabel(current, auto);
+  } catch {}
+
+  return { success: true, ...st, replay_resolution, replay_resolution_label, position: pos, realized_pnl: pnl };
 }

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -3,6 +3,8 @@
  */
 import { evaluate, getReplayApi } from '../connection.js';
 
+const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
@@ -32,9 +34,8 @@ export async function start({ date } = {}) {
   `);
 
   if (toast) {
-    // Stop replay to recover chart
+    // Stop replay to recover chart — do NOT hide toolbar (syncs to cloud account)
     try { await evaluate(`${rp}.stopReplay()`); } catch {}
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     throw new Error(`Replay date unavailable: "${toast}". The requested date has no data for this timeframe. Try a more recent date or switch to a higher timeframe (e.g., Daily).`);
   }
 
@@ -53,10 +54,16 @@ export async function step() {
 }
 
 export async function autoplay({ speed } = {}) {
+  // Validate BEFORE any CDP calls — invalid values corrupt cloud account state permanently
+  if (speed > 0 && !VALID_AUTOPLAY_DELAYS.includes(speed))
+    throw new Error(`Invalid autoplay delay ${speed}ms. Valid values: ${VALID_AUTOPLAY_DELAYS.join(', ')}`);
+
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) throw new Error('Replay is not started. Use replay_start first.');
-  if (speed > 0) await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  if (speed > 0) {
+    await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
+  }
   await evaluate(`${rp}.toggleAutoplay()`);
   const isAutoplay = await evaluate(wv(`${rp}.isAutoplayStarted()`));
   const currentDelay = await evaluate(wv(`${rp}.autoplayDelay()`));
@@ -67,12 +74,9 @@ export async function stop() {
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) {
-    // Try to hide toolbar even if not started
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     return { success: true, action: 'already_stopped' };
   }
   await evaluate(`${rp}.stopReplay()`);
-  try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
   return { success: true, action: 'replay_stopped' };
 }
 

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -22,6 +22,13 @@ export function registerReplayTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
+  server.tool('replay_set_resolution', 'Set replay update interval (tick granularity)', {
+    interval: z.string().optional().describe('Update interval. Values depend on chart timeframe — e.g., on 5m chart: "1T" (tick), "1S" (second), "1" (1 min), "5" (5 min). On daily: "1H", "2H", "3H", "4H", "1D". Use "auto" to reset. 1T/1S may require paid plan.'),
+  }, async ({ interval }) => {
+    try { return jsonResult(await core.setResolution({ interval })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
   server.tool('replay_stop', 'Stop replay and return to realtime', {}, async () => {
     try { return jsonResult(await core.stop()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -16,7 +16,7 @@ export function registerReplayTools(server) {
   });
 
   server.tool('replay_autoplay', 'Toggle autoplay in replay mode, optionally set speed', {
-    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Leave empty to just toggle. (default 0)'),
+    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Valid values: 100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000. Leave empty to just toggle.'),
   }, async ({ speed }) => {
     try { return jsonResult(await core.autoplay({ speed })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -7,7 +7,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 // Direct import for autoplay validation test
-import { autoplay } from '../src/core/replay.js';
+import { autoplay, setResolution } from '../src/core/replay.js';
 
 const VALID_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
 
@@ -64,6 +64,40 @@ describe('replay autoplay — delay validation', () => {
         `omitted speed should skip validation: ${err.message}`,
       );
     }
+  });
+});
+
+describe('replay setResolution — interval validation', () => {
+  // Valid resolutions are dynamic (depend on chart timeframe), so validation
+  // happens at runtime by querying TradingView. Without a live connection,
+  // we can only verify that "auto"/omitted resolve correctly before the CDP call.
+
+  it('accepts "auto" (resolves to null internally, no validation error)', async () => {
+    try {
+      await setResolution({ interval: 'auto' });
+    } catch (err) {
+      // Connection errors are expected (no TradingView running).
+      // Validation errors should NOT happen for "auto".
+      assert.ok(
+        !err.message.includes('Invalid replay resolution'),
+        `"auto" should be accepted: ${err.message}`,
+      );
+    }
+  });
+
+  it('accepts omitted interval (defaults to auto)', async () => {
+    try {
+      await setResolution({});
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid replay resolution'),
+        `omitted interval should default to auto: ${err.message}`,
+      );
+    }
+  });
+
+  it('setResolution is exported and callable', () => {
+    assert.equal(typeof setResolution, 'function');
   });
 });
 

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tests for replay.js — autoplay delay validation and hideReplayToolbar removal.
+ * Covers the fixes for issue #19 (cloud account state corruption).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+// Direct import for autoplay validation test
+import { autoplay } from '../src/core/replay.js';
+
+const VALID_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
+describe('replay autoplay — delay validation', () => {
+  for (const delay of VALID_DELAYS) {
+    it(`accepts valid delay ${delay}ms`, async () => {
+      // autoplay() will throw on CDP connection since TradingView isn't running,
+      // but it should NOT throw the validation error for valid delays.
+      try {
+        await autoplay({ speed: delay });
+      } catch (err) {
+        // Connection errors are expected (no TradingView running).
+        // Validation errors are NOT expected.
+        assert.ok(
+          !err.message.includes('Invalid autoplay delay'),
+          `Valid delay ${delay} was rejected: ${err.message}`,
+        );
+      }
+    });
+  }
+
+  const INVALID_DELAYS = [50, 60000, 99, 101, 500, 750, 1500, 9999, 20000];
+  for (const delay of INVALID_DELAYS) {
+    it(`rejects invalid delay ${delay}ms`, async () => {
+      await assert.rejects(
+        () => autoplay({ speed: delay }),
+        (err) => {
+          assert.ok(err.message.includes('Invalid autoplay delay'));
+          assert.ok(err.message.includes(String(delay)));
+          assert.ok(err.message.includes('Valid values:'));
+          return true;
+        },
+      );
+    });
+  }
+
+  it('skips validation when speed is 0 (just toggle)', async () => {
+    try {
+      await autoplay({ speed: 0 });
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `speed=0 should skip validation: ${err.message}`,
+      );
+    }
+  });
+
+  it('skips validation when speed is omitted', async () => {
+    try {
+      await autoplay({});
+    } catch (err) {
+      assert.ok(
+        !err.message.includes('Invalid autoplay delay'),
+        `omitted speed should skip validation: ${err.message}`,
+      );
+    }
+  });
+});
+
+describe('replay — no hideReplayToolbar calls (issue #19)', () => {
+  it('stop() does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    const stopFn = source.slice(source.indexOf('export async function stop('));
+    const stopBody = stopFn.slice(0, stopFn.indexOf('\nexport ') > 0 ? stopFn.indexOf('\nexport ') : stopFn.length);
+    assert.ok(
+      !stopBody.includes('hideReplayToolbar'),
+      'stop() must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('start() error recovery does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    // Check the toast error recovery block specifically
+    const toastBlock = source.slice(source.indexOf('if (toast)'), source.indexOf('const started = await'));
+    assert.ok(
+      !toastBlock.includes('hideReplayToolbar'),
+      'start() error recovery must not call hideReplayToolbar — it corrupts cloud account state',
+    );
+  });
+
+  it('hideReplayToolbar appears nowhere in the file', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    assert.ok(
+      !source.includes('hideReplayToolbar'),
+      'hideReplayToolbar must not appear anywhere in replay.js — it syncs hidden state to cloud account',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The replay update interval (the dropdown next to speed in the replay toolbar) was the **only replay control not exposed programmatically** — users had to click the UI button manually every time. This meant Claude or any MCP client could start replay, set speed, execute trades, and step through bars, but couldn't control *how granularly* the chart replays. A 5m chart would always step in 5-minute increments unless someone manually clicked the interval button.

Now a single natural language request like *"replay from March 1st at 9:30am, 5m timeframe, 3x speed, 1-second update interval"* triggers the full setup — date, timeframe, speed, interval — without the user touching the UI at all. The CLI equivalent is one command instead of four.

### What's new

- `replay_set_resolution` MCP tool — programmatic control of replay update interval
- Compound `tv replay start` CLI — full replay session setup in one shot
- Human-friendly speed multipliers, case-insensitive intervals, flexible date parsing

### CLI usage

```bash
# Full setup: March 1st at 9:30am, 5m chart timeframe, 3x speed, 1-second update interval
tv replay start -d 20250301 -h 0930 -tf 5 -s 3x -i 1s

# Target a specific tab when multiple charts are open (matches symbol in tab title)
tv replay start -c ES -d 20250301 -h 0930 -tf 5 -s 3x -i 1s

# Switch to a named layout first, then start replay on it
tv layout switch "My ES Setup"
tv replay start -d 20250301 -h 0930 -tf 5 -s 3x -i 1s

# Same thing, different date formats
tv replay start -d "3/1" -h 2pm -tf 5 -s 1x -i 1s
tv replay start -d "mar 1" -h 9:30am -tf 5 -s 5x -i 1s

# Relative dates
tv replay start -d -7d -tf 15 -s 10x
tv replay start -d yesterday -h 9:30 -tf 5 -s 1x -i 1s

# Standalone subcommands
tv replay autoplay -s 3x
tv replay resolution 1s
tv replay step
tv replay status
tv replay stop
```

### Flags

| Flag | Short | Values |
|------|-------|--------|
| `--chart` | `-c` | Symbol to match in tab title (ES, AAPL, NQ) |
| `--date` | `-d` | `20250301`, `3/1`, `mar 1`, `yesterday`, `-7d`, `-2w` |
| `--hour` | `-h` | `0930`, `9:30`, `2pm`, `14` |
| `--tf` | | `1`, `5`, `15`, `60`, `D`, `W` |
| `--speed` | `-s` | `1x`, `3x`, `5x`, `7x`, `10x`, `0.5x`, `0.3x`, `0.1x` (or raw ms) |
| `--interval` | `-i` | `1t`=tick, `1s`=second, `1`=min, `5`=5min, `chart`/`auto` |

### Speed reference

| Flag | Delay | Feel |
|------|-------|------|
| `10x` | 100ms | Fastest |
| `7x` | 143ms | |
| `5x` | 200ms | |
| `3x` | 300ms | |
| `1x` | 1000ms | Normal |
| `0.5x` | 2000ms | |
| `0.1x` | 10000ms | Slowest |

### Runtime validation (not hardcoded)

Valid replay resolutions depend on the chart's current timeframe. We **query `_allReplayResolutions.value()` from TradingView at runtime** and validate BEFORE calling `changeReplayResolution()`. Same defensive pattern from 6ccac64 (#19).

### Files changed

| File | What |
|------|------|
| `connection.js` | `getReplayUIController()` accessor |
| `core/replay.js` | `setResolution()`, `resolveLabel()`, resolution info in `status()` |
| `tools/replay.js` | New `replay_set_resolution` MCP tool |
| `cli/commands/replay.js` | Compound start, flexible date/time parser, speed multipliers, `-c` tab switch, case-insensitive intervals |
| `tests/replay.test.js` | 3 new tests for resolution validation |

## Test plan

- [ ] `tv replay start -d 20250301 -h 0930 -tf 5 -s 3x -i 1s` works end-to-end
- [ ] `tv replay start -c ES -d 20250301` switches to ES tab first
- [ ] `tv layout switch "name"` then `tv replay start` works for named layouts
- [ ] `tv replay start -d yesterday` works
- [ ] `tv replay start -d -7d -tf 15` works
- [ ] `tv replay autoplay -s 5x` maps to 200ms delay
- [ ] `tv replay resolution 1s` normalizes to `1S`
- [ ] Invalid speed (`-s 99x`) gives clear error with valid options
- [ ] Invalid interval gives clear error listing available resolutions
- [ ] Existing usage (`tv replay start -d "2025-03-01"`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)