### PR TITLE
Fix symbolInfo() throwing 'evaluate is not defined'

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -196,7 +196,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};


### PR DESCRIPTION
## Summary

Apply the DI pattern to `symbolInfo()` in `src/core/chart.js` — it was missed during the sanitization refactor in #30 and still references a bare `evaluate` identifier that doesn't exist in the module scope.

## The bug

`tv info` (CLI) and `chart_symbol_info` (MCP tool) both fail immediately:

```
$ tv info
{ "success": false, "error": "evaluate is not defined" }
```

`src/core/chart.js` imports `evaluate` as `_evaluate` and every other export resolves it through the shared `_resolve(_deps)` helper. `symbolInfo()` alone uses the bare name.

```js
// broken
export async function symbolInfo() {
  const result = await evaluate(`...`);  // ReferenceError
}
```

## The fix

Match the signature and resolution pattern used by `getState`, `setSymbol`, `setTimeframe`, `setType`, `getVisibleRange`, `setVisibleRange`, `scrollToDate`:

```js
export async function symbolInfo({ _deps } = {}) {
  const { evaluate } = _resolve(_deps);
  const result = await evaluate(`...`);
}
```

## Test plan

- [x] `tv info` now returns full metadata:
  ```
  { "success": true, "symbol": "BAC", "full_name": "NYSE:BAC",
    "exchange": "NYSE", "description": "Bank of America Corp",
    "type": "stock", "pro_name": "NYSE:BAC", ... }
  ```
- [x] `npm run test:unit` — 29/29 pass
- [x] `npm run test:cli` — 13/13 pass
- [x] No other call sites for `symbolInfo()` were changed — it's still invoked with no args from `src/tools/chart.js` and `src/cli/commands/chart.js`, and `{ _deps } = {}` preserves that behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)