### PR TITLE
fix: TV Desktop 3.1.0 compat for data.trades / data.strategy / data.equity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,13 +43,27 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 
 ### "Work on Pine Script"
 1. `pine_set_source` → inject code into editor
-2. `pine_smart_compile` → compile with auto-detection + error check
+2. `pine_smart_compile` → compile with auto-detection + error check. Pass `target: "save" | "add_to_chart" | "save_and_add"` to force the button choice (default = legacy heuristic).
 3. `pine_get_errors` → read compilation errors
 4. `pine_get_console` → read log.info() output
 5. `pine_get_source` → read current code back (WARNING: can be very large for complex scripts)
 6. `pine_save` → save to TradingView cloud
 7. `pine_new` → create blank indicator/strategy/library
 8. `pine_open` → load a saved script by name
+9. `pine_add_to_chart` → click Add-to-Chart and **confirm** study was replaced (polls study list). Use after editing a script that's already on the chart — `pine_smart_compile` may default to Save and leave the chart bound to old code.
+10. `pine_save_and_add_to_chart` → compound (save + dialog dismiss + add-to-chart) in a single round-trip.
+11. `chart_replace_study` → compound: re-add a Pine script with input overrides applied to the new study (eliminates "settings reset to defaults on re-add" friction).
+
+### "Profile a Pine script's execution cost"
+1. `pine_open` (or `pine_set_source` + `pine_smart_compile`) → load the script
+2. `pine_profiler_enable` → toggle TV's Profiler Mode on (idempotent)
+3. (let the script run / scroll bars so timings populate)
+4. `pine_profiler_get_data` with `top_n: 10` → per-line ms / pct, sorted hottest-first
+5. `pine_profiler_disable` → leave editor in pre-enable state
+6. If get_data returns empty, `pine_profiler_probe` dumps DOM landscape so selectors can be updated
+
+### "Did the script hit a runtime warning (timeout, max bars, loop limit)?"
+- `pine_runtime_warnings` → reads the chart pane for warning/error banners (e.g., "script takes too long, 40s limit"). Pure read. Distinct from `pine_get_errors` (compile markers) and `pine_get_console` (log output) — those don't capture runtime overlay banners.
 
 ### "Practice trading with replay"
 1. `replay_start` with `date: "2025-03-01"` → enter replay mode

--- a/README.md
+++ b/README.md
@@ -274,15 +274,60 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | Tool | Step |
 |------|------|
 | `pine_set_source` | 1. Inject code into editor |
-| `pine_smart_compile` | 2. Compile with auto-detection + error check |
+| `pine_smart_compile` | 2. Compile with auto-detection + error check (pass `target: "save" \| "add_to_chart" \| "save_and_add"` to override the heuristic) |
 | `pine_get_errors` | 3. Read compilation errors if any |
 | `pine_get_console` | 4. Read log.info() output |
 | `pine_save` | 5. Save to TradingView cloud |
+| `pine_add_to_chart` | Click Add-to-Chart and **confirm** study was replaced (polls study list). Use after editing a script that's already on the chart. |
+| `pine_save_and_add_to_chart` | Compound: save + dismiss save dialog + add-to-chart, single round-trip |
 | `pine_get_source` | Read current script (**warning: can be 200KB+ for complex scripts**) |
 | `pine_new` | Create blank indicator/strategy/library |
 | `pine_open` / `pine_list_scripts` | Open or list saved scripts |
 | `pine_analyze` | Offline static analysis (no chart needed) |
 | `pine_check` | Server-side compile check (no chart needed) |
+| `chart_replace_study` | Compound: re-add a Pine script with input overrides applied to the new study (`pine_open` → `pine_add_to_chart` → `indicator_set_inputs` in one round-trip). |
+
+### Pine Profiler
+
+Drives TradingView's built-in Pine Profiler UI (Pine Editor → "..." menu → Developer Tools → Profiler Mode) so agents can measure per-line execution cost. Useful for diagnosing scripts approaching TV's 40-second per-execution wall-clock limit.
+
+| Tool | What it does |
+|------|--------------|
+| `pine_profiler_enable` | Toggle Profiler Mode on for the open script (idempotent) |
+| `pine_profiler_disable` | Toggle Profiler Mode off (idempotent) |
+| `pine_profiler_get_data` | Read per-line metrics from the panel; pass `top_n` to limit output |
+| `pine_runtime_warnings` | Read runtime warning/error banners on the chart (40s timeout, max bars back, loop limit). Pure read. |
+| `pine_profiler_probe` | Dump DOM around the profiler — for debugging when selectors drift |
+
+Example workflow (CLI):
+
+```bash
+tv pine open "vse_parity_probe_1m"
+tv profiler enable
+# wait for the script to execute / scroll some bars
+tv profiler get --top 10
+tv profiler warnings        # check for "script takes too long" runtime banner
+tv profiler disable
+```
+
+Example workflow (MCP, conceptual):
+
+```jsonc
+// 1. Enable
+{"tool": "pine_profiler_enable"}
+// → { "success": true, "was_already_enabled": false, "panel_visible": true }
+
+// 2. Read top-10 hottest lines
+{"tool": "pine_profiler_get_data", "args": {"top_n": 10}}
+// → { "success": true, "total_execution_ms": 18723.4, "bar_count": 2880,
+//     "lines": [ {"line": 263, "ms": 4012.1, "pct": 21.4, "raw": "..."}, ... ] }
+
+// 3. Disable when done
+{"tool": "pine_profiler_disable"}
+// → { "success": true, "was_already_disabled": false }
+```
+
+If `pine_profiler_get_data` returns no rows, run `pine_profiler_probe` — it dumps the relevant DOM landscape (panel anchors, menu items, Monaco state) so selectors in `src/core/profiler.js` can be updated against whatever TradingView shipped most recently.
 
 ### Replay Mode
 
@@ -306,7 +351,7 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `batch_run` | Run action across multiple symbols/timeframes |
 | `watchlist_get` / `watchlist_add` | Read/modify watchlist |
 | `layout_list` / `layout_switch` | Manage saved layouts |
-| `ui_open_panel` / `ui_click` / `ui_evaluate` | UI automation |
+| `ui_open_panel` / `ui_click` / `ui_evaluate` | UI automation. `ui_click` accepts `event_chain: "minimal" \| "full"` (default minimal — opt into full for stubborn buttons). |
 | `tv_launch` / `tv_health_check` / `tv_discover` | Connection management |
 
 ## Context Management

--- a/agents/performance-analyst.md
+++ b/agents/performance-analyst.md
@@ -17,6 +17,12 @@ Use these TradingView MCP tools:
 4. `chart_get_state` — get current symbol, timeframe, studies
 5. `capture_screenshot` — capture the chart and strategy tester
 
+### Performance / runtime health
+
+If the strategy is slow, near TV's 40s execution wall-clock, or showing intermittent stalls, also pull:
+6. `pine_runtime_warnings` — pure read; surfaces TV's overlay banners (execution_timeout, max_bars_back, loop_limit, memory_limit, etc.). A non-zero `warning_count` means TV throttled or aborted the script — your performance metrics may be incomplete or misleading.
+7. `pine_profiler_enable` → `pine_profiler_get_data` (top_n: 10) → `pine_profiler_disable` — per-line cost (% of total). Returns `ms: null` (TV's profiler DOM only renders %, not absolute ms); the % distribution is what matters for finding hot lines. The strategy must be on the chart and have run recently.
+
 ## Analysis Framework
 
 Evaluate the strategy on:

--- a/skills/pine-develop/SKILL.md
+++ b/skills/pine-develop/SKILL.md
@@ -65,7 +65,18 @@ Common Pine Script errors:
 After clean compilation:
 1. `capture_screenshot` — take a screenshot to verify it looks right
 2. `data_get_strategy_results` — if it's a strategy, check performance
-3. Show the user the results
+3. `pine_runtime_warnings` — confirm no runtime banners (execution_timeout, max_bars_back, loop_limit). A `warning_count > 0` means the script compiled but is hitting a TV runtime limit; metrics in step 2 may be incomplete.
+4. Show the user the results
+
+## Step 6b: Profile if slow or near limits (optional)
+
+If step 3 reported `execution_timeout`, the script is visibly slow on high-tick instruments, or the user explicitly asks for performance analysis:
+
+1. `pine_profiler_enable` — toggle TV's Profiler Mode on
+2. Wait ~5–10 s for timings to populate
+3. `pine_profiler_get_data` with `top_n: 10` — per-line cost as % of total (TV does not expose absolute ms; only relative % + a visual bar)
+4. `pine_profiler_disable` — restore pre-profiler state
+5. Report the hottest lines back to the user with file:line refs so they can target the optimization
 
 ## Step 7: Iterate
 

--- a/src/cli/commands/chart.js
+++ b/src/cli/commands/chart.js
@@ -71,6 +71,17 @@ register('scroll', {
   },
 });
 
+register('replace-study', {
+  description: 'Re-add a Pine script with optional input overrides (compound, single round-trip)',
+  options: {
+    inputs: { type: 'string', short: 'i', description: 'JSON string of input overrides, e.g. \'{"length": 50}\'' },
+  },
+  handler: (opts, positionals) => {
+    if (!positionals[0]) throw new Error('Script name required. Usage: tv replace-study "vse_parity_probe_1m" --inputs \'{"emaLen": 5}\'');
+    return core.replaceStudy({ script_name: positionals.join(' '), inputs: opts.inputs });
+  },
+});
+
 register('discover', {
   description: 'Report which TradingView API paths are available',
   handler: () => healthCore.discover(),

--- a/src/cli/commands/pine.js
+++ b/src/cli/commands/pine.js
@@ -33,8 +33,25 @@ register('pine', {
       },
     }],
     ['compile', {
-      description: 'Smart compile: detect button, compile, check errors',
-      handler: () => core.smartCompile(),
+      description: 'Smart compile: detect button, compile, check errors. --target save|add_to_chart|save_and_add overrides heuristic',
+      options: {
+        target: { type: 'string', short: 't', description: 'Force button choice: save | add_to_chart | save_and_add' },
+      },
+      handler: (opts) => core.smartCompile({ target: opts.target }),
+    }],
+    ['add-to-chart', {
+      description: 'Click Add-to-Chart and confirm study replacement',
+      options: {
+        name: { type: 'string', short: 'n', description: 'Optional script_name to track study_id before/after' },
+      },
+      handler: (opts) => core.addToChart({ script_name: opts.name }),
+    }],
+    ['save-and-add', {
+      description: 'Save then Add-to-Chart (compound, single round-trip)',
+      options: {
+        name: { type: 'string', short: 'n', description: 'Optional script_name to track study_id before/after' },
+      },
+      handler: (opts) => core.saveAndAddToChart({ script_name: opts.name }),
     }],
     ['raw-compile', {
       description: 'Click compile/add button without smart detection',

--- a/src/cli/commands/profiler.js
+++ b/src/cli/commands/profiler.js
@@ -1,0 +1,36 @@
+import { register } from '../router.js';
+import * as core from '../../core/profiler.js';
+
+register('profiler', {
+  description: 'Pine Profiler tools',
+  subcommands: new Map([
+    ['enable', {
+      description: 'Enable Pine Profiler mode (idempotent)',
+      handler: () => core.enableProfiler(),
+    }],
+    ['disable', {
+      description: 'Disable Pine Profiler mode (idempotent)',
+      handler: () => core.disableProfiler(),
+    }],
+    ['get', {
+      description: 'Read profiler data (per-line ms / pct, sorted hottest-first)',
+      options: {
+        top: { type: 'string', short: 't', description: 'Return only the top N most expensive lines' },
+      },
+      handler: (opts) => core.getProfilerData({
+        top_n: opts.top !== undefined ? Number(opts.top) : undefined,
+      }),
+    }],
+    ['warnings', {
+      description: 'Read runtime warning/error banners on the chart (e.g., 40s timeout)',
+      options: {
+        severity: { type: 'string', short: 's', description: 'Filter: all | warning | error (default all)' },
+      },
+      handler: (opts) => core.getRuntimeWarnings({ severity_filter: opts.severity }),
+    }],
+    ['probe', {
+      description: 'Dump DOM landscape around the profiler — for selector debugging',
+      handler: () => core.probeProfilerDom(),
+    }],
+  ]),
+});

--- a/src/cli/commands/ui.js
+++ b/src/cli/commands/ui.js
@@ -9,8 +9,9 @@ register('ui', {
       options: {
         by: { type: 'string', short: 'b', description: 'Selector: aria-label, data-name, text, class-contains' },
         value: { type: 'string', short: 'v', description: 'Value to match' },
+        chain: { type: 'string', short: 'c', description: 'Event chain: minimal (default) | full — use full for stubborn buttons' },
       },
-      handler: (opts) => core.click({ by: opts.by || 'text', value: opts.value }),
+      handler: (opts) => core.click({ by: opts.by || 'text', value: opts.value, event_chain: opts.chain }),
     }],
     ['keyboard', {
       description: 'Press a keyboard key or shortcut',

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -14,6 +14,7 @@ import './commands/health.js';
 import './commands/chart.js';
 import './commands/data.js';
 import './commands/pine.js';
+import './commands/profiler.js';
 import './commands/capture.js';
 import './commands/replay.js';
 import './commands/drawing.js';

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,6 +115,72 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
+/**
+ * Compound: re-add a Pine script to the chart with optional input overrides
+ * applied to the new study in a single round-trip. Eliminates the
+ * "settings reset to defaults on re-add" friction.
+ *
+ *   1. Open the named Pine script in the editor (loads cloud source via pine-facade)
+ *   2. Click Add-to-Chart and poll chart state until the running study is replaced
+ *   3. Apply `inputs` to the new study via the same path as indicator_set_inputs
+ */
+export async function replaceStudy({ script_name, inputs: inputsRaw, _deps }) {
+  if (!script_name) throw new Error('script_name is required');
+  const { evaluate } = _resolve(_deps);
+
+  const inputs = inputsRaw
+    ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw)
+    : null;
+
+  // Step 1+2 live in pine.js — import lazily to avoid circular dep at module load
+  const pine = await import('./pine.js');
+  await pine.openScript({ name: script_name });
+  // Brief settle so editor binds source before we click add-to-chart
+  await new Promise(r => setTimeout(r, 400));
+  const addResult = await pine.addToChart({ script_name });
+
+  let inputs_applied = null;
+  let inputs_error = null;
+  if (inputs && typeof inputs === 'object' && Object.keys(inputs).length > 0 && addResult.study_id_after) {
+    try {
+      const inputsJson = JSON.stringify(inputs);
+      const result = await evaluate(`
+        (function() {
+          var chart = ${CHART_API};
+          var study = chart.getStudyById(${safeString(addResult.study_id_after)});
+          if (!study) return { error: 'Study not found post-replace: ' + ${safeString(addResult.study_id_after)} };
+          var currentInputs = study.getInputValues();
+          var overrides = ${inputsJson};
+          var updated = {};
+          for (var i = 0; i < currentInputs.length; i++) {
+            if (overrides.hasOwnProperty(currentInputs[i].id)) {
+              currentInputs[i].value = overrides[currentInputs[i].id];
+              updated[currentInputs[i].id] = overrides[currentInputs[i].id];
+            }
+          }
+          study.setInputValues(currentInputs);
+          return { updated_inputs: updated };
+        })()
+      `);
+      if (result?.error) inputs_error = result.error;
+      else inputs_applied = result.updated_inputs;
+    } catch (err) {
+      inputs_error = err.message;
+    }
+  }
+
+  return {
+    success: addResult.success && !inputs_error,
+    script_name,
+    study_id_before: addResult.study_id_before,
+    study_id_after: addResult.study_id_after,
+    study_replaced: addResult.study_replaced,
+    inputs_applied,
+    inputs_error,
+    elapsed_ms: addResult.elapsed_ms,
+  };
+}
+
 export async function getVisibleRange() {
   const result = await evaluate(`
     (function() {

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -172,11 +172,13 @@ export async function replaceStudy({ script_name, inputs: inputsRaw, _deps }) {
   return {
     success: addResult.success && !inputs_error,
     script_name,
+    button_clicked: addResult.button_clicked || null,
     study_id_before: addResult.study_id_before,
     study_id_after: addResult.study_id_after,
     study_replaced: addResult.study_replaced,
     inputs_applied,
     inputs_error,
+    add_to_chart_error: addResult.error || null,
     elapsed_ms: addResult.elapsed_ms,
   };
 }

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -132,20 +132,64 @@ export async function getIndicator({ entity_id }) {
   return { success: true, entity_id, visible: data?.visible, inputs };
 }
 
+// Identify the chart's user strategy source.
+//
+// TV Desktop 3.1.0 exposes overlay strategies with `metaInfo().is_price_study: true`
+// — the old filter `is_price_study === false` misidentifies them. The authoritative
+// marker is `metaInfo().id` starting with `StrategyScript` (e.g.
+// "StrategyScript$USER;<uuid>@tv-scripts"). We prefer that marker and fall back
+// to the legacy filter for older TV builds.
+const FIND_STRATEGY_SRC = `
+  function __findStrategy(sources) {
+    for (var i = 0; i < sources.length; i++) {
+      var s = sources[i];
+      try {
+        var id = s.metaInfo && (s.metaInfo() || {}).id;
+        if (id && /^StrategyScript/.test(String(id))) return s;
+      } catch(e) {}
+    }
+    // Legacy TV fallback
+    for (var j = 0; j < sources.length; j++) {
+      var t = sources[j];
+      try {
+        if (t.metaInfo && t.metaInfo().is_price_study === false &&
+            (t.ordersData || t.reportData || t._reportData)) return t;
+      } catch(e) {}
+    }
+    return null;
+  }
+`;
+
 export async function getStrategyResults() {
   const results = await evaluate(`
     (function() {
       try {
+        ${FIND_STRATEGY_SRC}
         var chart = ${CHART_API}._chartWidget;
         var sources = chart.model().model().dataSources();
-        var strat = null;
-        for (var i = 0; i < sources.length; i++) {
-          var s = sources[i];
-          if (s.metaInfo && s.metaInfo().is_price_study === false && (s.reportData || s.performance)) { strat = s; break; }
-        }
+        var strat = __findStrategy(sources);
         if (!strat) return {metrics: {}, source: 'internal_api', error: 'No strategy found on chart. Add a strategy indicator first.'};
         var metrics = {};
-        if (strat.reportData) {
+        // TV 3.1.0+: _reportData.performance is where metrics actually live.
+        if (strat._reportData && strat._reportData.performance) {
+          var perf1 = strat._reportData.performance;
+          for (var k1 in perf1) {
+            var v1 = perf1[k1];
+            if (v1 === null || v1 === undefined) continue;
+            if (typeof v1 === 'object') {
+              for (var k2 in v1) {
+                var v2 = v1[k2];
+                if (v2 !== null && v2 !== undefined && typeof v2 !== 'object' && typeof v2 !== 'function') {
+                  metrics[k1 + '.' + k2] = v2;
+                }
+              }
+            } else if (typeof v1 !== 'function') {
+              metrics[k1] = v1;
+            }
+          }
+        }
+        // Legacy paths (older TV)
+        if (Object.keys(metrics).length === 0 && strat.reportData) {
           var rd = typeof strat.reportData === 'function' ? strat.reportData() : strat.reportData;
           if (rd && typeof rd === 'object') {
             if (typeof rd.value === 'function') rd = rd.value();
@@ -169,24 +213,56 @@ export async function getTrades({ max_trades } = {}) {
   const trades = await evaluate(`
     (function() {
       try {
+        ${FIND_STRATEGY_SRC}
         var chart = ${CHART_API}._chartWidget;
         var sources = chart.model().model().dataSources();
-        var strat = null;
-        for (var i = 0; i < sources.length; i++) {
-          var s = sources[i];
-          if (s.metaInfo && s.metaInfo().is_price_study === false && (s.ordersData || s.reportData)) { strat = s; break; }
-        }
+        var strat = __findStrategy(sources);
         if (!strat) return {trades: [], source: 'internal_api', error: 'No strategy found on chart.'};
+
+        // TV 3.1.0+: _reportData.trades is the canonical closed-trade-pair list.
+        // Each entry: {e: entry, x: exit, q, tp, cp, rn, dd} with nested {v, p}.
+        if (strat._reportData && Array.isArray(strat._reportData.trades)) {
+          var rtrades = strat._reportData.trades;
+          var flat = [];
+          var cap = Math.min(rtrades.length, ${limit});
+          for (var t = 0; t < cap; t++) {
+            var tr = rtrades[t];
+            if (!tr) continue;
+            var e = tr.e || {}, x = tr.x || {};
+            flat.push({
+              entry_order_id: e.c || null,
+              entry_price: e.p,
+              entry_time_ms: e.tm,
+              entry_type: e.tp,
+              exit_order_id: x.c || null,
+              exit_price: x.p,
+              exit_time_ms: x.tm,
+              exit_type: x.tp,
+              quantity: tr.q,
+              pnl: tr.tp ? tr.tp.v : null,
+              pnl_pct: tr.tp ? tr.tp.p : null,
+              cum_pnl: tr.cp ? tr.cp.v : null,
+              cum_pnl_pct: tr.cp ? tr.cp.p : null,
+              runup: tr.rn ? tr.rn.v : null,
+              runup_pct: tr.rn ? tr.rn.p : null,
+              drawdown: tr.dd ? tr.dd.v : null,
+              drawdown_pct: tr.dd ? tr.dd.p : null
+            });
+          }
+          return {trades: flat, source: 'internal_api', total_trade_count: rtrades.length};
+        }
+
+        // Legacy TV fallback
         var orders = null;
         if (strat.ordersData) { orders = typeof strat.ordersData === 'function' ? strat.ordersData() : strat.ordersData; if (orders && typeof orders.value === 'function') orders = orders.value(); }
         if (!orders || !Array.isArray(orders)) {
           if (strat._orders) orders = strat._orders;
           else if (strat.tradesData) { orders = typeof strat.tradesData === 'function' ? strat.tradesData() : strat.tradesData; if (orders && typeof orders.value === 'function') orders = orders.value(); }
         }
-        if (!orders || !Array.isArray(orders)) return {trades: [], source: 'internal_api', error: 'ordersData() returned non-array.'};
+        if (!orders || !Array.isArray(orders)) return {trades: [], source: 'internal_api', error: 'no trade data (_reportData.trades or ordersData).'};
         var result = [];
-        for (var t = 0; t < Math.min(orders.length, ${limit}); t++) {
-          var o = orders[t];
+        for (var t2 = 0; t2 < Math.min(orders.length, ${limit}); t2++) {
+          var o = orders[t2];
           if (typeof o === 'object' && o !== null) {
             var trade = {};
             var okeys = Object.keys(o);
@@ -198,22 +274,29 @@ export async function getTrades({ max_trades } = {}) {
       } catch(e) { return {trades: [], source: 'internal_api', error: e.message}; }
     })()
   `);
-  return { success: true, trade_count: trades?.trades?.length || 0, source: trades?.source, trades: trades?.trades || [], error: trades?.error };
+  return { success: true, trade_count: trades?.trades?.length || 0, total_trade_count: trades?.total_trade_count, source: trades?.source, trades: trades?.trades || [], error: trades?.error };
 }
 
 export async function getEquity() {
   const equity = await evaluate(`
     (function() {
       try {
+        ${FIND_STRATEGY_SRC}
         var chart = ${CHART_API}._chartWidget;
         var sources = chart.model().model().dataSources();
-        var strat = null;
-        for (var i = 0; i < sources.length; i++) {
-          var s = sources[i];
-          if (s.metaInfo && s.metaInfo().is_price_study === false && (s.reportData || s.performance)) { strat = s; break; }
-        }
+        var strat = __findStrategy(sources);
         if (!strat) return {data: [], source: 'internal_api', error: 'No strategy found on chart.'};
         var data = [];
+        // TV 3.1.0+: _reportData.buyHold holds per-bar equity points
+        if (strat._reportData && Array.isArray(strat._reportData.buyHold)) {
+          var bh = strat._reportData.buyHold;
+          for (var bi = 0; bi < bh.length; bi++) {
+            var bv = bh[bi];
+            if (typeof bv === 'number') data.push({index: bi, value: bv});
+            else if (bv && typeof bv === 'object') data.push(Object.assign({index: bi}, bv));
+          }
+          if (data.length) return {data: data, source: 'internal_api'};
+        }
         if (strat.equityData) {
           var eq = typeof strat.equityData === 'function' ? strat.equityData() : strat.equityData;
           if (eq && typeof eq.value === 'function') eq = eq.value();

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -3,7 +3,57 @@
  * All functions accept plain options objects and return plain JS objects.
  * They throw on error (callers catch and format).
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
+
+const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function snapshotStudies() {
+  return await evaluate(`
+    (function() {
+      try {
+        var chart = ${CHART_API};
+        return chart.getAllStudies().map(function(s) { return { id: s.id, name: s.name || s.title || 'unknown' }; });
+      } catch(e) { return []; }
+    })()
+  `) || [];
+}
+
+async function dismissSaveConfirmDialog() {
+  return await evaluate(`
+    (function() {
+      var btns = document.querySelectorAll('button');
+      for (var i = 0; i < btns.length; i++) {
+        var b = btns[i];
+        if (b.offsetParent === null) continue;
+        var text = (b.textContent || '').trim();
+        if (/discard|don'?t save|open anyway|skip/i.test(text)) {
+          var parent = b.closest('[class*="dialog"], [class*="modal"], [class*="popup"], [role="dialog"]');
+          if (parent) { b.click(); return true; }
+        }
+      }
+      return false;
+    })()
+  `);
+}
+
+function detectStudyReplacement(before, after, scriptName) {
+  if (before.length !== after.length) return true;
+  if (scriptName) {
+    const b = before.find(s => s.name === scriptName);
+    const a = after.find(s => s.name === scriptName);
+    if (b && a && b.id !== a.id) return true;
+    if (!b && a) return true;
+    if (b && !a) return true;
+    return false;
+  }
+  const beforeIds = new Set(before.map(s => s.id));
+  const afterIds = new Set(after.map(s => s.id));
+  for (const id of afterIds) if (!beforeIds.has(id)) return true;
+  for (const id of beforeIds) if (!afterIds.has(id)) return true;
+  return false;
+}
 
 // ── Monaco finder (injected into TV page) ──
 const FIND_MONACO = `
@@ -426,9 +476,13 @@ export async function getConsole() {
   return { success: true, entries: entries || [], entry_count: entries?.length || 0 };
 }
 
-export async function smartCompile() {
+export async function smartCompile({ target } = {}) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
+
+  if (target && !['save', 'add_to_chart', 'save_and_add'].includes(target)) {
+    throw new Error(`Invalid target: ${target}. Must be one of: save, add_to_chart, save_and_add.`);
+  }
 
   const studiesBefore = await evaluate(`
     (function() {
@@ -440,28 +494,66 @@ export async function smartCompile() {
     })()
   `);
 
+  const targetJson = JSON.stringify(target || null);
   const buttonClicked = await evaluate(`
     (function() {
+      var target = ${targetJson};
       var btns = document.querySelectorAll('button');
-      var addBtn = null;
-      var updateBtn = null;
-      var saveBtn = null;
+      var addBtn = null, updateBtn = null, saveBtn = null, saveAndAddBtn = null;
       for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (/save and add to chart/i.test(text)) {
-          btns[i].click();
-          return 'Save and add to chart';
-        }
+        if (btns[i].offsetParent === null) continue;
+        var text = (btns[i].textContent || '').trim();
+        if (!saveAndAddBtn && /save and add to chart/i.test(text)) saveAndAddBtn = btns[i];
         if (!addBtn && /^add to chart$/i.test(text)) addBtn = btns[i];
         if (!updateBtn && /^update on chart$/i.test(text)) updateBtn = btns[i];
-        if (!saveBtn && btns[i].className.indexOf('saveButton') !== -1 && btns[i].offsetParent !== null) saveBtn = btns[i];
+        if (!saveBtn && btns[i].className.indexOf('saveButton') !== -1) saveBtn = btns[i];
       }
+      // Explicit-target routing
+      if (target === 'save') {
+        if (saveBtn) { saveBtn.click(); return 'Pine Save'; }
+        return null;
+      }
+      if (target === 'add_to_chart') {
+        if (addBtn) { addBtn.click(); return 'Add to chart'; }
+        if (updateBtn) { updateBtn.click(); return 'Update on chart'; }
+        return null;
+      }
+      if (target === 'save_and_add') {
+        if (saveAndAddBtn) { saveAndAddBtn.click(); return 'Save and add to chart'; }
+        // Compound fallback: click save then add (handled in JS-side step below — we just click save here)
+        if (saveBtn) { saveBtn.click(); return 'Pine Save (compound step 1)'; }
+        return null;
+      }
+      // Default heuristic (backward compat)
+      if (saveAndAddBtn) { saveAndAddBtn.click(); return 'Save and add to chart'; }
       if (addBtn) { addBtn.click(); return 'Add to chart'; }
       if (updateBtn) { updateBtn.click(); return 'Update on chart'; }
       if (saveBtn) { saveBtn.click(); return 'Pine Save'; }
       return null;
     })()
   `);
+
+  // For save_and_add, if the single Save+Add button wasn't found we clicked Save first;
+  // now dismiss the save-confirm dialog and click Add to chart in a second step.
+  if (target === 'save_and_add' && buttonClicked && /compound step 1/.test(buttonClicked)) {
+    await sleep(800);
+    await dismissSaveConfirmDialog();
+    await sleep(300);
+    await evaluate(`
+      (function() {
+        var btns = document.querySelectorAll('button');
+        for (var i = 0; i < btns.length; i++) {
+          if (btns[i].offsetParent === null) continue;
+          var text = (btns[i].textContent || '').trim();
+          if (/^add to chart$/i.test(text) || /^update on chart$/i.test(text)) {
+            btns[i].click();
+            return text;
+          }
+        }
+        return null;
+      })()
+    `);
+  }
 
   if (!buttonClicked) {
     const c = await getClient();
@@ -586,6 +678,133 @@ export async function openScript({ name }) {
   }
 
   return { success: true, name: result.name, script_id: result.id, lines: result.lines, source: 'internal_api', opened: true };
+}
+
+/**
+ * Click Add-to-Chart for the currently open Pine script and confirm replacement
+ * by polling chart.getAllStudies(). Distinct from `compile`/`smartCompile`:
+ * this guarantees the running study is rebound to the latest compiled source,
+ * not just saved to the cloud.
+ *
+ * Returns:
+ *   { success, button_clicked, study_id_before, study_id_after, study_replaced, elapsed_ms }
+ */
+export async function addToChart({ script_name } = {}) {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor.');
+
+  const start = Date.now();
+  const studiesBefore = await snapshotStudies();
+
+  // Pre-click cleanup: dismiss any lingering save-confirm dialog
+  await dismissSaveConfirmDialog();
+  await sleep(200);
+
+  const clicked = await evaluate(`
+    (function() {
+      var btns = document.querySelectorAll('button');
+      for (var i = 0; i < btns.length; i++) {
+        if (btns[i].offsetParent === null) continue;
+        var text = (btns[i].textContent || '').trim();
+        if (/save and add to chart/i.test(text)) { btns[i].click(); return text; }
+      }
+      for (var j = 0; j < btns.length; j++) {
+        if (btns[j].offsetParent === null) continue;
+        var t2 = (btns[j].textContent || '').trim();
+        if (/^add to chart$/i.test(t2) || /^update on chart$/i.test(t2)) { btns[j].click(); return t2; }
+      }
+      return null;
+    })()
+  `);
+
+  if (!clicked) {
+    return {
+      success: false,
+      error: 'No Add-to-Chart / Update-on-Chart / Save-and-Add button found',
+      study_id_before: script_name ? (studiesBefore.find(s => s.name === script_name)?.id || null) : null,
+      study_id_after: null,
+      study_replaced: false,
+      elapsed_ms: Date.now() - start,
+    };
+  }
+
+  // Post-click: dismiss any confirmation/warning dialog (e.g., "Save before adding")
+  await sleep(500);
+  await dismissSaveConfirmDialog();
+
+  // Poll for study replacement
+  const MAX_POLL_MS = 5000;
+  const POLL_INTERVAL_MS = 250;
+  let studiesAfter = studiesBefore;
+  let study_replaced = false;
+  const pollEnd = Date.now() + MAX_POLL_MS;
+  while (Date.now() < pollEnd) {
+    await sleep(POLL_INTERVAL_MS);
+    studiesAfter = await snapshotStudies();
+    if (detectStudyReplacement(studiesBefore, studiesAfter, script_name)) {
+      study_replaced = true;
+      break;
+    }
+  }
+
+  const study_id_before = script_name ? (studiesBefore.find(s => s.name === script_name)?.id || null) : null;
+  const study_id_after = script_name
+    ? (studiesAfter.find(s => s.name === script_name)?.id || null)
+    : (studiesAfter.find(s => !studiesBefore.some(b => b.id === s.id))?.id || null);
+
+  return {
+    success: true,
+    button_clicked: clicked,
+    script_name: script_name || null,
+    study_id_before,
+    study_id_after,
+    study_replaced,
+    elapsed_ms: Date.now() - start,
+  };
+}
+
+/**
+ * Compound: Save then Add-to-Chart, in a single MCP round-trip. Equivalent to
+ * smartCompile({ target: 'save_and_add' }) but returns study replacement
+ * confirmation instead of just button-click telemetry.
+ */
+export async function saveAndAddToChart({ script_name } = {}) {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor.');
+
+  const start = Date.now();
+  const studiesBefore = await snapshotStudies();
+
+  // Save first
+  const c = await getClient();
+  await c.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 2, key: 's', code: 'KeyS', windowsVirtualKeyCode: 83 });
+  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 's', code: 'KeyS' });
+  await sleep(800);
+
+  // Confirm Save dialog if shown
+  await evaluate(`
+    (function() {
+      var btns = document.querySelectorAll('button');
+      for (var i = 0; i < btns.length; i++) {
+        if (btns[i].offsetParent === null) continue;
+        var text = (btns[i].textContent || '').trim();
+        if (text === 'Save') {
+          var parent = btns[i].closest('[class*="dialog"], [class*="modal"], [class*="popup"], [role="dialog"]');
+          if (parent) { btns[i].click(); return true; }
+        }
+      }
+      return false;
+    })()
+  `);
+  await sleep(500);
+
+  // Then Add-to-Chart with replacement polling
+  const addResult = await addToChart({ script_name });
+  return {
+    ...addResult,
+    save_step: 'completed',
+    elapsed_ms: Date.now() - start,
+  };
 }
 
 export async function listScripts() {

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -700,6 +700,15 @@ export async function addToChart({ script_name } = {}) {
   await dismissSaveConfirmDialog();
   await sleep(200);
 
+  // TradingView's Pine Editor exposes the "add to chart" action differently
+  // depending on layout:
+  //   - Bottom-dock layout (older default): a labeled button "Save and add to chart",
+  //     "Add to chart", or "Update on chart" sits next to Save in the toolbar.
+  //   - Side-panel layout (newer/detached): no labeled button — saving the script
+  //     auto-binds the running study to the new compiled source. The Save button
+  //     IS the add-to-chart action in this layout.
+  // Strategy: try labeled buttons first, then fall back to dispatching Ctrl+S
+  // (which triggers the same backend save+rebind path).
   const clicked = await evaluate(`
     (function() {
       var btns = document.querySelectorAll('button');
@@ -717,15 +726,30 @@ export async function addToChart({ script_name } = {}) {
     })()
   `);
 
+  let buttonClickedLabel = clicked;
   if (!clicked) {
-    return {
-      success: false,
-      error: 'No Add-to-Chart / Update-on-Chart / Save-and-Add button found',
-      study_id_before: script_name ? (studiesBefore.find(s => s.name === script_name)?.id || null) : null,
-      study_id_after: null,
-      study_replaced: false,
-      elapsed_ms: Date.now() - start,
-    };
+    // Side-panel-layout fallback: Ctrl+S triggers TV's save+rebind flow which
+    // serves as the add-to-chart action when no labeled button is present.
+    const c = await getClient();
+    await c.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 2, key: 's', code: 'KeyS', windowsVirtualKeyCode: 83 });
+    await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 's', code: 'KeyS' });
+    buttonClickedLabel = 'Ctrl+S (side-panel layout fallback)';
+    await sleep(800);
+    // Confirm Save dialog if it appeared (new/unsaved script)
+    await evaluate(`
+      (function() {
+        var btns = document.querySelectorAll('button');
+        for (var i = 0; i < btns.length; i++) {
+          if (btns[i].offsetParent === null) continue;
+          var text = (btns[i].textContent || '').trim();
+          if (text === 'Save') {
+            var parent = btns[i].closest('[class*="dialog"], [class*="modal"], [class*="popup"], [role="dialog"]');
+            if (parent) { btns[i].click(); return true; }
+          }
+        }
+        return false;
+      })()
+    `);
   }
 
   // Post-click: dismiss any confirmation/warning dialog (e.g., "Save before adding")
@@ -754,7 +778,7 @@ export async function addToChart({ script_name } = {}) {
 
   return {
     success: true,
-    button_clicked: clicked,
+    button_clicked: buttonClickedLabel,
     script_name: script_name || null,
     study_id_before,
     study_id_after,

--- a/src/core/profiler.js
+++ b/src/core/profiler.js
@@ -1,0 +1,572 @@
+/**
+ * Pine Profiler core logic.
+ *
+ * The Pine Profiler is a TradingView UI feature (Pine Editor → "..." menu →
+ * Developer Tools → Profiler Mode) that overlays per-line execution metrics
+ * on the editor and renders a side panel with cost rows. There is no public
+ * Pine API for the profiler — these tools drive the UI via CDP and read
+ * rendered DOM.
+ *
+ * Selector strategy: TradingView ships UI changes frequently. Each step
+ * (open menu, click item, parse rows) tries multiple selector patterns
+ * before giving up, and `probeProfilerDom` exposes the raw landscape so
+ * humans can adapt selectors after a TV release without code spelunking.
+ */
+import { evaluate } from '../connection.js';
+import { ensurePineEditorOpen } from './pine.js';
+
+const SLEEP_AFTER_MENU_OPEN_MS = 300;
+const SLEEP_AFTER_TOGGLE_MS = 900;
+const SLEEP_AFTER_DISABLE_MS = 500;
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+/**
+ * Returns true if profiler mode appears to be active.
+ *
+ * Detection is heuristic — checks (in order):
+ *   1) any visible element with data-name or class containing "profiler"
+ *   2) any menu item with role=menuitemcheckbox + aria-checked=true + text matches /profil/i
+ *   3) any visible Monaco line decoration whose class hints at execution timing
+ */
+async function isProfilerEnabled() {
+  return await evaluate(`
+    (function() {
+      var direct = document.querySelectorAll('[data-name*="profiler" i], [class*="profiler" i]');
+      for (var i = 0; i < direct.length; i++) {
+        if (direct[i].offsetParent !== null) return true;
+      }
+      var checks = document.querySelectorAll('[role="menuitemcheckbox"][aria-checked="true"], [role="menuitemradio"][aria-checked="true"]');
+      for (var j = 0; j < checks.length; j++) {
+        if (/profil/i.test(checks[j].textContent || '')) return true;
+      }
+      var monaco = document.querySelector('.monaco-editor.pine-editor-monaco');
+      if (monaco) {
+        var deco = monaco.querySelector('[class*="execution-time"], [class*="executionTime"]');
+        if (deco && deco.offsetParent !== null) return true;
+      }
+      return false;
+    })()
+  `);
+}
+
+/**
+ * Open the Pine Editor's "..." (more options) menu next to the Publish Script
+ * button. Returns { opened: bool, reason?: string }.
+ */
+async function openMoreMenu() {
+  return await evaluate(`
+    (function() {
+      function visible(el) { return el && el.offsetParent !== null; }
+
+      // 1) Highest-confidence Pine Editor selector: the next sibling button
+      // after publishButton in the editor toolbar. Tried FIRST because
+      // toolbar order (Save | Publish | "...") is fixed across TV releases,
+      // and broader [aria-label="More"] selectors match many unrelated buttons
+      // elsewhere in the page (chart More, watchlist More, etc.).
+      var pub = document.querySelector('[class*="publishButton"]');
+      if (visible(pub)) {
+        var par = pub.parentElement;
+        if (par) {
+          var sibs = par.querySelectorAll('button');
+          var pubSeen = false;
+          for (var p = 0; p < sibs.length; p++) {
+            if (sibs[p] === pub) { pubSeen = true; continue; }
+            if (pubSeen && visible(sibs[p])) {
+              sibs[p].click();
+              return { opened: true, via: 'publishButton-next-sibling' };
+            }
+          }
+        }
+      }
+
+      // 2) Named data-name / aria selectors as fallback
+      var named = [
+        '[data-name="pine-editor-more-button"]',
+        '[data-name="pineEditor-more"]',
+        '[data-name="more-button"]',
+      ];
+      for (var s = 0; s < named.length; s++) {
+        var el = document.querySelector(named[s]);
+        if (visible(el)) { el.click(); return { opened: true, via: named[s] }; }
+      }
+
+      // 2) Search inside Pine Editor / bottom-widgetbar header for kebab buttons
+      var headerSelectors = [
+        '.pine-editor-container [class*="header"]',
+        '[class*="pine-editor"] [class*="header"]',
+        '[class*="bottom-widgetbar"] [class*="header"]',
+        '[class*="bottom-widgetbar-content"]',
+      ];
+      for (var h = 0; h < headerSelectors.length; h++) {
+        var headers = document.querySelectorAll(headerSelectors[h]);
+        for (var k = 0; k < headers.length; k++) {
+          var btns = headers[k].querySelectorAll('button, [role="button"]');
+          for (var i = 0; i < btns.length; i++) {
+            var b = btns[i];
+            if (!visible(b)) continue;
+            var aria = (b.getAttribute('aria-label') || '').toLowerCase();
+            var dn = (b.getAttribute('data-name') || '').toLowerCase();
+            if (aria.indexOf('more') !== -1 || dn.indexOf('more') !== -1) {
+              b.click();
+              return { opened: true, via: 'header-aria-more' };
+            }
+          }
+        }
+      }
+
+      // 3) Last-resort: any visible aria-label "More" element inside something pine-y
+      var allMore = document.querySelectorAll('[aria-label*="More" i]');
+      for (var m = 0; m < allMore.length; m++) {
+        if (!visible(allMore[m])) continue;
+        if (allMore[m].closest('[class*="pine"], [class*="bottom-widgetbar"]')) {
+          allMore[m].click();
+          return { opened: true, via: 'fallback-more-near-pine' };
+        }
+      }
+
+      return { opened: false, reason: 'three-dot menu button not found near Pine Editor' };
+    })()
+  `);
+}
+
+/**
+ * Find the "Profiler Mode" item in the open menu, read its checked state, and
+ * optionally click it to match the requested mode.
+ *   mode = 'on'      → click only if currently unchecked
+ *   mode = 'off'     → click only if currently checked
+ *   mode = 'toggle'  → click unconditionally
+ */
+async function clickProfilerMenuItem(mode) {
+  const modeJson = JSON.stringify(mode);
+  return await evaluate(`
+    (function() {
+      var mode = ${modeJson};
+      function visible(el) { return el && el.offsetParent !== null; }
+
+      var item = null;
+      var via = null;
+
+      var roleItems = document.querySelectorAll('[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]');
+      for (var i = 0; i < roleItems.length; i++) {
+        if (!visible(roleItems[i])) continue;
+        var t = (roleItems[i].textContent || '').trim();
+        if (/profil/i.test(t) && t.length < 80) { item = roleItems[i]; via = 'role-menuitem'; break; }
+      }
+
+      if (!item) {
+        var menus = document.querySelectorAll('[class*="menu"], [class*="dropdown"], [class*="popup"]');
+        for (var mIdx = 0; mIdx < menus.length; mIdx++) {
+          if (!visible(menus[mIdx])) continue;
+          var nodes = menus[mIdx].querySelectorAll('[class*="item"], [class*="row"], button, [role="button"]');
+          for (var j = 0; j < nodes.length; j++) {
+            if (!visible(nodes[j])) continue;
+            var txt = (nodes[j].textContent || '').trim();
+            if (/profil/i.test(txt) && txt.length < 80) { item = nodes[j]; via = 'menu-class-item'; break; }
+          }
+          if (item) break;
+        }
+      }
+
+      if (!item) return { found: false };
+
+      var checked = item.getAttribute('aria-checked') === 'true';
+      if (!checked) {
+        var inner = item.querySelector('[class*="checked"], [aria-checked="true"], [class*="enabled"]');
+        if (inner) checked = true;
+      }
+
+      var shouldClick = (mode === 'toggle')
+        || (mode === 'on' && !checked)
+        || (mode === 'off' && checked);
+
+      if (shouldClick) item.click();
+
+      return { found: true, was_checked: checked, clicked: shouldClick, via: via };
+    })()
+  `);
+}
+
+/**
+ * Best-effort menu close (Escape via document body click).
+ */
+async function closeMenuFallback() {
+  await evaluate(`
+    (function() {
+      var ev = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true });
+      document.dispatchEvent(ev);
+      return true;
+    })()
+  `);
+}
+
+export async function enableProfiler() {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor or Monaco not found.');
+
+  const wasAlreadyEnabled = await isProfilerEnabled();
+  if (wasAlreadyEnabled) {
+    return { success: true, was_already_enabled: true, panel_visible: true };
+  }
+
+  const menu = await openMoreMenu();
+  if (!menu?.opened) {
+    throw new Error('Could not open Pine Editor "..." menu: ' + (menu?.reason || 'unknown'));
+  }
+  await sleep(SLEEP_AFTER_MENU_OPEN_MS);
+
+  const click = await clickProfilerMenuItem('on');
+  if (!click.found) {
+    await closeMenuFallback();
+    throw new Error('Profiler Mode menu item not found in dropdown — TradingView UI may have changed. Run pine_profiler_probe to inspect.');
+  }
+  await sleep(SLEEP_AFTER_TOGGLE_MS);
+
+  const enabled = await isProfilerEnabled();
+  return {
+    success: enabled,
+    was_already_enabled: false,
+    panel_visible: enabled,
+    menu_item_via: click.via || null,
+  };
+}
+
+export async function disableProfiler() {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor or Monaco not found.');
+
+  const wasEnabled = await isProfilerEnabled();
+  if (!wasEnabled) {
+    return { success: true, was_already_disabled: true };
+  }
+
+  const menu = await openMoreMenu();
+  if (!menu?.opened) {
+    throw new Error('Could not open Pine Editor "..." menu: ' + (menu?.reason || 'unknown'));
+  }
+  await sleep(SLEEP_AFTER_MENU_OPEN_MS);
+
+  const click = await clickProfilerMenuItem('off');
+  if (!click.found) {
+    await closeMenuFallback();
+    throw new Error('Profiler Mode menu item not found in dropdown — TradingView UI may have changed. Run pine_profiler_probe to inspect.');
+  }
+  await sleep(SLEEP_AFTER_DISABLE_MS);
+
+  const stillEnabled = await isProfilerEnabled();
+  return {
+    success: !stillEnabled,
+    was_already_disabled: false,
+  };
+}
+
+/**
+ * Read the profiler panel and return per-line metrics.
+ *
+ * The profiler renders timing data in (at least) two places:
+ *   - inline gutter decorations on Monaco lines (per-line ms / pct)
+ *   - a side panel listing the same data, often virtualized
+ *
+ * Parser tries panel rows first (they survive virtualization scrolling
+ * relative to the editor cursor), then falls back to gutter decorations.
+ */
+export async function getProfilerData({ top_n } = {}) {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor or Monaco not found.');
+
+  const enabled = await isProfilerEnabled();
+  if (!enabled) {
+    throw new Error('Profiler mode is not enabled. Call pine_profiler_enable first.');
+  }
+
+  const data = await evaluate(`
+    (function() {
+      function visible(el) { return el && el.offsetParent !== null; }
+
+      // TradingView's Pine Profiler renders per-line cost as a horizontal bar
+      // overlay column inside the editor. Each row = one code line.
+      //   - Container:    <div class="container-mXbixDKH">
+      //     <div class="content-mXbixDKH">
+      //       <div class="barContainer-mXbixDKH">  ← one per line
+      //         <div class="bar-mXbixDKH">          ← visual bar
+      //         <div class="barText-mXbixDKH">N.N% ← cost as percent (only)
+      // Line numbers come from Monaco's .line-numbers gutter; correlate by Y.
+      // TV does not render raw ms in the DOM (only percent + visual bar width);
+      // ms remains null unless we find a separate display.
+
+      var rows = [];
+      var via = null;
+
+      var bars = document.querySelectorAll('[class*="barContainer-"]');
+      var profBars = [];
+      for (var b = 0; b < bars.length; b++) {
+        if (!visible(bars[b])) continue;
+        var txtEl = bars[b].querySelector('[class*="barText-"]');
+        if (!txtEl) continue;
+        var t = (txtEl.textContent || '').trim();
+        if (!/^[\\d.,]+\\s*%$/.test(t)) continue;
+        var rect = bars[b].getBoundingClientRect();
+        var pctVal = parseFloat(t.replace(/,/g, '').replace('%',''));
+        if (isNaN(pctVal)) continue;
+        profBars.push({ y: rect.y, h: rect.height, pct: pctVal, raw: t });
+      }
+
+      if (profBars.length > 0) {
+        via = 'editor-bar-overlay';
+
+        var monaco = document.querySelector('.monaco-editor.pine-editor-monaco');
+        var lineMap = [];
+        if (monaco) {
+          var lineEls = monaco.querySelectorAll('.line-numbers');
+          for (var l = 0; l < lineEls.length; l++) {
+            if (!visible(lineEls[l])) continue;
+            var lr = lineEls[l].getBoundingClientRect();
+            var ln = parseInt((lineEls[l].textContent || '').trim(), 10);
+            if (!isNaN(ln)) lineMap.push({ y: lr.y, h: lr.height, line: ln });
+          }
+        }
+
+        function nearestLine(by) {
+          var best = null, bestDist = Infinity;
+          for (var i = 0; i < lineMap.length; i++) {
+            var d = Math.abs(lineMap[i].y - by);
+            if (d < bestDist) { bestDist = d; best = lineMap[i]; }
+          }
+          if (!best || bestDist > (best.h || 18)) return null;
+          return best.line;
+        }
+
+        for (var p2 = 0; p2 < profBars.length; p2++) {
+          var pb = profBars[p2];
+          var line = nearestLine(pb.y);
+          rows.push({ line: line, ms: null, pct: pb.pct, raw: pb.raw });
+        }
+      }
+
+      // Fallback: legacy panel-row search (kept for forward compatibility
+      // if TV adds an explicit panel layout in the future)
+      if (rows.length === 0) {
+        var panel = null;
+        var panelCandidates = document.querySelectorAll('[data-name*="profiler" i], [class*="profiler" i]');
+        for (var pc = 0; pc < panelCandidates.length; pc++) {
+          if (!visible(panelCandidates[pc])) continue;
+          if (!panel || panelCandidates[pc].getBoundingClientRect().width > panel.getBoundingClientRect().width) {
+            panel = panelCandidates[pc];
+          }
+        }
+        if (panel) {
+          var sel = '[role="row"], [class*="profiler-line"], [class*="profilerLine"], [class*="profilerRow"], [class*="profiler-row"], [class*="profiler__row"]';
+          var rowEls = panel.querySelectorAll(sel);
+          via = 'panel';
+          for (var i = 0; i < rowEls.length; i++) {
+            var rEl = rowEls[i];
+            var text = (rEl.textContent || '').trim();
+            if (!text) continue;
+            var lineMatch = text.match(/(?:line\\s+)?(\\d+)\\b/i);
+            var msMatch = text.match(/([\\d.,]+)\\s*ms/i);
+            var pctMatch = text.match(/([\\d.,]+)\\s*%/);
+            var line = lineMatch ? parseInt(lineMatch[1], 10) : null;
+            var ms = msMatch ? parseFloat(msMatch[1].replace(/,/g, '')) : null;
+            var pct = pctMatch ? parseFloat(pctMatch[1].replace(/,/g, '')) : null;
+            if (line === null && ms === null && pct === null) continue;
+            rows.push({ line: line, ms: ms, pct: pct, raw: text.substring(0, 200) });
+          }
+        }
+      }
+
+      return {
+        rows: rows,
+        total_execution_ms: null,
+        bar_count: null,
+        parsed_via: via,
+      };
+    })()
+  `);
+
+  let lines = data?.rows || [];
+  lines.sort((a, b) => {
+    const aw = (a.ms ?? 0) || (a.pct ?? 0);
+    const bw = (b.ms ?? 0) || (b.pct ?? 0);
+    return bw - aw;
+  });
+
+  const topN = (typeof top_n === 'number' && top_n > 0) ? top_n : null;
+  if (topN !== null) lines = lines.slice(0, topN);
+
+  return {
+    success: true,
+    total_execution_ms: data?.total_execution_ms ?? null,
+    bar_count: data?.bar_count ?? null,
+    parsed_via: data?.parsed_via ?? null,
+    line_count: lines.length,
+    lines,
+    note: lines.length === 0
+      ? 'No profiler rows parsed. Panel may be virtualized (try scrolling the panel) or DOM selectors may need updating after a TV release. Run pine_profiler_probe.'
+      : undefined,
+  };
+}
+
+/**
+ * Read TradingView runtime warning/error banners attached to the chart pane.
+ *
+ * Pine has two distinct error surfaces:
+ *   - compile-time markers → exposed by `pine_get_errors` (Monaco markers)
+ *   - log.info / compile messages → exposed by `pine_get_console`
+ *   - runtime banners (timeout, max bars back, loop limit, OOM) → THIS function
+ *
+ * Runtime banners render as overlay elements on the chart pane attached to a
+ * specific study. They survive page state across reloads and are the only
+ * indicator that a script hit TV's 40-second execution wall-clock limit.
+ *
+ * `severity_filter` ∈ { 'all', 'warning', 'error' } (default 'all').
+ */
+export async function getRuntimeWarnings({ severity_filter } = {}) {
+  const filter = (severity_filter === 'warning' || severity_filter === 'error')
+    ? severity_filter : 'all';
+  const filterJson = JSON.stringify(filter);
+
+  const result = await evaluate(`
+    (function() {
+      var filter = ${filterJson};
+      function visible(el) { return el && el.offsetParent !== null; }
+
+      var SELECTORS = [
+        '[class*="study-error"]',
+        '[class*="study-warning"]',
+        '[class*="studyError"]',
+        '[class*="studyWarning"]',
+        '[class*="runtime-error"]',
+        '[class*="runtimeError"]',
+        '[class*="error-tooltip"]',
+        '[class*="errorTooltip"]',
+        '[role="alert"]',
+        '[role="status"]',
+        '[data-name*="study-error" i]',
+        '[data-name*="study-warning" i]',
+      ];
+
+      var seen = new Set();
+      var nodes = [];
+      for (var s = 0; s < SELECTORS.length; s++) {
+        var found = document.querySelectorAll(SELECTORS[s]);
+        for (var i = 0; i < found.length; i++) {
+          if (!visible(found[i])) continue;
+          if (seen.has(found[i])) continue;
+          seen.add(found[i]);
+          nodes.push({ el: found[i], hit: SELECTORS[s] });
+        }
+      }
+
+      function classifyCode(text) {
+        var t = (text || '').toLowerCase();
+        if (/40\\s*sec|too long to execute|execution time limit/.test(t)) return 'execution_timeout';
+        if (/max[\\s_-]*bars[\\s_-]*back|bars back/.test(t)) return 'max_bars_back';
+        if (/loop|infinite/.test(t)) return 'loop_limit';
+        if (/memor|out of/.test(t)) return 'memory_limit';
+        if (/array|index/.test(t)) return 'array_error';
+        if (/division|divide/.test(t)) return 'division_error';
+        if (/na\\b|n\\/a/.test(t)) return 'na_in_function';
+        return 'unknown';
+      }
+
+      function classifySeverity(el, text) {
+        var cls = (el.className && String(el.className) || '').toLowerCase();
+        var role = (el.getAttribute && el.getAttribute('role') || '').toLowerCase();
+        if (/error/.test(cls) || role === 'alert') return 'error';
+        if (/warn/.test(cls) || role === 'status') return 'warning';
+        if (/error|fail/.test((text || '').toLowerCase())) return 'error';
+        return 'warning';
+      }
+
+      function findStudy(el) {
+        var cur = el;
+        for (var d = 0; d < 12 && cur; d++) {
+          if (cur.getAttribute) {
+            var dn = cur.getAttribute('data-name') || '';
+            var aria = cur.getAttribute('aria-label') || '';
+            if (/study/i.test(dn) && cur.textContent) return cur.getAttribute('data-study-name') || aria || null;
+          }
+          cur = cur.parentElement;
+        }
+        var hint = el.querySelector && el.querySelector('[class*="title"], [class*="study-name"]');
+        if (hint) return (hint.textContent || '').trim().substring(0, 120);
+        return null;
+      }
+
+      var warnings = [];
+      for (var n = 0; n < nodes.length; n++) {
+        var el = nodes[n].el;
+        var raw = (el.textContent || '').trim();
+        if (!raw) continue;
+
+        var sev = classifySeverity(el, raw);
+        if (filter !== 'all' && sev !== filter) continue;
+
+        var code = classifyCode(raw);
+        warnings.push({
+          severity: sev,
+          code: code,
+          message: raw.substring(0, 500),
+          study: findStudy(el),
+          matched_selector: nodes[n].hit,
+          raw: raw.substring(0, 1000),
+        });
+      }
+
+      return { warnings: warnings };
+    })()
+  `);
+
+  const warnings = result?.warnings || [];
+  return {
+    success: true,
+    severity_filter: filter,
+    warning_count: warnings.length,
+    warnings,
+    note: warnings.length === 0
+      ? 'No runtime warning banners found on the chart pane. (Compile-time errors live in pine_get_errors / pine_get_console — this tool only reads runtime overlay banners.)'
+      : undefined,
+  };
+}
+
+/**
+ * Discovery helper: dump the DOM landscape around the profiler so a human can
+ * update selectors when TradingView ships a UI change. Not meant for routine
+ * use — call when enable/disable/get_data report failure.
+ */
+export async function probeProfilerDom() {
+  return await evaluate(`
+    (function() {
+      function describe(el, max) {
+        if (!el) return null;
+        var rect = el.getBoundingClientRect();
+        return {
+          tag: el.tagName ? el.tagName.toLowerCase() : null,
+          class: el.className ? String(el.className).substring(0, 200) : null,
+          data_name: el.getAttribute ? el.getAttribute('data-name') : null,
+          aria_label: el.getAttribute ? el.getAttribute('aria-label') : null,
+          role: el.getAttribute ? el.getAttribute('role') : null,
+          text: ((el.textContent || '').trim()).substring(0, max || 80),
+          visible: el.offsetParent !== null,
+          rect: { x: rect.x, y: rect.y, w: rect.width, h: rect.height },
+        };
+      }
+      function many(sel, cap) {
+        var nodes = document.querySelectorAll(sel);
+        var out = [];
+        var lim = Math.min(nodes.length, cap || 10);
+        for (var i = 0; i < lim; i++) out.push(describe(nodes[i], 120));
+        return { selector: sel, count: nodes.length, sampled: out };
+      }
+      return {
+        profiler_anchors: many('[data-name*="profiler" i], [class*="profiler" i]', 15),
+        more_buttons: many('[aria-label*="More" i], [data-name*="more" i]', 15),
+        open_menus: many('[role="menu"], [class*="menu"][class*="open"], [class*="dropdown"][class*="open"]', 10),
+        visible_menuitems: many('[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]', 30),
+        monaco_present: !!document.querySelector('.monaco-editor.pine-editor-monaco'),
+      };
+    })()
+  `);
+}

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -3,12 +3,15 @@
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
-export async function click({ by, value }) {
+export async function click({ by, value, event_chain }) {
   const escaped = JSON.stringify(value);
+  const chain = event_chain === 'full' ? 'full' : 'minimal';
+  const chainJson = JSON.stringify(chain);
   const result = await evaluate(`
     (function() {
       var by = ${JSON.stringify(by)};
       var value = ${escaped};
+      var chain = ${chainJson};
       var el = null;
       if (by === 'aria-label') el = document.querySelector('[aria-label="' + value.replace(/"/g, '\\\\"') + '"]');
       else if (by === 'data-name') el = document.querySelector('[data-name="' + value.replace(/"/g, '\\\\"') + '"]');
@@ -20,8 +23,22 @@ export async function click({ by, value }) {
         }
       } else if (by === 'class-contains') el = document.querySelector('[class*="' + value.replace(/"/g, '\\\\"') + '"]');
       if (!el) return { found: false };
-      el.click();
-      return { found: true, tag: el.tagName.toLowerCase(), text: (el.textContent || '').trim().substring(0, 80), aria_label: el.getAttribute('aria-label') || null, data_name: el.getAttribute('data-name') || null };
+
+      if (chain === 'full') {
+        var rect = el.getBoundingClientRect();
+        var cx = rect.x + rect.width / 2;
+        var cy = rect.y + rect.height / 2;
+        var common = { bubbles: true, cancelable: true, view: window, clientX: cx, clientY: cy, button: 0 };
+        try { el.dispatchEvent(new PointerEvent('pointerdown', Object.assign({ pointerType: 'mouse' }, common))); } catch(e) {}
+        el.dispatchEvent(new MouseEvent('mousedown', common));
+        try { el.dispatchEvent(new PointerEvent('pointerup', Object.assign({ pointerType: 'mouse' }, common))); } catch(e) {}
+        el.dispatchEvent(new MouseEvent('mouseup', common));
+        el.dispatchEvent(new MouseEvent('click', common));
+      } else {
+        el.click();
+      }
+
+      return { found: true, tag: el.tagName.toLowerCase(), text: (el.textContent || '').trim().substring(0, 80), aria_label: el.getAttribute('aria-label') || null, data_name: el.getAttribute('data-name') || null, chain: chain };
     })()
   `);
   if (!result || !result.found) throw new Error('No matching element found for ' + by + '="' + value + '"');

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { registerHealthTools } from './tools/health.js';
 import { registerChartTools } from './tools/chart.js';
 import { registerPineTools } from './tools/pine.js';
+import { registerProfilerTools } from './tools/profiler.js';
 import { registerDataTools } from './tools/data.js';
 import { registerCaptureTools } from './tools/capture.js';
 import { registerDrawingTools } from './tools/drawing.js';
@@ -73,6 +74,7 @@ CONTEXT MANAGEMENT:
 registerHealthTools(server);
 registerChartTools(server);
 registerPineTools(server);
+registerProfilerTools(server);
 registerDataTools(server);
 registerCaptureTools(server);
 registerDrawingTools(server);

--- a/src/tools/chart.js
+++ b/src/tools/chart.js
@@ -39,6 +39,14 @@ export function registerChartTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
+  server.tool('chart_replace_study', 'Compound: re-add a Pine script to the chart with optional input overrides applied to the new study in a single round-trip. Eliminates the "settings reset to defaults on re-add" friction. Orchestrates: pine_open → pine_add_to_chart (with study replacement polling) → indicator_set_inputs.', {
+    script_name: z.string().describe('Name of the saved Pine script to (re-)add'),
+    inputs: z.string().optional().describe('JSON string of input overrides applied to the new study, e.g. \'{"length": 50}\''),
+  }, async ({ script_name, inputs }) => {
+    try { return jsonResult(await core.replaceStudy({ script_name, inputs })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
   server.tool('chart_get_visible_range', 'Get the visible date range (unix timestamps) and bars range on the chart', {}, async () => {
     try { return jsonResult(await core.getVisibleRange()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -35,8 +35,25 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_smart_compile', 'Intelligent compile: detects button, compiles, checks errors, reports study changes', {}, async () => {
-    try { return jsonResult(await core.smartCompile()); }
+  server.tool('pine_smart_compile', 'Intelligent compile: detects button, compiles, checks errors, reports study changes. Pass target to override the heuristic: "save" | "add_to_chart" | "save_and_add". Default keeps the legacy heuristic.', {
+    target: z.enum(['save', 'add_to_chart', 'save_and_add']).optional()
+      .describe('Force the button choice. Default = heuristic (Save+Add if available, else Add, else Update, else Save).'),
+  }, async ({ target }) => {
+    try { return jsonResult(await core.smartCompile({ target })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('pine_add_to_chart', 'Click Add-to-Chart for the currently open Pine script and confirm the running study was replaced (polls chart.getAllStudies). Use this after editing a script that is already on the chart — pine_smart_compile may default to Save and leave the running study bound to old code.', {
+    script_name: z.string().optional().describe('Optional: name of the target script if multiple studies exist. Used to compute study_id_before/after.'),
+  }, async ({ script_name }) => {
+    try { return jsonResult(await core.addToChart({ script_name })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('pine_save_and_add_to_chart', 'Compound: save the script (handling the name dialog) then click Add-to-Chart, with study-replacement polling — single round-trip for the most common edit→deploy flow.', {
+    script_name: z.string().optional().describe('Optional script name for study_id tracking'),
+  }, async ({ script_name }) => {
+    try { return jsonResult(await core.saveAndAddToChart({ script_name })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 

--- a/src/tools/profiler.js
+++ b/src/tools/profiler.js
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/profiler.js';
+
+export function registerProfilerTools(server) {
+  server.tool(
+    'pine_profiler_enable',
+    'Enable Pine Profiler mode for the currently open Pine script. Opens the editor "..." menu and toggles Profiler Mode on. Idempotent — re-calling returns was_already_enabled=true.',
+    {},
+    async () => {
+      try { return jsonResult(await core.enableProfiler()); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'pine_profiler_disable',
+    'Disable Pine Profiler mode if currently enabled. Idempotent.',
+    {},
+    async () => {
+      try { return jsonResult(await core.disableProfiler()); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'pine_profiler_get_data',
+    'Read the Pine Profiler panel and return per-line execution metrics (ms, pct of total, line number). Sorted hottest-first. Profiler must be enabled (see pine_profiler_enable). Pass top_n to limit output.',
+    {
+      top_n: z.coerce.number().int().positive().optional()
+        .describe('Return only the N most expensive lines (sorted by ms desc, then pct desc)'),
+    },
+    async ({ top_n }) => {
+      try { return jsonResult(await core.getProfilerData({ top_n })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'pine_runtime_warnings',
+    'Read TradingView runtime warning/error banners on the chart pane (e.g., "script takes too long, 40s limit", max bars back, loop limit). Distinct from pine_get_errors (compile markers) and pine_get_console (log output). Pure read, no UI mutation.',
+    {
+      severity_filter: z.enum(['all', 'warning', 'error']).optional()
+        .describe('Filter by severity (default: all)'),
+    },
+    async ({ severity_filter }) => {
+      try { return jsonResult(await core.getRuntimeWarnings({ severity_filter })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'pine_profiler_probe',
+    'Discovery tool — dump the DOM landscape around the profiler (anchors, menus, menu items) so a human can update selectors when TradingView ships a UI change. Use only when the other profiler tools report failure.',
+    {},
+    async () => {
+      try { return jsonResult({ success: true, probe: await core.probeProfilerDom() }); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+}

--- a/src/tools/ui.js
+++ b/src/tools/ui.js
@@ -3,11 +3,12 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/ui.js';
 
 export function registerUiTools(server) {
-  server.tool('ui_click', 'Click a UI element by aria-label, data-name, text content, or class substring', {
+  server.tool('ui_click', 'Click a UI element by aria-label, data-name, text content, or class substring. Default uses element.click() (works for most TV buttons in modern builds). Pass event_chain="full" to dispatch the full pointerdown→mousedown→pointerup→mouseup→click sequence for stubborn buttons with defensive React handlers.', {
     by: z.enum(['aria-label', 'data-name', 'text', 'class-contains']).describe('Selector strategy'),
     value: z.string().describe('Value to match against the chosen selector strategy'),
-  }, async ({ by, value }) => {
-    try { return jsonResult(await core.click({ by, value })); }
+    event_chain: z.enum(['minimal', 'full']).optional().describe('Click style. "minimal" (default): plain element.click(). "full": pointer + mouse event sequence — try this if a button does not respond to "minimal".'),
+  }, async ({ by, value, event_chain }) => {
+    try { return jsonResult(await core.click({ by, value, event_chain })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 


### PR DESCRIPTION
## Problem

On TV Desktop 3.1.0 (Electron 38 / Chrome 140), `data_get_trades`, `data_get_strategy_results`, and `data_get_equity` return `trade_count: 0` with `error: "No strategy found on chart"` even when a strategy is clearly attached and Strategy Tester displays thousands of trades.

## Root cause

Two assumptions in `src/core/data.js` no longer hold on TV 3.1.0:

1. **Scrapers filter sources by `metaInfo().is_price_study === false`.** TV 3.1.0 overlay strategies have `is_price_study: true`, so this filter misses them entirely.
2. **Trade / performance / equity data moved from the public `ordersData` / `reportData` / `equityData` accessors to the underscore-prefixed private `_reportData.trades` / `_reportData.performance` / `_reportData.buyHold`.**

The canonical strategy marker is now `metaInfo().id` starting with `StrategyScript` (e.g. `StrategyScript$USER;<uuid>@tv-scripts`) — that's the authoritative "this is a user strategy" flag, independent of overlay behavior.

## Fix

- Added a `__findStrategy(sources)` helper (inlined into each of the three functions' evaluate blocks): prefers the `StrategyScript` metaId marker, falls back to the legacy `is_price_study === false && (ordersData || reportData || _reportData)` filter for older TV builds.
- `getStrategyResults`: prefers `_reportData.performance`, flattens nested `all` / `long` / `short` sub-objects with dotted keys (`all.totalTrades`, `long.netProfit`, etc.). Legacy `reportData` / `performance()` paths still execute when `_reportData` is absent.
- `getTrades`: prefers `_reportData.trades`, emits a normalized shape (`entry_order_id`, `entry_price`, `entry_time_ms`, `entry_type`, `exit_*`, `quantity`, `pnl{_pct}`, `cum_pnl{_pct}`, `runup{_pct}`, `drawdown{_pct}`). Adds `total_trade_count` alongside the (limit-capped) `trade_count`. Legacy `ordersData` / `_orders` / `tradesData` path preserved.
- `getEquity`: prefers `_reportData.buyHold` per-bar equity points, falls back to legacy `equityData`.

## Verification

Tested live on **TV Desktop 3.1.0.7818** with a Bollinger Bands strategy on SPY 5m over 365 days, and with a large VSE strategy on EURUSD 1m over entire history:

| Call | Before | After |
|---|---|---|
| `data trades` | `trade_count: 0`, `error: "No strategy found on chart"` | 454 closed-trade pairs (Bollinger) / 9000 (VSE) with normalized columns |
| `data strategy` | `metric_count: 0` | 106 flattened metrics incl. `sharpeRatio`, `sortinoRatio`, `maxStrategyDrawDown`, `buyHoldReturn`, `all.totalTrades`, `all.profitFactor`, `all.winRate`, plus `long.*` / `short.*` breakdowns |
| `data equity` | `error: "No strategy found on chart"` | 9001 per-bar equity points |

No regression path tested on pre-3.1.0 TV; the legacy code paths are intact and fire when `_reportData` is absent.

## Notes for maintainers

- Zero new dependencies, zero changes to the connection layer, no schema change to tool outputs (only additive fields: `total_trade_count`, dotted-key `all.*` metrics, etc.).
- If you'd prefer the legacy flat-metric shape over dotted nesting for performance keys, happy to adjust.
- The three patched functions share the same `__findStrategy` helper inline — could be extracted to a module-level helper if you prefer, let me know.

Thanks for the excellent tool!
