### PR TITLE
Fix ReferenceError in listDrawings/getProperties/removeOne/clearAll

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -45,8 +45,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
 }
 
 export async function listDrawings() {
-  const apiPath = await getChartApi();
-  const shapes = await evaluate(`
+  const apiPath = await _getChartApi();
+  const shapes = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var all = api.getAllShapes();
@@ -57,8 +57,8 @@ export async function listDrawings() {
 }
 
 export async function getProperties({ entity_id }) {
-  const apiPath = await getChartApi();
-  const result = await evaluate(`
+  const apiPath = await _getChartApi();
+  const result = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -86,8 +86,8 @@ export async function getProperties({ entity_id }) {
 }
 
 export async function removeOne({ entity_id }) {
-  const apiPath = await getChartApi();
-  const result = await evaluate(`
+  const apiPath = await _getChartApi();
+  const result = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -107,7 +107,7 @@ export async function removeOne({ entity_id }) {
 }
 
 export async function clearAll() {
-  const apiPath = await getChartApi();
-  await evaluate(`${apiPath}.removeAllShapes()`);
+  const apiPath = await _getChartApi();
+  await _evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };
 }


### PR DESCRIPTION
## Summary

The DI refactor in f23eb1b migrated `drawShape` to resolve `evaluate` and `getChartApi` via `_resolve(_deps)`, but left the other four exported functions in `src/core/drawing.js` calling bare `getChartApi()` and `evaluate()` — both of which were renamed to `_getChartApi` and `_evaluate` on import.

Result: `draw_list`, `draw_get_properties`, `draw_remove_one`, and `draw_clear` have been throwing `getChartApi is not defined` at the Node level since that refactor. The bug was masked because `draw_shape` (the most-used drawing tool) worked fine — only callers exercising the read/delete tools see the failure.

This patch switches the four broken functions to use the underscore-prefixed import names directly. Adopting full `_resolve(_deps)` parity would be cleaner but requires changing public signatures, so this is the minimal fix.

## How it was found

A live trading session needed `draw_list` after a `draw_shape` round-trip and got the ReferenceError. Verified the breakage is silent — `draw_shape` returns valid entity IDs even while the read/delete tools are broken, so the regression went unnoticed for ~22 days post-refactor.

Worked around in the broken session via `ui_evaluate` against `_exposed_chartWidgetCollection.activeCharWidgetModel().value().dataSources()` directly, which confirmed the chart-side API is healthy — the breakage is purely on the MCP wrapper side.

## Test plan

- [ ] `draw_shape` still creates lines and returns valid entity IDs (regression check — was the only path that worked before this fix)
- [ ] `draw_list` returns the shape array without throwing
- [ ] `draw_get_properties` returns properties for an entity ID created by `draw_shape`
- [ ] `draw_remove_one` deletes by entity ID
- [ ] `draw_clear` removes all drawings