### PR TITLE
feat: support running MCP server inside a Docker container

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1,9 +1,10 @@
 import CDP from 'chrome-remote-interface';
+import http from 'http';
 
 let client = null;
 let targetInfo = null;
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_HOST = process.env.CDP_HOST ?? 'localhost';
+const CDP_PORT = Number(process.env.CDP_PORT ?? 9222);
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 
@@ -70,7 +71,13 @@ export async function connect() {
         throw new Error('No TradingView chart target found. Is TradingView open with a chart?');
       }
       targetInfo = target;
-      client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
+      // Use the WebSocket URL directly so chrome-remote-interface doesn't send
+      // a Host header that Chrome rejects (e.g. "host.docker.internal:9222").
+      // Chrome returns ws://localhost/... so we rewrite the host+port to the
+      // actual connection address.
+      const wsUrl = (target.webSocketDebuggerUrl || '')
+        .replace(/^ws:\/\/[^/]+/, `ws://${CDP_HOST}:${CDP_PORT}`);
+      client = await CDP({ target: wsUrl, headers: { Host: 'localhost' } });
 
       // Enable required domains
       await client.Runtime.enable();
@@ -87,9 +94,26 @@ export async function connect() {
   throw new Error(`CDP connection failed after ${MAX_RETRIES} attempts: ${lastError?.message}`);
 }
 
+// Node's built-in fetch treats Host as a forbidden header and ignores overrides.
+// Use http.request instead so we can force Host: localhost, which Chrome requires
+// when the connecting address is not localhost (e.g. host.docker.internal).
+function httpGet(hostname, port, path) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ hostname, port, path, method: 'GET', headers: { Host: 'localhost' } }, (res) => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); }
+        catch { reject(new Error(`Invalid JSON from CDP: ${data.slice(0, 120)}`)); }
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 async function findChartTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
+  const targets = await httpGet(CDP_HOST, CDP_PORT, '/json/list');
   // Prefer targets with tradingview.com/chart in the URL
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))


### PR DESCRIPTION
## Summary

- Make `CDP_HOST` and `CDP_PORT` configurable via environment variables (defaults unchanged: `localhost:9222`) so the MCP server can reach TradingView Desktop on the host machine when running inside a container
- Replace `fetch()` with `http.request()` for the `/json/list` call — Node's built-in `fetch` silently drops `Host` header overrides (it's a forbidden header), causing Chrome's DevTools server to reject the request with `"Host header disallowed"` when connecting from a non-localhost address
- Pass `Host: localhost` on the WebSocket upgrade request for the same reason

## Why this is needed

When running the MCP server in a Docker container on Mac/Windows, the container connects to `host.docker.internal:9222` instead of `localhost:9222`. Chrome's CDP server checks the `Host` header on both HTTP and WebSocket requests and rejects anything that isn't `localhost` — even when launched with `--remote-debugging-address=0.0.0.0`.

## Backwards compatibility

Fully compatible. When `CDP_HOST` is not set it defaults to `localhost`, and Chrome does not check the `Host` header for loopback connections — so the override is a no-op for all existing native installs.

## Usage (Docker)

```dockerfile
FROM node:22-alpine
WORKDIR /app
COPY package*.json ./
RUN npm ci --omit=dev
COPY src/ ./src/
ENTRYPOINT ["node", "src/server.js"]
```

```json
{
  "mcpServers": {
    "tradingview": {
      "command": "docker",
      "args": [
        "run", "--rm", "-i",
        "-e", "CDP_HOST=host.docker.internal",
        "--add-host=host.docker.internal:host-gateway",
        "tradingview-mcp"
      ]
    }
  }
}
```

Launch TradingView with `--remote-debugging-port=9222 --remote-debugging-address=0.0.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)