### PR TITLE
feat: Stock Screener tools + screen/filter/column management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+85 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 
@@ -62,6 +62,25 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 ### "Screen multiple symbols"
 - `batch_run` with `symbols: ["ES1!", "NQ1!", "YM1!"]` and `action: "screenshot"` or `"get_ohlcv"`
 
+### "Use the Stock Screener"
+The built-in TradingView Screener (floating dialog with rankable columns: Price, Change %, Volume, Market cap, P/E, Sector, etc.) is available as four dedicated tools:
+
+1. `screener_open` → opens the Screener dialog (no-op if already open). First open can take 3–5s while TradingView loads data.
+2. `screener_get` → reads the currently-displayed screen. Returns `{ screen, columns, row_count, rows, filters }`. Pass `limit` to cap rows (default 100, max 500).
+3. `screener_status` → `{ open, width, height }` without touching the UI.
+4. `screener_close` → closes the dialog.
+
+You can also toggle the screener via `ui_open_panel` with `panel: "screener"`.
+
+### "Manage the active screen"
+The screener has three management tools for pruning / inspecting the current screen. Each takes an `action` parameter.
+
+- `screener_screens` — actions: `active` (current preset name), `menu_actions` (which screen-actions are enabled in the UI), `save` (persist unsaved changes). Stretch actions (`list`, `switch`, `save_as`, `delete`, `rename`, `create_new`) return `not_implemented_yet` — use TradingView UI directly for those.
+- `screener_filters` — actions: `list` (all pills), `remove` with `filter: "Beta"` (idempotent — removing a missing filter is a no-op), `clear` (remove every pill). Stretch: `add`, `modify`.
+- `screener_columns` — action: `list` (current headers). Stretch: `reset`, `remove`, `add`, `reorder`.
+
+Reading the current state (list/active) is stable. Mutations (remove/clear/save) work on any non-built-in screen and persist via TradingView's cloud auto-save. Built-in presets like "All stocks" reject mutations that would overwrite them — use the stretch `save_as` path (or TradingView UI) to fork first.
+
 ### "Draw on the chart"
 - `draw_shape` → horizontal_line, trend_line, rectangle, text (pass point + optional point2)
 - `draw_list` → see what's drawn
@@ -109,6 +128,14 @@ These tools can return large payloads. Follow these rules to avoid context bloat
 | `data_get_ohlcv` (summary) | ~500 bytes |
 | `data_get_ohlcv` (100 bars) | ~8 KB |
 | `capture_screenshot` | ~300 bytes (returns file path, not image data) |
+| `screener_get` (100 rows) | ~30 KB — pass `limit` to cap |
+| `screener_get` (5 rows) | ~2 KB — use for preview/debugging |
+| `screener_status` | ~100 bytes |
+| `screener_screens` (active) | ~100 bytes |
+| `screener_screens` (menu_actions) | ~500 bytes |
+| `screener_filters` (list, 16 pills) | ~1 KB |
+| `screener_filters` (remove/clear) | ~500 bytes |
+| `screener_columns` (list, 12 cols) | ~300 bytes |
 
 ## Tool Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,14 @@ If you're unsure whether a feature fits, open an issue to discuss before submitt
 
 ```bash
 npm install
-npm test          # 29 offline tests (no TradingView needed)
-tv status         # verify CDP connection (TradingView must be running)
+npm run test:offline   # 205 offline tests (no TradingView needed)
+npm test               # live tests (TradingView must be running on port 9222)
+tv status              # verify CDP connection
 ```
 
 ## Pull Requests
 
 - Keep changes focused — one feature or fix per PR
-- Add tests for new functionality where possible
-- Ensure `npm test` passes (29/29)
+- Add tests for new functionality where possible. Use dependency-injected mocks (see `tests/screener_*.test.js` or `tests/replay.test.js`) so the test runs offline.
+- Ensure `npm run test:offline` passes (205/205) before opening the PR
 - Test against a live TradingView Desktop instance before submitting

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Gives your AI assistant eyes and hands on your own chart:
 - **Draw on charts** — trend lines, horizontal lines, rectangles, text annotations
 - **Manage alerts** — create, list, and delete price alerts
 - **Replay practice** — step through historical bars, practice entries/exits
+- **Stock Screener** — open the built-in screener, read rows, inspect/prune the active screen (filters, columns, saved presets)
 - **Screenshots** — capture chart state for AI visual analysis
 - **Multi-pane layouts** — set up 2x2, 3x1, etc. grids with different symbols per pane
 - **Monitor your chart** — stream JSONL from your locally running chart for local monitoring scripts
@@ -175,6 +176,10 @@ tv layout list/switch
 tv pane list/layout/focus/symbol
 tv tab list/new/close/switch
 tv replay start/step/stop/status/autoplay/trade
+tv screener open/get/status/close
+tv screener active/menu-actions/save/save-as/switch/delete-screen/rename/create-new
+tv screener filters/filter-remove/filter-clear/filter-add/filter-modify
+tv screener columns/column-reset/column-remove/column-add/column-reorder
 tv stream quote/bars/values/lines/labels/tables/all
 tv ui click/keyboard/hover/scroll/find/eval/type/panel/fullscreen/mouse
 tv screenshot / discover / ui-state / range / scroll
@@ -214,8 +219,12 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Set up a 4-chart grid" | `pane_set_layout` → `pane_set_symbol` for each pane |
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
+| "Open the Stock Screener and read rows" | `screener_open` → `screener_get` |
+| "What filters are on the screener?" | `screener_filters` (action: `list`) |
+| "Remove the Beta filter" | `screener_filters` (action: `remove`, filter: "Beta") |
+| "Save the current screen" | `screener_screens` (action: `save`) |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (85 MCP tools)
 
 ### Chart Reading
 
@@ -295,6 +304,22 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `replay_status` | Check position, P&L, date |
 | `replay_stop` | Return to realtime |
 
+### Stock Screener
+
+Access the built-in floating Screener dialog (Symbol, Price, Change %, Volume, Market cap, P/E, Sector, etc.).
+
+| Tool | What it does |
+|------|-------------|
+| `screener_open` | Open the Screener dialog (no-op if already open) |
+| `screener_get` | Read the active screen — `{ screen, columns, row_count, rows, filters }`. Pass `limit` to cap rows (default 100, max 500) |
+| `screener_status` | `{ open, width, height }` without touching the UI |
+| `screener_close` | Close the dialog |
+| `screener_screens` | Manage saved presets. Actions: `active`, `menu_actions`, `save`. Stretch (return `not_implemented_yet`): `list`, `switch`, `save_as`, `delete`, `rename`, `create_new` |
+| `screener_filters` | Manage filter pills. Actions: `list`, `remove` (idempotent), `clear`. Stretch: `add`, `modify` |
+| `screener_columns` | Manage table columns. Action: `list`. Stretch: `reset`, `remove`, `add`, `reorder` |
+
+Mutations persist through TradingView's cloud auto-save. Built-in presets (e.g. "All stocks") reject destructive actions that would overwrite them — fork via the TradingView UI first, then mutate the copy.
+
 ### Drawing, Alerts, UI Automation
 
 | Tool | What it does |
@@ -339,11 +364,17 @@ The key flag: `--remote-debugging-port=9222`
 ## Testing
 
 ```bash
-# Requires TradingView running with --remote-debugging-port=9222
+# Offline suite — no TradingView needed (205 tests)
+npm run test:offline
+
+# Just the screener suite (61 tests)
+npm run test:screener
+
+# Live suite — requires TradingView running with --remote-debugging-port=9222
 npm test
 ```
 
-29 tests covering: Pine Script static analysis, server-side compilation, and CLI routing.
+The offline suite covers Pine Script static analysis, CLI routing, replay flows, CDP-injection sanitization, and the full Screener surface (core + filters + columns + screens) via dependency-injected mocks. The live `npm test` suite verifies end-to-end against a running TradingView Desktop instance.
 
 ## Architecture
 
@@ -351,7 +382,7 @@ npm test
 Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
 ```
 
-- **Transport**: MCP over stdio (78 tools) + CLI (`tv` command, 30 commands with 66 subcommands)
+- **Transport**: MCP over stdio (85 tools) + CLI (`tv` command, 31 commands with 88 subcommands)
 - **Connection**: Chrome DevTools Protocol on localhost:9222
 - **Streaming**: Poll-and-diff loop with deduplication, JSONL output to stdout
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -588,9 +591,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test:e2e": "node --test tests/e2e.test.js",
     "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:screener": "node --test tests/screener.test.js tests/screener_screens.test.js tests/screener_filters.test.js tests/screener_columns.test.js",
+    "test:offline": "node --test tests/cli.test.js tests/pine_analyze.test.js tests/replay.test.js tests/sanitization.test.js tests/screener.test.js tests/screener_screens.test.js tests/screener_filters.test.js tests/screener_columns.test.js",
+    "test:all": "node --test tests/*.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/cli/commands/screener.js
+++ b/src/cli/commands/screener.js
@@ -1,0 +1,147 @@
+import { register } from '../router.js';
+import * as core from '../../core/screener.js';
+import * as screens from '../../core/screener_screens.js';
+import * as filters from '../../core/screener_filters.js';
+import * as columns from '../../core/screener_columns.js';
+
+register('screener', {
+  description: 'Stock Screener — dialog lifecycle + screens / filters / columns management',
+  subcommands: new Map([
+    // Dialog lifecycle ────────────────────────────────────────────────
+    ['open', {
+      description: 'Open the Stock Screener dialog',
+      handler: () => core.open(),
+    }],
+    ['close', {
+      description: 'Close the Stock Screener dialog',
+      handler: () => core.close(),
+    }],
+    ['status', {
+      description: 'Check whether the Stock Screener is open',
+      handler: () => core.status(),
+    }],
+    ['get', {
+      description: 'Read rows from the open Stock Screener (run `tv screener open` first)',
+      options: {
+        limit: { type: 'string', short: 'l', description: 'Max rows to return (default 100, max 500)' },
+      },
+      handler: (opts) => core.get({ limit: opts.limit ? Number(opts.limit) : undefined }),
+    }],
+
+    // Screens (saved presets) ─────────────────────────────────────────
+    ['active', {
+      description: 'Show the currently active screen name',
+      handler: () => screens.active(),
+    }],
+    ['menu-actions', {
+      description: 'Inspect which screen actions are currently enabled in the UI',
+      handler: () => screens.menu_actions(),
+    }],
+    ['save', {
+      description: 'Save changes to the current screen (no-op if nothing to save or built-in preset)',
+      handler: () => screens.save(),
+    }],
+    ['save-as', {
+      description: '(stretch) Save current state as a new named screen',
+      options: {
+        name: { type: 'string', short: 'n', description: 'New screen name' },
+      },
+      handler: (opts) => screens.save_as({ name: opts.name }),
+    }],
+    ['switch', {
+      description: '(stretch) Switch to a saved screen by name',
+      options: {
+        name: { type: 'string', short: 'n', description: 'Screen name to switch to' },
+      },
+      handler: (opts) => screens.switchTo({ name: opts.name }),
+    }],
+    ['delete-screen', {
+      description: '(stretch) Delete a saved screen by name',
+      options: {
+        name: { type: 'string', short: 'n', description: 'Screen name to delete' },
+      },
+      handler: (opts) => screens.remove({ name: opts.name }),
+    }],
+    ['rename', {
+      description: '(stretch) Rename a saved screen',
+      options: {
+        name: { type: 'string', description: 'Current name' },
+        'new-name': { type: 'string', description: 'New name' },
+      },
+      handler: (opts) => screens.rename({ name: opts.name, new_name: opts['new-name'] }),
+    }],
+    ['create-new', {
+      description: '(stretch) Create a new empty screen with a name',
+      options: {
+        name: { type: 'string', short: 'n', description: 'New screen name' },
+      },
+      handler: (opts) => screens.createNew({ name: opts.name }),
+    }],
+
+    // Filters ─────────────────────────────────────────────────────────
+    ['filters', {
+      description: 'List active filter pills on the current screen',
+      handler: () => filters.list(),
+    }],
+    ['filter-remove', {
+      description: 'Remove a filter pill by label (idempotent)',
+      options: {
+        filter: { type: 'string', short: 'f', description: 'Filter label (e.g. "Market cap")' },
+      },
+      handler: (opts) => filters.remove({ filter: opts.filter }),
+    }],
+    ['filter-clear', {
+      description: 'Remove every filter pill from the current screen',
+      handler: () => filters.clear(),
+    }],
+    ['filter-add', {
+      description: '(stretch) Add a filter pill',
+      options: {
+        filter: { type: 'string', short: 'f', description: 'Filter name' },
+        operator: { type: 'string', description: 'Comparison operator' },
+        value: { type: 'string', description: 'Value' },
+      },
+      handler: (opts) => filters.add({ filter: opts.filter, operator: opts.operator, value: opts.value }),
+    }],
+    ['filter-modify', {
+      description: '(stretch) Modify a filter pill value',
+      options: {
+        filter: { type: 'string', short: 'f', description: 'Filter name' },
+        operator: { type: 'string', description: 'New operator' },
+        value: { type: 'string', description: 'New value' },
+      },
+      handler: (opts) => filters.modify({ filter: opts.filter, operator: opts.operator, value: opts.value }),
+    }],
+
+    // Columns ─────────────────────────────────────────────────────────
+    ['columns', {
+      description: 'List current column headers',
+      handler: () => columns.list(),
+    }],
+    ['column-reset', {
+      description: '(stretch) Reset columns to screen default',
+      handler: () => columns.reset(),
+    }],
+    ['column-remove', {
+      description: '(stretch) Hide a column by name',
+      options: {
+        column: { type: 'string', short: 'c', description: 'Column name' },
+      },
+      handler: (opts) => columns.remove({ column: opts.column }),
+    }],
+    ['column-add', {
+      description: '(stretch) Show a column by name',
+      options: {
+        column: { type: 'string', short: 'c', description: 'Column name' },
+      },
+      handler: (opts) => columns.add({ column: opts.column }),
+    }],
+    ['column-reorder', {
+      description: '(stretch) Reorder columns to a desired layout',
+      options: {
+        columns: { type: 'string', description: 'Comma-separated desired column order' },
+      },
+      handler: (opts) => columns.reorder({ columns: opts.columns ? opts.columns.split(',').map(s => s.trim()) : [] }),
+    }],
+  ]),
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -19,6 +19,7 @@ import './commands/replay.js';
 import './commands/drawing.js';
 import './commands/alerts.js';
 import './commands/watchlist.js';
+import './commands/screener.js';
 import './commands/layout.js';
 import './commands/indicator.js';
 import './commands/ui.js';

--- a/src/core/_screener_shared.js
+++ b/src/core/_screener_shared.js
@@ -1,0 +1,73 @@
+/**
+ * Shared helpers used by screener_screens, screener_filters, screener_columns.
+ * Only internal to the screener submodules — not exported from src/core/index.js.
+ *
+ * Per CONTRIBUTING.md: UI automation only (no direct REST/server access).
+ */
+import { evaluate as _evaluate, getClient as _getClient } from '../connection.js';
+
+export function resolveDeps(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    getClient: deps?.getClient || _getClient,
+  };
+}
+
+// Probe expression — detects "open + data_loaded" like the main screener module.
+// Kept in a separate expr because the main module's IS_OPEN_EXPR also returns
+// width/height which these submodules don't need.
+const IS_OPEN_EXPR = `
+  (function() {
+    var container = document.querySelector('[class*="screenerContainer"]');
+    if (!container) return false;
+    var dialog = container.closest('[class*="js-dialog"]');
+    var visible = dialog && /visible-/.test(dialog.className) && container.offsetParent !== null;
+    return !!visible;
+  })()
+`;
+
+/**
+ * Throws a structured error if the screener dialog isn't currently open.
+ * Returns true when open.
+ */
+export async function assertScreenerOpen(evaluate) {
+  const open = await evaluate(IS_OPEN_EXPR);
+  if (!open) {
+    const err = new Error('Screener is not open. Call screener_open first.');
+    err.code = 'not_open';
+    throw err;
+  }
+  return true;
+}
+
+/**
+ * Returns a result object for "screener is not open" without throwing —
+ * used for `list` actions that shouldn't hard-fail when closed.
+ */
+export function notOpenResult(action) {
+  return {
+    success: false,
+    action,
+    open: false,
+    error: 'Screener is not open. Call screener_open first.',
+  };
+}
+
+/**
+ * Standard "stretch" / not-yet-implemented response.
+ * Returned by actions that are declared in the schema but whose DOM flow
+ * hasn't been wired yet.
+ */
+export function notImplemented(action, hint) {
+  return {
+    success: false,
+    action,
+    error: 'not_implemented_yet',
+    hint: hint || 'Use the TradingView UI directly for now.',
+  };
+}
+
+/**
+ * Small sleep utility — consistent with rest of codebase pattern.
+ */
+export const sleep = (ms) => new Promise(r => setTimeout(r, ms));

--- a/src/core/screener.js
+++ b/src/core/screener.js
@@ -1,0 +1,220 @@
+/**
+ * Core Stock Screener logic.
+ *
+ * The TradingView Screener is a floating dialog (not a docked side panel),
+ * toggled via the right-toolbar button [data-name="screener-dialog-button"].
+ *
+ * Open state: .js-dialog.visible-RY6N1NHl contains [class*="screenerContainer"]
+ * When open, the dialog covers the toolbar button, so close via the dialog's
+ * own "Close" button rather than the toolbar toggle.
+ *
+ * Per CONTRIBUTING.md: UI automation only (no direct REST/server access).
+ */
+import {
+  evaluate as _evaluate,
+  getClient as _getClient,
+  requireFinite,
+} from '../connection.js';
+
+function _resolve(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    getClient: deps?.getClient || _getClient,
+  };
+}
+
+const IS_OPEN_EXPR = `
+  (function() {
+    var container = document.querySelector('[class*="screenerContainer"]');
+    if (!container) return { open: false };
+    var dialog = container.closest('[class*="js-dialog"]');
+    var visible = dialog && /visible-/.test(dialog.className) && container.offsetParent !== null;
+    if (!visible) return { open: false };
+    var rect = container.getBoundingClientRect();
+    // Check whether rows have loaded (first symbol cell has real text).
+    var firstRow = container.querySelector('tbody tr');
+    var firstCell = firstRow ? firstRow.querySelector('td') : null;
+    var firstCellText = firstCell ? (firstCell.textContent || '').trim() : '';
+    return {
+      open: true,
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+      data_loaded: firstCellText.length > 0,
+    };
+  })()
+`;
+
+export async function status({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  const state = await evaluate(IS_OPEN_EXPR);
+  return { success: true, open: !!state?.open, width: state?.width ?? null, height: state?.height ?? null };
+}
+
+export async function open({ _deps } = {}) {
+  const { evaluate, getClient } = _resolve(_deps);
+
+  const initial = await evaluate(IS_OPEN_EXPR);
+  if (initial?.open) {
+    return { success: true, action: 'already_open', open: true, width: initial.width, height: initial.height };
+  }
+
+  // Toolbar button is in the right-toolbar. Programmatic .click() doesn't fire
+  // the app's handler, so we need a real CDP mouse click.
+  const btnRect = await evaluate(`
+    (function() {
+      var btn = document.querySelector('[data-name="screener-dialog-button"]');
+      if (!btn) return null;
+      var r = btn.getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    })()
+  `);
+  if (!btnRect) throw new Error('Screener toolbar button not found (is the chart toolbar visible?)');
+
+  const cx = requireFinite(btnRect.x, 'button.x');
+  const cy = requireFinite(btnRect.y, 'button.y');
+
+  const c = await getClient();
+  await c.Input.dispatchMouseEvent({ type: 'mouseMoved', x: cx, y: cy });
+  await c.Input.dispatchMouseEvent({ type: 'mousePressed', x: cx, y: cy, button: 'left', buttons: 1, clickCount: 1 });
+  await c.Input.dispatchMouseEvent({ type: 'mouseReleased', x: cx, y: cy, button: 'left' });
+
+  // Wait for dialog to appear AND data to load (poll up to ~6s). First open
+  // can be slow while TradingView fetches screener rows from its servers.
+  let lastSeen = null;
+  for (let i = 0; i < 30; i++) {
+    await new Promise(r => setTimeout(r, 200));
+    const s = await evaluate(IS_OPEN_EXPR);
+    if (s?.open && s?.data_loaded) {
+      return { success: true, action: 'opened', open: true, width: s.width, height: s.height };
+    }
+    if (s?.open) lastSeen = s;
+  }
+  if (lastSeen) {
+    // Dialog opened but rows never populated. Return success with a warning
+    // rather than failing — the caller can still see columns, and the next
+    // screener_get will pick up rows when they arrive.
+    return {
+      success: true,
+      action: 'opened',
+      open: true,
+      width: lastSeen.width,
+      height: lastSeen.height,
+      warning: 'Dialog opened but rows did not populate within 6s; call screener_get again shortly.',
+    };
+  }
+  throw new Error('Screener did not open within 6s (dialog not found)');
+}
+
+export async function close({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+
+  const state = await evaluate(IS_OPEN_EXPR);
+  if (!state?.open) return { success: true, action: 'already_closed', open: false };
+
+  // Click the Close button scoped to the screener dialog.
+  const result = await evaluate(`
+    (function() {
+      var container = document.querySelector('[class*="screenerContainer"]');
+      if (!container) return { found: false, reason: 'no_container' };
+      var dialog = container.closest('[class*="js-dialog"]');
+      if (!dialog) return { found: false, reason: 'no_dialog' };
+      var closeBtn = dialog.querySelector('button[aria-label="Close"]');
+      if (!closeBtn) return { found: false, reason: 'no_close_button' };
+      closeBtn.click();
+      return { found: true };
+    })()
+  `);
+  if (!result?.found) throw new Error('Close button not found: ' + (result?.reason || 'unknown'));
+
+  // Wait for dialog to disappear (poll up to 2s)
+  for (let i = 0; i < 10; i++) {
+    await new Promise(r => setTimeout(r, 200));
+    const s = await evaluate(IS_OPEN_EXPR);
+    if (!s?.open) return { success: true, action: 'closed', open: false };
+  }
+  throw new Error('Screener did not close within 2s');
+}
+
+export async function get({ limit, _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  const cap = Number.isFinite(Number(limit)) ? Math.max(1, Math.min(500, Number(limit))) : 100;
+
+  const data = await evaluate(`
+    (function() {
+      var container = document.querySelector('[class*="screenerContainer"]');
+      if (!container || container.offsetParent === null) {
+        return { open: false };
+      }
+
+      // Current screen/preset name (e.g., "All stocks")
+      var titleEl = document.querySelector('[data-name="screener-topbar-screen-title"]');
+      var title = titleEl ? (titleEl.textContent || '').trim() : null;
+
+      // Markets / source tabs visible above the filter row (e.g., "US", "Watchlist")
+      // These live outside the table. We collect visible text from the known tab row.
+      var table = container.querySelector('table');
+      if (!table) return { open: true, error: 'table_not_found', title: title, columns: [], rows: [], row_count: 0 };
+
+      var ths = table.querySelectorAll('thead th, tr:first-child th');
+      var columns = [];
+      for (var i = 0; i < ths.length; i++) {
+        var txt = (ths[i].textContent || '').trim();
+        if (txt) columns.push(txt);
+      }
+
+      var trs = table.querySelectorAll('tbody tr');
+      var rows = [];
+      var max = Math.min(trs.length, ${cap});
+      for (var r = 0; r < max; r++) {
+        var tds = trs[r].querySelectorAll('td');
+        var cells = [];
+        for (var j = 0; j < tds.length; j++) {
+          var t = (tds[j].textContent || '').trim();
+          cells.push(t);
+        }
+        // Build a { column: value } object mapped to column headers
+        var obj = { symbol: cells[0] || null };
+        for (var k = 1; k < columns.length && k < cells.length; k++) {
+          obj[columns[k]] = cells[k];
+        }
+        rows.push(obj);
+      }
+
+      // Capture visible filter pill labels for discoverability
+      var pills = [];
+      var pillEls = container.querySelectorAll('[data-name^="screener-filter-pill-"]');
+      for (var p = 0; p < pillEls.length; p++) {
+        var label = (pillEls[p].textContent || '').trim();
+        if (label) pills.push(label);
+      }
+
+      return {
+        open: true,
+        title: title,
+        columns: columns,
+        row_count: trs.length,
+        returned: rows.length,
+        rows: rows,
+        filters: pills,
+      };
+    })()
+  `);
+
+  if (!data?.open) {
+    return { success: false, open: false, error: 'Screener is not open. Call screener_open first.' };
+  }
+  if (data?.error) {
+    return { success: false, open: true, error: data.error };
+  }
+
+  return {
+    success: true,
+    open: true,
+    screen: data.title,
+    columns: data.columns || [],
+    row_count: data.row_count || 0,
+    returned: data.returned || 0,
+    rows: data.rows || [],
+    filters: data.filters || [],
+  };
+}

--- a/src/core/screener_columns.js
+++ b/src/core/screener_columns.js
@@ -1,0 +1,92 @@
+/**
+ * Core Screener Columns management.
+ *
+ * Column headers live in `[class*="screenerContainer"] table thead th`.
+ * Column setup (add/reorder/hide/reset) happens via the "Column setup" button
+ * `[data-qa-id="screener-add-column-button"]` which opens a catalog panel.
+ *
+ * MVP actions: list.
+ * Stretch actions: reset, remove, add, reorder — catalog-navigation flow
+ * isn't automated yet; these return `not_implemented_yet`.
+ *
+ * Per CONTRIBUTING.md: UI automation only.
+ */
+import {
+  resolveDeps,
+  notOpenResult,
+  notImplemented,
+} from './_screener_shared.js';
+
+const LIST_EXPR = `
+  (function() {
+    var container = document.querySelector('[class*="screenerContainer"]');
+    if (!container || container.offsetParent === null) return null;
+    var table = container.querySelector('table');
+    if (!table) return { error: 'table_not_found' };
+    var ths = table.querySelectorAll('thead th, tr:first-child th');
+    var cols = [];
+    for (var i = 0; i < ths.length; i++) {
+      var t = (ths[i].textContent || '').trim();
+      // Skip the trailing sticky-scroll spacer column (no text)
+      if (!t) continue;
+      cols.push(t);
+    }
+    return { columns: cols };
+  })()
+`;
+
+export async function list({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const result = await evaluate(LIST_EXPR);
+  if (result === null) return notOpenResult('list');
+  if (result.error) return { success: false, action: 'list', open: true, error: result.error };
+  return {
+    success: true,
+    action: 'list',
+    open: true,
+    count: result.columns.length,
+    columns: result.columns,
+  };
+}
+
+// ── Stretch actions ──────────────────────────────────────────────────────
+
+export async function reset({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(LIST_EXPR);
+  if (probe === null) return notOpenResult('reset');
+  return notImplemented(
+    'reset',
+    'Resetting columns requires the Column setup catalog ([data-qa-id="screener-add-column-button"]) → "Reset to default" action. Not yet automated.',
+  );
+}
+
+export async function remove({ column, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(LIST_EXPR);
+  if (probe === null) return notOpenResult('remove');
+  return notImplemented(
+    'remove',
+    'Removing a column requires the Column setup catalog or a per-header context menu. Not yet automated — hide the column in TradingView UI.',
+  );
+}
+
+export async function add({ column, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(LIST_EXPR);
+  if (probe === null) return notOpenResult('add');
+  return notImplemented(
+    'add',
+    'Adding a column requires navigating the Column setup catalog. Not yet automated — add the column in TradingView UI.',
+  );
+}
+
+export async function reorder({ columns, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(LIST_EXPR);
+  if (probe === null) return notOpenResult('reorder');
+  return notImplemented(
+    'reorder',
+    'Reordering columns requires drag-and-drop in the Column setup panel. Not yet automated.',
+  );
+}

--- a/src/core/screener_filters.js
+++ b/src/core/screener_filters.js
@@ -1,0 +1,301 @@
+/**
+ * Core Screener Filters management.
+ *
+ * Filter pills live in `[data-name^="screener-filter-pill-"]` inside the
+ * screener container. Clicking a pill opens a popover whose header has a
+ * `[data-qa-id="popover-header-remove-button"]` — clicking that detaches
+ * the filter from the current screen.
+ *
+ * MVP actions: list, remove, clear.
+ * Stretch actions: add, modify — return `not_implemented_yet` for now.
+ *
+ * Per CONTRIBUTING.md: UI automation only.
+ */
+import { safeString } from '../connection.js';
+import {
+  resolveDeps,
+  assertScreenerOpen,
+  notOpenResult,
+  notImplemented,
+  sleep,
+} from './_screener_shared.js';
+
+/**
+ * Dismiss any filter-pill popover that's currently open. Important before
+ * clicking the next pill so we don't pick up the previous popover's remove
+ * button. Clicks an empty spot inside the screener container and waits for
+ * the popover to unmount.
+ */
+async function closeAnyPopover(evaluate) {
+  const anyVisible = await evaluate(`
+    (function() {
+      var pops = document.querySelectorAll('[class*="popover"]');
+      for (var i = 0; i < pops.length; i++) {
+        if (pops[i].offsetParent !== null) return true;
+      }
+      return false;
+    })()
+  `);
+  if (!anyVisible) return;
+  // Click just outside any pill — the screener table area dismisses popovers.
+  await evaluate(`
+    (function() {
+      var container = document.querySelector('[class*="screenerContainer"]');
+      if (!container) return;
+      var table = container.querySelector('table');
+      if (table) {
+        var r = table.getBoundingClientRect();
+        var evt = new MouseEvent('mousedown', { bubbles: true, cancelable: true, clientX: r.x + 40, clientY: r.y + r.height - 40 });
+        document.elementFromPoint(r.x + 40, r.y + r.height - 40)?.dispatchEvent(evt);
+      }
+      document.body.click();
+    })()
+  `);
+  await sleep(250);
+}
+
+const LIST_EXPR = `
+  (function() {
+    var container = document.querySelector('[class*="screenerContainer"]');
+    if (!container) return null;
+    var pills = container.querySelectorAll('[data-name^="screener-filter-pill-"]');
+    var out = [];
+    for (var i = 0; i < pills.length; i++) {
+      var el = pills[i];
+      var label = (el.textContent || '').trim();
+      var id = el.getAttribute('data-name') || '';
+      out.push({ label: label, id: id });
+    }
+    return out;
+  })()
+`;
+
+export async function list({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const pills = await evaluate(LIST_EXPR);
+  if (pills === null) return notOpenResult('list');
+  return {
+    success: true,
+    action: 'list',
+    open: true,
+    count: pills.length,
+    filters: pills,
+  };
+}
+
+/**
+ * Remove a single filter pill whose label matches `filter` (case-insensitive,
+ * trimmed, substring match preferred over exact so "Market cap" matches
+ * "Market cap" and "market").
+ *
+ * Returns { success, action, removed, remaining } — idempotent: removing a
+ * filter that doesn't exist returns success with removed=[] and full list.
+ */
+export async function remove({ filter, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  if (!filter || typeof filter !== 'string' || !filter.trim()) {
+    throw new Error('remove requires a non-empty `filter` label');
+  }
+  await assertScreenerOpen(evaluate);
+  // Clear any stale popover so we don't pick up the previous one.
+  await closeAnyPopover(evaluate);
+
+  const before = await evaluate(LIST_EXPR) || [];
+
+  // Click the matching pill's popover, then the remove button.
+  const clickResult = await evaluate(`
+    (function() {
+      var needle = ${safeString(filter.trim().toLowerCase())};
+      var pills = document.querySelectorAll('[data-name^="screener-filter-pill-"]');
+      var match = null;
+      for (var i = 0; i < pills.length; i++) {
+        var label = (pills[i].textContent || '').trim().toLowerCase();
+        if (label === needle) { match = pills[i]; break; }
+      }
+      if (!match) {
+        for (var j = 0; j < pills.length; j++) {
+          var l = (pills[j].textContent || '').trim().toLowerCase();
+          if (l.indexOf(needle) !== -1) { match = pills[j]; break; }
+        }
+      }
+      if (!match) return { found: false };
+      var matchedLabel = (match.textContent || '').trim();
+      match.click();
+      return { found: true, matchedLabel: matchedLabel };
+    })()
+  `);
+
+  if (!clickResult?.found) {
+    // Idempotent: no-op success.
+    return {
+      success: true,
+      action: 'remove',
+      filter: filter,
+      removed: [],
+      remaining: before.map(p => p.label),
+      note: 'filter not found — nothing to remove',
+    };
+  }
+
+  // Wait for popover to render.
+  await sleep(350);
+
+  // Search every visible popover for the remove button. Some pills (market
+  // source selectors like "Index", "Watchlist") open a categorical-choice
+  // popover with no remove button — those are not user-removable.
+  const removeBtnResult = await evaluate(`
+    (function() {
+      var pops = document.querySelectorAll('[class*="popover"]');
+      for (var i = 0; i < pops.length; i++) {
+        var p = pops[i];
+        if (p.offsetParent === null) continue;
+        var btn = p.querySelector('[data-qa-id="popover-header-remove-button"]');
+        if (btn) { btn.click(); return { ok: true }; }
+      }
+      var anyVisible = false;
+      pops.forEach(function(p) { if (p.offsetParent !== null) anyVisible = true; });
+      return { ok: false, reason: anyVisible ? 'no_remove_button' : 'no_popover' };
+    })()
+  `);
+
+  if (!removeBtnResult?.ok) {
+    // Best-effort cleanup: close the popover.
+    await evaluate(`document.body.click()`);
+    if (removeBtnResult?.reason === 'no_remove_button') {
+      // Pill is a market-source selector or otherwise not user-removable —
+      // return a clean non-throwing result so callers (including clear())
+      // can skip it.
+      return {
+        success: false,
+        action: 'remove',
+        filter: clickResult.matchedLabel,
+        removed: [],
+        remaining: before.map(p => p.label),
+        error: 'not_removable',
+        hint: 'This pill is not a user filter (likely a market source like "Index" or "Watchlist"). Use TradingView UI to change it.',
+      };
+    }
+    throw new Error('Failed to remove filter: ' + (removeBtnResult?.reason || 'unknown'));
+  }
+
+  // Wait for DOM to settle.
+  await sleep(400);
+
+  const after = await evaluate(LIST_EXPR) || [];
+  const beforeLabels = before.map(p => p.label);
+  const afterLabels = after.map(p => p.label);
+  const removed = beforeLabels.filter(l => !afterLabels.includes(l));
+
+  return {
+    success: true,
+    action: 'remove',
+    filter: clickResult.matchedLabel,
+    removed: removed,
+    remaining: afterLabels,
+  };
+}
+
+/**
+ * Remove every filter pill one at a time. Iterates until no pills remain or
+ * the loop has made no progress (safety bound ~50 iterations).
+ */
+export async function clear({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  await assertScreenerOpen(evaluate);
+
+  const before = await evaluate(LIST_EXPR) || [];
+  const beforeLabels = before.map(p => p.label);
+
+  let removedTotal = 0;
+  const skipped = [];
+  // Track pill ids we've already tried-and-skipped so we don't loop on them.
+  const skippedIds = new Set();
+  let guard = 0;
+  const MAX = 50;
+
+  while (guard < MAX) {
+    guard++;
+    // Close any stale popover before each iteration.
+    await closeAnyPopover(evaluate);
+
+    const current = await evaluate(LIST_EXPR) || [];
+    // Find the first pill we haven't already skipped.
+    const nextPill = current.find(p => !skippedIds.has(p.id));
+    if (!nextPill) break;
+
+    // Click that specific pill by data-name.
+    const clickResult = await evaluate(`
+      (function() {
+        var pill = document.querySelector('[data-name="' + ${safeString(nextPill.id)} + '"]');
+        if (!pill) return { found: false };
+        pill.click();
+        return { found: true, label: (pill.textContent || '').trim() };
+      })()
+    `);
+    if (!clickResult?.found) {
+      skippedIds.add(nextPill.id);
+      continue;
+    }
+
+    await sleep(300);
+
+    const removeResult = await evaluate(`
+      (function() {
+        var pops = document.querySelectorAll('[class*="popover"]');
+        for (var i = 0; i < pops.length; i++) {
+          var p = pops[i];
+          if (p.offsetParent === null) continue;
+          var btn = p.querySelector('[data-qa-id="popover-header-remove-button"]');
+          if (btn) { btn.click(); return { ok: true }; }
+        }
+        return { ok: false };
+      })()
+    `);
+
+    if (!removeResult?.ok) {
+      // Not user-removable (market source, etc.) — skip this pill and move on.
+      await evaluate(`document.body.click()`);
+      skippedIds.add(nextPill.id);
+      skipped.push(nextPill.label);
+      await sleep(200);
+      continue;
+    }
+    removedTotal++;
+    await sleep(300);
+  }
+
+  const after = await evaluate(LIST_EXPR) || [];
+  const afterLabels = after.map(p => p.label);
+
+  return {
+    success: true,
+    action: 'clear',
+    removed_count: removedTotal,
+    removed: beforeLabels.filter(l => !afterLabels.includes(l)),
+    remaining: afterLabels,
+    skipped,
+  };
+}
+
+// ── Stretch actions (schemas exposed, flows deferred) ────────────────────
+
+export async function add({ filter, operator, value, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  // Soft pre-check so we still return a clean error when closed.
+  const probe = await evaluate(LIST_EXPR);
+  if (probe === null) return notOpenResult('add');
+  return notImplemented(
+    'add',
+    'Adding filters requires navigating the TradingView filter catalog (click the + button, pick a category, set operator/value). This UI flow is not yet automated — add the filter in TradingView, then use screener_screens.save to persist.',
+  );
+}
+
+export async function modify({ filter, operator, value, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(LIST_EXPR);
+  if (probe === null) return notOpenResult('modify');
+  return notImplemented(
+    'modify',
+    'Modifying filter values requires interacting with the per-filter popover inputs. Not yet automated — adjust the filter in TradingView UI directly.',
+  );
+}

--- a/src/core/screener_screens.js
+++ b/src/core/screener_screens.js
@@ -1,0 +1,230 @@
+/**
+ * Core Screener Screens (preset) management.
+ *
+ * The "screen" is the named preset shown in the top-left of the dialog
+ * (e.g., "All stocks", "Pre-market gainers"). The screen-actions menu opens
+ * when you click the title: `[data-name="screener-topbar-screen-title"]`.
+ *
+ * Menu items (by `data-qa-id`):
+ *   screener-screen-actions-save-screen       — Save (disabled if no changes)
+ *   screener-screen-actions-save-screen-as    — "Make a copy…" (save-as)
+ *   screener-screen-actions-rename-screen     — Rename (disabled for built-ins)
+ *   screener-screen-actions-create-new-screen — Create blank screen
+ *   screener-screen-actions-load-screen       — "Open screen…" (switch)
+ *   screener-screen-actions-export-csv        — CSV export
+ *
+ * MVP: active (read current screen name), menu_actions (report availability).
+ * Stretch: list, switch, save_as, save, delete, rename, create_new.
+ *
+ * The modal flows behind "Open screen…" and "Make a copy…" require typing
+ * into an input and confirming — these are deferred to a follow-up once the
+ * modal DOM is fully characterised.
+ *
+ * Per CONTRIBUTING.md: UI automation only.
+ */
+import { safeString } from '../connection.js';
+import {
+  resolveDeps,
+  assertScreenerOpen,
+  notOpenResult,
+  notImplemented,
+  sleep,
+} from './_screener_shared.js';
+
+const ACTIVE_EXPR = `
+  (function() {
+    var container = document.querySelector('[class*="screenerContainer"]');
+    if (!container || container.offsetParent === null) return null;
+    var titleEl = document.querySelector('[data-name="screener-topbar-screen-title"]');
+    if (!titleEl) return { error: 'no_title' };
+    return { name: (titleEl.textContent || '').trim() };
+  })()
+`;
+
+/** Return the currently active screen name. */
+export async function active({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const result = await evaluate(ACTIVE_EXPR);
+  if (result === null) return notOpenResult('active');
+  if (result.error) return { success: false, action: 'active', open: true, error: result.error };
+  return { success: true, action: 'active', open: true, screen: result.name };
+}
+
+/**
+ * Open the screen-actions menu and report which actions are currently
+ * available (aria-disabled=false). Closes the menu before returning.
+ *
+ * Returns { success, active, available, disabled } where:
+ *   available — actions with aria-disabled !== "true"
+ *   disabled  — actions with aria-disabled === "true" (e.g., Rename on builtins)
+ */
+export async function menu_actions({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  await assertScreenerOpen(evaluate);
+
+  // Open the menu.
+  await evaluate(`
+    (function() {
+      var el = document.querySelector('[data-name="screener-topbar-screen-title"]');
+      if (el) el.click();
+    })()
+  `);
+  await sleep(500);
+
+  const snapshot = await evaluate(`
+    (function() {
+      var menu = document.querySelector('[class*="menu-jTwl4vFK"]');
+      if (!menu) return { err: 'menu_not_found' };
+      var items = menu.querySelectorAll('[data-qa-id^="screener-screen-actions-"]');
+      var out = [];
+      for (var i = 0; i < items.length; i++) {
+        out.push({
+          qaId: items[i].getAttribute('data-qa-id'),
+          label: (items[i].textContent || '').trim(),
+          disabled: items[i].getAttribute('aria-disabled') === 'true',
+        });
+      }
+      return { items: out };
+    })()
+  `);
+
+  // Dismiss menu.
+  await evaluate(`document.body.click()`);
+  await sleep(200);
+
+  if (snapshot?.err) {
+    throw new Error('Screen-actions menu did not open: ' + snapshot.err);
+  }
+
+  const items = snapshot?.items || [];
+  const available = items.filter(i => !i.disabled).map(i => i.label);
+  const disabled = items.filter(i => i.disabled).map(i => i.label);
+
+  return {
+    success: true,
+    action: 'menu_actions',
+    available,
+    disabled,
+    items,
+  };
+}
+
+/**
+ * Internal helper: open the screen-actions menu and click a menu item by
+ * its `data-qa-id` suffix (e.g., "save-screen-as"). Returns { clicked, disabled }.
+ */
+async function clickMenuAction(evaluate, suffix) {
+  await evaluate(`
+    (function() {
+      var el = document.querySelector('[data-name="screener-topbar-screen-title"]');
+      if (el) el.click();
+    })()
+  `);
+  await sleep(500);
+
+  const result = await evaluate(`
+    (function() {
+      var qa = ${safeString('screener-screen-actions-' + suffix)};
+      var menu = document.querySelector('[class*="menu-jTwl4vFK"]');
+      if (!menu) return { clicked: false, reason: 'menu_not_found' };
+      var item = menu.querySelector('[data-qa-id="' + qa + '"]');
+      if (!item) return { clicked: false, reason: 'item_not_found' };
+      if (item.getAttribute('aria-disabled') === 'true') {
+        // Close menu via body click.
+        document.body.click();
+        return { clicked: false, reason: 'item_disabled' };
+      }
+      item.click();
+      return { clicked: true };
+    })()
+  `);
+
+  return result || { clicked: false, reason: 'unknown' };
+}
+
+/**
+ * Save the current screen state (if "Save screen" is enabled — i.e. there
+ * are unsaved changes to a screen you own). Returns { success, action,
+ * saved } — saved=false when nothing to save or the action was disabled.
+ */
+export async function save({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  await assertScreenerOpen(evaluate);
+
+  const r = await clickMenuAction(evaluate, 'save-screen');
+  if (!r.clicked) {
+    return {
+      success: true,
+      action: 'save',
+      saved: false,
+      reason: r.reason || 'unknown',
+      hint: r.reason === 'item_disabled'
+        ? 'Save is disabled — either no unsaved changes, or the current screen is a built-in preset (use save_as to copy it).'
+        : 'Save menu item not found.',
+    };
+  }
+  await sleep(700);
+  return { success: true, action: 'save', saved: true };
+}
+
+// ── Stretch actions — return not_implemented_yet with explanatory hints ──
+
+export async function list({ _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(ACTIVE_EXPR);
+  if (probe === null) return notOpenResult('list');
+  return notImplemented(
+    'list',
+    'Listing saved screens requires opening the "Open screen…" modal. Not yet automated — use screener_screens.active to get the current one, or browse the dropdown in TradingView.',
+  );
+}
+
+export async function switchTo({ name, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(ACTIVE_EXPR);
+  if (probe === null) return notOpenResult('switch');
+  return notImplemented(
+    'switch',
+    'Switching screens requires the "Open screen…" modal flow. Not yet automated — switch manually in TradingView.',
+  );
+}
+
+export async function save_as({ name, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(ACTIVE_EXPR);
+  if (probe === null) return notOpenResult('save_as');
+  return notImplemented(
+    'save_as',
+    'Save-as requires clicking "Make a copy…" and typing a name into a modal. Not yet automated — use TradingView UI directly.',
+  );
+}
+
+export async function remove({ name, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(ACTIVE_EXPR);
+  if (probe === null) return notOpenResult('delete');
+  return notImplemented(
+    'delete',
+    'Deleting a saved screen requires the "Open screen…" modal and a per-row delete affordance. Not yet automated.',
+  );
+}
+
+export async function rename({ name, new_name, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(ACTIVE_EXPR);
+  if (probe === null) return notOpenResult('rename');
+  return notImplemented(
+    'rename',
+    'Rename requires the rename modal flow. Not yet automated.',
+  );
+}
+
+export async function createNew({ name, _deps } = {}) {
+  const { evaluate } = resolveDeps(_deps);
+  const probe = await evaluate(ACTIVE_EXPR);
+  if (probe === null) return notOpenResult('create_new');
+  return notImplemented(
+    'create_new',
+    '"Create new screen…" opens a modal for the new screen name. Not yet automated.',
+  );
+}

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -29,6 +29,23 @@ export async function click({ by, value }) {
 }
 
 export async function openPanel({ panel, action }) {
+  // Screener is a floating dialog, handled by a dedicated core module.
+  if (panel === 'screener') {
+    const screener = await import('./screener.js');
+    const state = await screener.status();
+    const wasOpen = !!state.open;
+    let performed = 'none';
+    if (action === 'open' && !wasOpen) { await screener.open(); performed = 'opened'; }
+    else if (action === 'close' && wasOpen) { await screener.close(); performed = 'closed'; }
+    else if (action === 'toggle') {
+      if (wasOpen) { await screener.close(); performed = 'closed'; }
+      else { await screener.open(); performed = 'opened'; }
+    } else {
+      performed = wasOpen ? 'already_open' : 'already_closed';
+    }
+    return { success: true, panel, action, was_open: wasOpen, performed };
+  }
+
   const isBottomPanel = panel === 'pine-editor' || panel === 'strategy-tester';
   if (isBottomPanel) {
     const widgetName = panel === 'pine-editor' ? 'pine-editor' : 'backtesting';

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,10 @@ import { registerBatchTools } from './tools/batch.js';
 import { registerReplayTools } from './tools/replay.js';
 import { registerIndicatorTools } from './tools/indicators.js';
 import { registerWatchlistTools } from './tools/watchlist.js';
+import { registerScreenerTools } from './tools/screener.js';
+import { registerScreenerScreensTools } from './tools/screener_screens.js';
+import { registerScreenerFiltersTools } from './tools/screener_filters.js';
+import { registerScreenerColumnsTools } from './tools/screener_columns.js';
 import { registerUiTools } from './tools/ui.js';
 import { registerPaneTools } from './tools/pane.js';
 import { registerTabTools } from './tools/tab.js';
@@ -22,7 +26,7 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 78 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — 85 tools for reading and controlling a live TradingView Desktop chart.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 
@@ -59,6 +63,8 @@ Alerts: alert_create, alert_list, alert_delete
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch
+Screener: screener_open → screener_get → screener_close (floating dialog of stocks with Symbol, Price, Change %, Volume, Market cap, P/E, Sector, etc.)
+Screener management: screener_screens (active/menu_actions/save preset), screener_filters (list/remove/clear pills), screener_columns (list current headers) — use these to inspect and prune the current screen. Modal-driven flows (switch/save_as/add filter/add column) return not_implemented_yet.
 
 CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv
@@ -81,6 +87,10 @@ registerBatchTools(server);
 registerReplayTools(server);
 registerIndicatorTools(server);
 registerWatchlistTools(server);
+registerScreenerTools(server);
+registerScreenerScreensTools(server);
+registerScreenerFiltersTools(server);
+registerScreenerColumnsTools(server);
 registerUiTools(server);
 registerPaneTools(server);
 registerTabTools(server);

--- a/src/tools/screener.js
+++ b/src/tools/screener.js
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/screener.js';
+
+export function registerScreenerTools(server) {
+  server.tool(
+    'screener_open',
+    'Open the TradingView Stock Screener dialog. Returns { success, action, open, width, height }. No-op if already open.',
+    {},
+    async () => {
+      try { return jsonResult(await core.open()); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'screener_close',
+    'Close the Stock Screener dialog if open. No-op if already closed.',
+    {},
+    async () => {
+      try { return jsonResult(await core.close()); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'screener_status',
+    'Check whether the Stock Screener dialog is currently open. Returns { success, open, width, height }.',
+    {},
+    async () => {
+      try { return jsonResult(await core.status()); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'screener_get',
+    'Read rows from the currently-open Stock Screener. Returns the active screen name, column headers, row count, and up to `limit` rows as { column: value } objects. Call screener_open first.',
+    {
+      limit: z.number().int().min(1).max(500).optional().describe('Maximum rows to return (default 100, max 500).'),
+    },
+    async ({ limit }) => {
+      try { return jsonResult(await core.get({ limit })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+}

--- a/src/tools/screener_columns.js
+++ b/src/tools/screener_columns.js
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/screener_columns.js';
+
+/**
+ * MVP action: list. Stretch (reset, remove, add, reorder) return not_implemented_yet.
+ */
+export function registerScreenerColumnsTools(server) {
+  server.tool(
+    'screener_columns',
+    'Manage visible columns in the open Stock Screener. Actions: list (returns current column headers). Stretch actions (reset, remove, add, reorder) return not_implemented_yet — use the "Column setup" button in TradingView for now. Call screener_open first.',
+    {
+      action: z.enum(['list', 'reset', 'remove', 'add', 'reorder']).describe('The column action to perform.'),
+      column: z.string().optional().describe('Column name — for remove/add.'),
+      columns: z.array(z.string()).optional().describe('Full desired column order — for reorder (stretch).'),
+    },
+    async ({ action, column, columns }) => {
+      try {
+        let result;
+        switch (action) {
+          case 'list':    result = await core.list(); break;
+          case 'reset':   result = await core.reset(); break;
+          case 'remove':  result = await core.remove({ column }); break;
+          case 'add':     result = await core.add({ column }); break;
+          case 'reorder': result = await core.reorder({ columns }); break;
+          default:        throw new Error('unknown action: ' + action);
+        }
+        return jsonResult(result);
+      } catch (err) {
+        return jsonResult({ success: false, error: err.message }, true);
+      }
+    },
+  );
+}

--- a/src/tools/screener_filters.js
+++ b/src/tools/screener_filters.js
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/screener_filters.js';
+
+/**
+ * MVP actions: list, remove, clear.
+ * Stretch (add, modify) return not_implemented_yet.
+ */
+export function registerScreenerFiltersTools(server) {
+  server.tool(
+    'screener_filters',
+    'Manage filter pills in the open Stock Screener. Actions: list (returns visible filter pills with labels), remove (removes a pill by label — idempotent), clear (removes all pills). Stretch actions (add, modify) return not_implemented_yet — use the TradingView UI to add/configure filters. Call screener_open first.',
+    {
+      action: z.enum(['list', 'remove', 'clear', 'add', 'modify']).describe('The filter action to perform.'),
+      filter: z.string().optional().describe('Filter pill label (e.g., "Market cap", "Price"). Required for remove/modify; used by add.'),
+      operator: z.string().optional().describe('Comparison operator — reserved for add/modify (stretch).'),
+      value: z.union([z.string(), z.number()]).optional().describe('Filter value — reserved for add/modify (stretch).'),
+    },
+    async ({ action, filter, operator, value }) => {
+      try {
+        let result;
+        switch (action) {
+          case 'list':    result = await core.list(); break;
+          case 'remove':  result = await core.remove({ filter }); break;
+          case 'clear':   result = await core.clear(); break;
+          case 'add':     result = await core.add({ filter, operator, value }); break;
+          case 'modify':  result = await core.modify({ filter, operator, value }); break;
+          default:        throw new Error('unknown action: ' + action);
+        }
+        return jsonResult(result);
+      } catch (err) {
+        return jsonResult({ success: false, error: err.message }, true);
+      }
+    },
+  );
+}

--- a/src/tools/screener_screens.js
+++ b/src/tools/screener_screens.js
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/screener_screens.js';
+
+/**
+ * Action-dispatched tool — matches the pattern of chart_manage_indicator.
+ * MVP actions: active, menu_actions, save.
+ * Stretch actions (list, switch, save_as, delete, rename, create_new) return
+ * `not_implemented_yet` at the core layer until the modal DOM flows are wired.
+ */
+export function registerScreenerScreensTools(server) {
+  server.tool(
+    'screener_screens',
+    'Manage Stock Screener saved screens (presets). Actions: active (returns current screen name), menu_actions (lists which screen actions are currently enabled/disabled in the UI), save (saves current screen changes to the cloud if enabled). Stretch actions (list, switch, save_as, delete, rename, create_new) return not_implemented_yet — use the TradingView UI directly for those.',
+    {
+      action: z.enum([
+        'active', 'menu_actions', 'save',
+        'list', 'switch', 'save_as', 'delete', 'rename', 'create_new',
+      ]).describe('The screen management action to perform.'),
+      name: z.string().optional().describe('Screen name — required for switch/delete/rename (source).'),
+      new_name: z.string().optional().describe('Target name — used by save_as/rename/create_new.'),
+    },
+    async ({ action, name, new_name }) => {
+      try {
+        let result;
+        switch (action) {
+          case 'active':       result = await core.active(); break;
+          case 'menu_actions': result = await core.menu_actions(); break;
+          case 'save':         result = await core.save(); break;
+          case 'list':         result = await core.list(); break;
+          case 'switch':       result = await core.switchTo({ name }); break;
+          case 'save_as':      result = await core.save_as({ name: new_name || name }); break;
+          case 'delete':       result = await core.remove({ name }); break;
+          case 'rename':       result = await core.rename({ name, new_name }); break;
+          case 'create_new':   result = await core.createNew({ name: new_name || name }); break;
+          default:             throw new Error('unknown action: ' + action);
+        }
+        return jsonResult(result);
+      } catch (err) {
+        return jsonResult({ success: false, error: err.message }, true);
+      }
+    },
+  );
+}

--- a/src/tools/ui.js
+++ b/src/tools/ui.js
@@ -11,8 +11,8 @@ export function registerUiTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('ui_open_panel', 'Open, close, or toggle TradingView panels (pine-editor, strategy-tester, watchlist, alerts, trading)', {
-    panel: z.enum(['pine-editor', 'strategy-tester', 'watchlist', 'alerts', 'trading']).describe('Panel name'),
+  server.tool('ui_open_panel', 'Open, close, or toggle TradingView panels (pine-editor, strategy-tester, watchlist, alerts, trading, screener)', {
+    panel: z.enum(['pine-editor', 'strategy-tester', 'watchlist', 'alerts', 'trading', 'screener']).describe('Panel name'),
     action: z.enum(['open', 'close', 'toggle']).describe('Action to perform'),
   }, async ({ panel, action }) => {
     try { return jsonResult(await core.openPanel({ panel, action })); }

--- a/tests/screener.test.js
+++ b/tests/screener.test.js
@@ -1,0 +1,254 @@
+/**
+ * Tests for src/core/screener.js — status, open, close, get.
+ * All tests use dependency injection; no live TradingView required.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { status, open, close, get } from '../src/core/screener.js';
+
+// ── Mock helpers ─────────────────────────────────────────────────────────
+
+function mockEvaluate(sequence) {
+  let idx = 0;
+  const calls = [];
+  const fn = async (expr) => {
+    calls.push(expr);
+    const val = sequence[Math.min(idx, sequence.length - 1)];
+    idx++;
+    return val;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function mockClient() {
+  const mouseEvents = [];
+  return {
+    Input: {
+      dispatchMouseEvent: async (opts) => { mouseEvents.push(opts); },
+    },
+    _mouseEvents: mouseEvents,
+  };
+}
+
+// ── status() ─────────────────────────────────────────────────────────────
+
+describe('status()', () => {
+  it('returns open=false when no container in DOM', async () => {
+    const evaluate = mockEvaluate([{ open: false }]);
+    const result = await status({ _deps: { evaluate } });
+    assert.equal(result.success, true);
+    assert.equal(result.open, false);
+    assert.equal(result.width, null);
+    assert.equal(result.height, null);
+  });
+
+  it('returns open=true with dimensions when screener is visible', async () => {
+    const evaluate = mockEvaluate([{ open: true, width: 540, height: 772, data_loaded: true }]);
+    const result = await status({ _deps: { evaluate } });
+    assert.equal(result.open, true);
+    assert.equal(result.width, 540);
+    assert.equal(result.height, 772);
+  });
+
+  it('status check expression references screenerContainer and js-dialog', async () => {
+    const evaluate = mockEvaluate([{ open: false }]);
+    await status({ _deps: { evaluate } });
+    const expr = evaluate.calls[0];
+    assert.match(expr, /screenerContainer/);
+    assert.match(expr, /js-dialog/);
+    assert.match(expr, /visible-/);
+  });
+});
+
+// ── open() ───────────────────────────────────────────────────────────────
+
+describe('open()', () => {
+  it('returns already_open without clicking when screener already visible', async () => {
+    const evaluate = mockEvaluate([{ open: true, width: 540, height: 772, data_loaded: true }]);
+    const client = mockClient();
+    const result = await open({ _deps: { evaluate, getClient: async () => client } });
+    assert.equal(result.action, 'already_open');
+    assert.equal(result.open, true);
+    assert.equal(client._mouseEvents.length, 0, 'no mouse events dispatched');
+  });
+
+  it('dispatches mouse press+release at button center when closed', async () => {
+    const evaluate = mockEvaluate([
+      { open: false },              // initial status
+      { x: 1129.5, y: 519 },        // button rect
+      { open: true, width: 540, height: 772, data_loaded: true }, // first poll after click
+    ]);
+    const client = mockClient();
+    const result = await open({ _deps: { evaluate, getClient: async () => client } });
+    assert.equal(result.action, 'opened');
+    assert.equal(result.open, true);
+    const types = client._mouseEvents.map(e => e.type);
+    assert.deepEqual(types, ['mouseMoved', 'mousePressed', 'mouseReleased']);
+    assert.equal(client._mouseEvents[1].x, 1129.5);
+    assert.equal(client._mouseEvents[1].y, 519);
+    assert.equal(client._mouseEvents[1].button, 'left');
+  });
+
+  it('throws when the screener toolbar button is missing', async () => {
+    const evaluate = mockEvaluate([{ open: false }, null]);
+    const client = mockClient();
+    await assert.rejects(
+      open({ _deps: { evaluate, getClient: async () => client } }),
+      /toolbar button not found/
+    );
+  });
+
+  it('throws if dialog never appears after clicking', async () => {
+    const evaluate = mockEvaluate([
+      { open: false },
+      { x: 100, y: 200 },
+      { open: false }, // every subsequent poll also returns closed
+    ]);
+    const client = mockClient();
+    await assert.rejects(
+      open({ _deps: { evaluate, getClient: async () => client } }),
+      /did not open within/
+    );
+  });
+
+  it('returns warning when dialog opens but rows never load', async () => {
+    const evaluate = mockEvaluate([
+      { open: false },
+      { x: 100, y: 200 },
+      // every poll: dialog visible but data_loaded=false
+      { open: true, width: 540, height: 772, data_loaded: false },
+    ]);
+    const client = mockClient();
+    const result = await open({ _deps: { evaluate, getClient: async () => client } });
+    assert.equal(result.success, true);
+    assert.equal(result.action, 'opened');
+    assert.equal(result.open, true);
+    assert.match(result.warning, /rows did not populate/);
+  });
+
+  it('rejects non-finite button coordinates from DOM probe', async () => {
+    const evaluate = mockEvaluate([{ open: false }, { x: NaN, y: 200 }]);
+    const client = mockClient();
+    await assert.rejects(
+      open({ _deps: { evaluate, getClient: async () => client } }),
+      /button\.x must be a finite number/
+    );
+  });
+});
+
+// ── close() ──────────────────────────────────────────────────────────────
+
+describe('close()', () => {
+  it('returns already_closed without clicking when screener not visible', async () => {
+    const evaluate = mockEvaluate([{ open: false }]);
+    const result = await close({ _deps: { evaluate } });
+    assert.equal(result.action, 'already_closed');
+    assert.equal(result.open, false);
+    // Only the status check was executed — no close click issued
+    assert.equal(evaluate.calls.length, 1);
+  });
+
+  it('clicks close button when open and polls for close', async () => {
+    const evaluate = mockEvaluate([
+      { open: true, width: 540, height: 772, data_loaded: true }, // initial status
+      { found: true },                         // close button click result
+      { open: false },                         // first poll after click
+    ]);
+    const result = await close({ _deps: { evaluate } });
+    assert.equal(result.action, 'closed');
+    assert.equal(result.open, false);
+  });
+
+  it('throws descriptive error when close button missing', async () => {
+    const evaluate = mockEvaluate([
+      { open: true, width: 540, height: 772, data_loaded: true },
+      { found: false, reason: 'no_close_button' },
+    ]);
+    await assert.rejects(
+      close({ _deps: { evaluate } }),
+      /no_close_button/
+    );
+  });
+
+  it('throws if dialog does not disappear after click', async () => {
+    const evaluate = mockEvaluate([
+      { open: true, width: 540, height: 772, data_loaded: true },
+      { found: true },
+      { open: true, width: 540, height: 772, data_loaded: true },
+    ]);
+    await assert.rejects(
+      close({ _deps: { evaluate } }),
+      /did not close within/
+    );
+  });
+});
+
+// ── get() ────────────────────────────────────────────────────────────────
+
+describe('get()', () => {
+  it('returns error when screener is not open', async () => {
+    const evaluate = mockEvaluate([{ open: false }]);
+    const result = await get({ _deps: { evaluate } });
+    assert.equal(result.success, false);
+    assert.equal(result.open, false);
+    assert.match(result.error, /not open/);
+  });
+
+  it('maps columns to values per row', async () => {
+    const evaluate = mockEvaluate([{
+      open: true,
+      title: 'All stocks',
+      columns: ['Symbol', 'Price', 'Change %'],
+      row_count: 100,
+      returned: 2,
+      rows: [
+        { symbol: 'NVDA', Price: '196.51 USD', 'Change %': '+3.80%' },
+        { symbol: 'AAPL', Price: '258.83 USD', 'Change %': '-0.14%' },
+      ],
+      filters: ['Price', 'Market cap'],
+    }]);
+    const result = await get({ _deps: { evaluate } });
+    assert.equal(result.success, true);
+    assert.equal(result.open, true);
+    assert.equal(result.screen, 'All stocks');
+    assert.deepEqual(result.columns, ['Symbol', 'Price', 'Change %']);
+    assert.equal(result.row_count, 100);
+    assert.equal(result.returned, 2);
+    assert.equal(result.rows[0].symbol, 'NVDA');
+    assert.equal(result.rows[0]['Price'], '196.51 USD');
+    assert.deepEqual(result.filters, ['Price', 'Market cap']);
+  });
+
+  it('clamps limit into [1, 500] when computing the query', async () => {
+    const evaluate = mockEvaluate([{
+      open: true, title: '', columns: [], row_count: 0, returned: 0, rows: [], filters: [],
+    }]);
+    await get({ limit: 9999, _deps: { evaluate } });
+    // Max = 500 so the generated expression must reference that cap
+    assert.match(evaluate.calls[0], /500\)/);
+
+    const ev2 = mockEvaluate([{
+      open: true, title: '', columns: [], row_count: 0, returned: 0, rows: [], filters: [],
+    }]);
+    await get({ limit: 0, _deps: { evaluate: ev2 } });
+    // Min = 1
+    assert.match(ev2.calls[0], /, 1\)/);
+  });
+
+  it('defaults limit to 100 when not provided', async () => {
+    const evaluate = mockEvaluate([{
+      open: true, title: '', columns: [], row_count: 0, returned: 0, rows: [], filters: [],
+    }]);
+    await get({ _deps: { evaluate } });
+    assert.match(evaluate.calls[0], /, 100\)/);
+  });
+
+  it('propagates table_not_found error from the DOM probe', async () => {
+    const evaluate = mockEvaluate([{ open: true, error: 'table_not_found' }]);
+    const result = await get({ _deps: { evaluate } });
+    assert.equal(result.success, false);
+    assert.equal(result.open, true);
+    assert.equal(result.error, 'table_not_found');
+  });
+});

--- a/tests/screener_columns.test.js
+++ b/tests/screener_columns.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests for src/core/screener_columns.js — list + stretch stubs.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { list, reset, remove, add, reorder } from '../src/core/screener_columns.js';
+
+function mockEvaluate(handler) {
+  const calls = [];
+  const fn = async (expr) => { calls.push(expr); return handler(expr, calls.length - 1); };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('screener_columns.list()', () => {
+  it('returns not-open when screener is closed', async () => {
+    const evaluate = mockEvaluate(() => null);
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.open, false);
+    assert.match(r.error, /not open/i);
+  });
+
+  it('returns columns when open', async () => {
+    const cols = ['Symbol', 'Price', 'Change %', 'Volume', 'Market cap'];
+    const evaluate = mockEvaluate(() => ({ columns: cols }));
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.action, 'list');
+    assert.equal(r.count, 5);
+    assert.deepEqual(r.columns, cols);
+  });
+
+  it('propagates table_not_found error from probe', async () => {
+    const evaluate = mockEvaluate(() => ({ error: 'table_not_found' }));
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.error, 'table_not_found');
+    assert.equal(r.open, true);
+  });
+});
+
+describe('screener_columns stretch actions', () => {
+  it('reset returns not-open when closed', async () => {
+    const evaluate = mockEvaluate(() => null);
+    const r = await reset({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.open, false);
+  });
+
+  it('reset returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ columns: ['Symbol'] }));
+    const r = await reset({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.error, 'not_implemented_yet');
+    assert.ok(r.hint);
+  });
+
+  it('remove returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ columns: [] }));
+    const r = await remove({ column: 'Price', _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+
+  it('add returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ columns: [] }));
+    const r = await add({ column: 'Beta', _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+
+  it('reorder returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ columns: [] }));
+    const r = await reorder({ columns: ['Symbol', 'Price'], _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+});

--- a/tests/screener_filters.test.js
+++ b/tests/screener_filters.test.js
@@ -1,0 +1,309 @@
+/**
+ * Tests for src/core/screener_filters.js — list, remove, clear + stretch stubs.
+ * All tests use dependency injection; no live TradingView required.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { list, remove, clear, add, modify } from '../src/core/screener_filters.js';
+
+// ── mock evaluate ───────────────────────────────────────────────────────
+
+function mockEvaluate(handler) {
+  const calls = [];
+  const fn = async (expr) => {
+    calls.push(expr);
+    return handler(expr, calls.length - 1);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// Common helpers to script typical flows ────────────────────────────────
+
+function closedScreener() {
+  // Any LIST_EXPR returns null when screener closed.
+  return mockEvaluate((expr) => {
+    if (/screenerContainer/.test(expr)) return null;
+    return null;
+  });
+}
+
+// ── list() ──────────────────────────────────────────────────────────────
+
+describe('screener_filters.list()', () => {
+  it('returns not-open result when screener is closed', async () => {
+    const evaluate = closedScreener();
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.action, 'list');
+    assert.equal(r.open, false);
+    assert.match(r.error, /not open/i);
+  });
+
+  it('returns the pill list when screener is open', async () => {
+    const pills = [
+      { label: 'Price', id: 'screener-filter-pill-abc' },
+      { label: 'Market cap', id: 'screener-filter-pill-def' },
+    ];
+    const evaluate = mockEvaluate(() => pills);
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.action, 'list');
+    assert.equal(r.count, 2);
+    assert.deepEqual(r.filters, pills);
+  });
+
+  it('returns empty list when screener has no pills', async () => {
+    const evaluate = mockEvaluate(() => []);
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.count, 0);
+    assert.deepEqual(r.filters, []);
+  });
+});
+
+// ── remove() ────────────────────────────────────────────────────────────
+
+/**
+ * Build a content-matching mock so the tests are stable across call-order
+ * changes (e.g., the pre-click popover cleanup adds probes we don't want to
+ * count by index).
+ */
+function scriptedEvaluate({ open = true, listBefore = [], listAfter = [], clickResult, removeResult }) {
+  return mockEvaluate((expr) => {
+    // IS_OPEN_EXPR check
+    if (/return !!visible/.test(expr)) return open;
+    // closeAnyPopover: probe-any-visible-popover → return false to skip click
+    if (/\[class\*="popover"\]/.test(expr) && /return true/.test(expr) && !/remove-button/.test(expr)) return false;
+    // LIST_EXPR
+    if (/screener-filter-pill-/.test(expr) && /out\.push/.test(expr)) {
+      // First call returns before, subsequent calls return after
+      if (!scriptedEvaluate._state.listCallCount) scriptedEvaluate._state.listCallCount = 0;
+      scriptedEvaluate._state.listCallCount++;
+      return scriptedEvaluate._state.listCallCount === 1 ? listBefore : listAfter;
+    }
+    // Click-match expression (the pill-match click in remove())
+    if (/pills\.length/.test(expr) && /match\.click/.test(expr)) return clickResult;
+    // Remove button search
+    if (/popover-header-remove-button/.test(expr)) return removeResult;
+    return null;
+  });
+}
+// Reset state between tests
+function resetState() { scriptedEvaluate._state = { listCallCount: 0 }; }
+
+describe('screener_filters.remove()', () => {
+  it('throws when filter argument is missing or empty', async () => {
+    resetState();
+    const evaluate = scriptedEvaluate({});
+    await assert.rejects(() => remove({ _deps: { evaluate } }), /non-empty/);
+    await assert.rejects(() => remove({ filter: '', _deps: { evaluate } }), /non-empty/);
+    await assert.rejects(() => remove({ filter: '   ', _deps: { evaluate } }), /non-empty/);
+  });
+
+  it('throws "not open" when screener is closed', async () => {
+    resetState();
+    const evaluate = scriptedEvaluate({ open: false });
+    await assert.rejects(() => remove({ filter: 'Price', _deps: { evaluate } }), /not open/i);
+  });
+
+  it('is idempotent when the named filter does not exist', async () => {
+    resetState();
+    const evaluate = scriptedEvaluate({
+      listBefore: [{ label: 'Price', id: 'p1' }],
+      clickResult: { found: false },
+    });
+    const r = await remove({ filter: 'DoesNotExist', _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.action, 'remove');
+    assert.deepEqual(r.removed, []);
+    assert.deepEqual(r.remaining, ['Price']);
+    assert.match(r.note, /not found/);
+  });
+
+  it('sanitizes filter name (safeString) in DOM query', async () => {
+    resetState();
+    const captured = [];
+    const evaluate = mockEvaluate((expr) => {
+      captured.push(expr);
+      if (/return !!visible/.test(expr)) return true;
+      if (/\[class\*="popover"\]/.test(expr) && /return true/.test(expr) && !/remove-button/.test(expr)) return false;
+      if (/screener-filter-pill-/.test(expr) && /out\.push/.test(expr)) return [];
+      if (/pills\.length/.test(expr) && /match\.click/.test(expr)) return { found: false };
+      return null;
+    });
+    const payload = `"); alert('xss'); ("`;
+    await remove({ filter: payload, _deps: { evaluate } });
+    // Find the click-match expression — must contain the JSON-stringified payload
+    const clickExpr = captured.find(e => /pills\.length/.test(e) && /match\.click/.test(e));
+    assert.ok(clickExpr, 'click expression was dispatched');
+    const safe = JSON.stringify(payload.trim().toLowerCase());
+    assert.ok(clickExpr.includes(safe),
+      'payload must be inlined via safeString/JSON.stringify');
+    assert.equal(safe[0], '"');
+    assert.equal(safe[safe.length - 1], '"');
+  });
+
+  it('happy path: clicks pill, clicks remove button, returns diff', async () => {
+    resetState();
+    const evaluate = scriptedEvaluate({
+      listBefore: [
+        { label: 'Price', id: 'p1' },
+        { label: 'Market cap', id: 'p2' },
+        { label: 'Beta', id: 'p3' },
+      ],
+      listAfter: [
+        { label: 'Price', id: 'p1' },
+        { label: 'Market cap', id: 'p2' },
+      ],
+      clickResult: { found: true, matchedLabel: 'Beta' },
+      removeResult: { ok: true },
+    });
+    const r = await remove({ filter: 'Beta', _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.action, 'remove');
+    assert.equal(r.filter, 'Beta');
+    assert.deepEqual(r.removed, ['Beta']);
+    assert.deepEqual(r.remaining, ['Price', 'Market cap']);
+  });
+
+  it('returns non-throwing "not_removable" when popover has no remove button (market-source pill)', async () => {
+    resetState();
+    const evaluate = scriptedEvaluate({
+      listBefore: [{ label: 'Index', id: 'p1' }],
+      clickResult: { found: true, matchedLabel: 'Index' },
+      removeResult: { ok: false, reason: 'no_remove_button' },
+    });
+    const r = await remove({ filter: 'Index', _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.error, 'not_removable');
+    assert.deepEqual(r.removed, []);
+    assert.match(r.hint, /market source/i);
+  });
+
+  it('throws when no popover appears at all', async () => {
+    resetState();
+    const evaluate = scriptedEvaluate({
+      listBefore: [{ label: 'Beta', id: 'p1' }],
+      clickResult: { found: true, matchedLabel: 'Beta' },
+      removeResult: { ok: false, reason: 'no_popover' },
+    });
+    await assert.rejects(
+      () => remove({ filter: 'Beta', _deps: { evaluate } }),
+      /no_popover/,
+    );
+  });
+});
+
+// ── clear() ─────────────────────────────────────────────────────────────
+
+describe('screener_filters.clear()', () => {
+  it('throws "not open" when screener is closed', async () => {
+    const evaluate = mockEvaluate(() => false);
+    await assert.rejects(() => clear({ _deps: { evaluate } }), /not open/i);
+  });
+
+  it('is a no-op when there are no pills', async () => {
+    const evaluate = mockEvaluate((expr, idx) => {
+      if (idx === 0) return true;              // assertOpen
+      if (idx === 1) return [];                // LIST (before)
+      if (idx === 2) return [];                // LIST (loop iter 1) → empty, break
+      if (idx === 3) return [];                // LIST (after)
+      return null;
+    });
+    const r = await clear({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.action, 'clear');
+    assert.equal(r.removed_count, 0);
+    assert.deepEqual(r.removed, []);
+    assert.deepEqual(r.remaining, []);
+  });
+
+  it('removes pills one-by-one until empty', async () => {
+    let pills = [
+      { label: 'Price', id: 'p1' },
+      { label: 'Beta', id: 'p2' },
+    ];
+    const evaluate = mockEvaluate((expr) => {
+      // assertOpen
+      if (/screenerContainer/.test(expr) && /return !!visible/.test(expr)) return true;
+      // LIST_EXPR — returns current pills (clone to avoid mutation aliasing)
+      if (/screener-filter-pill-/.test(expr) && /out\.push/.test(expr)) return pills.map(p => ({...p}));
+      // Pill click by id (now uses data-name selector)
+      if (/document\.querySelector\('\[data-name="/.test(expr)) {
+        if (pills.length === 0) return { found: false };
+        return { found: true, label: pills[0].label };
+      }
+      // Remove button click
+      if (/popover-header-remove-button/.test(expr)) {
+        pills = pills.slice(1);
+        return { ok: true };
+      }
+      return null;
+    });
+    const r = await clear({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.removed_count, 2);
+    assert.deepEqual(r.removed.sort(), ['Beta', 'Price']);
+    assert.deepEqual(r.remaining, []);
+  });
+
+  it('skips non-removable pills and continues (no infinite loop)', async () => {
+    // "Index" has no remove button — clear should skip it and succeed on the rest.
+    let pills = [
+      { label: 'Index', id: 'p1' },
+      { label: 'Price', id: 'p2' },
+    ];
+    let lastClicked = null;
+    const evaluate = mockEvaluate((expr) => {
+      if (/screenerContainer/.test(expr) && /return !!visible/.test(expr)) return true;
+      if (/screener-filter-pill-/.test(expr) && /out\.push/.test(expr)) return pills.map(p => ({...p}));
+      if (/document\.querySelector\('\[data-name="/.test(expr)) {
+        if (expr.includes('"p1"')) { lastClicked = 'Index'; return { found: true, label: 'Index' }; }
+        if (expr.includes('"p2"')) { lastClicked = 'Price'; return { found: true, label: 'Price' }; }
+        return { found: false };
+      }
+      if (/popover-header-remove-button/.test(expr)) {
+        if (lastClicked === 'Index') return { ok: false };
+        if (lastClicked === 'Price') {
+          pills = pills.filter(p => p.label !== 'Price');
+          return { ok: true };
+        }
+        return { ok: false };
+      }
+      return null;
+    });
+    const r = await clear({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.removed_count, 1);
+    assert.deepEqual(r.removed, ['Price']);
+    assert.deepEqual(r.remaining, ['Index']);
+    assert.deepEqual(r.skipped, ['Index']);
+  });
+});
+
+// ── stretch stubs ───────────────────────────────────────────────────────
+
+describe('screener_filters stretch actions', () => {
+  it('add returns not_implemented_yet with hint when screener is open', async () => {
+    const evaluate = mockEvaluate(() => []);
+    const r = await add({ filter: 'Price', _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.error, 'not_implemented_yet');
+    assert.ok(r.hint);
+  });
+
+  it('add returns not-open result when screener is closed', async () => {
+    const evaluate = mockEvaluate(() => null);
+    const r = await add({ filter: 'Price', _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.open, false);
+  });
+
+  it('modify returns not_implemented_yet with hint when screener is open', async () => {
+    const evaluate = mockEvaluate(() => []);
+    const r = await modify({ filter: 'Price', value: 100, _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+});

--- a/tests/screener_screens.test.js
+++ b/tests/screener_screens.test.js
@@ -1,0 +1,203 @@
+/**
+ * Tests for src/core/screener_screens.js — active, menu_actions, save + stretch stubs.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  active,
+  menu_actions,
+  save,
+  list,
+  switchTo,
+  save_as,
+  remove,
+  rename,
+  createNew,
+} from '../src/core/screener_screens.js';
+
+function mockEvaluate(handler) {
+  const calls = [];
+  const fn = async (expr) => { calls.push(expr); return handler(expr, calls.length - 1); };
+  fn.calls = calls;
+  return fn;
+}
+
+// ── active() ────────────────────────────────────────────────────────────
+
+describe('screener_screens.active()', () => {
+  it('returns not-open when closed', async () => {
+    const evaluate = mockEvaluate(() => null);
+    const r = await active({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.open, false);
+  });
+
+  it('returns the current screen name', async () => {
+    const evaluate = mockEvaluate(() => ({ name: 'All stocks' }));
+    const r = await active({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.action, 'active');
+    assert.equal(r.screen, 'All stocks');
+  });
+
+  it('surfaces no_title error from probe', async () => {
+    const evaluate = mockEvaluate(() => ({ error: 'no_title' }));
+    const r = await active({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.error, 'no_title');
+  });
+});
+
+// ── menu_actions() ──────────────────────────────────────────────────────
+
+describe('screener_screens.menu_actions()', () => {
+  it('throws "not open" when screener is closed', async () => {
+    const evaluate = mockEvaluate(() => false);
+    await assert.rejects(() => menu_actions({ _deps: { evaluate } }), /not open/i);
+  });
+
+  it('returns available/disabled action split', async () => {
+    const items = [
+      { qaId: 'screener-screen-actions-save-screen', label: 'Save screen', disabled: false },
+      { qaId: 'screener-screen-actions-share-screen', label: 'Share screen', disabled: true },
+      { qaId: 'screener-screen-actions-save-screen-as', label: 'Make a copy…', disabled: false },
+      { qaId: 'screener-screen-actions-rename-screen', label: 'Rename…', disabled: true },
+    ];
+    const evaluate = mockEvaluate((expr, idx) => {
+      if (idx === 0) return true;                          // assertOpen
+      if (idx === 1) return null;                          // open menu click
+      if (idx === 2) return { items };                     // snapshot
+      if (idx === 3) return null;                          // dismiss
+      return null;
+    });
+    const r = await menu_actions({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.deepEqual(r.available, ['Save screen', 'Make a copy…']);
+    assert.deepEqual(r.disabled, ['Share screen', 'Rename…']);
+  });
+
+  it('throws descriptive error if the menu never opens', async () => {
+    const evaluate = mockEvaluate((expr, idx) => {
+      if (idx === 0) return true;
+      if (idx === 1) return null;
+      if (idx === 2) return { err: 'menu_not_found' };
+      return null;
+    });
+    await assert.rejects(() => menu_actions({ _deps: { evaluate } }), /menu_not_found/);
+  });
+});
+
+// ── save() ──────────────────────────────────────────────────────────────
+
+describe('screener_screens.save()', () => {
+  it('throws "not open" when screener is closed', async () => {
+    const evaluate = mockEvaluate(() => false);
+    await assert.rejects(() => save({ _deps: { evaluate } }), /not open/i);
+  });
+
+  it('returns saved=true when save action is clicked', async () => {
+    const evaluate = mockEvaluate((expr, idx) => {
+      if (idx === 0) return true;                   // assertOpen
+      if (idx === 1) return null;                   // open menu
+      if (idx === 2) return { clicked: true };      // click save
+      return null;
+    });
+    const r = await save({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.saved, true);
+    assert.equal(r.action, 'save');
+  });
+
+  it('returns saved=false with hint when save is disabled', async () => {
+    const evaluate = mockEvaluate((expr, idx) => {
+      if (idx === 0) return true;
+      if (idx === 1) return null;
+      if (idx === 2) return { clicked: false, reason: 'item_disabled' };
+      return null;
+    });
+    const r = await save({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.saved, false);
+    assert.equal(r.reason, 'item_disabled');
+    assert.match(r.hint, /built-in preset|unsaved changes/i);
+  });
+
+  it('returns saved=false with reason when menu item is missing', async () => {
+    const evaluate = mockEvaluate((expr, idx) => {
+      if (idx === 0) return true;
+      if (idx === 1) return null;
+      if (idx === 2) return { clicked: false, reason: 'item_not_found' };
+      return null;
+    });
+    const r = await save({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(r.saved, false);
+    assert.equal(r.reason, 'item_not_found');
+  });
+
+  it('includes "screener-screen-actions-save-screen" qa-id in the click expression', async () => {
+    const captured = [];
+    const evaluate = mockEvaluate((expr, idx) => {
+      captured.push(expr);
+      if (idx === 0) return true;
+      if (idx === 1) return null;
+      if (idx === 2) return { clicked: true };
+      return null;
+    });
+    await save({ _deps: { evaluate } });
+    // The third call is the click expression — must include the qa-id.
+    assert.ok(captured[2].includes('screener-screen-actions-save-screen'),
+      'expression references save-screen qa-id');
+    // And must use JSON-stringified form via safeString.
+    assert.ok(captured[2].includes('"screener-screen-actions-save-screen"'));
+  });
+});
+
+// ── stretch stubs ───────────────────────────────────────────────────────
+
+describe('screener_screens stretch actions', () => {
+  it('list returns not-open when closed', async () => {
+    const evaluate = mockEvaluate(() => null);
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.open, false);
+  });
+
+  it('list returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ name: 'All stocks' }));
+    const r = await list({ _deps: { evaluate } });
+    assert.equal(r.success, false);
+    assert.equal(r.error, 'not_implemented_yet');
+    assert.ok(r.hint);
+  });
+
+  it('switchTo returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ name: 'All stocks' }));
+    const r = await switchTo({ name: 'Pre-market gainers', _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+
+  it('save_as returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ name: 'All stocks' }));
+    const r = await save_as({ name: 'My screen', _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+
+  it('remove returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ name: 'All stocks' }));
+    const r = await remove({ name: 'Old screen', _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+
+  it('rename returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ name: 'All stocks' }));
+    const r = await rename({ name: 'Old', new_name: 'New', _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+
+  it('createNew returns not_implemented_yet when open', async () => {
+    const evaluate = mockEvaluate(() => ({ name: 'All stocks' }));
+    const r = await createNew({ name: 'New screen', _deps: { evaluate } });
+    assert.equal(r.error, 'not_implemented_yet');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `screener_open` / `screener_get` / `screener_status` / `screener_close` for the built-in TradingView Screener dialog, plus `screener` as a valid `ui_open_panel` target.
- Adds three action-dispatched management tools against the active screen: `screener_screens` (active/menu_actions/save), `screener_filters` (list/remove/clear), `screener_columns` (list). Modal-driven ops (switch/save_as/add filter/add column) return structured `not_implemented_yet` stubs with UI hints.
- Mirrors every MCP tool as `tv screener ...` CLI subcommands.
- Documents the surface in `CLAUDE.md` / `README.md` and updates `CONTRIBUTING.md` with current test counts and `test:offline`.

## Scope (per CONTRIBUTING.md)
- Pure UI automation over CDP against the locally running TradingView Desktop.
- No new network calls, no data caching or export, no trade execution.
- No auth or subscription bypass.

## Test plan
- [x] `npm run test:offline` passes 205/205 (61 new DI-backed screener tests)
- [x] `npm run test:screener` passes 61/61
- [x] Live smoke against BATS:AAPL covers: `tv screener active`, `menu-actions`, `filter-remove --filter "PEG"`, `filter-remove --filter "Index"` (returns `not_removable` with market-source hint), `filter-clear`, `columns`
- [x] Stretch actions return `{ success: false, error: "not_implemented_yet", hint: ... }`