### PR TITLE
Fix replay state corruption safeguards

### DIFF
--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -3,6 +3,8 @@
  */
 import { evaluate, getReplayApi } from '../connection.js';
 
+const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
+
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
@@ -34,7 +36,6 @@ export async function start({ date } = {}) {
   if (toast) {
     // Stop replay to recover chart
     try { await evaluate(`${rp}.stopReplay()`); } catch {}
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     throw new Error(`Replay date unavailable: "${toast}". The requested date has no data for this timeframe. Try a more recent date or switch to a higher timeframe (e.g., Daily).`);
   }
 
@@ -53,6 +54,10 @@ export async function step() {
 }
 
 export async function autoplay({ speed } = {}) {
+  if (speed > 0 && !VALID_AUTOPLAY_DELAYS.includes(speed)) {
+    throw new Error(`Invalid autoplay delay ${speed}. Valid values: ${VALID_AUTOPLAY_DELAYS.join(', ')}`);
+  }
+
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) throw new Error('Replay is not started. Use replay_start first.');
@@ -67,12 +72,9 @@ export async function stop() {
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
   if (!started) {
-    // Try to hide toolbar even if not started
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
     return { success: true, action: 'already_stopped' };
   }
   await evaluate(`${rp}.stopReplay()`);
-  try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
   return { success: true, action: 'replay_stopped' };
 }
 

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -1,0 +1,40 @@
+/**
+ * Replay safety tests for issue #19.
+ * These tests are offline and only verify local guardrails.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { autoplay } from '../src/core/replay.js';
+
+const INVALID_DELAYS = [50, 99, 101, 500, 750, 1500, 9999, 20000, 60000];
+const EXPECTED_DELAYS = '[100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000]';
+
+describe('replay autoplay guardrails', () => {
+  for (const delay of INVALID_DELAYS) {
+    it(`rejects invalid delay ${delay}ms`, async () => {
+      await assert.rejects(
+        () => autoplay({ speed: delay }),
+        err => {
+          assert.ok(err.message.includes('Invalid autoplay delay'));
+          assert.ok(err.message.includes(String(delay)));
+          assert.ok(err.message.includes('Valid values:'));
+          return true;
+        },
+      );
+    });
+  }
+
+  it('keeps the exact safe delay list in source', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    assert.ok(source.includes(`const VALID_AUTOPLAY_DELAYS = ${EXPECTED_DELAYS};`));
+  });
+});
+
+describe('replay toolbar safety', () => {
+  it('replay core does not call hideReplayToolbar', () => {
+    const source = readFileSync(new URL('../src/core/replay.js', import.meta.url), 'utf8');
+    assert.ok(!source.includes('hideReplayToolbar'));
+  });
+});


### PR DESCRIPTION
## Summary

This fixes the critical replay-state corruption bug described in #19.

## What changed

- Removed every `hideReplayToolbar()` call from `src/core/replay.js` so the tool no longer syncs a hidden replay toolbar state into the user's TradingView cloud account.
- Added strict pre-validation for `replay_autoplay` speeds using TradingView's known-safe delay list: `100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000`.
- Added an offline regression test file covering both guardrails.

## Why

This code path can permanently poison replay controls across layouts, browsers, and devices because TradingView syncs that state through the account. Invalid autoplay delays are not a normal input error here; they are state corruption.

## Verification

- `node --check src/core/replay.js`
- `node --check tests/replay.test.js`
- `node --test tests/replay.test.js`

## Issues

Closes #19