### PR TITLE
Improve Windows detection and runtime validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Launch scripts and `tv_launch` auto-detect TradingView. If auto-detection fails:
 | Platform | Common Locations |
 |----------|-----------------|
 | **Mac** | `/Applications/TradingView.app/Contents/MacOS/TradingView` |
-| **Windows** | `%LOCALAPPDATA%\TradingView\TradingView.exe`, `%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe` |
+| **Windows** | `%LOCALAPPDATA%\TradingView\TradingView.exe`, `%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe` (`Get-AppxPackage` fallback for Appx installs) |
 | **Linux** | `/opt/TradingView/tradingview`, `~/.local/share/TradingView/TradingView`, `/snap/tradingview/current/tradingview` |
 
 The key flag: `--remote-debugging-port=9222`

--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -21,13 +21,19 @@ REM Check MSIX / Windows Store installs
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
 )
+REM Use Get-AppxPackage for Appx installs when WindowsApps directory listing is blocked
+if "%TV_EXE%"=="" (
+    for /f "tokens=*" %%i in ('powershell -NoProfile -Command "Get-AppxPackage -Name '*TradingView*' | Select-Object -ExpandProperty InstallLocation" 2^>nul') do (
+        if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
+    )
+)
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
 )
 
 if "%TV_EXE%"=="" (
     echo Error: TradingView not found.
-    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps
+    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps, Get-AppxPackage, PATH
     echo.
     echo If installed elsewhere, run manually:
     echo   "C:\path\to\TradingView.exe" --remote-debugging-port=%PORT%

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -5,6 +5,18 @@ import { evaluate, evaluateAsync } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
+const FALLBACK_CHART_TYPES = {
+  Bars: 0,
+  Candles: 1,
+  Line: 2,
+  Area: 3,
+  Renko: 4,
+  Kagi: 5,
+  PointAndFigure: 6,
+  LineBreak: 7,
+  HeikinAshi: 8,
+  HollowCandles: 9,
+};
 
 export async function getState() {
   const state = await evaluate(`
@@ -54,14 +66,15 @@ export async function setTimeframe({ timeframe }) {
 }
 
 export async function setType({ chart_type }) {
-  const typeMap = {
-    'Bars': 0, 'Candles': 1, 'Line': 2, 'Area': 3,
-    'Renko': 4, 'Kagi': 5, 'PointAndFigure': 6, 'LineBreak': 7,
-    'HeikinAshi': 8, 'HollowCandles': 9,
-  };
-  const typeNum = typeMap[chart_type] ?? Number(chart_type);
+  const available = await getAvailableChartTypes();
+  const typeMap = available.length
+    ? Object.fromEntries(available.map(({ name, value }) => [name, value]))
+    : FALLBACK_CHART_TYPES;
+
+  const typeNum = resolveChartType(chart_type, typeMap);
   if (isNaN(typeNum)) {
-    throw new Error(`Unknown chart type: ${chart_type}. Use a name (Candles, Line, etc.) or number (0-9).`);
+    const valid = formatAvailableChartTypes(typeMap);
+    throw new Error(`Unknown chart type: ${chart_type}. Available chart types: ${valid}`);
   }
   await evaluate(`
     (function() {
@@ -70,6 +83,93 @@ export async function setType({ chart_type }) {
     })()
   `);
   return { success: true, chart_type, type_num: typeNum };
+}
+
+async function getAvailableChartTypes() {
+  const result = await evaluate(`
+    (function() {
+      var chart = ${CHART_API};
+      var seen = {};
+      var out = [];
+
+      function push(name, value) {
+        if (typeof value !== 'number' || !isFinite(value)) return;
+        if (!name || typeof name !== 'string') name = String(value);
+        var key = name + '|' + value;
+        if (seen[key]) return;
+        seen[key] = true;
+        out.push({ name: name.replace(/\\s+/g, ''), value: value });
+      }
+
+      function read(entry, fallbackKey) {
+        if (entry == null) return;
+        if (Array.isArray(entry)) {
+          for (var i = 0; i < entry.length; i++) read(entry[i], String(i));
+          return;
+        }
+        if (typeof entry === 'object' && typeof entry.value === 'function') {
+          try { read(entry.value(), fallbackKey); } catch (e) {}
+          return;
+        }
+        if (typeof entry === 'object') {
+          var name = entry.name || entry.title || entry.label || entry.text || entry.id || entry.key || fallbackKey;
+          var value = entry.value;
+          if (typeof value !== 'number') value = entry.type;
+          if (typeof value !== 'number') value = entry.index;
+          if (typeof value === 'number') push(name, value);
+          return;
+        }
+      }
+
+      function readObject(obj) {
+        if (!obj || typeof obj !== 'object') return;
+        var keys = Object.keys(obj);
+        for (var i = 0; i < keys.length; i++) {
+          var key = keys[i];
+          var value = obj[key];
+          if (typeof value === 'number') push(key, value);
+          else if (value && typeof value === 'object') read(value, key);
+        }
+      }
+
+      var candidates = [
+        chart.chartTypes,
+        chart.getChartTypes && chart.getChartTypes(),
+        chart._chartTypes,
+        chart._chartWidget && chart._chartWidget._chartTypes,
+        window.TradingView && window.TradingView.ChartType,
+        window.TradingView && window.TradingView.ChartTypes,
+        window.ChartType,
+        window.ChartTypes,
+      ];
+
+      for (var i = 0; i < candidates.length; i++) {
+        read(candidates[i]);
+        readObject(candidates[i]);
+      }
+
+      return out;
+    })()
+  `);
+  return Array.isArray(result) ? result : [];
+}
+
+function resolveChartType(input, typeMap) {
+  if (Object.prototype.hasOwnProperty.call(typeMap, input)) return typeMap[input];
+
+  const normalized = String(input).replace(/\s+/g, '').toLowerCase();
+  for (const [name, value] of Object.entries(typeMap)) {
+    if (name.toLowerCase() === normalized) return value;
+  }
+
+  return Number(input);
+}
+
+function formatAvailableChartTypes(typeMap) {
+  return Object.entries(typeMap)
+    .sort((a, b) => a[1] - b[1])
+    .map(([name, value]) => `${name}(${value})`)
+    .join(', ');
 }
 
 export async function manageIndicator({ action, indicator, entity_id, inputs: inputsRaw }) {

--- a/src/core/pane.js
+++ b/src/core/pane.js
@@ -90,9 +90,11 @@ export async function setLayout({ layout }) {
     '3x1': '3h', '1x3': '3v',
   };
   const resolved = aliases[code] || code;
+  const availableLayouts = await getAvailableLayouts();
+  const knownLayouts = availableLayouts.length ? availableLayouts : Object.keys(LAYOUT_NAMES);
 
-  if (!LAYOUT_NAMES[resolved]) {
-    const available = Object.entries(LAYOUT_NAMES).map(([k, v]) => `  ${k} — ${v}`).join('\n');
+  if (!knownLayouts.includes(resolved)) {
+    const available = knownLayouts.map(k => `  ${k} — ${LAYOUT_NAMES[k] || k}`).join('\n');
     throw new Error(`Unknown layout "${layout}". Available layouts:\n${available}`);
   }
 
@@ -103,10 +105,79 @@ export async function setLayout({ layout }) {
   return {
     success: true,
     layout: resolved,
-    layout_name: LAYOUT_NAMES[resolved],
+    layout_name: LAYOUT_NAMES[resolved] || resolved,
     chart_count: state.chart_count,
     panes: state.panes,
   };
+}
+
+async function getAvailableLayouts() {
+  const result = await evaluate(`
+    (function() {
+      var cwc = ${CWC};
+      var seen = {};
+      var out = [];
+      var layoutCode = /^(s|\\d+h|\\d+v|\\d+s|\\d+(?:-\\d+)?)$/i;
+
+      function push(value) {
+        if (typeof value !== 'string') return;
+        var code = value.replace(/\\s+/g, '');
+        if (!layoutCode.test(code)) return;
+        code = code.toLowerCase();
+        if (seen[code]) return;
+        seen[code] = true;
+        out.push(code);
+      }
+
+      function read(entry, fallbackKey) {
+        if (entry == null) return;
+        if (Array.isArray(entry)) {
+          for (var i = 0; i < entry.length; i++) read(entry[i], String(i));
+          return;
+        }
+        if (typeof entry === 'object' && typeof entry.value === 'function') {
+          try { read(entry.value(), fallbackKey); } catch (e) {}
+          return;
+        }
+        if (typeof entry === 'string') {
+          push(entry);
+          return;
+        }
+        if (typeof entry === 'object') {
+          push(entry.code);
+          push(entry.id);
+          push(entry.key);
+          push(entry.value);
+          push(entry.layoutType);
+          push(entry.name);
+          push(fallbackKey);
+        }
+      }
+
+      var candidates = [
+        cwc._layoutTypeItems,
+        cwc.layoutTypeItems,
+        cwc._layoutTypeOptions,
+        cwc.layoutTypeOptions,
+        cwc._availableLayouts,
+        cwc.availableLayouts,
+        cwc._layouts,
+        cwc.layouts,
+        cwc.getLayoutTypes && cwc.getLayoutTypes(),
+      ];
+
+      for (var i = 0; i < candidates.length; i++) read(candidates[i]);
+
+      var keys = Object.keys(cwc || {});
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j];
+        if (/layout/i.test(key)) read(cwc[key], key);
+      }
+
+      return out;
+    })()
+  `);
+  return Array.isArray(result) ? result : [];
 }
 
 /**

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -3,6 +3,8 @@
  */
 import { evaluate, getReplayApi } from '../connection.js';
 
+const FALLBACK_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
@@ -56,6 +58,10 @@ export async function autoplay({ speed } = {}) {
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) throw new Error('Replay is not started. Use replay_start first.');
+  const validDelays = await getAvailableAutoplayDelays(rp);
+  if (speed > 0 && !validDelays.includes(speed)) {
+    throw new Error(`Invalid autoplay delay ${speed}. Available delays: ${validDelays.join(', ')}`);
+  }
   if (speed > 0) await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
   await evaluate(`${rp}.toggleAutoplay()`);
   const isAutoplay = await evaluate(wv(`${rp}.isAutoplayStarted()`));
@@ -110,4 +116,58 @@ export async function status() {
   const pos = await evaluate(wv(`${rp}.position()`));
   const pnl = await evaluate(wv(`${rp}.realizedPL()`));
   return { success: true, ...st, position: pos, realized_pnl: pnl };
+}
+
+async function getAvailableAutoplayDelays(rp) {
+  const result = await evaluate(`
+    (function() {
+      var replay = ${rp};
+      var seen = {};
+      var out = [];
+
+      function push(value) {
+        if (typeof value !== 'number' || !isFinite(value)) return;
+        if (seen[value]) return;
+        seen[value] = true;
+        out.push(value);
+      }
+
+      function read(entry) {
+        if (entry == null) return;
+        if (Array.isArray(entry)) {
+          for (var i = 0; i < entry.length; i++) read(entry[i]);
+          return;
+        }
+        if (typeof entry === 'number') {
+          push(entry);
+          return;
+        }
+        if (typeof entry === 'object' && typeof entry.value === 'function') {
+          try { read(entry.value()); } catch (e) {}
+          return;
+        }
+        if (typeof entry === 'object') {
+          if (typeof entry.value === 'number') push(entry.value);
+          if (typeof entry.id === 'number') push(entry.id);
+          if (typeof entry.delay === 'number') push(entry.delay);
+          if (typeof entry.autoplayDelay === 'number') push(entry.autoplayDelay);
+        }
+      }
+
+      var candidates = [
+        replay.findAutoplayDelayOptionItems && replay.findAutoplayDelayOptionItems(),
+        replay._replayManager && replay._replayManager.findAutoplayDelayOptionItems && replay._replayManager.findAutoplayDelayOptionItems(),
+        replay._replayUIController && replay._replayUIController._replayManager &&
+          replay._replayUIController._replayManager.findAutoplayDelayOptionItems &&
+          replay._replayUIController._replayManager.findAutoplayDelayOptionItems(),
+      ];
+
+      for (var i = 0; i < candidates.length; i++) {
+        try { read(candidates[i]); } catch (e) {}
+      }
+
+      return out.sort(function(a, b) { return a - b; });
+    })()
+  `);
+  return Array.isArray(result) && result.length ? result : FALLBACK_AUTOPLAY_DELAYS;
 }

--- a/src/tools/chart.js
+++ b/src/tools/chart.js
@@ -23,7 +23,7 @@ export function registerChartTools(server) {
   });
 
   server.tool('chart_set_type', 'Change chart type', {
-    chart_type: z.string().describe('Chart type: Bars(0), Candles(1), Line(2), Area(3), Renko(4), Kagi(5), PointAndFigure(6), LineBreak(7), HeikinAshi(8), HollowCandles(9) — pass name or number'),
+    chart_type: z.string().describe('Chart type name or numeric code. Common examples: Candles, Line, Area, Bars, Renko, HeikinAshi. Valid values are checked against TradingView runtime state when available.'),
   }, async ({ chart_type }) => {
     try { return jsonResult(await core.setType({ chart_type })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/src/tools/pane.js
+++ b/src/tools/pane.js
@@ -9,7 +9,7 @@ export function registerPaneTools(server) {
   });
 
   server.tool('pane_set_layout', 'Change the chart grid layout (e.g., single, 2x2, 2h, 3v)', {
-    layout: z.string().describe('Layout code: s (single), 2h, 2v, 2-1, 1-2, 3h, 3v, 4 (2x2), 6, 8. Also accepts: single, 2x1, 1x2, 2x2, quad'),
+    layout: z.string().describe('Layout code or alias. Common values: s, 2h, 2v, 2-1, 1-2, 3h, 3v, 4, 6, 8, plus aliases like single, 2x1, 1x2, 2x2, quad. Valid values are checked against TradingView runtime state when available.'),
   }, async ({ layout }) => {
     try { return jsonResult(await core.setLayout({ layout })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -16,7 +16,7 @@ export function registerReplayTools(server) {
   });
 
   server.tool('replay_autoplay', 'Toggle autoplay in replay mode, optionally set speed', {
-    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Leave empty to just toggle. (default 0)'),
+    speed: z.coerce.number().optional().describe('Autoplay delay in ms (lower = faster). Leave empty to just toggle. Valid values are checked against TradingView runtime state when available, with a safe fallback list if it is not exposed.'),
   }, async ({ speed }) => {
     try { return jsonResult(await core.autoplay({ speed })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }


### PR DESCRIPTION
## Summary

This PR bundles two fixes:

1. Windows launcher detection now handles Appx installs more reliably.
2. Validation for chart types, pane layouts, and replay autoplay speeds now prefers TradingView's live runtime state instead of trusting only hardcoded allowlists.

## What changed

- Added a `Get-AppxPackage` fallback to `scripts/launch_tv_debug.bat` so Appx/WindowsApps installs can be found without relying only on `dir` access.
- Updated the Windows detection note in the README.
- Updated `chart_set_type` to query TradingView runtime chart-type values when available, with fallback to the previous known-safe map.
- Updated `pane_set_layout` to query layout codes from TradingView runtime state when available, with fallback to the previous known-safe list.
- Updated `replay_autoplay` to query live autoplay delay options when available, with fallback to the previous known-safe delays.
- Kept the external tool/CLI surface stable while tightening validation before mutation.

## Verification

- `node --check src/core/chart.js`
- `node --check src/core/pane.js`
- `node --check src/core/replay.js`
- `node --check src/tools/chart.js`
- `node --check src/tools/pane.js`
- `node --check src/tools/replay.js`
- `npm run test:cli`

## Issues

Closes #23
Closes #25