### PR TITLE
Support MSIX/Microsoft Store TradingView installs on Windows

### DIFF
--- a/scripts/launch_tv_debug.ps1
+++ b/scripts/launch_tv_debug.ps1
@@ -1,0 +1,62 @@
+# Launch TradingView Desktop on Windows with Chrome DevTools Protocol enabled.
+# Handles both classic Win32 installs and MSIX/UWP (Microsoft Store) installs.
+# Usage: powershell -ExecutionPolicy Bypass -File scripts\launch_tv_debug.ps1 [-Port 9222]
+
+param([int]$Port = 9222)
+
+$ErrorActionPreference = "Stop"
+
+function Test-Cdp {
+    param([int]$Port)
+    try {
+        $r = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/json/version" -UseBasicParsing -TimeoutSec 2
+        return $r.StatusCode -eq 200
+    } catch { return $false }
+}
+
+Get-Process -Name "TradingView*" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+
+$classic = @(
+    "$env:LOCALAPPDATA\TradingView\TradingView.exe",
+    "$env:PROGRAMFILES\TradingView\TradingView.exe",
+    "${env:PROGRAMFILES(x86)}\TradingView\TradingView.exe"
+) | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+if ($classic) {
+    Write-Host "Found classic install: $classic"
+    Start-Process -FilePath $classic -ArgumentList "--remote-debugging-port=$Port"
+} else {
+    $pkg = Get-AppxPackage -Name "TradingView.Desktop" -ErrorAction SilentlyContinue
+    if (-not $pkg) {
+        Write-Error "TradingView not found. Install from tradingview.com/desktop or Microsoft Store."
+        exit 1
+    }
+    $manifest = [xml](Get-Content (Join-Path $pkg.InstallLocation "AppxManifest.xml"))
+    $appId = $manifest.Package.Applications.Application.Id
+    $aumid = "$($pkg.PackageFamilyName)!$appId"
+    Write-Host "Found MSIX install. AUMID: $aumid"
+
+    # MSIX activation does not accept CLI args via .exe launch, but a .lnk
+    # whose TargetPath is shell:AppsFolder\<AUMID> forwards Arguments correctly.
+    $lnk = Join-Path $env:TEMP "TV_Debug_$Port.lnk"
+    $ws = New-Object -ComObject WScript.Shell
+    $sc = $ws.CreateShortcut($lnk)
+    $sc.TargetPath = "shell:AppsFolder\$aumid"
+    $sc.Arguments = "--remote-debugging-port=$Port"
+    $sc.Save()
+    Start-Process -FilePath $lnk
+}
+
+Write-Host "Waiting for CDP on port $Port..."
+$deadline = (Get-Date).AddSeconds(30)
+while ((Get-Date) -lt $deadline) {
+    if (Test-Cdp -Port $Port) {
+        Write-Host "CDP ready at http://127.0.0.1:$Port"
+        Invoke-WebRequest -Uri "http://127.0.0.1:$Port/json/version" -UseBasicParsing | Select-Object -ExpandProperty Content
+        exit 0
+    }
+    Start-Sleep -Seconds 1
+}
+Write-Error "CDP did not come up within 30s."
+exit 1

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -2,8 +2,48 @@
  * Core health/discovery/launch logic.
  */
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Locate an MSIX/Store TradingView install on Windows and return its AUMID.
+// Returns { aumid, installLocation } or null.
+function findWindowsMsixInstall() {
+  if (process.platform !== 'win32') return null;
+  try {
+    const ps = `Get-AppxPackage -Name 'TradingView*' | Select-Object -First 1 PackageFamilyName, InstallLocation | ConvertTo-Json -Compress`;
+    const out = execSync(`powershell -NoProfile -ExecutionPolicy Bypass -Command "${ps}"`, { timeout: 8000 }).toString().trim();
+    if (!out) return null;
+    const pkg = JSON.parse(out);
+    if (!pkg || !pkg.PackageFamilyName || !pkg.InstallLocation) return null;
+    const manifestRead = `[xml]$m = Get-Content -LiteralPath '${pkg.InstallLocation.replace(/'/g, "''")}\\AppxManifest.xml'; $m.Package.Applications.Application.Id`;
+    const appId = execSync(`powershell -NoProfile -ExecutionPolicy Bypass -Command "${manifestRead}"`, { timeout: 5000 }).toString().trim();
+    if (!appId) return null;
+    return { aumid: `${pkg.PackageFamilyName}!${appId}`, installLocation: pkg.InstallLocation };
+  } catch {
+    return null;
+  }
+}
+
+// Launch an MSIX-packaged app with CLI args by creating a .lnk shortcut whose
+// TargetPath is shell:AppsFolder\<AUMID> and Arguments carries the flags. This
+// is the only reliable way to pass args through the MSIX activation manager.
+function launchMsixWithArgs(aumid, args, port) {
+  const dir = join(tmpdir(), 'tradingview-mcp');
+  mkdirSync(dir, { recursive: true });
+  const lnk = join(dir, `tv_debug_${port}.lnk`);
+  const psScript = `
+    $ws = New-Object -ComObject WScript.Shell
+    $sc = $ws.CreateShortcut('${lnk.replace(/'/g, "''")}')
+    $sc.TargetPath = 'shell:AppsFolder\\${aumid}'
+    $sc.Arguments = '${args.join(' ').replace(/'/g, "''")}'
+    $sc.Save()
+    Start-Process -FilePath '${lnk.replace(/'/g, "''")}'
+  `.trim().replace(/\n\s*/g, '; ');
+  execSync(`powershell -NoProfile -ExecutionPolicy Bypass -Command "${psScript}"`, { timeout: 10000 });
+  return lnk;
+}
 
 export async function healthCheck() {
   await getClient();
@@ -207,7 +247,13 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
-  if (!tvPath) {
+  // Windows: fall back to MSIX/Store install if no classic .exe found.
+  let msix = null;
+  if (!tvPath && platform === 'win32') {
+    msix = findWindowsMsixInstall();
+  }
+
+  if (!tvPath && !msix) {
     throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
   }
 
@@ -219,15 +265,23 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* may not be running */ }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
-  child.unref();
+  let child = null;
+  let launchedVia = null;
+  if (tvPath) {
+    child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
+    child.unref();
+    launchedVia = tvPath;
+  } else {
+    launchMsixWithArgs(msix.aumid, [`--remote-debugging-port=${cdpPort}`], cdpPort);
+    launchedVia = `msix:${msix.aumid}`;
+  }
 
   for (let i = 0; i < 15; i++) {
     await new Promise(r => setTimeout(r, 1000));
     try {
       const http = await import('http');
       const ready = await new Promise((resolve) => {
-        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+        http.get(`http://127.0.0.1:${cdpPort}/json/version`, (res) => {
           let data = '';
           res.on('data', (chunk) => data += chunk);
           res.on('end', () => resolve(data));
@@ -236,8 +290,8 @@ export async function launch({ port, kill_existing } = {}) {
       if (ready) {
         const info = JSON.parse(ready);
         return {
-          success: true, platform, binary: tvPath, pid: child.pid,
-          cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
+          success: true, platform, binary: launchedVia, pid: child ? child.pid : null,
+          cdp_port: cdpPort, cdp_url: `http://127.0.0.1:${cdpPort}`,
           browser: info.Browser, user_agent: info['User-Agent'],
         };
       }
@@ -245,7 +299,7 @@ export async function launch({ port, kill_existing } = {}) {
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform, binary: launchedVia, pid: child ? child.pid : null, cdp_port: cdpPort, cdp_ready: false,
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
 }


### PR DESCRIPTION
The Windows path probes only knew about classic Win32 installs under LOCALAPPDATA / Program Files. Users who installed TradingView Desktop from the Microsoft Store get an MSIX-packaged copy under %PROGRAMFILES%\WindowsApps, which (a) `where TradingView.exe` cannot discover and (b) cannot be launched via the bare .exe path with custom CLI args because of MSIX activation restrictions.

Changes:
- After the existing path probes fail on win32, fall back to Get-AppxPackage to discover an MSIX TradingView install and resolve its AUMID from AppxManifest.xml.
- Launch MSIX-packaged TradingView through a shortcut whose TargetPath is shell:AppsFolder\<AUMID> and whose Arguments carries --remote-debugging-port. This is the only reliable mechanism to pass CLI args through the MSIX activation manager.
- Probe CDP readiness via 127.0.0.1 instead of localhost. On Windows, localhost resolves to ::1 first but Electron only binds the debug port on IPv4, causing the readiness loop to time out even when CDP is up.
- Add scripts/launch_tv_debug.ps1 as a standalone launcher that uses the same MSIX path, useful for users who want to start TradingView with CDP enabled outside of the MCP server.