### PR TITLE
fix: layout_switch dismisses unsaved-changes dialog in non-English locales

### DIFF
--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -140,14 +140,21 @@ export async function layoutSwitch({ name }) {
   `);
   if (!result?.success) throw new Error(result?.error || 'Unknown error switching layout');
 
-  // Handle "unsaved changes" confirmation dialog
+  // Handle "unsaved changes" confirmation dialog (multilingual)
   await new Promise(r => setTimeout(r, 500));
   const dismissed = await evaluate(`
     (function() {
+      // Match the "proceed / discard changes" button across locales.
+      // EN: "Open anyway", "Don't save", "Discard"
+      // PT: "Abrir mesmo assim", "Descartar", "Não salvar"
+      // ES: "Abrir de todos modos", "Descartar", "No guardar"
+      // FR: "Ouvrir quand même", "Ne pas enregistrer", "Abandonner"
+      // DE: "Trotzdem öffnen", "Nicht speichern", "Verwerfen"
+      var rx = /open anyway|don'?t save|discard|abrir mesmo|descartar|não salvar|abrir de todos|no guardar|ouvrir quand|ne pas enregistrer|abandonner|trotzdem öffnen|nicht speichern|verwerfen/i;
       var btns = document.querySelectorAll('button');
       for (var i = 0; i < btns.length; i++) {
         var text = btns[i].textContent.trim();
-        if (/open anyway|don't save|discard/i.test(text)) {
+        if (rx.test(text)) {
           btns[i].click();
           return true;
         }


### PR DESCRIPTION
## Summary

`layoutSwitch` already clicks the "proceed / discard changes" button of the TradingView "unsaved changes" confirmation dialog, but the current regex only matches the English button text (`Open anyway | Don't save | Discard`).

On a TradingView Desktop installed with a non-English locale the dialog's buttons are localized — e.g. on Portuguese (PT-BR):

> Você tem alterações não salvas. Você tem certeza que quer continuar?
> [ Cancelar ] [ **Abrir mesmo assim** ]

The regex misses the localized label, the click never fires, the dialog stays open, and every subsequent `layout_switch` is silently blocked (`unsaved_dialog_dismissed: false` in the response).

## Change

Extended the regex in `src/core/ui.js` to also match the equivalent button in Portuguese, Spanish, French, and German. English matches are unchanged. The covered strings are documented in a comment above the regex so future locales are easy to add.

## Verification

Reproduced on a PT-BR TradingView Desktop build: the dialog is now dismissed and `unsaved_dialog_dismissed: true` is returned.

## Notes

Pure regex change — no new dependencies, no API surface changes, no behaviour change for EN users. Single-file diff in `src/core/ui.js`.
