### PR TITLE
fix(launch): detect Windows Store (MSIX) TradingView install on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -2,7 +2,7 @@
  * Core health/discovery/launch logic.
  */
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 
 export async function healthCheck() {
@@ -173,6 +173,8 @@ export async function launch({ port, kill_existing } = {}) {
       `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
       `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
       `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      // Windows Store (MSIX) install — scan versioned package folder
+      ...(() => { try { const base = `${process.env.PROGRAMFILES}\\WindowsApps`; return readdirSync(base).filter(d => d.startsWith('TradingView.Desktop_')).map(d => `${base}\\${d}\\TradingView.exe`); } catch { return []; } })(),
     ],
     linux: [
       '/opt/TradingView/tradingview',


### PR DESCRIPTION
## Summary

- `tv_launch` on Windows only searched `LOCALAPPDATA` and `Program Files` for `TradingView.exe`, missing installations from the Microsoft Store
- The Store version installs into a versioned folder under `C:\Program Files\WindowsApps\TradingView.Desktop_<version>_x64__<id>\`
- Adds a runtime scan of `WindowsApps` for folders starting with `TradingView.Desktop_` and appends their exe paths to the Windows candidate list

## What changed

**`src/core/health.js`**
- Added `readdirSync` to the `fs` import
- Added a try/catch scan of `%PROGRAMFILES%\WindowsApps` for `TradingView.Desktop_*` folders, appending `TradingView.exe` paths to the Windows search list - silently no-ops if the folder is not accessible or the Store version is not installed

## Tested on

Windows 11 with TradingView Desktop installed via the Microsoft Store (package `TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj`). `tv_health_check` returned `cdp_connected: true` after relaunching with `--remote-debugging-port=9222`.

## Reviewer notes

The `WindowsApps` directory is ACL-protected on most machines, so the `readdirSync` call will throw for non-admin users - the `try/catch` ensures this degrades gracefully with no impact on non-Store installs.