### PR TITLE
fix: TradingView Electron 38 CDP compatibility

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -2,7 +2,7 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
-const CDP_HOST = 'localhost';
+const CDP_HOST = '127.0.0.1';
 const CDP_PORT = 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
@@ -73,9 +73,11 @@ export async function connect() {
       client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
 
       // Enable required domains
-      await client.Runtime.enable();
-      await client.Page.enable();
-      await client.DOM.enable();
+      // Note: Runtime.enable(), Page.enable(), DOM.enable() are skipped.
+      // TradingView Electron 38 doesn't respond to CDP enable() calls, but the
+      // underlying methods (Runtime.evaluate, Page.captureScreenshot, etc.) work
+      // fine without explicit enabling. This was verified via raw WebSocket testing.
+      // If Page.captureScreenshot fails in the future, re-enable Page.enable() only.
 
       return client;
     } catch (err) {
@@ -91,9 +93,14 @@ async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
   // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
-    || null;
+  const chartTarget = targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url));
+  if (chartTarget) return chartTarget;
+  // Fallback: any tradingview.com page (symbol page etc.)
+  const webTarget = targets.find(t => t.type === 'page' && /tradingview\.com/i.test(t.url));
+  if (webTarget) return webTarget;
+  // Last resort: the main TradingView app window (file:// with /window/)
+  // This covers TradingView Desktop on Mac where the chart lives in an internal webview
+  return targets.find(t => t.type === 'page' && /\/app\.asar\/app\/window\/index\.html/i.test(t.url)) || null;
 }
 
 export async function getTargetInfo() {


### PR DESCRIPTION
## Problem

TradingView Desktop 3.1.0 (Electron 38) has two CDP compatibility issues that prevent the MCP from connecting:

### 1. localhost resolves incorrectly on some Macs
 fails with connection refused, but  works fine. Verified via raw Python WebSocket testing.

### 2. CDP enable() calls hang
TradingView Electron 38 doesn't respond to `Runtime.enable()`, `Page.enable()`, or `DOM.enable()` CDP commands. This causes `chrome-remote-interface` to hang indefinitely waiting for responses. Critically, `Runtime.evaluate()` and `Page.captureScreenshot()` work perfectly without any prior `.enable()` calls — verified via direct raw WebSocket.

### 3. Target detection misses TradingView Desktop
`findChartTarget()` only looked for `tradingview.com/chart` or `tradingview.com` URLs. TradingView Desktop exposes the chart in a window target with URL `file:///Applications/TradingView.app/Contents/Resources/app.asar/app/window/index.html` — these were being skipped.

## Fixes Applied

1. **Use `127.0.0.1` instead of `localhost`**
2. **Skip all CDP `.enable()` calls** — verified working via raw WebSocket on TradingView Desktop 3.1.0
3. **Add window target fallback** — `findChartTarget()` now falls back to `/app.asar/app/window/index.html` as last resort

## Testing Done

Verified with raw Python WebSocket against TradingView Desktop 3.1.0 on macOS:
- `Runtime.evaluate('1+1')` → works without `Runtime.enable()`
- `Page.captureScreenshot()` → works without `Page.enable()`
- `window.TradingViewApi` → only accessible in chart webview, not outer window (this is a known architectural limitation of TradingView Desktop, separate from this PR)

## Breaking Change Note

These changes remove `.enable()` calls that **were required** for real Chrome/Chromium. If the MCP is used with a browser-based chart, `.enable()` may need to be conditionally re-enabled. However, the TradingView MCP is specifically designed for TradingView Desktop, so this should not be an issue in practice.