### PR TITLE
Fix getChartApi not defined in drawing management functions

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };


### PR DESCRIPTION
## Summary

- `draw_list`, `draw_clear`, `draw_remove_one`, and `draw_get_properties` all fail with `getChartApi is not defined`
- Root cause: these four functions call `getChartApi()` and `evaluate()` directly, but both are imported as `_getChartApi` and `_evaluate` — only `drawShape()` properly calls `_resolve(_deps)` to bring them into scope
- Fix: add `_deps` parameter and `_resolve(_deps)` call to all four functions, matching the existing `drawShape()` pattern

## Test plan

- [x] `draw_list` — returns all shapes on chart
- [x] `draw_remove_one` — removes shape by entity ID
- [x] `draw_clear` — removes all shapes
- [x] `draw_get_properties` — returns shape properties

All four were manually tested via MCP after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)