### PR TITLE
fix: reconnect CDP client after tab switch

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -132,6 +132,26 @@ export async function disconnect() {
   }
 }
 
+export async function connectToTarget(targetId) {
+  await disconnect();
+  let lastError;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
+      await client.Runtime.enable();
+      await client.Page.enable();
+      await client.DOM.enable();
+      targetInfo = { id: targetId };
+      return client;
+    } catch (err) {
+      lastError = err;
+      const delay = Math.min(BASE_DELAY * Math.pow(2, attempt), 30000);
+      await new Promise(r => setTimeout(r, delay));
+    }
+  }
+  throw new Error(`CDP connect to target ${targetId} failed after ${MAX_RETRIES} attempts: ${lastError?.message}`);
+}
+
 // --- Direct API path helpers ---
 // Each returns the STRING expression path after verifying it exists.
 // Callers use the returned string in their own evaluate() calls.

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,7 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
+import { getClient, evaluate, connectToTarget } from '../connection.js';
 
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
@@ -95,10 +95,11 @@ export async function switchTab({ index }) {
 
   const target = tabs.tabs[idx];
 
-  // Use CDP Target.activateTarget to bring the tab to front
+  // Activate the tab visually and reconnect CDP client to the new target
   try {
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
-    const text = await resp.text();
+    await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
+    await new Promise(r => setTimeout(r, 500));
+    await connectToTarget(target.id);
     return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
   } catch (e) {
     throw new Error(`Failed to activate tab ${idx}: ${e.message}`);


### PR DESCRIPTION
## Summary
`switchTab()` called `/json/activate` to bring the target tab to front but
left the CDP client connected to the previous target. Every subsequent
`evaluate()` call still ran against the old tab.

This adds `connectToTarget()` to `connection.js`, which disconnects from the
current target, reconnects to the new one with exponential backoff, and
re-enables Runtime/Page/DOM domains. `switchTab()` now calls it after
activation with a 500ms settle delay.