### PR TITLE
fix(windows): support MSIX-packaged TradingView Desktop in tv_launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ TradingView Desktop must be running with Chrome DevTools Protocol enabled on por
 scripts\launch_tv_debug.bat
 ```
 
+> **Windows MSIX note:** TradingView Desktop on Windows ships as an MSIX package (even when downloaded from tradingview.com/desktop/), installed under `C:\Program Files\WindowsApps\`. The Windows sandbox blocks direct `.exe` invocation with CLI flags, so `launch_tv_debug.bat` will not find a native install. Use the MCP tool `tv_launch` instead (or your AI assistant) — it auto-detects the MSIX package and launches via `IApplicationActivationManager`, the official Microsoft COM API for activating packaged apps with arguments.
+
 **Linux:**
 ```bash
 ./scripts/launch_tv_debug_linux.sh
@@ -331,7 +333,8 @@ Launch scripts and `tv_launch` auto-detect TradingView. If auto-detection fails:
 | Platform | Common Locations |
 |----------|-----------------|
 | **Mac** | `/Applications/TradingView.app/Contents/MacOS/TradingView` |
-| **Windows** | `%LOCALAPPDATA%\TradingView\TradingView.exe`, `%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe` |
+| **Windows (legacy)** | `%LOCALAPPDATA%\TradingView\TradingView.exe`, `%PROGRAMFILES%\TradingView\TradingView.exe` |
+| **Windows (MSIX)** | Auto-detected via `Get-AppxPackage -Name TradingView.Desktop`; launched via `IApplicationActivationManager` COM API — use `tv_launch`, not `.exe` directly |
 | **Linux** | `/opt/TradingView/tradingview`, `~/.local/share/TradingView/TradingView`, `/snap/tradingview/current/tradingview` |
 
 The key flag: `--remote-debugging-port=9222`

--- a/scripts/launch_msix.ps1
+++ b/scripts/launch_msix.ps1
@@ -1,0 +1,77 @@
+# =====================================================
+#  TradingView Desktop MSIX Debug Launcher (helper)
+#  Used by src/core/health.js -> launch() on Windows
+#  when TradingView is installed as an MSIX package
+#  (Program Files\WindowsApps\), which blocks direct
+#  .exe invocation with --remote-debugging-port=<port>.
+#
+#  Launches via IApplicationActivationManager, the
+#  official Microsoft COM API for activating packaged
+#  apps with arguments.
+#
+#  Emits a single-line JSON result to stdout.
+# =====================================================
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Aumid,
+
+    [Parameter(Mandatory = $false)]
+    [int]$Port = 9222
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public class TVLauncher {
+    [ComImport]
+    [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IApplicationActivationManager {
+        int ActivateApplication(
+            [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+            int options,
+            out uint processId);
+    }
+
+    [ComImport]
+    [Guid("45ba127d-10a8-46ea-8ab7-56ea9078943c")]
+    public class ApplicationActivationManager { }
+
+    public static uint Launch(string aumid, string args) {
+        var mgr = (IApplicationActivationManager)new ApplicationActivationManager();
+        uint pid = 0;
+        int hr = mgr.ActivateApplication(aumid, args, 0, out pid);
+        if (hr != 0) {
+            throw new Exception("HRESULT=0x" + hr.ToString("X8"));
+        }
+        return pid;
+    }
+}
+"@
+
+try {
+    $launchedPid = [TVLauncher]::Launch($Aumid, "--remote-debugging-port=$Port")
+    $result = [ordered]@{
+        success = $true
+        pid     = [int]$launchedPid
+        aumid   = $Aumid
+        port    = $Port
+    }
+    $result | ConvertTo-Json -Compress
+    exit 0
+}
+catch {
+    $err = [ordered]@{
+        success = $false
+        error   = $_.Exception.Message
+        aumid   = $Aumid
+    }
+    $err | ConvertTo-Json -Compress
+    exit 1
+}

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -4,6 +4,49 @@
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
 import { existsSync } from 'fs';
 import { execSync, spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MSIX_LAUNCHER_SCRIPT = join(__dirname, '..', '..', 'scripts', 'launch_msix.ps1');
+
+// Detect MSIX TradingView install on Windows. TradingView ships its Windows
+// Desktop app as an MSIX package even from tradingview.com/desktop/, which
+// installs under C:\Program Files\WindowsApps\ where the exe cannot be
+// launched directly with --remote-debugging-port=<port> due to Windows
+// packaged-app sandbox restrictions.
+//
+// Returns { packageFamilyName, installLocation } on success, null otherwise.
+function findMsixTradingView() {
+  if (process.platform !== 'win32') return null;
+  try {
+    const cmd = 'powershell -NoProfile -Command "Get-AppxPackage -Name \'TradingView.Desktop\' | Select-Object -First 1 PackageFamilyName, InstallLocation | ConvertTo-Json -Compress"';
+    const out = execSync(cmd, { timeout: 8000, windowsHide: true }).toString().trim();
+    if (!out) return null;
+    const info = JSON.parse(out);
+    if (!info || !info.PackageFamilyName) return null;
+    return {
+      packageFamilyName: info.PackageFamilyName,
+      installLocation: info.InstallLocation || null,
+      aumid: `${info.PackageFamilyName}!TradingView.Desktop`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Launch an MSIX-packaged TradingView via IApplicationActivationManager.
+// Returns { pid, aumid, port }.
+function launchMsixTradingView({ aumid, port }) {
+  const cmd = `powershell -NoProfile -ExecutionPolicy Bypass -File "${MSIX_LAUNCHER_SCRIPT}" -Aumid "${aumid}" -Port ${port}`;
+  const out = execSync(cmd, { timeout: 15000, windowsHide: true }).toString().trim();
+  const result = JSON.parse(out);
+  if (!result.success) {
+    throw new Error(`MSIX launch failed: ${result.error || 'unknown'}`);
+  }
+  return { pid: result.pid, aumid: result.aumid, port: result.port };
+}
 
 export async function healthCheck() {
   await getClient();
@@ -207,7 +250,11 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
-  if (!tvPath) {
+  // Windows: if no native .exe was found, TradingView may be installed as an
+  // MSIX packaged app. Detect via Get-AppxPackage and launch via COM.
+  const msix = !tvPath ? findMsixTradingView() : null;
+
+  if (!tvPath && !msix) {
     throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
   }
 
@@ -219,8 +266,19 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* may not be running */ }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
-  child.unref();
+  let pid, launchMethod, binary;
+  if (msix) {
+    const res = launchMsixTradingView({ aumid: msix.aumid, port: cdpPort });
+    pid = res.pid;
+    launchMethod = 'msix';
+    binary = msix.aumid;
+  } else {
+    const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
+    child.unref();
+    pid = child.pid;
+    launchMethod = 'native';
+    binary = tvPath;
+  }
 
   for (let i = 0; i < 15; i++) {
     await new Promise(r => setTimeout(r, 1000));
@@ -236,7 +294,7 @@ export async function launch({ port, kill_existing } = {}) {
       if (ready) {
         const info = JSON.parse(ready);
         return {
-          success: true, platform, binary: tvPath, pid: child.pid,
+          success: true, platform, launch_method: launchMethod, binary, pid,
           cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
           browser: info.Browser, user_agent: info['User-Agent'],
         };
@@ -245,7 +303,7 @@ export async function launch({ port, kill_existing } = {}) {
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform, launch_method: launchMethod, binary, pid, cdp_port: cdpPort, cdp_ready: false,
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
 }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -140,14 +140,47 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
     });
 
     it('tv_launch — auto-detect binary (verify path resolution only)', async () => {
-      // tv_launch is destructive (kills TradingView), so we only test path detection
+      // tv_launch is destructive (kills TradingView), so we only verify that
+      // *some* install is discoverable on this platform — legacy binary, or
+      // (Windows only) an MSIX package.
       const { existsSync } = await import('fs');
-      const paths = [
-        '/Applications/TradingView.app/Contents/MacOS/TradingView',
-        `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
-      ];
-      const found = paths.some(p => existsSync(p));
-      assert.ok(found, 'TradingView binary found on disk');
+      const { execSync } = await import('child_process');
+      const platform = process.platform;
+
+      const candidatePaths = {
+        darwin: [
+          '/Applications/TradingView.app/Contents/MacOS/TradingView',
+          `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
+        ],
+        win32: [
+          `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
+          `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
+          `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+        ],
+        linux: [
+          '/opt/TradingView/tradingview',
+          '/opt/TradingView/TradingView',
+          `${process.env.HOME}/.local/share/TradingView/TradingView`,
+          '/usr/bin/tradingview',
+          '/snap/tradingview/current/tradingview',
+        ],
+      };
+
+      const paths = candidatePaths[platform] || candidatePaths.linux;
+      let found = paths.some(p => p && existsSync(p));
+
+      // Windows: also accept MSIX packaged install (now supported by launch()).
+      if (!found && platform === 'win32') {
+        try {
+          const out = execSync(
+            'powershell -NoProfile -Command "Get-AppxPackage -Name TradingView.Desktop | Select -First 1 -ExpandProperty PackageFamilyName"',
+            { timeout: 8000, windowsHide: true }
+          ).toString().trim();
+          if (out) found = true;
+        } catch { /* ignore */ }
+      }
+
+      assert.ok(found, `TradingView install not found on ${platform}`);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds Windows MSIX support to `tv_launch` so it works on the current TradingView Desktop distribution without external scripts.

TradingView Desktop on Windows now ships **exclusively as an MSIX package** — even when downloaded from tradingview.com/desktop/ (not Microsoft Store). MSIX apps install under `C:\Program Files\WindowsApps\` where Windows blocks direct `.exe` invocation with command-line arguments for security reasons. This means the existing logic in `launch()`:

```js
spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, ... })
```

silently fails on every current Windows install — the `.exe` path isn't even discoverable since the scanned paths (`%LOCALAPPDATA%\TradingView`, `%PROGRAMFILES%\TradingView`) no longer exist. Users see `tv_health_check` → *CDP fetch failed* and MCP servers marked disconnected.

## The fix

Use Microsoft's official `IApplicationActivationManager` COM API, which is the sanctioned way to activate packaged apps with arguments. The flag goes through the sandbox cleanly.

- **`findMsixTradingView()`** — detects the TradingView.Desktop MSIX package via `Get-AppxPackage` and returns the package family name + AUMID.
- **`launchMsixTradingView()`** — invokes a parametrized PowerShell helper (`scripts/launch_msix.ps1`) that activates via COM and returns JSON with the process ID.
- **`launch()`** — tries legacy native paths first (no change for users on older installs), falls back to MSIX only when nothing is found. Return object gains `launch_method: 'native' | 'msix'` for observability.
- **e2e test** — the `tv_launch — auto-detect binary` test previously only looked at hardcoded Mac paths and failed on any Windows machine. Now platform-aware and accepts MSIX package presence as a valid discovery result.
- **README** — adds an MSIX note to the Windows quick-start and the install-location table. Keeps the existing `launch_tv_debug.bat` docs but flags that it won't find MSIX installs and points users at `tv_launch` instead.

## Verified locally

Windows 11 Home, TradingView Desktop 3.0.0 MSIX (PackageFamilyName `TradingView.Desktop_n534cwy3pjxzj`, Electron 38.2.2, Chrome 140.0.7339):

```jsonc
// tv_launch via MCP — zero external scripts, zero permission prompts
{
  \"success\": true,
  \"platform\": \"win32\",
  \"launch_method\": \"msix\",
  \"binary\": \"TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop\",
  \"pid\": 19136,
  \"cdp_port\": 9222,
  \"cdp_url\": \"http://localhost:9222\",
  \"browser\": \"Chrome/140.0.7339.133\",
  \"user_agent\": \"... TradingView/3.0.0 ... Electron/38.2.2 ...\"
}
```

`npm test` — `tv_launch — auto-detect binary (verify path resolution only)` now passes on Windows (was failing before this PR on non-Mac). Rest of e2e suite unaffected by this change.

## Design notes

- **Why a separate `.ps1` instead of inline PowerShell?** The COM activation requires an `Add-Type` C# block. Inline-escaping that through `execSync` + cmd is fragile (quote hell, encoding). A parametrized `.ps1` stays readable, is greppable by users, and keeps the Node code tiny.
- **Why fall back to MSIX, not try it first?** Preserves existing behavior for anyone still on a legacy native install (though those are rare in 2026).
- **Security considerations:** `IApplicationActivationManager` is an OS-provided COM interface — no third-party deps. The only argument passed is `--remote-debugging-port=<port>`, same flag the existing native path uses. No new attack surface.
- **Prior art:** @emremigh published a [working MSIX launcher](https://github.com/emremigh/tradingview-mcp-windows-msix-fix) as an external fix. This PR brings that approach into the core `tv_launch` tool so users don't need a separate script.

## Test plan

- [x] `npm test` — previously failing `tv_launch` test now passes on Windows
- [x] Live `tv_launch` MCP call on Windows 11 MSIX install → CDP ready in a single call
- [ ] Reviewer verification on a native Windows install (legacy path unchanged, should be a no-op)
- [ ] Reviewer verification on macOS / Linux (MSIX branch is win32-only, should be a no-op)

## Fixes

- Closes #14 (Windows App)
- Closes #23 (launch_tv_debug.bat doesn't detect Appx/WindowsApps installs)
- Closes #42 (Windows MSIX: CDP fails with --remote-debugging-port)