### PR TITLE
Add CI and agent guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  offline-checks:
+    name: Offline checks
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 20.x
+          - 22.x
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check JavaScript syntax
+        run: npm run check:syntax
+
+      - name: Run offline tests
+        run: npm run test:offline

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: node-syntax-check
+        name: node syntax check
+        entry: npm run check:syntax
+        language: system
+        pass_filenames: false
+        files: \.js$
+
+      - id: npm-offline-tests
+        name: npm offline tests
+        entry: npm run test:offline
+        language: system
+        pass_filenames: false
+        files: ^(src|tests)/.*\.js$|^package(-lock)?\.json$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# TradingView MCP — Agent Instructions
+
+Read this file before making changes, then read `CLAUDE.md` for tool-specific behavior and context management rules.
+
+## What This Repo Is
+
+`tradingview-mcp` is an MCP bridge for controlling a local TradingView Desktop chart through Chrome DevTools Protocol on port 9222. Many tools read chart state, but some can change symbols, edit Pine scripts, create alerts, enter replay mode, or launch/kill the desktop app.
+
+## Safety Rules
+
+- Do not place trades, create real alerts, save Pine scripts, or alter a user's chart layout unless the task explicitly asks for it.
+- Do not launch or kill TradingView during automated tests. Keep CI and pre-commit checks offline.
+- Do not commit screenshots, local chart state, credentials, cookies, tokens, or TradingView session data.
+- Treat `tests/e2e.test.js` and replay/UI tests as manual checks that require an intentionally prepared local TradingView session.
+- Prefer adding deterministic unit tests around parsing, validation, CLI routing, and injection-safety behavior.
+
+## Workflow
+
+- Branch from `origin/main`.
+- Keep changes small and reversible.
+- Run `npm ci` after dependency changes.
+- For routine code changes, run:
+  ```bash
+  npm run check:syntax
+  npm run test:offline
+  ```
+- Run CDP-dependent tests only when a local TradingView Desktop session is intentionally running with `--remote-debugging-port=9222`.
+
+## Pull Requests
+
+Include:
+
+- Summary of behavior changed.
+- Test plan, separating offline checks from any manual CDP checks.
+- Blast radius, especially for chart mutation, Pine, alert, replay, or launch behavior.
+- Rollback notes.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
+    "check:syntax": "find src tests -name '*.js' -print0 | xargs -0 -n1 node --check",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
+    "test:offline": "SKIP_NETWORK_TESTS=1 node --test tests/pine_analyze.test.js tests/sanitization.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
     "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
     "test:cli": "node --test tests/cli.test.js",

--- a/tests/pine_analyze.test.js
+++ b/tests/pine_analyze.test.js
@@ -8,6 +8,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
+const describeNetwork = process.env.SKIP_NETWORK_TESTS === '1' ? describe.skip : describe;
+
 // Extracted analyze function matching the tool's logic
 function analyze(source) {
   const lines = source.split('\n');
@@ -240,7 +242,7 @@ strategy.entry("Long", strategy.long)`);
   });
 });
 
-describe('pine_check — server compile', () => {
+describeNetwork('pine_check — server compile', () => {
   it('should compile valid Pine Script via TradingView API', async () => {
     const source = `//@version=6
 indicator("API Test", overlay=true)


### PR DESCRIPTION
## Summary
- add AGENTS.md with safe automation guidance for TradingView MCP agents
- add GitHub Actions CI for deterministic syntax and offline unit checks on Node 20/22
- add pre-commit hooks that mirror the safe local checks
- allow `test:offline` to skip TradingView server-compile tests via `SKIP_NETWORK_TESTS=1`

## Blast radius
- CI/pre-commit/docs/test harness only; no runtime chart-control behavior changes
- does not launch TradingView, place trades, create alerts, save Pine scripts, or touch user chart state

## Test plan
- `npm ci`
- `npm run check:syntax`
- `npm run test:offline`
- `pre-commit run --all-files`

## Rollback
- revert this PR to remove the workflow, pre-commit config, AGENTS.md, and the offline-test skip hook

## Notes
- The existing default `npm test` still includes CDP E2E and requires TradingView Desktop running on port 9222; CI intentionally avoids that path.