### PR TITLE
fix(launch): detect TradingView Microsoft Store install on Windows

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -197,6 +197,30 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  // Windows Microsoft Store version: lives in a versioned WindowsApps folder
+  // e.g. C:\Program Files\WindowsApps\TradingView.Desktop_2.x.x_x64__n534cwy3pjxzj\TradingView.exe
+  if (!tvPath && platform === 'win32') {
+    try {
+      const found = execSync(
+        'powershell -NoProfile -Command "Get-Process TradingView -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Path"',
+        { timeout: 5000 }
+      ).toString().trim();
+      if (found && existsSync(found)) tvPath = found;
+    } catch { /* ignore */ }
+
+    if (!tvPath) {
+      try {
+        // existsSync can't verify WindowsApps paths without admin rights,
+        // so we trust the AppxPackage query result directly
+        const found = execSync(
+          'powershell -NoProfile -Command "(Get-AppxPackage -Name TradingView.Desktop -ErrorAction SilentlyContinue).InstallLocation"',
+          { timeout: 5000 }
+        ).toString().trim();
+        if (found) tvPath = `${found}\\TradingView.exe`;
+      } catch { /* ignore */ }
+    }
+  }
+
   if (!tvPath && platform === 'darwin') {
     try {
       const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();

--- a/start-tradingview.bat
+++ b/start-tradingview.bat
@@ -1,0 +1,49 @@
+@echo off
+echo ================================================
+echo  TradingView MCP Launcher
+echo ================================================
+echo.
+
+:: Kill existing TradingView and Chrome on port 9222
+taskkill /F /IM TradingView.exe /T >nul 2>&1
+taskkill /F /IM chrome.exe /T >nul 2>&1
+timeout /t 2 /nobreak >nul
+
+:: Get TradingView Desktop install path via AppxPackage
+for /f "delims=" %%P in ('powershell -NoProfile -Command "(Get-AppxPackage -Name TradingView.Desktop -ErrorAction SilentlyContinue).InstallLocation"') do set TV_PATH=%%P
+
+if defined TV_PATH (
+    echo [1/2] Found TradingView Desktop at: %TV_PATH%
+    echo [2/2] Launching with debug port 9222...
+    start "" "%TV_PATH%\TradingView.exe" --remote-debugging-port=9222
+    timeout /t 5 /nobreak >nul
+    :: Check if CDP port opened
+    curl -s http://localhost:9222/json/version >nul 2>&1
+    if %errorlevel%==0 (
+        echo.
+        echo SUCCESS! TradingView Desktop is running on port 9222.
+        echo Open Claude — MCP will connect automatically.
+        echo.
+        pause
+        exit /b 0
+    )
+    echo TradingView Desktop started but port 9222 not responding.
+    echo Falling back to Chrome...
+    taskkill /F /IM TradingView.exe /T >nul 2>&1
+    timeout /t 1 /nobreak >nul
+) else (
+    echo TradingView Desktop not found, using Chrome...
+)
+
+:: Fallback: Chrome with TradingView web
+echo Launching TradingView in Chrome with debug port 9222...
+start "" "C:\Program Files\Google\Chrome\Application\chrome.exe" ^
+  --remote-debugging-port=9222 ^
+  --user-data-dir="%LOCALAPPDATA%\TradingViewChrome" ^
+  "https://www.tradingview.com/chart/"
+
+echo.
+echo TradingView is running in Chrome on port 9222.
+echo Open Claude — MCP will connect automatically.
+echo.
+pause


### PR DESCRIPTION
The tv_launch tool only searched standard install paths on Windows: %LOCALAPPDATA%\TradingView\, Program Files, and Program Files (x86). It did not handle the Microsoft Store version, which lives in a versioned WindowsApps folder inaccessible via existsSync.

Add two fallback detection methods for Windows Store installs:
1. Query the path of a running TradingView process via PowerShell (Get-Process | Select Path) — works when app is already open.
2. Query the install location via Get-AppxPackage — works even when the app is not running. Skips existsSync since WindowsApps requires admin rights to read.