### PR TITLE
feat: add data_get_pine_shapes for reading plotshape/plotchar signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 3. `data_get_pine_lines` → key price levels from custom indicators
 4. `data_get_pine_labels` → labeled levels with context (e.g., "Settlement", "ASN O/U")
 5. `data_get_pine_tables` → session stats, analytics tables
+6. `data_get_pine_shapes` → plotshape/plotchar signals (triangles, diamonds, squares) with OHLC of the bar they fired on
 6. `data_get_ohlcv` with `summary: true` → price action summary
 7. `capture_screenshot` → visual confirmation
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 
 ### Custom Indicator Data (Pine Drawings)
 
-Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any visible Pine indicator.
+Read `line.new()`, `label.new()`, `table.new()`, `box.new()`, and `plotshape()` output from any visible Pine indicator.
 
 | Tool | When to use | Output size |
 |------|------------|-------------|
@@ -236,6 +236,7 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `data_get_pine_labels` | Read text annotations + prices ("PDH 24550", "Bias Long") | ~2-5KB |
 | `data_get_pine_tables` | Read data tables (session stats, analytics dashboards) | ~1-4KB |
 | `data_get_pine_boxes` | Read price zones / ranges as {high, low} pairs | ~1-2KB |
+| `data_get_pine_shapes` | Read plotshape/plotchar signals (triangles, squares, diamonds) with OHLC | ~2-10KB |
 
 **Always use `study_filter`** to target a specific indicator: `study_filter: "Profiler"`.
 

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -429,6 +429,125 @@ export async function getPineTables({ study_filter } = {}) {
   return { success: true, study_count: studies.length, studies };
 }
 
+/**
+ * Read plotshape/plotchar markers from Pine Script indicators.
+ * These are stored in the study's bar data series (not _primitivesCollection),
+ * so buildGraphicsJS can't reach them. We scan each study's metaInfo for
+ * "shapes" type plots, then read the bar data to find which bars have active markers.
+ */
+export async function getPineShapes({ study_filter, last_n_bars } = {}) {
+  const filter = study_filter || '';
+  const maxBars = last_n_bars || 100;
+  const raw = await evaluate(`
+    (function() {
+      var chart = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget;
+      var model = chart.model();
+      var sources = model.model().dataSources();
+      var mainSeries = model.mainSeries();
+      var mainBars = mainSeries.bars();
+      var filter = ${safeString(filter)};
+      var maxBars = ${maxBars};
+      var results = [];
+
+      for (var si = 0; si < sources.length; si++) {
+        var s = sources[si];
+        if (!s.metaInfo) continue;
+        try {
+          var meta = s.metaInfo();
+          var name = meta.description || meta.shortDescription || '';
+          if (!name) continue;
+          if (filter && name.indexOf(filter) === -1) continue;
+          if (!meta.plots) continue;
+
+          // Find shape-type plots and their metadata
+          var shapePlots = [];
+          for (var pi = 0; pi < meta.plots.length; pi++) {
+            var plot = meta.plots[pi];
+            if (plot.type !== 'shapes') continue;
+            var style = meta.styles && meta.styles[plot.id] ? meta.styles[plot.id] : {};
+            var defaults = meta.defaults && meta.defaults.styles && meta.defaults.styles[plot.id]
+              ? meta.defaults.styles[plot.id] : {};
+            shapePlots.push({
+              plotIndex: pi,
+              dataIndex: pi + 1,
+              id: plot.id,
+              title: style.title || plot.id,
+              shape: defaults.plottype || 'unknown',
+              location: defaults.location || 'AboveBar',
+              color: defaults.color || null,
+              size: style.size || 'auto'
+            });
+          }
+          if (shapePlots.length === 0) continue;
+
+          // Scan bar data for active shape markers
+          var data = s._data;
+          if (!data) continue;
+          var lastIdx = data.lastIndex();
+          var firstIdx = Math.max(data.firstIndex(), lastIdx - maxBars + 1);
+
+          var signals = [];
+          for (var b = lastIdx; b >= firstIdx; b--) {
+            var row = data.valueAt(b);
+            if (!row) continue;
+            for (var sp = 0; sp < shapePlots.length; sp++) {
+              var di = shapePlots[sp].dataIndex;
+              var val = row[di];
+              if (val && val !== 0 && !isNaN(val)) {
+                // Get OHLC from main series
+                var mainRow = mainBars.valueAt(b);
+                var ohlc = null;
+                if (mainRow) {
+                  ohlc = {
+                    time: new Date(mainRow[0] * 1000).toISOString(),
+                    timestamp: mainRow[0],
+                    open: mainRow[1],
+                    high: mainRow[2],
+                    low: mainRow[3],
+                    close: mainRow[4]
+                  };
+                }
+                signals.push({
+                  plot: shapePlots[sp].title,
+                  shape: shapePlots[sp].shape,
+                  location: shapePlots[sp].location,
+                  color: shapePlots[sp].color,
+                  barIndex: b,
+                  value: val,
+                  ohlc: ohlc
+                });
+              }
+            }
+          }
+
+          if (shapePlots.length > 0) {
+            results.push({
+              name: name,
+              shapePlots: shapePlots,
+              signals: signals,
+              signalCount: signals.length,
+              barsScanned: lastIdx - firstIdx + 1
+            });
+          }
+        } catch(e) {}
+      }
+      return results;
+    })()
+  `);
+
+  if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
+
+  const studies = raw.map(s => ({
+    name: s.name,
+    shape_plots: s.shapePlots,
+    signal_count: s.signalCount,
+    bars_scanned: s.barsScanned,
+    signals: s.signals,
+  }));
+
+  return { success: true, study_count: studies.length, studies };
+}
+
 export async function getPineBoxes({ study_filter, verbose } = {}) {
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwgboxes', 'boxes', filter));

--- a/src/server.js
+++ b/src/server.js
@@ -37,7 +37,8 @@ Reading custom Pine indicator output (line.new/label.new/table.new/box.new drawi
 - data_get_pine_labels → text annotations with prices ("PDH 24550", "Bias Long", etc.)
 - data_get_pine_tables → table data as formatted rows (session stats, analytics dashboards)
 - data_get_pine_boxes → price zones as {high, low} pairs
-- ALWAYS pass study_filter to target a specific indicator by name (e.g., study_filter="Profiler")
+- data_get_pine_shapes → plotshape/plotchar markers (triangles, diamonds, squares) with OHLC of the bar they fired on
+- ALWAYS pass study_filter to target a specific indicator by name (e.g., study_filter="Flow Matrix")
 - Indicators must be VISIBLE on chart for these to work
 
 Changing the chart:

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -79,6 +79,14 @@ export function registerDataTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
+  server.tool('data_get_pine_shapes', 'Read plotshape/plotchar markers from Pine Script indicators. Returns which bars have active shape signals (triangles, diamonds, squares, circles, labels) with OHLC data. Use study_filter to target a specific indicator.', {
+    study_filter: z.string().optional().describe('Substring to match study name (e.g., "Flow Matrix"). Omit for all.'),
+    last_n_bars: z.coerce.number().optional().describe('Number of recent bars to scan (default 100, max 500)'),
+  }, async ({ study_filter, last_n_bars }) => {
+    try { return jsonResult(await core.getPineShapes({ study_filter, last_n_bars })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
   server.tool('data_get_study_values', 'Get current indicator values from the data window for all visible studies (RSI, MACD, Bollinger Bands, EMAs, custom indicators with plot()).', {}, async () => {
     try { return jsonResult(await core.getStudyValues()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }


### PR DESCRIPTION
New tool that reads plotshape() and plotchar() markers from Pine Script indicators. Unlike box.new/label.new/line.new which store data in _primitivesCollection, plotshape outputs are stored in the study bar data series. This tool scans the study metaInfo for shapes type plots, then reads the bar data to find which bars have active markers.

Returns per signal: plot title, shape type, location, color, bar index, and OHLC of the candle the signal fired on. Configurable scan depth via last_n_bars param (default 100).

Also returns metadata about all shape plots defined by the indicator so the LLM knows what signals the indicator can produce.

