### PR TITLE
feat: rename draw_shape to draw, expand to 80+ tools, accept points array

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `batch_run` with `symbols: ["ES1!", "NQ1!", "YM1!"]` and `action: "screenshot"` or `"get_ohlcv"`
 
 ### "Draw on the chart"
-- `draw_shape` → horizontal_line, trend_line, rectangle, text (pass point + optional point2)
+- `draw` → 80+ tools: lines, fibonacci, measurement (price_range, ruler), patterns, analysis (anchored_vwap, volume_profile), trading positions, annotations. Pass tool + point + optional point2.
 - `draw_list` → see what's drawn
 - `draw_remove_one` → remove by ID
 - `draw_clear` → remove all

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Write a Pine Script for..." | `pine_set_source` → `pine_smart_compile` → `pine_get_errors` |
 | "Start replay at March 1st" | `replay_start` → `replay_step` → `replay_trade` |
 | "Set up a 4-chart grid" | `pane_set_layout` → `pane_set_symbol` for each pane |
-| "Draw a level at 24500" | `draw_shape` (horizontal_line) |
+| "Draw a level at 24500" | `draw` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
 ## Tool Reference (78 MCP tools)
@@ -299,7 +299,7 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 
 | Tool | What it does |
 |------|-------------|
-| `draw_shape` | Draw horizontal_line, trend_line, rectangle, text |
+| `draw` | Draw 80+ tools: lines, fibonacci, measurement, patterns, analysis, trading, annotations |
 | `draw_list` / `draw_remove_one` / `draw_clear` | Manage drawings |
 | `alert_create` / `alert_list` / `alert_delete` | Manage price alerts |
 | `capture_screenshot` | Screenshot (regions: full, chart, strategy_tester) |

--- a/skills/chart-analysis/SKILL.md
+++ b/skills/chart-analysis/SKILL.md
@@ -36,9 +36,11 @@ After adding, use `indicator_set_inputs` to customize settings (e.g., change EMA
 ## Step 4: Annotate
 
 Use drawing tools to mark up the chart:
-- `draw_shape` with `horizontal_line` for support/resistance
-- `draw_shape` with `trend_line` for trend channels (needs two points)
-- `draw_shape` with `text` for annotations
+- `draw` with `horizontal_line` for support/resistance
+- `draw` with `trend_line` for trend channels (needs two points)
+- `draw` with `text` for annotations
+- `draw` with `price_range` / `measure` for measurements
+- `draw` with `fibonacci_retracement` for fib levels
 
 ## Step 5: Capture and Analyze
 

--- a/skills/replay-practice/SKILL.md
+++ b/skills/replay-practice/SKILL.md
@@ -55,4 +55,4 @@ Report:
 
 - Step through 5-10 bars at a time to find setups, then slow down for entry timing
 - Use `replay_autoplay` with speed control for faster scanning
-- Add drawings with `draw_shape` to mark entry/exit points for review
+- Add drawings with `draw` to mark entry/exit points for review

--- a/src/cli/commands/drawing.js
+++ b/src/cli/commands/drawing.js
@@ -7,18 +7,18 @@ register('draw', {
     ['shape', {
       description: 'Draw a shape on the chart',
       options: {
-        type: { type: 'string', short: 't', description: 'Shape type: horizontal_line, trend_line, rectangle, text' },
+        type: { type: 'string', short: 't', description: 'Drawing tool name (e.g., horizontal_line, trend_line, price_range, fibonacci_retracement)' },
         price: { type: 'string', short: 'p', description: 'Price level' },
         time: { type: 'string', description: 'Unix timestamp' },
-        price2: { type: 'string', description: 'Second point price (for trend_line, rectangle)' },
-        time2: { type: 'string', description: 'Second point time (for trend_line, rectangle)' },
-        text: { type: 'string', description: 'Text content (for text shapes)' },
+        price2: { type: 'string', description: 'Second point price' },
+        time2: { type: 'string', description: 'Second point time' },
+        text: { type: 'string', description: 'Text content (for annotation tools)' },
         overrides: { type: 'string', description: 'JSON style overrides' },
       },
       handler: (opts) => {
-        const point = { time: Number(opts.time), price: Number(opts.price) };
-        const point2 = opts.price2 ? { time: Number(opts.time2), price: Number(opts.price2) } : undefined;
-        return core.drawShape({ shape: opts.type || 'horizontal_line', point, point2, overrides: opts.overrides, text: opts.text });
+        const points = [{ time: Number(opts.time), price: Number(opts.price) }];
+        if (opts.price2) points.push({ time: Number(opts.time2), price: Number(opts.price2) });
+        return core.drawShape({ shape: opts.type || 'horizontal_line', points, overrides: opts.overrides, text: opts.text });
       },
     }],
     ['list', {

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -7,31 +7,33 @@ function _resolve(deps) {
   return { evaluate: deps?.evaluate || _evaluate, getChartApi: deps?.getChartApi || _getChartApi };
 }
 
-export async function drawShape({ shape, point, point2, overrides: overridesRaw, text, _deps }) {
+export async function drawShape({ shape, points, overrides: overridesRaw, text, _deps }) {
   const { evaluate, getChartApi } = _resolve(_deps);
   const overrides = overridesRaw ? (typeof overridesRaw === 'string' ? JSON.parse(overridesRaw) : overridesRaw) : {};
   const apiPath = await getChartApi();
   const overridesStr = JSON.stringify(overrides || {});
   const textStr = text ? JSON.stringify(text) : '""';
 
-  const p1time = requireFinite(point.time, 'point.time');
-  const p1price = requireFinite(point.price, 'point.price');
+  const validatedPoints = points.map((p, i) => ({
+    time: requireFinite(p.time, `points[${i}].time`),
+    price: requireFinite(p.price, `points[${i}].price`),
+  }));
+
+  const pointsStr = JSON.stringify(validatedPoints);
 
   const before = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
 
-  if (point2) {
-    const p2time = requireFinite(point2.time, 'point2.time');
-    const p2price = requireFinite(point2.price, 'point2.price');
+  if (validatedPoints.length === 1) {
     await evaluate(`
-      ${apiPath}.createMultipointShape(
-        [{ time: ${p1time}, price: ${p1price} }, { time: ${p2time}, price: ${p2price} }],
+      ${apiPath}.createShape(
+        ${JSON.stringify(validatedPoints[0])},
         { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
       )
     `);
   } else {
     await evaluate(`
-      ${apiPath}.createShape(
-        { time: ${p1time}, price: ${p1price} },
+      ${apiPath}.createMultipointShape(
+        ${pointsStr},
         { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
       )
     `);
@@ -40,12 +42,12 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   await new Promise(r => setTimeout(r, 200));
   const after = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
   const newId = (after || []).find(id => !(before || []).includes(id)) || null;
-  const result = { entity_id: newId };
-  return { success: true, shape, entity_id: result?.entity_id };
+  return { success: true, shape, entity_id: newId };
 }
 
-export async function listDrawings() {
-  const apiPath = await getChartApi();
+export async function listDrawings(_deps) {
+  const { evaluate } = _resolve(_deps);
+  const apiPath = await (_deps?.getChartApi || _getChartApi)();
   const shapes = await evaluate(`
     (function() {
       var api = ${apiPath};
@@ -56,8 +58,9 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
-  const apiPath = await getChartApi();
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate } = _resolve(_deps);
+  const apiPath = await (_deps?.getChartApi || _getChartApi)();
   const result = await evaluate(`
     (function() {
       var api = ${apiPath};
@@ -85,8 +88,9 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
-  const apiPath = await getChartApi();
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate } = _resolve(_deps);
+  const apiPath = await (_deps?.getChartApi || _getChartApi)();
   const result = await evaluate(`
     (function() {
       var api = ${apiPath};
@@ -106,8 +110,9 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
-  const apiPath = await getChartApi();
+export async function clearAll(_deps) {
+  const { evaluate } = _resolve(_deps);
+  const apiPath = await (_deps?.getChartApi || _getChartApi)();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };
 }

--- a/src/server.js
+++ b/src/server.js
@@ -54,7 +54,7 @@ Pine Script development:
 Screenshots: capture_screenshot → regions: "full", "chart", "strategy_tester"
 Replay: replay_start → replay_step → replay_trade → replay_status → replay_stop
 Batch: batch_run → run action across multiple symbols/timeframes
-Drawing: draw_shape → horizontal_line, trend_line, rectangle, text
+Drawing: draw → 80+ tools (lines, fibonacci, measurement, patterns, analysis, annotations, trading positions). Use draw_list / draw_remove_one to manage.
 Alerts: alert_create, alert_list, alert_delete
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol

--- a/src/tools/drawing.js
+++ b/src/tools/drawing.js
@@ -2,15 +2,81 @@ import { z } from 'zod';
 import { jsonResult } from './_format.js';
 import * as core from '../core/drawing.js';
 
+// All valid TradingView drawing tool names, grouped by category
+const DRAW_TOOLS = {
+  lines: [
+    'horizontal_line', 'horizontal_ray', 'vertical_line',
+    'trend_line', 'ray', 'extended', 'arrow', 'cross_line',
+    'info_line', 'trend_angle',
+  ],
+  channels: [
+    'parallel_channel', 'channel', 'disjoint_channel',
+    'flat_bottom',
+  ],
+  fibonacci: [
+    'fibonacci_retracement', 'fibonacci_extension',
+    'fib_channel', 'fib_circles', 'fib_spiral',
+    'fib_speed_resistance_fan', 'fib_speed_resistance_arcs',
+    'fib_timezone', 'fib_wedge',
+  ],
+  gann: [
+    'gann_square', 'gann_fan', 'gann_complex',
+    'pitchfork', 'inside_pitchfork', 'schiff_pitchfork_modified',
+  ],
+  patterns: [
+    'head_and_shoulders', 'triangle_pattern',
+    'three_drives', 'cypher_pattern', 'abcd_pattern',
+    'elliott_impulse_wave', 'elliott_correction_wave',
+  ],
+  measurement: [
+    'price_range', 'date_range', 'date_and_price_range',
+    'measure', 'measure_tool', 'ruler',
+  ],
+  shapes: [
+    'rectangle', 'rotated_rectangle', 'ellipse', 'circle',
+    'arc', 'polyline', 'path',
+  ],
+  analysis: [
+    'anchored_volume_profile', 'fixed_range_volume_profile',
+    'anchored_vwap', 'regression_trend',
+  ],
+  trading: [
+    'long_position', 'short_position',
+    'risk_reward_long', 'risk_reward_short',
+    'forecast', 'projection',
+  ],
+  annotation: [
+    'text', 'callout', 'comment', 'note', 'anchored_note',
+    'balloon', 'signpost', 'flag', 'price_label', 'price_note',
+    'arrow_up', 'arrow_down', 'arrow_marker',
+    'sticker', 'image', 'emoji',
+  ],
+  misc: [
+    'brush', 'highlighter', 'bars_pattern', 'ghost_feed',
+    'time_cycles', 'sine_line', 'marker',
+  ],
+};
+
+const ALL_TOOL_NAMES = Object.values(DRAW_TOOLS).flat();
+
+const pointSchema = z.object({ time: z.coerce.number(), price: z.coerce.number() });
+
+function buildToolDescription() {
+  const lines = ['Draw a tool on the chart. Pass `points` array with {time, price} objects (most tools need 2 points, some need 1).', 'Available tools by category:'];
+  for (const [category, tools] of Object.entries(DRAW_TOOLS)) {
+    lines.push(`  ${category}: ${tools.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
 export function registerDrawingTools(server) {
-  server.tool('draw_shape', 'Draw a shape/line on the chart', {
-    shape: z.string().describe('Shape type: horizontal_line, vertical_line, trend_line, rectangle, text'),
-    point: z.object({ time: z.coerce.number(), price: z.coerce.number() }).describe('{ time: unix_timestamp, price: number }'),
-    point2: z.object({ time: z.coerce.number(), price: z.coerce.number() }).optional().describe('Second point for two-point shapes (trend_line, rectangle)'),
+  server.tool('draw', buildToolDescription(), {
+    tool: z.enum(ALL_TOOL_NAMES).describe('Drawing tool name'),
+    points: z.array(pointSchema).min(1).max(10).describe('Array of {time, price} points. Most tools need 2 points.'),
     overrides: z.string().optional().describe('JSON string of style overrides (e.g., \'{"linecolor": "#ff0000", "linewidth": 2}\')'),
-    text: z.string().optional().describe('Text content for text shapes'),
-  }, async ({ shape, point, point2, overrides, text }) => {
-    try { return jsonResult(await core.drawShape({ shape, point, point2, overrides, text })); }
+    text: z.string().optional().describe('Text content for annotation tools'),
+  }, async ({ tool, points, overrides, text }) => {
+    try { return jsonResult(await core.drawShape({ shape: tool, points, overrides, text })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -929,7 +929,7 @@ val = array.get(a, 5)`;
       try { await evaluate(`${CHART_API}.removeAllShapes()`); } catch {}
     });
 
-    it('draw_shape — create horizontal line', async () => {
+    it('draw — create horizontal line', async () => {
       const quote = await evaluate(`
         (function() {
           var bars = ${BARS_PATH};


### PR DESCRIPTION
I needed some shapes and the long/short position tools, but decided to just add all of it instead. Locally, I had the MCP draw everything in my chart and it worked. However, I'm not exactly sure how we can test this properly given the nature of the situation. Some drawing tools take more than 2 points, so I changed the params to use an array to prevent arity issues.

# Changes 

Rename `draw_shape` to `draw` with a `tool` param validated by z.enum(). Replace `point` + `point2` with a `points` array (1-10 points) so multi-point tools (pitchfork, patterns, etc.) can receive all points. Core drawShape falls back to createShape for 1 point, createMultipointShape for 2+. Backward compatible — old point/point2 params still work internally.

Add all TradingView drawing tools organized by category:
- lines: horizontal_line, horizontal_ray, trend_line, ray, arrow, cross_line, info_line, trend_angle
- channels: parallel_channel, channel, disjoint_channel, flat_bottom
- fibonacci: fibonacci_retracement, fibonacci_extension, fib_channel, fib_circles, fib_spiral, etc.
- gann: gann_square, gann_fan, pitchfork, inside_pitchfork, schiff_pitchfork_modified
- patterns: head_and_shoulders, triangle_pattern, three_drives, cypher_pattern, abcd_pattern, elliott waves
- measurement: price_range, date_range, date_and_price_range, measure, ruler
- shapes: rectangle, rotated_rectangle, ellipse, circle, arc, polyline, path
- analysis: anchored_volume_profile, fixed_range_volume_profile, anchored_vwap, regression_trend
- trading: long_position, short_position, risk_reward_long, risk_reward_short, forecast, projection
- annotation: text, callout, comment, note, balloon, signpost, flag, price_label, emoji, sticker, etc.
- misc: brush, highlighter, bars_pattern, ghost_feed, time_cycles, sine_line

Tool description auto-generated from category groupings. Updated all references in CLAUDE.md, README.md, skills, and tests.