### PR TITLE
fix: add missing bin entry in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {


### PR DESCRIPTION
## Summary

- Regenerated  to include the missing  field for the  CLI entry point ()
- The  entry was defined in  but absent from the lockfile, which could cause  or global installs to not register the CLI command correctly

## Test plan

- [ ] Run  fresh and verify  appears in 
- [ ] Verify  still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)