### PR TITLE
feat: add tv_ensure and tv_reconnect tools

### DIFF
--- a/scripts/ensure_tv_cdp.sh
+++ b/scripts/ensure_tv_cdp.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Ensure TradingView Desktop is running with CDP enabled.
+# Idempotent: exits immediately if CDP is already responding.
+# Usage: ./scripts/ensure_tv_cdp.sh [port]
+
+PORT="${1:-9222}"
+
+# Step 1: Check if CDP is already available
+if curl -s --max-time 2 "http://localhost:$PORT/json/version" > /dev/null 2>&1; then
+  echo "CDP already available on port $PORT"
+  curl -s "http://localhost:$PORT/json/version" | python3 -m json.tool 2>/dev/null
+  exit 0
+fi
+
+echo "CDP not responding on port $PORT"
+
+# Step 2: Check if TV is running without CDP
+TV_RUNNING=false
+if pgrep -f TradingView > /dev/null 2>&1; then
+  TV_RUNNING=true
+  echo "TradingView running without CDP — killing..."
+  pkill -f TradingView 2>/dev/null
+  sleep 2
+else
+  echo "TradingView not running"
+fi
+
+# Step 3: Launch with CDP via open (macOS) or direct binary
+if [[ "$(uname)" == "Darwin" ]]; then
+  open -a TradingView --args --remote-debugging-port=$PORT
+else
+  # Linux: auto-detect binary
+  TV_BIN=""
+  for loc in /opt/TradingView/tradingview /opt/TradingView/TradingView "$HOME/.local/share/TradingView/TradingView" /usr/bin/tradingview /snap/tradingview/current/tradingview; do
+    if [ -f "$loc" ]; then
+      TV_BIN="$loc"
+      break
+    fi
+  done
+  if [ -z "$TV_BIN" ]; then
+    TV_BIN=$(which tradingview 2>/dev/null)
+  fi
+  if [ -z "$TV_BIN" ]; then
+    echo "Error: TradingView binary not found"
+    exit 1
+  fi
+  "$TV_BIN" --remote-debugging-port=$PORT &
+fi
+
+echo "Launched TradingView with --remote-debugging-port=$PORT"
+
+# Step 4: Wait for CDP to come online
+echo "Waiting for CDP..."
+for i in $(seq 1 20); do
+  if curl -s --max-time 2 "http://localhost:$PORT/json/version" > /dev/null 2>&1; then
+    echo "CDP ready after ${i}s"
+    curl -s "http://localhost:$PORT/json/version" | python3 -m json.tool 2>/dev/null
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Warning: CDP not responding after 20s. TradingView may still be loading."
+echo "Check manually: curl http://localhost:$PORT/json/version"
+exit 1

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -1,7 +1,8 @@
 /**
- * Core health/discovery/launch logic.
+ * Core health/discovery/launch/reconnect logic.
  */
-import { getClient, getTargetInfo, evaluate } from '../connection.js';
+import { getClient, getTargetInfo, evaluate, disconnect } from '../connection.js';
+import { waitForChartReady } from '../wait.js';
 import { existsSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 
@@ -248,4 +249,163 @@ export async function launch({ port, kill_existing } = {}) {
     success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
+}
+
+/**
+ * Ensure TradingView Desktop is running with CDP enabled.
+ * Idempotent: if CDP is already responding, returns immediately.
+ * If TV is running without CDP, kills it and relaunches with the debug port.
+ * If TV isn't running at all, launches it fresh.
+ */
+export async function ensureCDP({ port } = {}) {
+  const cdpPort = port || 9222;
+  const http = await import('http');
+
+  // Step 1: Check if CDP is already responding
+  const cdpAlive = await new Promise((resolve) => {
+    http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+      let data = '';
+      res.on('data', (chunk) => data += chunk);
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); } catch { resolve(null); }
+      });
+    }).on('error', () => resolve(null));
+  });
+
+  if (cdpAlive) {
+    // CDP is up — just run a health check and return
+    try {
+      const health = await healthCheck();
+      return {
+        success: true,
+        action: 'none',
+        message: 'CDP already available',
+        cdp_port: cdpPort,
+        browser: cdpAlive.Browser,
+        chart_symbol: health.chart_symbol,
+        chart_resolution: health.chart_resolution,
+        api_available: health.api_available,
+      };
+    } catch (err) {
+      return {
+        success: true,
+        action: 'none',
+        message: 'CDP responding but chart API not ready yet',
+        cdp_port: cdpPort,
+        browser: cdpAlive.Browser,
+        warning: err.message,
+      };
+    }
+  }
+
+  // Step 2: CDP not responding — check if TV process is running without it
+  const platform = process.platform;
+  let tvRunning = false;
+  try {
+    if (platform === 'win32') {
+      execSync('tasklist /FI "IMAGENAME eq TradingView.exe" | findstr TradingView', { timeout: 3000 });
+      tvRunning = true;
+    } else {
+      execSync('pgrep -f TradingView', { timeout: 3000 });
+      tvRunning = true;
+    }
+  } catch { /* not running */ }
+
+  // Step 3: Launch (tv_launch handles kill + relaunch + polling)
+  const result = await launch({ port: cdpPort, kill_existing: tvRunning });
+  return {
+    ...result,
+    action: tvRunning ? 'restarted' : 'launched',
+    message: tvRunning
+      ? 'TradingView was running without CDP — killed and relaunched with debug port'
+      : 'TradingView was not running — launched with debug port',
+  };
+}
+
+/**
+ * Reconnect TradingView Desktop by reloading the page to re-establish
+ * the backend WebSocket session. Use this when the TV session was taken
+ * over by a browser/phone and you've switched back to Desktop.
+ *
+ * Flow: disconnect CDP → reload page → wait for chart ready → health check.
+ */
+export async function reconnect() {
+  // Step 1: Get a CDP handle (this should work even when TV session is stale
+  // because CDP connects to the local Electron process, not TV's backend)
+  let c;
+  try {
+    c = await getClient();
+  } catch (err) {
+    return {
+      success: false,
+      error: `CDP connection failed: ${err.message}`,
+      hint: 'TradingView Desktop may not be running. Use tv_launch to start it.',
+    };
+  }
+
+  // Step 2: Capture pre-reload state
+  let priorSymbol = 'unknown';
+  let priorResolution = 'unknown';
+  try {
+    const state = await evaluate(`
+      (function() {
+        try {
+          var chart = window.TradingViewApi._activeChartWidgetWV.value();
+          return { symbol: chart.symbol(), resolution: chart.resolution() };
+        } catch(e) { return { symbol: 'unknown', resolution: 'unknown' }; }
+      })()
+    `);
+    priorSymbol = state?.symbol || 'unknown';
+    priorResolution = state?.resolution || 'unknown';
+  } catch { /* best effort */ }
+
+  // Step 3: Reload the page to force TV to re-authenticate backend session
+  try {
+    await c.Page.reload({ ignoreCache: true });
+  } catch {
+    // Page.reload may break the CDP connection; that's expected
+  }
+
+  // Step 4: Drop the stale CDP client so connect() will re-establish
+  await disconnect();
+
+  // Step 5: Wait for the page to reload and Electron to settle
+  await new Promise(r => setTimeout(r, 3000));
+
+  // Step 6: Re-establish CDP and wait for chart
+  try {
+    await getClient();
+  } catch (err) {
+    return {
+      success: false,
+      error: `CDP reconnect after reload failed: ${err.message}`,
+      hint: 'TradingView may still be loading. Try tv_health_check in a few seconds.',
+    };
+  }
+
+  // Step 7: Wait for chart data to stabilize (longer timeout for full page reload)
+  const chartReady = await waitForChartReady(null, null, 20000);
+
+  // Step 8: Verify with a health check
+  try {
+    const health = await healthCheck();
+    return {
+      success: true,
+      reconnected: true,
+      chart_ready: chartReady,
+      prior_symbol: priorSymbol,
+      prior_resolution: priorResolution,
+      current_symbol: health.chart_symbol,
+      current_resolution: health.chart_resolution,
+      api_available: health.api_available,
+    };
+  } catch (err) {
+    return {
+      success: true,
+      reconnected: true,
+      chart_ready: chartReady,
+      prior_symbol: priorSymbol,
+      warning: `Page reloaded but health check failed: ${err.message}. Chart may still be loading.`,
+    };
+  }
 }

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -25,4 +25,16 @@ export function registerHealthTools(server) {
     try { return jsonResult(await core.launch({ port, kill_existing })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
+
+  server.tool('tv_ensure', 'Ensure TradingView Desktop is running with CDP enabled. Idempotent: no-op if CDP is already up. If TV is running without CDP, kills and relaunches. If TV is not running, launches it. Call this before any TV tool when unsure if CDP is available.', {
+    port: z.coerce.number().optional().describe('CDP port (default 9222)'),
+  }, async ({ port }) => {
+    try { return jsonResult(await core.ensureCDP({ port })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('tv_reconnect', 'Reconnect TradingView Desktop by reloading the page to reclaim the backend session. Use when TV was opened in a browser/phone and the Desktop session went stale.', {}, async () => {
+    try { return jsonResult(await core.reconnect()); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
 }


### PR DESCRIPTION
## Summary
- **`tv_ensure`**: Idempotent CDP pre-flight. Checks if CDP is already responding before doing anything. If TV is running without CDP, kills and relaunches with the debug port. If TV isn't running, launches fresh. Eliminates the manual "is CDP up?" dance.
- **`tv_reconnect`**: Reloads the TV Desktop page via `Page.reload()` to re-establish the backend WebSocket session when it goes stale (e.g., after using TV in a browser/phone). CDP to the local Electron process still works even when the backend session is disconnected.
- **`ensure_tv_cdp.sh`**: Standalone shell script version of `tv_ensure` for use outside MCP (cron jobs, CI, other scripts).

## Motivation
When TV Desktop is running without `--remote-debugging-port`, all MCP tools fail silently. And when TV's backend session gets stolen by another device, the chart data goes stale even though CDP still connects. These two tools close both gaps with a single idempotent call.

## Test plan
- [ ] `tv_ensure` returns `action: "none"` when CDP is already up
- [ ] `tv_ensure` kills and relaunches TV when running without CDP
- [ ] `tv_ensure` launches TV fresh when not running
- [ ] `tv_reconnect` restores chart API after session goes stale
- [ ] `ensure_tv_cdp.sh` exits 0 immediately when CDP is responding
- [ ] `ensure_tv_cdp.sh` kills, relaunches, and waits when TV lacks CDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)