### PR TITLE
fix: detect MSIX/WindowsApps TradingView install using PowerShell

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -16,10 +16,9 @@ REM Check common install locations
 if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
-
-REM Check MSIX / Windows Store installs
+REM Check MSIX / Windows Store installs (WindowsApps is access-restricted; use PowerShell to bypass)
 if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+    for /f "tokens=*" %%i in ('powershell -NoProfile -Command "Get-ChildItem \"$env:PROGRAMFILES\WindowsApps\" -Filter TradingView.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName" 2^>nul') do set "TV_EXE=%%i"
 )
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"


### PR DESCRIPTION
## Summary

- The existing `dir /s /b` approach for detecting MSIX/WindowsApps installs silently fails on Windows because `C:\Program Files\WindowsApps` is access-restricted for standard users
- Replaced with a `powershell Get-ChildItem` call that can traverse the restricted directory without elevated privileges
- Verified working on Windows 11 with TradingView installed as an MSIX package via Windows Store

## What changed

`scripts/launch_tv_debug.bat`: replaced `dir /s /b` WindowsApps detection with a PowerShell `Get-ChildItem` call that bypasses the directory access restriction.

## Why

On standard Windows accounts, `C:\Program Files\WindowsApps` cannot be listed with `dir`, causing MSIX detection to silently fail and the script to report TradingView as not found even when installed. PowerShell `Get-ChildItem -ErrorAction SilentlyContinue` resolves this without requiring admin rights.

## Testing

Tested on Windows 11 with TradingView Desktop installed via Windows Store (MSIX). Script now correctly detects and launches TradingView with `--remote-debugging-port=9222`.

Generated with [Claude Code](https://claude.com/claude-code)