### PR TITLE
feat: make CDP host/port configurable via environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,8 +2,8 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_HOST = process.env.CDP_HOST || 'localhost';
+const CDP_PORT = parseInt(process.env.CDP_PORT || '9222', 10);
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -4,8 +4,8 @@
  */
 import { getClient, evaluate } from '../connection.js';
 
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_HOST = process.env.CDP_HOST || 'localhost';
+const CDP_PORT = parseInt(process.env.CDP_PORT || '9222', 10);
 
 /**
  * List all open chart tabs (CDP page targets).


### PR DESCRIPTION
## Summary

- `CDP_HOST` and `CDP_PORT` were hardcoded to `localhost:9222` in `src/connection.js` and `src/core/tab.js`
- When port 9222 is already occupied by another Electron/Chromium process (e.g. a headless Chrome instance, VS Code extension host, or another app), TradingView falls back to the next available port and the MCP server fails to connect
- This PR reads both values from environment variables with the existing defaults (`localhost` / `9222`), so no behaviour changes for users who don't set them

## What changed

| File | Change |
|------|--------|
| `src/connection.js` | `CDP_HOST` / `CDP_PORT` read from `process.env` with fallback defaults |
| `src/core/tab.js` | Same — tab listing also hard-coded the port independently |

## Usage after this change

Override the port without touching source files:
```bash
# CLI
CDP_PORT=9223 node src/server.js

# MCP config (e.g. ~/.claude/.mcp.json)
{
  "mcpServers": {
    "tradingview": {
      "command": "node",
      "args": ["src/server.js"],
      "env": { "CDP_PORT": "9223" }
    }
  }
}
```

## Test plan

- [ ] Default behaviour unchanged: `node src/server.js` with TradingView on port 9222 still connects
- [ ] Override works: `CDP_PORT=9223 node src/server.js` connects when TradingView is on 9223
- [ ] `tv status` returns `cdp_connected: true` in both cases
- [ ] `CDP_HOST` override works for remote/tunnelled setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
