### PR TITLE
fix: default screenshot region to 'full' when unspecified

### DIFF
--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -13,7 +13,7 @@ export async function captureScreenshot({ region, filename, method } = {}) {
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_');
+  const fname = (filename || `tv_${region || 'full'}_${ts}`).replace(/[\/\\]/g, '_');
   const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
 
   if (method === 'api') {


### PR DESCRIPTION
## Summary
Calling `captureScreenshot()` without a `region` parameter produces filenames
like `tv_undefined_2025-04-03T...png`. The template string interpolates
`region` directly, so an omitted argument lands the literal "undefined" in
the filename. This adds `region || 'full'` so the default reads
`tv_full_2025-04-03T...png`.