### PR TITLE
fix(chart): resolve evaluate via _deps in scrollToDate and getVisible…

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,7 +115,8 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
-export async function getVisibleRange() {
+export async function getVisibleRange({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -157,7 +158,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);


### PR DESCRIPTION

## Bug

`scrollToDate` and `getVisibleRange` in `src/core/chart.js` referenced `evaluate(...)` directly. The file imports it as `_evaluate` and exposes it through `_resolve(_deps).evaluate` so test seams can inject mocks. These were the only two exports in the file that skipped that indirection.

## Symptom

`chart_scroll_to_date` returned this for every documented input format:

`{ "success": false, "error": "evaluate is not defined" }`

`chart_get_visible_range` failed the same way.

## Why these two

Every other exported function in `src/core/chart.js` (`getState`, `setSymbol`, `setTimeframe`, `setChartType`, `manageIndicator`, `setVisibleRange`, etc.) starts with `const { evaluate } = _resolve(_deps);`. These two appear to predate the `_deps` indirection and were missed during the refactor that added it.

## Fix

Two lines: add `_deps` to the function signatures and resolve `evaluate` through it, matching the existing pattern verbatim.

## Verification

Tested against a live Chrome session with `--remote-debugging-port=9222` and a TradingView chart open. After the fix:

- `chart_scroll_to_date` with `"1777296360"` (unix-as-string) — success
- `chart_scroll_to_date` with `"2026-04-27T13:26:00Z"` (ISO datetime) — success
- `chart_scroll_to_date` with `"2026-04-27"` (ISO date-only) — success
- `chart_get_visible_range` (no args) — success

## Note on tests

`tests/e2e.test.js` exercises the underlying TradingView API directly via `evaluate(...)` rather than calling the exported `scrollToDate` / `getVisibleRange`, so the bug wasn't caught by CI. A unit test that imports those two functions with a mocked `_deps` would prevent regression.