### PR TITLE
Fix Windows MSIX install detection in tv_launch (Get-AppxPackage fallback)

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -189,6 +189,19 @@ export async function launch({ port, kill_existing } = {}) {
     if (p && existsSync(p)) { tvPath = p; break; }
   }
 
+  if (!tvPath && platform === 'win32') {
+    // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
+    // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
+    try {
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const installDir = execSync(ps, { timeout: 5000 }).toString().trim();
+      if (installDir) {
+        const candidate = `${installDir}\\TradingView.exe`;
+        if (existsSync(candidate)) tvPath = candidate;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath) {
     try {
       const cmd = platform === 'win32' ? 'where TradingView.exe' : 'which tradingview';


### PR DESCRIPTION
## Problem

TradingView's official Windows distribution is now an MSIX package downloaded from [tradingview.com/desktop](https://www.tradingview.com/desktop/). MSIX installs land in `C:\Program Files\WindowsApps\TradingView.Desktop_<version>_x64__<hash>\`, which is ACL-restricted — `dir` enumeration silently returns nothing without elevation, and the standard install paths don't apply.

As a result, `src/core/health.js` `launch()` (the function backing the `tv_launch` MCP tool) reports "TradingView not found on win32" even when the user has the official installer running. The current detection in `pathMap.win32` only checks:

- `%LOCALAPPDATA%\TradingView\TradingView.exe`
- `%PROGRAMFILES%\TradingView\TradingView.exe`
- `%PROGRAMFILES(X86)%\TradingView\TradingView.exe`

…then falls back to `where TradingView.exe`. None of these resolve an MSIX install.

**Reproduced on Windows 11 Pro** with TradingView Desktop 3.0.0.7652 from the official `.msix`:
- 10 `TradingView.exe` processes running from `C:\Program Files\WindowsApps\TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj\`
- `mcp__tradingview__tv_launch` returns: `TradingView not found on win32. Searched: C:\Users\<u>\AppData\Local\TradingView\TradingView.exe, C:\Program Files\TradingView\TradingView.exe, ...`

## Fix

Add a Windows-specific detection branch in `launch()` that queries the Appx package database via PowerShell:

\`\`\`powershell
(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation
\`\`\`

`Get-AppxPackage` works without elevation. The new branch is gated on `platform === 'win32'` and runs **between** the existing static `pathMap` loop and the `where TradingView.exe` fallback, so:
- Legacy/non-MSIX installs continue to be detected by the existing `pathMap` paths (no behavior change)
- MSIX installs are now found via the Appx query
- The query is by package name, not folder pattern, so it remains correct across TradingView version bumps

## Verification

Tested locally on Windows 11 Pro with TradingView Desktop 3.0.0.7652 (official `.msix`):

1. \`Get-AppxPackage\` returns \`C:\Program Files\WindowsApps\TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj\` as expected
2. Patched \`launch()\` resolves the full \`TradingView.exe\` path
3. \`mcp__tradingview__tv_launch\` starts TV with \`--remote-debugging-port=9222\` and CDP comes up on port 9222
4. \`mcp__tradingview__tv_health_check\` returns:
   \`\`\`json
   {
     "success": true,
     "cdp_connected": true,
     "target_url": "https://www.tradingview.com/chart/...",
     "chart_symbol": "BATS:META",
     "chart_resolution": "1D",
     "api_available": true
   }
   \`\`\`
5. \`chart_get_state\` and \`quote_get\` both return live data against the connected chart

## Notes

- **Related to #27** — that PR adds the same `Get-AppxPackage` fallback to `scripts/launch_tv_debug.bat` (the manual launcher). This PR addresses the parallel gap in `health.js` (the programmatic launcher used by the MCP tool). They're complementary and don't overlap.
- **Related to #18** — that PR refactors `launch()` to use dependency injection but doesn't add MSIX detection. If #18 merges first, this patch will need a one-line rebase to call `deps.execSync` instead of `execSync`. Happy to rebase if that lands.
- **No new tests** — there's currently no test infrastructure in `tests/e2e.test.js` that mocks `execSync`/`existsSync` for `launch()` (the existing `tv_launch` test only validates macOS paths via real `existsSync`). #18 adds that infrastructure; once it's merged I can add a Windows MSIX detection unit test in a follow-up.
- `npm test` (29 offline tests) still passes locally — no existing test paths are touched.