### PR TITLE
feat: add draw_position tool for Long/Short position drawings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 
 ### "Draw on the chart"
 - `draw_shape` → horizontal_line, trend_line, rectangle, text (pass point + optional point2)
+- `draw_position` → native Long/Short position with entry, TP, SL price levels (auto-converts to ticks)
 - `draw_list` → see what's drawn
 - `draw_remove_one` → remove by ID
 - `draw_clear` → remove all

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,6 +44,79 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
+export async function drawPosition({ direction, entry_price, stop_loss, take_profit, entry_time, account_size, risk, lot_size, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+
+  if (direction !== 'long' && direction !== 'short') {
+    throw new Error('direction must be "long" or "short"');
+  }
+
+  const entry = requireFinite(entry_price, 'entry_price');
+  const sl = requireFinite(stop_loss, 'stop_loss');
+  const tp = requireFinite(take_profit, 'take_profit');
+
+  if (direction === 'long') {
+    if (sl >= entry) throw new Error('long position: stop_loss must be below entry_price');
+    if (tp <= entry) throw new Error('long position: take_profit must be above entry_price');
+  } else {
+    if (sl <= entry) throw new Error('short position: stop_loss must be above entry_price');
+    if (tp >= entry) throw new Error('short position: take_profit must be below entry_price');
+  }
+
+  const apiPath = await getChartApi();
+
+  const pricescale = await evaluate(
+    `${apiPath}._chartWidget.model().mainSeries().symbolInfo().pricescale`
+  );
+  if (!pricescale || pricescale <= 0) {
+    throw new Error('Could not determine pricescale from symbol info');
+  }
+
+  const stopLevel = Math.round(Math.abs(entry - sl) * pricescale);
+  const profitLevel = Math.round(Math.abs(tp - entry) * pricescale);
+
+  let time = entry_time;
+  if (time == null) {
+    const range = await evaluate(`${apiPath}.getVisibleRange()`);
+    time = range?.to || Math.floor(Date.now() / 1000);
+  }
+  time = requireFinite(time, 'entry_time');
+
+  const shapeName = direction === 'long' ? 'long_position' : 'short_position';
+
+  const overrides = { stopLevel, profitLevel };
+  if (account_size != null) overrides.accountSize = requireFinite(account_size, 'account_size');
+  if (risk != null) overrides.risk = requireFinite(risk, 'risk');
+  if (lot_size != null) overrides.lotSize = requireFinite(lot_size, 'lot_size');
+
+  const overridesStr = JSON.stringify(overrides);
+
+  const before = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
+
+  await evaluate(`
+    ${apiPath}.createShape(
+      { time: ${time}, price: ${entry} },
+      { shape: ${safeString(shapeName)}, overrides: ${overridesStr} }
+    )
+  `);
+
+  await new Promise(r => setTimeout(r, 200));
+  const after = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
+  const entityId = (after || []).find(id => !(before || []).includes(id)) || null;
+
+  const rr = stopLevel > 0 ? Math.round((profitLevel / stopLevel) * 100) / 100 : null;
+
+  return {
+    success: true,
+    direction,
+    entity_id: entityId,
+    entry_price: entry,
+    stop_loss: sl,
+    take_profit: tp,
+    risk_reward_ratio: rr,
+  };
+}
+
 export async function listDrawings() {
   const apiPath = await getChartApi();
   const shapes = await evaluate(`

--- a/src/tools/drawing.js
+++ b/src/tools/drawing.js
@@ -37,4 +37,18 @@ export function registerDrawingTools(server) {
     try { return jsonResult(await core.getProperties({ entity_id })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
+
+  server.tool('draw_position', 'Draw a Long or Short position on the chart with entry, take-profit, and stop-loss price levels', {
+    direction: z.enum(['long', 'short']).describe('Trade direction'),
+    entry_price: z.coerce.number().describe('Entry price level'),
+    stop_loss: z.coerce.number().describe('Stop-loss price level'),
+    take_profit: z.coerce.number().describe('Take-profit price level'),
+    entry_time: z.coerce.number().optional().describe('Unix timestamp for horizontal placement (defaults to latest visible bar)'),
+    account_size: z.coerce.number().optional().describe('Account balance for P&L calculation'),
+    risk: z.coerce.number().optional().describe('Risk as percentage of account (e.g. 2 for 2%)'),
+    lot_size: z.coerce.number().optional().describe('Lot/contract size'),
+  }, async ({ direction, entry_price, stop_loss, take_profit, entry_time, account_size, risk, lot_size }) => {
+    try { return jsonResult(await core.drawPosition({ direction, entry_price, stop_loss, take_profit, entry_time, account_size, risk, lot_size })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
 }

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -8,7 +8,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
-import { drawShape } from '../src/core/drawing.js';
+import { drawShape, drawPosition } from '../src/core/drawing.js';
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
 
@@ -281,6 +281,190 @@ describe('drawing.js — sanitized evaluate calls', () => {
     const call = evaluate.calls.find(c => c.includes('createMultipointShape'));
     assert.ok(call, 'createMultipointShape called');
     assert.ok(call.includes('"trend_line"'), 'shape name via safeString');
+  });
+});
+
+// ── drawing.js — drawPosition validation ────────────────────────────────
+
+describe('drawing.js — drawPosition validation', () => {
+  it('rejects long with stop_loss >= entry_price', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'long', entry_price: 100, stop_loss: 100, take_profit: 110, _deps }),
+      /long position: stop_loss must be below entry_price/,
+    );
+    await assert.rejects(
+      () => drawPosition({ direction: 'long', entry_price: 100, stop_loss: 105, take_profit: 110, _deps }),
+      /long position: stop_loss must be below entry_price/,
+    );
+  });
+
+  it('rejects long with take_profit <= entry_price', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'long', entry_price: 100, stop_loss: 90, take_profit: 100, _deps }),
+      /long position: take_profit must be above entry_price/,
+    );
+    await assert.rejects(
+      () => drawPosition({ direction: 'long', entry_price: 100, stop_loss: 90, take_profit: 95, _deps }),
+      /long position: take_profit must be above entry_price/,
+    );
+  });
+
+  it('rejects short with stop_loss <= entry_price', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'short', entry_price: 100, stop_loss: 100, take_profit: 90, _deps }),
+      /short position: stop_loss must be above entry_price/,
+    );
+    await assert.rejects(
+      () => drawPosition({ direction: 'short', entry_price: 100, stop_loss: 95, take_profit: 90, _deps }),
+      /short position: stop_loss must be above entry_price/,
+    );
+  });
+
+  it('rejects short with take_profit >= entry_price', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'short', entry_price: 100, stop_loss: 110, take_profit: 100, _deps }),
+      /short position: take_profit must be below entry_price/,
+    );
+    await assert.rejects(
+      () => drawPosition({ direction: 'short', entry_price: 100, stop_loss: 110, take_profit: 105, _deps }),
+      /short position: take_profit must be below entry_price/,
+    );
+  });
+
+  it('rejects invalid direction', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'up', entry_price: 100, stop_loss: 90, take_profit: 110, _deps }),
+      /direction must be "long" or "short"/,
+    );
+    await assert.rejects(
+      () => drawPosition({ direction: undefined, entry_price: 100, stop_loss: 90, take_profit: 110, _deps }),
+      /direction must be "long" or "short"/,
+    );
+  });
+
+  it('rejects NaN entry_price', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'long', entry_price: NaN, stop_loss: 90, take_profit: 110, _deps }),
+      /entry_price must be a finite number/,
+    );
+  });
+
+  it('rejects Infinity stop_loss', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'long', entry_price: 100, stop_loss: Infinity, take_profit: 110, _deps }),
+      /stop_loss must be a finite number/,
+    );
+  });
+
+  it('rejects undefined take_profit', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => drawPosition({ direction: 'long', entry_price: 100, stop_loss: 90, take_profit: undefined, _deps }),
+      /take_profit must be a finite number/,
+    );
+  });
+
+  function makeEvalFn() {
+    const calls = [];
+    const fn = async (expr) => {
+      calls.push(expr);
+      if (expr.includes('pricescale')) return 100000;
+      if (expr.includes('getVisibleRange')) return { to: 1700000000 };
+      if (expr.includes('getAllShapes')) return ['existing1'];
+      return undefined;
+    };
+    fn.calls = calls;
+    return fn;
+  }
+
+  it('creates long_position shape with correct createShape call', async () => {
+    const evalFn = makeEvalFn();
+    const _deps = {
+      evaluate: evalFn,
+      getChartApi: async () => 'window.__api',
+    };
+    const result = await drawPosition({
+      direction: 'long',
+      entry_price: 100,
+      stop_loss: 90,
+      take_profit: 120,
+      _deps,
+    });
+    assert.equal(result.success, true);
+    assert.equal(result.direction, 'long');
+    const createCall = evalFn.calls.find(c => c.includes('createShape'));
+    assert.ok(createCall, 'createShape was called');
+    assert.ok(createCall.includes('"long_position"'), 'shape name is long_position');
+    assert.ok(createCall.includes('stopLevel'), 'overrides contain stopLevel');
+    assert.ok(createCall.includes('profitLevel'), 'overrides contain profitLevel');
+  });
+
+  it('creates short_position shape', async () => {
+    const evalFn = makeEvalFn();
+    const _deps = {
+      evaluate: evalFn,
+      getChartApi: async () => 'window.__api',
+    };
+    const result = await drawPosition({
+      direction: 'short',
+      entry_price: 100,
+      stop_loss: 110,
+      take_profit: 80,
+      _deps,
+    });
+    assert.equal(result.success, true);
+    assert.equal(result.direction, 'short');
+    const createCall = evalFn.calls.find(c => c.includes('createShape'));
+    assert.ok(createCall.includes('"short_position"'), 'shape name is short_position');
+  });
+
+  it('passes optional overrides when provided', async () => {
+    const evalFn = makeEvalFn();
+    const _deps = {
+      evaluate: evalFn,
+      getChartApi: async () => 'window.__api',
+    };
+    await drawPosition({
+      direction: 'long',
+      entry_price: 100,
+      stop_loss: 90,
+      take_profit: 120,
+      account_size: 10000,
+      risk: 1,
+      lot_size: 0.5,
+      _deps,
+    });
+    const createCall = evalFn.calls.find(c => c.includes('createShape'));
+    assert.ok(createCall.includes('accountSize'), 'overrides contain accountSize');
+    assert.ok(createCall.includes('risk'), 'overrides contain risk');
+    assert.ok(createCall.includes('lotSize'), 'overrides contain lotSize');
+  });
+
+  it('skips getVisibleRange when entry_time is provided', async () => {
+    const evalFn = makeEvalFn();
+    const _deps = {
+      evaluate: evalFn,
+      getChartApi: async () => 'window.__api',
+    };
+    await drawPosition({
+      direction: 'long',
+      entry_price: 100,
+      stop_loss: 90,
+      take_profit: 120,
+      entry_time: 1700000000,
+      _deps,
+    });
+    const rangeCall = evalFn.calls.find(c => c.includes('getVisibleRange'));
+    assert.equal(rangeCall, undefined, 'getVisibleRange was not called');
+    const createCall = evalFn.calls.find(c => c.includes('createShape'));
+    assert.ok(createCall.includes('1700000000'), 'entry_time used in createShape');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a new `draw_position` MCP tool that draws native TradingView **Long Position** and **Short Position** forecasting shapes on the chart.

- Accepts intuitive **price-based** parameters (entry, stop-loss, take-profit) and auto-converts to TradingView's internal tick-based `stopLevel`/`profitLevel` using the symbol's `pricescale`
- Supports optional money management parameters (`account_size`, `risk`, `lot_size`)
- Returns the entity ID and calculated risk/reward ratio
- Renders using TradingView's native position drawing with green/red zones, auto-calculated R:R, quantity, and P&L

### New tool: `draw_position`

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `direction` | `"long"` / `"short"` | yes | Trade direction |
| `entry_price` | number | yes | Entry price level |
| `stop_loss` | number | yes | Stop-loss price level |
| `take_profit` | number | yes | Take-profit price level |
| `entry_time` | number | no | Unix timestamp (defaults to latest visible bar) |
| `account_size` | number | no | Account balance for P&L calculation |
| `risk` | number | no | Risk as % of account |
| `lot_size` | number | no | Lot/contract size |

### Files changed

- `src/core/drawing.js` — `drawPosition()` core function with price-to-tick conversion and validation
- `src/tools/drawing.js` — MCP tool registration with Zod schema
- `tests/sanitization.test.js` — 12 new unit tests covering validation and shape creation
- `CLAUDE.md` — Updated decision tree

## Test plan

- [x] 12 unit tests added (direction validation, price ordering, requireFinite, shape creation, optional overrides, entry_time handling)
- [x] All 78 tests pass (`node --test tests/sanitization.test.js`)
- [x] Live-tested on TradingView Desktop (EURUSD 4H) — both long and short positions render correctly with native TradingView green/red zones
- [x] Verified optional params (account_size, risk, lot_size) pass through correctly
- [x] Verified pricescale-based tick conversion produces correct stopLevel/profitLevel values