### PR TITLE
feat(alerts): add alert_create_indicator for Pine alertcondition signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Gives your AI assistant eyes and hands on your own chart:
 - **Chart navigation** — change symbols, timeframes, zoom to dates, add/remove indicators
 - **Visual analysis** — read your chart's indicator values, price levels, and annotations
 - **Draw on charts** — trend lines, horizontal lines, rectangles, text annotations
-- **Manage alerts** — create, list, and delete price alerts
+- **Manage alerts** — create, list, and delete price alerts; create Pine `alertcondition()` (indicator) alerts that POST to a webhook URL on signal fire
 - **Replay practice** — step through historical bars, practice entries/exits
 - **Screenshots** — capture chart state for AI visual analysis
 - **Multi-pane layouts** — set up 2x2, 3x1, etc. grids with different symbols per pane
@@ -302,6 +302,7 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `draw_shape` | Draw horizontal_line, trend_line, rectangle, text |
 | `draw_list` / `draw_remove_one` / `draw_clear` | Manage drawings |
 | `alert_create` / `alert_list` / `alert_delete` | Manage price alerts |
+| `alert_create_indicator` | Create alerts that fire on Pine `alertcondition()` signals (strategy BUY/SELL → webhook) |
 | `capture_screenshot` | Screenshot (regions: full, chart, strategy_tester) |
 | `batch_run` | Run action across multiple symbols/timeframes |
 | `watchlist_get` / `watchlist_add` | Read/modify watchlist |

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -121,3 +121,194 @@ export async function deleteAlerts({ delete_all }) {
   }
   throw new Error('Individual alert deletion not yet supported. Use delete_all: true.');
 }
+
+const INDICATOR_DEFAULT_EXPIRATION_DAYS = 30;
+const INDICATOR_MAX_EXPIRATION_DAYS = 60;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Create an *indicator* alert that fires on a Pine `alertcondition()` signal.
+ *
+ * Companion to `create()` — where `create()` produces a price-level alert via
+ * the TV alert dialog, this posts directly to TV's REST endpoint with an
+ * `alert_cond` condition referencing a saved Pine script's plot index. The
+ * intended use is automating strategy-style Pine alerts (BUY/SELL signals
+ * piped to a webhook URL) without clicking through the UI for each one.
+ *
+ * Required arguments (caller must look these up from a saved Pine script):
+ *   - pine_id        — e.g. "USER;abc123..." (from `pine_list_scripts`)
+ *   - alert_cond_id  — e.g. "plot_12" (Pine plot index of the alertcondition)
+ *   - inputs         — input map matching the script's `input.X(...)` order:
+ *                      { in_0: ..., in_1: ..., __profile: false, pineFeatures: '...' }
+ *   - offsets_by_plot — { plot_0: 0, ..., plot_N-1: 0 } where N = the
+ *                       alert_cond_id index
+ *
+ * Optional:
+ *   - pine_version    — saved script version (default "1.0")
+ *   - symbol          — TV symbol like "OANDA:USDJPY". Defaults to active chart.
+ *   - currency        — currency-id for the symbol marker. Defaults to active chart.
+ *   - resolution      — TF like "60", "240", "D". Defaults to active chart.
+ *   - message         — alert payload. Supports {{ticker}}, {{close}} placeholders.
+ *   - web_hook        — webhook URL TV will POST the message to on fire.
+ *   - frequency       — "on_bar_close" (default), "once_per_bar", or "all".
+ *   - expiration_days — defaults to 30, capped at 60.
+ *   - active          — defaults to true.
+ *
+ * Determining `alert_cond_id` (gotcha): TV counts Pine plot-emitting calls in
+ * source order — `plot()`, `plotshape()`, `bgcolor()`, AND `alertcondition()`.
+ * `hline()` is NOT counted. So a script with 10 `plot()` + 2 `plotshape()` +
+ * 2 `alertcondition()` (BUY then SELL) yields BUY = `plot_12`, SELL = `plot_13`.
+ * Easiest discovery: create one alert manually in the TV UI, then call
+ * `alert_list` and read the resulting `alert_cond_id` plus the `inputs` /
+ * `offsets_by_plot` shape from the response.
+ *
+ * CORS note: do NOT add a Content-Type header on the fetch — a custom
+ * Content-Type triggers a preflight OPTIONS that pricealerts.tradingview.com
+ * rejects. The server happily parses the body without an explicit Content-Type.
+ */
+export async function createIndicator({
+  pine_id,
+  pine_version,
+  alert_cond_id,
+  inputs,
+  offsets_by_plot,
+  symbol,
+  currency,
+  resolution,
+  message,
+  web_hook,
+  frequency,
+  expiration_days,
+  active,
+} = {}) {
+  if (!pine_id || typeof pine_id !== 'string') {
+    return { success: false, error: 'pine_id is required (e.g. "USER;abc123..." from pine_list_scripts)', source: 'rest_api' };
+  }
+  if (!alert_cond_id || typeof alert_cond_id !== 'string') {
+    return { success: false, error: 'alert_cond_id is required (e.g. "plot_12")', source: 'rest_api' };
+  }
+  if (!inputs || typeof inputs !== 'object') {
+    return { success: false, error: 'inputs is required (object matching the script\'s input.X order)', source: 'rest_api' };
+  }
+  if (!offsets_by_plot || typeof offsets_by_plot !== 'object') {
+    return { success: false, error: 'offsets_by_plot is required (e.g. { plot_0: 0, plot_1: 0, ... })', source: 'rest_api' };
+  }
+
+  // Resolve symbol / currency / resolution from active chart if not provided.
+  let resolvedSymbol = symbol;
+  let resolvedCurrency = currency;
+  let resolvedResolution = resolution;
+
+  if (!resolvedSymbol || !resolvedCurrency || !resolvedResolution) {
+    const symbolInfo = await evaluate(`
+      (function() {
+        try {
+          var chart = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget;
+          var model = chart.model();
+          var sym = model.mainSeries().symbol();
+          var info = model.mainSeries().symbolInfo ? model.mainSeries().symbolInfo() : null;
+          return {
+            symbol: sym,
+            currency: (info && info.currency_code) || 'USD',
+            resolution: model.mainSeries().properties().interval.value() || '1'
+          };
+        } catch(e) { return { error: e.message }; }
+      })()
+    `);
+    if (!symbolInfo || symbolInfo.error || !symbolInfo.symbol) {
+      return { success: false, error: 'Could not read active chart symbol: ' + (symbolInfo?.error || 'unknown') + ' — pass symbol/currency/resolution explicitly', source: 'rest_api' };
+    }
+    resolvedSymbol = resolvedSymbol || symbolInfo.symbol;
+    resolvedCurrency = resolvedCurrency || symbolInfo.currency;
+    resolvedResolution = resolvedResolution || String(symbolInfo.resolution || '1');
+  }
+
+  const symbolMarker = '=' + JSON.stringify({
+    symbol: resolvedSymbol,
+    adjustment: 'dividends',
+    'currency-id': resolvedCurrency,
+  });
+
+  const days = Number.isFinite(Number(expiration_days)) && Number(expiration_days) > 0
+    ? Math.min(Math.floor(Number(expiration_days)), INDICATOR_MAX_EXPIRATION_DAYS)
+    : INDICATOR_DEFAULT_EXPIRATION_DAYS;
+  const expiration = new Date(Date.now() + days * MS_PER_DAY).toISOString();
+
+  const payload = {
+    symbol: symbolMarker,
+    resolution: String(resolvedResolution),
+    message: message || '',
+    sound_file: null,
+    sound_duration: 0,
+    popup: false,
+    expiration,
+    auto_deactivate: false,
+    email: false,
+    sms_over_email: false,
+    mobile_push: false,
+    web_hook: web_hook || null,
+    name: null,
+    conditions: [{
+      type: 'alert_cond',
+      frequency: frequency || 'on_bar_close',
+      alert_cond_id,
+      series: [{
+        type: 'study',
+        study: 'Script@tv-scripting-101',
+        offsets_by_plot,
+        inputs,
+        pine_id,
+        pine_version: pine_version || '1.0',
+      }],
+      resolution: String(resolvedResolution),
+    }],
+    active: active !== false,
+    ignore_warnings: true,
+  };
+
+  // CORS-critical: do NOT set a Content-Type header. A custom Content-Type
+  // triggers a preflight OPTIONS that pricealerts.tradingview.com rejects.
+  // The server happily parses the body without an explicit Content-Type.
+  // Embedding the body as a JSON string literal (via JSON.stringify) is the
+  // simplest safe way to inject it into the evaluateAsync template.
+  const body = JSON.stringify({ payload });
+  const response = await evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/create_alert', {
+      method: 'POST',
+      credentials: 'include',
+      body: ${JSON.stringify(body)}
+    }).then(function(r) { return r.text().then(function(t) { return { status: r.status, body: t }; }); })
+      .catch(function(e) { return { error: e.message }; })
+  `);
+
+  if (!response || response.error) {
+    return { success: false, error: response?.error || 'no response', source: 'rest_api' };
+  }
+
+  let parsed = null;
+  try { parsed = JSON.parse(response.body); } catch (e) { /* not JSON */ }
+
+  if (parsed?.s === 'ok' && parsed?.r) {
+    const created = parsed.r;
+    return {
+      success: true,
+      alert_id: created.alert_id || null,
+      symbol: resolvedSymbol,
+      pine_id,
+      alert_cond_id,
+      resolution: String(resolvedResolution),
+      message: payload.message,
+      web_hook: payload.web_hook,
+      expiration: created.expiration || expiration,
+      source: 'rest_api',
+    };
+  }
+
+  return {
+    success: false,
+    error: parsed?.errmsg || parsed?.err?.code || (response.body ? String(response.body).substring(0, 200) : 'unknown'),
+    http_status: response.status,
+    hint: 'Common cause: alert_cond_id off-by-one (try plot_N+/-1) or inputs schema mismatch. Create one alert manually in the TV UI and call alert_list to compare.',
+    source: 'rest_api',
+  };
+}

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -23,4 +23,23 @@ export function registerAlertTools(server) {
     try { return jsonResult(await core.deleteAlerts({ delete_all })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
+
+  server.tool('alert_create_indicator', 'Create an indicator alert that fires on a Pine alertcondition() signal (e.g. strategy BUY/SELL). Posts directly to pricealerts.tradingview.com/create_alert with an alert_cond condition. Companion to alert_create (which targets the price-alert dialog). Returns alert_id on success.', {
+    pine_id: z.string().describe('Saved Pine script id (e.g. "USER;abc123...") from pine_list_scripts.'),
+    alert_cond_id: z.string().describe('Pine plot index of the target alertcondition (e.g. "plot_12"). TV counts plot/plotshape/bgcolor/alertcondition in source order; hline does NOT count. To discover: create one alert manually in the TV UI, then call alert_list and read the alert_cond_id.'),
+    inputs: z.record(z.any()).describe('Pine input map matching the script\'s input.X declarations in order. Must include `__profile: false` and `pineFeatures` bitset. Example: { pineFeatures: \'{"indicator":1,"plot":1,"ta":1,"alertcondition":1}\', in_0: 14, in_1: 75, __profile: false }'),
+    offsets_by_plot: z.record(z.number()).describe('Plot offsets map: { plot_0: 0, plot_1: 0, ..., plot_N-1: 0 } where N = the alert_cond_id index. Each plot before the alertcondition needs an entry, all zero is fine.'),
+    pine_version: z.string().optional().describe('Saved script version from pine_list_scripts (default "1.0")'),
+    symbol: z.string().optional().describe('TV symbol (e.g. "OANDA:USDJPY"). Defaults to active chart.'),
+    currency: z.string().optional().describe('currency-id for the symbol marker (e.g. "JPY", "USD"). Defaults to active chart.'),
+    resolution: z.string().optional().describe('Timeframe (e.g. "60", "240", "D"). Defaults to active chart.'),
+    message: z.string().optional().describe('Alert payload. Supports {{ticker}}, {{close}}, and other TV placeholders. Sent verbatim to web_hook.'),
+    web_hook: z.string().optional().describe('Webhook URL TV will POST the message to on fire. Omit for no webhook.'),
+    frequency: z.string().optional().describe('"on_bar_close" (default), "once_per_bar", or "all".'),
+    expiration_days: z.coerce.number().int().min(1).max(60).optional().describe('Days until auto-expiration (default 30, capped at 60).'),
+    active: z.coerce.boolean().optional().describe('Whether the alert starts active (default true).'),
+  }, async (args) => {
+    try { return jsonResult(await core.createIndicator(args)); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
 }


### PR DESCRIPTION
## Summary

Adds `alert_create_indicator`, a companion to the existing `alert_create` tool. Where `alert_create` produces price-level alerts via the TV alert dialog, this new tool posts directly to `pricealerts.tradingview.com/create_alert` with an `alert_cond` condition referencing a saved Pine script's plot index — so it fires on Pine `alertcondition()` signals (the format used by every strategy-style script).

## Motivation

Discovered while wiring a Japanese FX automation system that routes Pine strategy signals through TradingView webhooks into MT4. Strategy automation workflows like this need to wire each Pine `alertcondition(buySignal, ...)` and `alertcondition(sellSignal, ...)` to a webhook URL. Currently this requires opening the alert dialog in the TV UI and clicking through it for every BUY/SELL pair across N strategies. With this PR, batches of 10+ alerts can be created from one MCP call sequence — 9 indicator alerts created in ~3 seconds via the new tool, vs ~5 minutes of UI clicking for the same set.

## Example

```js
alert_create_indicator({
  pine_id: 'USER;fd4afa4abf87427e84c0f9b2df9ced79',
  pine_version: '1.0',
  alert_cond_id: 'plot_12',         // BUY alertcondition's plot index
  inputs: {
    pineFeatures: '{"indicator":1,"plot":1,"ta":1,"alertcondition":1,"request.security":1}',
    in_0: true, in_1: true, in_2: true, in_3: 14, in_4: 3, in_5: 1.5, in_6: true,
    __fast_calc: false, __profile: false,
  },
  offsets_by_plot: { plot_0: 0, plot_1: 0, /* ... */ plot_11: 0 },
  symbol: 'OANDA:USDJPY',
  currency: 'JPY',
  resolution: '60',
  message: '{"secret":"...","symbol":"{{ticker}}","action":"buy","price":{{close}}}',
  web_hook: 'https://your-server/api/tv-webhook',
})
// → { success: true, alert_id: 4559193672, ... }
```

Optional fields fall back to the active chart for `symbol` / `currency` / `resolution` (same logic as `create()`); `frequency` defaults to `on_bar_close`; `active` defaults to `true`; `expiration_days` defaults to 30 (capped at 60).

## How `alert_cond_id` is determined (the gotcha worth documenting)

TV counts Pine plot-emitting calls in source order:

- ✅ Counted: `plot()`, `plotshape()`, `bgcolor()`, `alertcondition()`
- ❌ Not counted: `hline()`

So a script with 10 `plot()` + 2 `plotshape()` + 2 `alertcondition()` (BUY then SELL) yields BUY = `plot_12`, SELL = `plot_13`. A script with 1 `plot()` + 1 `bgcolor()` + 1 `plotshape()` + 1 `alertcondition()` yields the alertcondition at `plot_3` — `bgcolor()` consumes a plot index.

The easiest discovery method (also documented in the schema description): create one alert manually in the TV UI, call `alert_list`, and read the resulting `alert_cond_id` plus the `inputs` / `offsets_by_plot` shape from the response.

## Implementation notes

- Same CORS pitfall as PR #107 documents: no `Content-Type` header, plain string body. A custom Content-Type triggers a preflight OPTIONS that `pricealerts.tradingview.com` rejects.
- Self-contained: does not depend on PR #107's REST infrastructure. Inlines a small expiration-days helper and embeds the body via `JSON.stringify` (which is itself a safe template-literal injection — no `safeBacktickBody` needed).
- Purely additive: does not touch existing `create()` / `list()` / `deleteAlerts()` functions. Should not conflict with PR #107 if/when that lands (PR #107 modifies `create()`; this only adds `createIndicator()`).
- On error, the response includes a `hint:` field pointing the caller toward common causes (off-by-one `alert_cond_id`, inputs schema mismatch).

## Test plan

- [x] Manually verified by creating 9 live indicator alerts across 5 strategies (jaja, RSI MR, monthly carry; mix of `request.security`, `bgcolor`, plain `plot` + `alertcondition`); all returned `s: ok` and showed up in `alert_list` with `active: true`.
- [x] Verified the bgcolor-counts-as-plot behavior empirically by reproducing an off-by-one error (`plot_2` returned `s: error` for a script with `plot + bgcolor + plotshape + alertcondition`; `plot_3` succeeded).
- [x] Verified webhook delivery end-to-end: TV → `web_hook` URL → receiver got the message JSON with `{{ticker}}` / `{{close}}` substituted.
- [ ] No automated tests added — this calls TV's live REST API and there's no obvious mock surface; happy to add if there's a preferred pattern.

## Out of scope

- Auto-discovery of `pine_id` / `inputs` / `alert_cond_id` from the active chart's already-attached studies. Natural follow-up; could leverage the same internal study-config inspection used by `chart_get_state`. Keeping this PR focused on the underlying primitive.
