### PR TITLE
Add .claude/ to .gitignore and sync package-lock.json bin entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/current.pine
 temp_*
 *.log
 discovery-log.json
+.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {


### PR DESCRIPTION
## Summary

- Add `.claude/` to `.gitignore` — this directory is created by Claude Code and contains local session/settings files that should never be committed (analogous to `.idea/` or `.vscode/`)
- Sync `package-lock.json` with the `bin` field already declared in `package.json` — running `npm install` revealed this entry was missing from the lockfile

## Test plan

- [ ] Confirm `.claude/` no longer appears as an untracked file after `npm install` in a fresh clone
- [ ] Confirm `npm install` produces no lockfile diff on a clean checkout

🤖 Generated with [Claude Code](https://claude.ai/claude-code)