### PR TITLE
Fix Windows launch script for MSIX / Microsoft Store TradingView installs

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -1,33 +1,46 @@
 @echo off
+setlocal
 REM Launch TradingView Desktop on Windows with Chrome DevTools Protocol enabled
+REM Handles both standalone (%LOCALAPPDATA%\TradingView) and MSIX / Microsoft
+REM Store installs under %PROGRAMFILES%\WindowsApps.
 REM Usage: scripts\launch_tv_debug.bat [port]
 
-set PORT=%1
-if "%PORT%"=="" set PORT=9222
+set "PORT=%1"
+if "%PORT%"=="" set "PORT=9222"
 
 REM Kill existing TradingView instances
 taskkill /F /IM TradingView.exe >nul 2>&1
-timeout /t 2 /nobreak >nul
+REM Use ping as a sleep — works in both cmd.exe and cmd-under-bash
+ping -n 3 127.0.0.1 >nul
 
-REM Auto-detect TradingView install location
+REM --- Detect install ------------------------------------------------------
 set "TV_EXE="
+set "TV_IS_MSIX="
 
-REM Check common install locations
+REM 1) Standard Electron installer locations
 if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%\TradingView\TradingView.exe"
-if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
-if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
+if not defined TV_EXE if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
+if not defined TV_EXE if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
-if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
-)
-if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
+REM 2) MSIX / Store install — WindowsApps is ACL-protected so `dir` and
+REM    direct `start` both fail. Use PowerShell Get-AppxPackage instead.
+if not defined TV_EXE (
+    for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name '*TradingView*' | Select-Object -First 1 -ExpandProperty InstallLocation) 2>$null"`) do (
+        if exist "%%i\TradingView.exe" (
+            set "TV_EXE=%%i\TradingView.exe"
+            set "TV_IS_MSIX=1"
+        )
+    )
 )
 
-if "%TV_EXE%"=="" (
+REM 3) PATH fallback
+if not defined TV_EXE (
+    for /f "usebackq delims=" %%i in (`where TradingView.exe 2^>nul`) do set "TV_EXE=%%i"
+)
+
+if not defined TV_EXE (
     echo Error: TradingView not found.
-    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps
+    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps ^(Get-AppxPackage^), PATH
     echo.
     echo If installed elsewhere, run manually:
     echo   "C:\path\to\TradingView.exe" --remote-debugging-port=%PORT%
@@ -35,17 +48,39 @@ if "%TV_EXE%"=="" (
 )
 
 echo Found TradingView at: %TV_EXE%
+if defined TV_IS_MSIX echo Install type: MSIX / Microsoft Store
+
+REM --- Launch --------------------------------------------------------------
+REM cmd's `start` fails on WindowsApps exes with "Access is denied" because
+REM the AppContainer loader requires MSIX activation. PowerShell Start-Process
+REM uses ShellExecute, which activates the package correctly and preserves
+REM argv (including --remote-debugging-port). Use it for MSIX installs;
+REM standard installs also work fine via the same path, so use it always.
 echo Starting with --remote-debugging-port=%PORT%...
-start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+powershell -NoProfile -Command "Start-Process -FilePath '%TV_EXE%' -ArgumentList '--remote-debugging-port=%PORT%'"
+if errorlevel 1 (
+    echo Error: Failed to launch TradingView via PowerShell Start-Process.
+    exit /b 1
+)
 
+REM --- Wait for CDP --------------------------------------------------------
 echo Waiting for CDP to become available...
-timeout /t 5 /nobreak >nul
+ping -n 6 127.0.0.1 >nul
 
+set /a WAIT_ATTEMPTS=0
 :check
 curl -s http://localhost:%PORT%/json/version >nul 2>&1
 if %errorlevel% neq 0 (
-    echo Still waiting...
-    timeout /t 2 /nobreak >nul
+    set /a WAIT_ATTEMPTS+=1
+    if %WAIT_ATTEMPTS% geq 30 (
+        echo.
+        echo Error: CDP did not come up on port %PORT% within ~65s.
+        echo If you just installed TradingView, open it once manually, sign in,
+        echo then re-run this script.
+        exit /b 1
+    )
+    echo Still waiting... ^(%WAIT_ATTEMPTS%/30^)
+    ping -n 3 127.0.0.1 >nul
     goto check
 )
 
@@ -53,3 +88,4 @@ echo.
 echo CDP ready at http://localhost:%PORT%
 curl -s http://localhost:%PORT%/json/version
 echo.
+endlocal


### PR DESCRIPTION
## Problem

`scripts/launch_tv_debug.bat` doesn't work when TradingView Desktop is installed from the Microsoft Store (MSIX). On an affected machine:

```
$ scripts\launch_tv_debug.bat
Error: TradingView not found.
```

…even though TradingView is installed at
`C:\Program Files\WindowsApps\TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj\TradingView.exe`.

Two independent failures combine:

1. **Detection.** The existing MSIX probe uses `dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe"`. `WindowsApps` is ACL-protected by TrustedInstaller, so an unelevated `dir` returns no results and the script falls through to "not found".
2. **Launch.** Even when given the correct path, `cmd`'s `start "" "<WindowsApps path>"` returns `Access is denied` — MSIX apps run under an AppContainer that requires activation via the shell/MSIX loader, not a raw `CreateProcess`.

There's also a myth-trap worth calling out: the conclusion "MSIX strips argv, you need the non-Store installer" is wrong. MSIX honors argv fine — but only when the app is activated through `ShellExecute` (which is what `Start-Process` uses).

## Fix

- **Detect via `Get-AppxPackage`** — works without elevation, returns the install location directly from the MSIX database.
- **Launch via PowerShell `Start-Process`** — uses `ShellExecute`, properly activates the MSIX package, and preserves argv (including `--remote-debugging-port=9222`). Used for both MSIX and standalone installs since it works for both.
- **Bounded CDP wait** (30 attempts / ~65s) instead of the previous infinite loop, with a helpful message if the app never opens.
- **Shell-agnostic sleeps** — `ping -n N 127.0.0.1 >nul` instead of `timeout /t N /nobreak >nul`. `timeout` errors out when the .bat runs under `cmd`-under-git-bash; `ping` works in both contexts.
- Prints `Install type: MSIX / Microsoft Store` when applicable, so users can tell at a glance which code path fired.

## Testing

Verified end-to-end on the affected machine (TradingView Desktop 3.0.0.7652, Windows 11, MSIX install):

```
Found TradingView at: C:\Program Files\WindowsApps\TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj\TradingView.exe
Install type: MSIX / Microsoft Store
Starting with --remote-debugging-port=9222...
Waiting for CDP to become available...

CDP ready at http://localhost:9222
{
   "Browser": "Chrome/140.0.7339.133",
   "User-Agent": "... TradingView/3.0.0 ... Electron/38.2.2 ... TVDesktop/3.0.0",
   "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser/..."
}
```

`tv status` against the resulting CDP session returns `cdp_connected: true` with the expected chart state; `tv quote` returns live OHLCV.

`npm run test:unit` shows 27/29 pass on this branch — the 2 failures (`cli.test.js` "pine check (server compile)" cases at lines 133 and 142) also fail identically on `main` and are network-dependent on TradingView's Pine server-compile endpoint. Not introduced by this PR. This PR is Windows-script-only — no JS runtime code changes.

## Out of scope

Not changing the Mac / Linux launch scripts or any source under `src/`. Happy to update `SETUP_GUIDE.md` / `README.md` in a follow-up to reflect that MSIX installs are now supported out of the box, if you'd like that in this PR instead.