### PR TITLE
Fix Windows libuv assertion on CLI exit after fetch

### DIFF
--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -132,7 +132,10 @@ async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
     console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    // Set exitCode and let the event loop drain — avoids a Windows libuv
+    // double-close assertion when undici's fetch keepalive socket is still
+    // open at process.exit() time.
+    process.exitCode = 0;
   } catch (err) {
     handleError(err);
   }


### PR DESCRIPTION
## Summary

- Replace `process.exit(0)` with `process.exitCode = 0` on the CLI success path in `src/cli/router.js`
- Lets Node's event loop drain naturally instead of force-closing undici's fetch keepalive socket
- Fixes `tv pine check` (and any future CLI command that uses `fetch`) crashing on Windows

## The bug

On Windows, running a CLI command that makes a `fetch()` call crashes after the JSON output is printed:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

The process exits with status `0xC0000409` (`STATUS_STACK_BUFFER_OVERRUN`). This is a libuv double-close bug triggered when `process.exit()` tears down an undici keepalive socket that is still in the process of closing.

Repro on a clean Windows clone (with this branch reverted):

```bash
echo '//@version=6
indicator("test")
plot(close)' | node src/cli/index.js pine check
# → JSON printed, then: Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)
# → exit status 3221226505 (0xC0000409)
```

## The fix

Just let the event loop drain. `process.exitCode = 0` signals the desired exit status without forcing an immediate teardown; Node closes undici's socket cleanly (~150ms for the pine-facade connection) then exits 0.

Error paths still use `process.exit(1|2)` — short-circuiting on errors is still the right call there.

## Test plan

- [x] `npm run test:cli` — 13/13 pass on Windows (was 11/13; 2 pine-check tests were failing with `actual: 3221226505, expected: 0`)
- [x] `npm run test:unit` — 29/29 pass
- [x] Direct repro: `echo ... | node src/cli/index.js pine check; echo "Exit: $?"` now prints `Exit: 0`
- [x] No change on macOS/Linux expected (the libuv path that asserts on Windows doesn't trigger there)
- [x] Streaming / long-running commands unaffected (they never reach `execute`'s successful return path mid-stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)