### PR TITLE
chore(cdp): env-var overrides for TV CDP host/port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,8 +2,8 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_HOST = process.env.TV_CDP_HOST || 'localhost';
+const CDP_PORT = Number(process.env.TV_CDP_PORT) || 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -4,8 +4,8 @@
  */
 import { getClient, evaluate } from '../connection.js';
 
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_HOST = process.env.TV_CDP_HOST || 'localhost';
+const CDP_PORT = Number(process.env.TV_CDP_PORT) || 9222;
 
 /**
  * List all open chart tabs (CDP page targets).


### PR DESCRIPTION
Adds `TV_CDP_HOST` / `TV_CDP_PORT` env-var support to `src/connection.js` and `src/core/tab.js`, so the MCP can connect to a TV instance on any CDP port.

**Motivation:** Running TV on the default `:9222` clashes with other CDP-enabled processes (Chrome, etc.). Previously the only fix was patching the hardcoded port locally.

**Usage:**
```
TV_CDP_PORT=9223 node src/server.js
# connects to TV launched with --remote-debugging-port=9223
```

Backwards-compatible — defaults to `localhost:9222` when env vars are unset.