### PR TITLE
Fix: draw_clear, draw_list, draw_remove_one, draw_get_properties were…

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -45,8 +45,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
 }
 
 export async function listDrawings() {
-  const apiPath = await getChartApi();
-  const shapes = await evaluate(`
+  const apiPath = await _getChartApi();
+  const shapes = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var all = api.getAllShapes();
@@ -57,8 +57,8 @@ export async function listDrawings() {
 }
 
 export async function getProperties({ entity_id }) {
-  const apiPath = await getChartApi();
-  const result = await evaluate(`
+  const apiPath = await _getChartApi();
+  const result = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -86,8 +86,8 @@ export async function getProperties({ entity_id }) {
 }
 
 export async function removeOne({ entity_id }) {
-  const apiPath = await getChartApi();
-  const result = await evaluate(`
+  const apiPath = await _getChartApi();
+  const result = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -107,7 +107,7 @@ export async function removeOne({ entity_id }) {
 }
 
 export async function clearAll() {
-  const apiPath = await getChartApi();
-  await evaluate(`${apiPath}.removeAllShapes()`);
+  const apiPath = await _getChartApi();
+  await _evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };
 }


### PR DESCRIPTION
## Problem

`src/core/drawing.js` imports its dependencies with underscore-prefixed aliases (`evaluate as _evaluate`, `getChartApi as _getChartApi`) for the DI pattern used by `drawShape`. But four sibling functions — `listDrawings`, `getProperties`, `removeOne`, and `clearAll` — still call the bare names `getChartApi()` and `evaluate()`, which don't exist in scope. Calling any of these throws:

```
ReferenceError: getChartApi is not defined
```

## Reproduction

```
draw_clear  → error: "getChartApi is not defined"
draw_list   → same
draw_remove_one → same
draw_get_properties → same
draw_shape  → works (uses the _resolve(deps) pattern correctly)
```

## Fix

Rename the bare references in the four affected functions to use the imported aliases. `drawShape` is unchanged. Minimal surgical change: 8 insertions / 8 deletions.

## Why existing tests didn't catch this

`drawing.js` currently has no direct test coverage in the `npm test` suite (pine_analyze / cli / e2e don't invoke these paths). I verified the module loads and the fixed functions execute without the ReferenceError.

## Scope

Bug fix only. No public API changes. No behavior change beyond fixing the crash. Single-concern per CONTRIBUTING.md.