### PR TITLE
Add crypto swing-trading rules config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,19 @@
+{
+  "watchlist": {
+    "majors": ["BINANCE:BTCUSDT", "BINANCE:ETHUSDT", "BINANCE:SOLUSDT"],
+    "alts": ["BINANCE:LINKUSDT", "BINANCE:AVAXUSDT", "BINANCE:SUIUSDT"],
+    "macro": ["CRYPTOCAP:TOTAL", "CRYPTOCAP:TOTAL3", "CRYPTOCAP:BTC.D"]
+  },
+  "timeframes_to_check": ["1W", "1D", "4H"],
+  "bias_criteria": {
+    "bullish": "Price above 50D EMA, RSI on daily between 45 and 70, higher highs and higher lows on 4H",
+    "bearish": "Price below 50D EMA, RSI on daily below 45, lower highs and lower lows on 4H",
+    "neutral": "Price chopping around 50D EMA, RSI between 40 and 60, no clear structure"
+  },
+  "risk_rules": {
+    "max_risk_per_trade": "1% of portfolio",
+    "min_rr_ratio": 2,
+    "no_trades_during": ["major US CPI", "FOMC", "weekend thin liquidity"]
+  },
+  "indicators_i_care_about": ["RSI (14)", "MACD (12, 26, 9)", "50 EMA", "200 EMA", "Volume"]
+}


### PR DESCRIPTION
## Summary

- Adds `rules.json` — a crypto swing-trading configuration file with watchlist (BTC, ETH, SOL, alts, macro dominance tickers), multi-timeframe bias criteria (1W/1D/4H), risk rules (1% max risk, 2:1 min R:R), and indicator preferences
- Updates `package-lock.json` to reflect current dependency state after fresh install

## What a reviewer should know

`rules.json` is intended as a reference configuration example for users setting up the TradingView MCP for crypto trading workflows. It demonstrates how to structure a personal trading ruleset that the MCP can reference for context-aware analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)