### PR TITLE
feat: add output_dir parameter to screenshot tools

### DIFF
--- a/src/core/batch.js
+++ b/src/core/batch.js
@@ -3,17 +3,15 @@
  */
 import { evaluate, evaluateAsync, getClient, getChartApi, getChartCollection, safeString } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
-import { writeFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { resolveScreenshotDir } from './paths.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const SCREENSHOT_DIR = join(dirname(dirname(__dirname)), 'screenshots');
-
-export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_count }) {
+export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_count, output_dir }) {
   const tfs = timeframes && timeframes.length > 0 ? timeframes : [null];
   const delay = delay_ms || 2000;
   const results = [];
+  const targetDir = action === 'screenshot' ? resolveScreenshotDir(output_dir) : null;
 
   let colPath, apiPath;
   try { colPath = await getChartCollection(); } catch {}
@@ -36,12 +34,11 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
 
         let actionResult;
         if (action === 'screenshot') {
-          mkdirSync(SCREENSHOT_DIR, { recursive: true });
           const client = await getClient();
           const { data } = await client.Page.captureScreenshot({ format: 'png' });
           const ts = new Date().toISOString().replace(/[:.]/g, '-');
           const fname = `batch_${symbol}_${tf || 'default'}_${ts}`.replace(/[\/\\]/g, '_') + '.png';
-          const filePath = join(SCREENSHOT_DIR, fname);
+          const filePath = join(targetDir, fname);
           writeFileSync(filePath, Buffer.from(data, 'base64'));
           actionResult = { file_path: filePath };
         } else if (action === 'get_ohlcv' && apiPath) {

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -2,19 +2,16 @@
  * Core screenshot/capture logic.
  */
 import { getClient, evaluate, getChartCollection } from '../connection.js';
-import { writeFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { resolveScreenshotDir } from './paths.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const SCREENSHOT_DIR = join(dirname(dirname(__dirname)), 'screenshots');
-
-export async function captureScreenshot({ region, filename, method } = {}) {
-  mkdirSync(SCREENSHOT_DIR, { recursive: true });
+export async function captureScreenshot({ region, filename, method, output_dir } = {}) {
+  const targetDir = resolveScreenshotDir(output_dir);
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
   const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_');
-  const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
+  const filePath = join(targetDir, `${fname}.png`);
 
   if (method === 'api') {
     try {

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -3,21 +3,18 @@
  */
 import { getClient, evaluate, getChartCollection } from '../connection.js';
 import { waitForChartRender } from '../wait.js';
-import { writeFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { resolveScreenshotDir } from './paths.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const SCREENSHOT_DIR = join(dirname(dirname(__dirname)), 'screenshots');
-
-export async function captureScreenshot({ region, filename, method, waitForRender = false } = {}) {
-  mkdirSync(SCREENSHOT_DIR, { recursive: true });
+export async function captureScreenshot({ region, filename, method, waitForRender = false, output_dir } = {}) {
+  const targetDir = resolveScreenshotDir(output_dir);
 
   if (waitForRender) await waitForChartRender();
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
   const fname = (filename || `tv_${region || 'full'}_${ts}`).replace(/[\/\\]/g, '_').replace(/\.\./g, '_');
-  const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
+  const filePath = join(targetDir, `${fname}.png`);
 
   if (method === 'api') {
     try {

--- a/src/core/paths.js
+++ b/src/core/paths.js
@@ -1,0 +1,15 @@
+import { mkdirSync } from 'fs';
+import { join, dirname, isAbsolute, resolve, normalize } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const PROJECT_ROOT = dirname(dirname(__dirname));
+export const DEFAULT_SCREENSHOT_DIR = join(PROJECT_ROOT, 'screenshots');
+
+export function resolveScreenshotDir(output_dir) {
+  const dir = !output_dir
+    ? DEFAULT_SCREENSHOT_DIR
+    : isAbsolute(output_dir) ? normalize(output_dir) : resolve(PROJECT_ROOT, output_dir);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}

--- a/src/tools/batch.js
+++ b/src/tools/batch.js
@@ -9,8 +9,9 @@ export function registerBatchTools(server) {
     action: z.string().describe('Action to run: screenshot, get_ohlcv, get_strategy_results'),
     delay_ms: z.coerce.number().optional().describe('Delay between iterations in ms (default 2000)'),
     ohlcv_count: z.coerce.number().optional().describe('Bar count for get_ohlcv action (default 100)'),
-  }, async ({ symbols, timeframes, action, delay_ms, ohlcv_count }) => {
-    try { return jsonResult(await core.batchRun({ symbols, timeframes, action, delay_ms, ohlcv_count })); }
+    output_dir: z.string().optional().describe('Absolute path to save directory for batch screenshots (default: screenshots/ in project root)'),
+  }, async ({ symbols, timeframes, action, delay_ms, ohlcv_count, output_dir }) => {
+    try { return jsonResult(await core.batchRun({ symbols, timeframes, action, delay_ms, ohlcv_count, output_dir })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }

--- a/src/tools/capture.js
+++ b/src/tools/capture.js
@@ -7,8 +7,9 @@ export function registerCaptureTools(server) {
     region: z.string().optional().describe('Region to capture: full, chart, strategy_tester (default full)'),
     filename: z.string().optional().describe('Custom filename (without extension)'),
     method: z.string().optional().describe('Capture method: cdp (Page.captureScreenshot) or api (chartWidgetCollection.takeScreenshot) (default cdp)'),
-  }, async ({ region, filename, method }) => {
-    try { return jsonResult(await core.captureScreenshot({ region, filename, method })); }
+    output_dir: z.string().optional().describe('Absolute path to save directory (default: screenshots/ in project root)'),
+  }, async ({ region, filename, method, output_dir }) => {
+    try { return jsonResult(await core.captureScreenshot({ region, filename, method, output_dir })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }

--- a/src/tools/capture.js
+++ b/src/tools/capture.js
@@ -8,8 +8,9 @@ export function registerCaptureTools(server) {
     filename: z.string().optional().describe('Custom filename (without extension)'),
     method: z.string().optional().describe('Capture method: cdp (Page.captureScreenshot) or api (chartWidgetCollection.takeScreenshot) (default cdp)'),
     wait_for_render: z.boolean().optional().describe('Wait for the chart canvas to stabilize before capturing. Use after chart_set_symbol or chart_set_timeframe to avoid stale frames.'),
-  }, async ({ region, filename, method, wait_for_render }) => {
-    try { return jsonResult(await core.captureScreenshot({ region, filename, method, waitForRender: wait_for_render })); }
+    output_dir: z.string().optional().describe('Absolute path to save directory (default: screenshots/ in project root)'),
+  }, async ({ region, filename, method, wait_for_render, output_dir }) => {
+    try { return jsonResult(await core.captureScreenshot({ region, filename, method, waitForRender: wait_for_render, output_dir })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }


### PR DESCRIPTION
## Summary
- Adds an optional `output_dir` parameter to `capture_screenshot` and `batch_run` tools
- When omitted, screenshots save to `screenshots/` in the project root (unchanged behavior)
- When provided, screenshots save to the specified directory (created automatically if missing)
- Extracts shared path resolution into `src/core/paths.js` to avoid duplication

## Motivation
When the MCP server is used from Claude Desktop (cowork mode), screenshots save to a folder the client can't read. This parameter lets callers specify an accessible directory.

## Test plan
- [x] Call `capture_screenshot` without `output_dir` — saves to `screenshots/` as before
- [x] Call `capture_screenshot` with `output_dir: "/tmp/test"` — saves there
- [x] Call `batch_run` with `action: "screenshot"` and `output_dir` — saves batch screenshots to specified dir
- [x] Returned `file_path` reflects the custom directory