### PR TITLE
fix(quote_get): honor symbol parameter via chart switch + restore

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -2,11 +2,18 @@
  * Core data access logic.
  */
 import { evaluate, evaluateAsync, KNOWN_PATHS, safeString } from '../connection.js';
+import { waitForChartReady } from '../wait.js';
 
 const MAX_OHLCV_BARS = 500;
 const MAX_TRADES = 20;
 const CHART_API = KNOWN_PATHS.chartApi;
 const BARS_PATH = KNOWN_PATHS.mainSeriesBars;
+
+// Serializes getQuote() calls that mutate chart symbol so concurrent callers
+// can't race over the shared chart state. JS is single-threaded but our
+// awaits interleave; without this every parallel quote_get(symbol) would
+// read whichever symbol the chart happened to be on at evaluate() time.
+let _quoteLock = Promise.resolve();
 
 function buildGraphicsJS(collectionName, mapKey, filter) {
   return `
@@ -243,38 +250,85 @@ export async function getEquity() {
 }
 
 export async function getQuote({ symbol } = {}) {
-  const data = await evaluate(`
-    (function() {
-      var api = ${CHART_API};
-      var sym = ${safeString(symbol || '')};
-      if (!sym) { try { sym = api.symbol(); } catch(e) {} }
-      if (!sym) { try { sym = api.symbolExt().symbol; } catch(e) {} }
-      var ext = {};
-      try { ext = api.symbolExt() || {}; } catch(e) {}
-      var bars = ${BARS_PATH};
-      var quote = { symbol: sym };
-      if (bars && typeof bars.lastIndex === 'function') {
-        var last = bars.valueAt(bars.lastIndex());
-        if (last) { quote.time = last[0]; quote.open = last[1]; quote.high = last[2]; quote.low = last[3]; quote.close = last[4]; quote.last = last[4]; quote.volume = last[5] || 0; }
-      }
+  // Serialize: chained on _quoteLock so parallel callers run one after another.
+  // Catch on the lock chain prevents a single failure from poisoning the chain.
+  const run = _quoteLock.then(() => _getQuoteInternal({ symbol }));
+  _quoteLock = run.then(() => {}, () => {});
+  return run;
+}
+
+async function _getQuoteInternal({ symbol } = {}) {
+  const requested = (symbol || '').toString().trim();
+  let originalSymbol = null;
+  let needsRestore = false;
+
+  if (requested) {
+    try { originalSymbol = await evaluate(`${CHART_API}.symbol()`); } catch (e) {}
+    const bare = (s) => (s || '').toString().split(':').pop().toUpperCase();
+    if (bare(originalSymbol) !== bare(requested)) {
+      needsRestore = true;
+      await evaluateAsync(`
+        (function() {
+          var chart = ${CHART_API};
+          return new Promise(function(resolve) {
+            chart.setSymbol(${safeString(requested)}, {});
+            setTimeout(resolve, 500);
+          });
+        })()
+      `);
+      await waitForChartReady(requested);
+    }
+  }
+
+  try {
+    const data = await evaluate(`
+      (function() {
+        var api = ${CHART_API};
+        var sym = '';
+        try { sym = api.symbol(); } catch(e) {}
+        if (!sym) { try { sym = api.symbolExt().symbol; } catch(e) {} }
+        var ext = {};
+        try { ext = api.symbolExt() || {}; } catch(e) {}
+        var bars = ${BARS_PATH};
+        var quote = { symbol: sym };
+        if (bars && typeof bars.lastIndex === 'function') {
+          var last = bars.valueAt(bars.lastIndex());
+          if (last) { quote.time = last[0]; quote.open = last[1]; quote.high = last[2]; quote.low = last[3]; quote.close = last[4]; quote.last = last[4]; quote.volume = last[5] || 0; }
+        }
+        try {
+          var bidEl = document.querySelector('[class*="bid"] [class*="price"], [class*="dom-"] [class*="bid"]');
+          var askEl = document.querySelector('[class*="ask"] [class*="price"], [class*="dom-"] [class*="ask"]');
+          if (bidEl) quote.bid = parseFloat(bidEl.textContent.replace(/[^0-9.\\-]/g, ''));
+          if (askEl) quote.ask = parseFloat(askEl.textContent.replace(/[^0-9.\\-]/g, ''));
+        } catch(e) {}
+        try {
+          var hdr = document.querySelector('[class*="headerRow"] [class*="last-"]');
+          if (hdr) { var hdrPrice = parseFloat(hdr.textContent.replace(/[^0-9.\\-]/g, '')); if (!isNaN(hdrPrice)) quote.header_price = hdrPrice; }
+        } catch(e) {}
+        if (ext.description) quote.description = ext.description;
+        if (ext.exchange) quote.exchange = ext.exchange;
+        if (ext.type) quote.type = ext.type;
+        return quote;
+      })()
+    `);
+    if (!data || (!data.last && !data.close)) throw new Error('Could not retrieve quote. The chart may still be loading.');
+    return { success: true, ...data };
+  } finally {
+    if (needsRestore && originalSymbol) {
       try {
-        var bidEl = document.querySelector('[class*="bid"] [class*="price"], [class*="dom-"] [class*="bid"]');
-        var askEl = document.querySelector('[class*="ask"] [class*="price"], [class*="dom-"] [class*="ask"]');
-        if (bidEl) quote.bid = parseFloat(bidEl.textContent.replace(/[^0-9.\\-]/g, ''));
-        if (askEl) quote.ask = parseFloat(askEl.textContent.replace(/[^0-9.\\-]/g, ''));
-      } catch(e) {}
-      try {
-        var hdr = document.querySelector('[class*="headerRow"] [class*="last-"]');
-        if (hdr) { var hdrPrice = parseFloat(hdr.textContent.replace(/[^0-9.\\-]/g, '')); if (!isNaN(hdrPrice)) quote.header_price = hdrPrice; }
-      } catch(e) {}
-      if (ext.description) quote.description = ext.description;
-      if (ext.exchange) quote.exchange = ext.exchange;
-      if (ext.type) quote.type = ext.type;
-      return quote;
-    })()
-  `);
-  if (!data || (!data.last && !data.close)) throw new Error('Could not retrieve quote. The chart may still be loading.');
-  return { success: true, ...data };
+        await evaluateAsync(`
+          (function() {
+            var chart = ${CHART_API};
+            return new Promise(function(resolve) {
+              chart.setSymbol(${safeString(originalSymbol)}, {});
+              setTimeout(resolve, 500);
+            });
+          })()
+        `);
+        await waitForChartReady(originalSymbol);
+      } catch (e) {}
+    }
+  }
 }
 
 export async function getDepth() {

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -35,8 +35,8 @@ export function registerDataTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('quote_get', 'Get real-time quote data for a symbol (price, OHLC, volume)', {
-    symbol: z.string().optional().describe('Symbol to quote (blank = current chart symbol)'),
+  server.tool('quote_get', 'Get real-time quote data for a symbol (price, OHLC, volume). If symbol is provided and differs from the current chart, the chart is briefly switched to fetch the quote and then restored — adds ~1-2s and serializes parallel calls.', {
+    symbol: z.string().optional().describe('Symbol to quote (blank = current chart symbol). Non-blank values cause a chart switch + restore.'),
   }, async ({ symbol }) => {
     try { return jsonResult(await core.getQuote({ symbol })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }


### PR DESCRIPTION
## Summary

`quote_get`'s `symbol` parameter was accepted but ignored for data — it was only stamped onto the returned object as a label. The IIFE always read OHLC from the active chart's `bars()`, so e.g. `quote_get('NVDA')` while the chart was on TSLA returned TSLA's OHLC with `symbol: 'NVDA'` glued on top. Calling parallel `quote_get` across many symbols therefore returned identical data for all of them.

This PR makes `quote_get` actually honor the `symbol` parameter.

## Implementation

- When a symbol is provided and differs from the current chart symbol (compared by bare ticker, after exchange prefix), `getQuote` now calls `chart.setSymbol`, awaits `waitForChartReady`, reads the quote, and restores the original symbol in a `finally` block so errors don't leave the chart on the wrong ticker.
- A module-level Promise-chain lock (`_quoteLock`) serializes parallel callers so concurrent `quote_get(A)` / `quote_get(B)` don't race over the shared chart state.
- Same-symbol calls (no switch needed) skip the switch entirely — zero added latency.
- Tool description in `tools/data.js` is updated so callers know the cross-symbol path costs ~1-2s and serializes.

## Tradeoffs

- ~1-2s overhead per cross-symbol quote (chart load + restore).
- Cross-symbol calls serialize through the lock — no parallel speedup, but data is finally correct.
- A truly non-mutating implementation exists at `_chartApiInstance._sessions.qs_snapshoter_basic-symbol-quotes_*` (TV's internal WebSocket snapshot service), but reverse-engineering its protocol is a much larger change. Left as future work.

## Test plan

- [x] Smoke test: 4 parallel `quote_get` calls (AAPL, NVDA, META, AMD) from a chart on MSFT — each returned distinct correct OHLC + description; chart restored to MSFT after.
- [x] Same-symbol fast-path: `quote_get` with the chart's current symbol returns immediately without switching.
- [x] Existing e2e tests: the embedded IIFE is unchanged in shape (only the `sym` resolution moved out, since the chart is now guaranteed to be on the right symbol when the IIFE runs); size-limit test stays under 500 bytes.
- [ ] CI on upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)