### PR TITLE
security: remove ui_evaluate tool — unrestricted JS execution in authenticated session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/current.pine
 temp_*
 *.log
 discovery-log.json
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,21 @@
 {
   "name": "tradingview-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradingview-mcp",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "tradingview-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "MCP bridge for TradingView Desktop via Chrome DevTools Protocol",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "type": "module",
   "main": "src/server.js",
   "bin": {

--- a/src/cli/commands/ui.js
+++ b/src/cli/commands/ui.js
@@ -58,13 +58,6 @@ register('ui', {
         return core.findElement({ query: positionals.join(' '), strategy: opts.strategy });
       },
     }],
-    ['eval', {
-      description: 'Execute JavaScript in TradingView page context',
-      handler: (opts, positionals) => {
-        if (!positionals[0]) throw new Error('Expression required. Usage: tv ui eval "1+1"');
-        return core.uiEvaluate({ expression: positionals.join(' ') });
-      },
-    }],
     ['type', {
       description: 'Type text into focused input',
       handler: (opts, positionals) => {

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -161,7 +161,7 @@ export async function uiState() {
 
 export async function launch({ port, kill_existing } = {}) {
   const cdpPort = port || 9222;
-  const killFirst = kill_existing !== false;
+  const killFirst = kill_existing === true;
   const platform = process.platform;
 
   const pathMap = {

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -287,7 +287,3 @@ export async function findElement({ query, strategy }) {
   return { success: true, query, strategy: strat, count: results?.length || 0, elements: results || [] };
 }
 
-export async function uiEvaluate({ expression }) {
-  const result = await evaluate(expression);
-  return { success: true, result };
-}

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -20,7 +20,7 @@ export function registerHealthTools(server) {
 
   server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux.', {
     port: z.coerce.number().optional().describe('CDP port (default 9222)'),
-    kill_existing: z.coerce.boolean().optional().describe('Kill existing TradingView instances first (default true)'),
+    kill_existing: z.coerce.boolean().default(false).describe('Kill existing TradingView instances first (default false)'),
   }, async ({ port, kill_existing }) => {
     try { return jsonResult(await core.launch({ port, kill_existing })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/src/tools/ui.js
+++ b/src/tools/ui.js
@@ -85,10 +85,4 @@ export function registerUiTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('ui_evaluate', 'Execute JavaScript code in the TradingView page context for advanced automation', {
-    expression: z.string().describe('JavaScript expression to evaluate in the page context. Wrap in IIFE for complex logic.'),
-  }, async ({ expression }) => {
-    try { return jsonResult(await core.uiEvaluate({ expression })); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
-  });
 }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1124,11 +1124,6 @@ val = array.get(a, 5)`;
       assert.ok(results.length > 0, 'Found visible buttons');
     });
 
-    it('ui_evaluate — execute arbitrary JS', async () => {
-      const result = await evaluate('1 + 1');
-      assert.equal(result, 2, 'JS evaluation works');
-    });
-
     it('layout_list — find layout dropdown button', async () => {
       const found = await evaluate(`
         !!(document.querySelector('[data-name="save-load-menu"]')

--- a/tests/pine_analyze.test.js
+++ b/tests/pine_analyze.test.js
@@ -7,111 +7,12 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { analyze as _analyze } from '../src/core/pine.js';
 
-// Extracted analyze function matching the tool's logic
+// Wrapper: production analyze() takes {source} and returns {diagnostics, ...}
+// Tests were written against a bare (source) -> diagnostics[] signature
 function analyze(source) {
-  const lines = source.split('\n');
-  const diagnostics = [];
-  let isV6 = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith('//@version=6')) { isV6 = true; break; }
-    if (trimmed.startsWith('//@version=')) break;
-    if (trimmed === '' || trimmed.startsWith('//')) continue;
-    break;
-  }
-
-  const arrays = new Map();
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const fromMatch = line.match(/(\w+)\s*=\s*array\.from\(([^)]*)\)/);
-    if (fromMatch) {
-      const name = fromMatch[1].trim();
-      const args = fromMatch[2].trim();
-      const size = args === '' ? 0 : args.split(',').length;
-      arrays.set(name, { name, size, line: i + 1 });
-      continue;
-    }
-    const newMatch = line.match(/(\w+)\s*=\s*array\.new(?:<\w+>|_\w+)\((\d+)?/);
-    if (newMatch) {
-      const name = newMatch[1].trim();
-      const size = newMatch[2] !== undefined ? parseInt(newMatch[2], 10) : null;
-      arrays.set(name, { name, size, line: i + 1 });
-    }
-  }
-
-  // Array OOB
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const pattern = /array\.(get|set)\(\s*(\w+)\s*,\s*(-?\d+)/g;
-    let match;
-    while ((match = pattern.exec(line)) !== null) {
-      const method = match[1];
-      const arrName = match[2];
-      const idx = parseInt(match[3], 10);
-      const info = arrays.get(arrName);
-      if (!info || info.size === null) continue;
-      if (idx < 0 || idx >= info.size) {
-        diagnostics.push({
-          line: i + 1,
-          message: `array.${method}(${arrName}, ${idx}) — index ${idx} out of bounds (array size is ${info.size})`,
-          severity: 'error',
-        });
-      }
-    }
-  }
-
-  // Unguarded first/last on empty arrays
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const firstLastPattern = /(\w+)\.(first|last)\(\)/g;
-    let match;
-    while ((match = firstLastPattern.exec(line)) !== null) {
-      const arrName = match[1];
-      if (arrName === 'array') continue;
-      const info = arrays.get(arrName);
-      if (info && info.size === 0) {
-        diagnostics.push({
-          line: i + 1,
-          message: `${arrName}.${match[2]}() called on possibly empty array`,
-          severity: 'warning',
-        });
-      }
-    }
-  }
-
-  // strategy.entry without strategy()
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (trimmed.includes('strategy.entry') || trimmed.includes('strategy.close')) {
-      let hasStrategyDecl = false;
-      for (const l of lines) {
-        if (l.trim().startsWith('strategy(')) { hasStrategyDecl = true; break; }
-      }
-      if (!hasStrategyDecl) {
-        diagnostics.push({
-          line: i + 1,
-          message: 'strategy.entry/close used but no strategy() declaration found',
-          severity: 'error',
-        });
-        break;
-      }
-    }
-  }
-
-  // Old version warning
-  if (!isV6 && source.includes('//@version=')) {
-    const vMatch = source.match(/\/\/@version=(\d+)/);
-    if (vMatch && parseInt(vMatch[1]) < 5) {
-      diagnostics.push({
-        line: 1,
-        message: `Script uses Pine v${vMatch[1]} — consider upgrading to v6`,
-        severity: 'info',
-      });
-    }
-  }
-
-  return diagnostics;
+  return _analyze({ source }).diagnostics;
 }
 
 describe('pine_analyze — static analysis', () => {


### PR DESCRIPTION
## Problem

`ui_evaluate` accepts an arbitrary JavaScript expression and executes it in the TradingView page context via CDP `Runtime.evaluate()` with no validation or restriction. Any MCP client — including a compromised one — can:

- Read session tokens and cookies
- Execute actions on the user's authenticated TradingView account
- Access any data visible to the page

PR #30 addressed injection in *structured* tool inputs (symbol, timeframe, entity_id) via `safeString()`. This tool bypasses all of that by design — it takes raw JS and runs it.

## Fix

Remove `ui_evaluate` entirely: core function, MCP tool registration, CLI subcommand, and e2e test.

The 80+ remaining tools provide comprehensive coverage for chart analysis, Pine Script development, UI automation, and drawing. None of the documented workflows in CLAUDE.md reference `ui_evaluate`.

## Also included (minor)

- Align `package.json` version to `2.0.0` (matches `server.js`)
- Default `kill_existing` to `false` in `tv_launch` (was `true` — kills running TradingView without warning)
- Add `engines` field (`node >= 18`)
- Add `.env` to `.gitignore`
- Import `analyze()` in tests instead of duplicating 105 lines

## Test plan

- [x] 82 offline tests pass (including upstream sanitization audit suite)
- [x] `grep -rn 'uiEvaluate|ui_evaluate' src/` returns zero matches
- [x] No remaining references in CLI commands

Ref: SECURITY.md scope items 1 (code injection) and 3 (session token leakage)