### PR TITLE
Harden bridge chart controls and tool schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+68 tools for reading and controlling a live TradingView Desktop chart via CDP
+on port 9222, with an Electron bridge fallback on port 9229 when TradingView is
+already running without direct CDP.
 
 ## Decision Tree — Which Tool When
 
@@ -35,7 +37,7 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 
 ### "Change the chart"
 - `chart_set_symbol` → switch ticker (e.g., "AAPL", "ES1!", "NYMEX:CL1!")
-- `chart_set_timeframe` → switch resolution (e.g., "1", "5", "15", "60", "D", "W")
+- `chart_set_timeframe` → switch resolution (e.g., "1", "5", "15", "60", "1h", "4h", "D", "W")
 - `chart_set_type` → switch chart style (Candles, HeikinAshi, Line, Area, Renko, etc.)
 - `chart_manage_indicator` → add or remove studies (use full name: "Relative Strength Index", not "RSI")
 - `chart_scroll_to_date` → jump to a date (ISO format: "2025-01-15")
@@ -123,7 +125,7 @@ These tools can return large payloads. Follow these rules to avoid context bloat
 ## Architecture
 
 ```
-Claude Code ←→ MCP Server (stdio) ←→ CDP (localhost:9222) ←→ TradingView Desktop (Electron)
+Claude Code ←→ MCP Server (stdio) ←→ CDP (localhost:9222) or Electron bridge (localhost:9229) ←→ TradingView Desktop
 ```
 
 Pine graphics path: `study._graphics._primitivesCollection.dwglines.get('lines').get(false)._primitivesDataById`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TradingView MCP Bridge
 
-Personal AI assistant for your TradingView Desktop charts. Connects Claude Code to your local TradingView app via Chrome DevTools Protocol for AI-assisted chart analysis, Pine Script development, and workflow automation.
+Personal AI assistant for your TradingView Desktop charts. Connects Claude Code to your local TradingView app via Chrome DevTools Protocol, with an Electron bridge fallback for already-running TradingView Desktop sessions, for AI-assisted chart analysis, Pine Script development, and workflow automation.
 
 > **For personal use only.** See [Disclaimer](#disclaimer) for important information about TradingView's Terms of Service.
 
@@ -27,9 +27,11 @@ cd tradingview-mcp
 npm install
 ```
 
-### 2. Launch TradingView with CDP
+### 2. Launch TradingView
 
-TradingView Desktop must be running with Chrome DevTools Protocol enabled on port 9222.
+Best path: run TradingView Desktop with Chrome DevTools Protocol enabled on port 9222.
+If TradingView is already running without port 9222, the server can fall back to
+an Electron inspector bridge on port 9229 without relaunching TradingView.
 
 **Mac:**
 ```bash
@@ -206,19 +208,21 @@ The key flag: `--remote-debugging-port=9222`
 
 ```bash
 # Requires TradingView running with --remote-debugging-port=9222
+# or an already-running TradingView Desktop session reachable through the
+# Electron bridge fallback.
 npm test
 ```
 
-29 E2E tests covering: CDP connection, chart control, OHLCV data, Pine graphics pipeline, data window values, UI control, screenshots, and context size validation.
+57 tests covering: connection adapter, chart control, OHLCV data, Pine graphics pipeline, data window values, UI control, screenshots, context size validation, tool schema conversion, timeframe normalization, replay date parsing, and Pine compile parsing.
 
 ## Architecture
 
 ```
-Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
+Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222) or Electron bridge (port 9229)  ←→  TradingView Desktop
 ```
 
 - **Transport**: MCP over stdio
-- **Connection**: Chrome DevTools Protocol on localhost:9222
+- **Connection**: Chrome DevTools Protocol on localhost:9222, with an Electron webContents debugger bridge fallback on localhost:9229
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
+    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/tool_schema.test.js tests/chart_timeframe.test.js tests/replay.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js",
-    "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js"
+    "test:unit": "node --test tests/pine_analyze.test.js tests/tool_schema.test.js tests/chart_timeframe.test.js tests/replay.test.js",
+    "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js tests/tool_schema.test.js tests/chart_timeframe.test.js tests/replay.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/skills/chart-control/SKILL.md
+++ b/skills/chart-control/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: chart-control
+description: Use for safe TradingView chart-only operations through MCP: checking the current chart, changing symbol/timeframe/chart type, reading study inventory, and verifying the result without touching Pine Editor slots or relaunching TradingView.
+---
+
+# Chart Control
+
+Use this skill for chart-only requests such as "what chart am I on?" or
+"change the timeframe to 1h."
+
+## Core Rule
+
+Chart control is not Pine editing. Do not call Pine Editor write tools, do not
+push Pine, and do not relaunch or kill TradingView for chart-only changes.
+
+## Safe Flow
+
+1. Run `tv_health_check` or `chart_get_state`.
+2. Apply the requested chart-only change:
+   - timeframe: `chart_set_timeframe`
+   - symbol: `chart_set_symbol`
+   - chart type: `chart_set_type`
+3. Verify with `chart_get_state`.
+4. Report the actual symbol, resolution, and loaded studies.
+
+## Timeframe Inputs
+
+The MCP chart timeframe tool accepts common operator wording:
+
+- `1`, `5`, `15`, `60`
+- `1m`, `5m`, `15 minutes`
+- `1h`, `4h`
+- `D`, `W`, `M`
+
+Hour aliases normalize to TradingView minute counts, so `1h` becomes `60`.
+
+## Fallback Discipline
+
+If an MCP wrapper drops arguments or reports a schema error, first verify that
+the server is running the legacy-schema conversion in `src/tool-schema.js`.
+
+Only use direct CDP evaluation as a temporary diagnostic fallback. If direct
+Node/CDP is used, close the returned client in a `finally` block so no helper
+process stays alive after success.
+
+## Stop Conditions
+
+- Pine Editor write is required.
+- TradingView needs to be relaunched.
+- A chart-only operation would alter study inputs, delete indicators, or touch
+  a production Pine slot.
+
+Stop and ask for explicit approval before any of those.

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,9 +1,14 @@
 import CDP from 'chrome-remote-interface';
+import { execFileSync } from 'node:child_process';
 
 let client = null;
 let targetInfo = null;
+let bridgeMode = false;
+let mainClient = null; // V8 inspector client (bridge mode only)
+
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
+const INSPECTOR_PORT = 9229;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 
@@ -23,50 +28,277 @@ export { KNOWN_PATHS };
 export async function getClient() {
   if (client) {
     try {
-      // Quick liveness check
-      await client.Runtime.evaluate({ expression: '1', returnByValue: true });
+      if (bridgeMode) {
+        await evaluateViaBridge('1');
+      } else {
+        await client.Runtime.evaluate({ expression: '1', returnByValue: true });
+      }
       return client;
     } catch {
-      client = null;
-      targetInfo = null;
+      await cleanupAll();
     }
   }
   return connect();
 }
 
 export async function connect() {
-  let lastError;
+  let cdpError;
+
+  // --- Attempt 1: Normal CDP on port 9222 ---
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const target = await findChartTarget();
-      if (!target) {
-        throw new Error('No TradingView chart target found. Is TradingView open with a chart?');
-      }
+      const target = await findChartTarget(CDP_PORT);
+      if (!target) throw new Error('No TradingView chart target found');
       targetInfo = target;
       client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
-
-      // Enable required domains
       await client.Runtime.enable();
       await client.Page.enable();
       await client.DOM.enable();
-
+      bridgeMode = false;
       return client;
     } catch (err) {
-      lastError = err;
+      cdpError = err;
       const delay = Math.min(BASE_DELAY * Math.pow(2, attempt), 30000);
       await new Promise(r => setTimeout(r, delay));
     }
   }
-  throw new Error(`CDP connection failed after ${MAX_RETRIES} attempts: ${lastError?.message}`);
+
+  // --- Attempt 2: SIGUSR1 bridge via V8 inspector on port 9229 ---
+  try {
+    return await connectViaBridge();
+  } catch (bridgeErr) {
+    throw new Error(
+      `CDP connection failed after ${MAX_RETRIES} attempts: ${cdpError?.message}. ` +
+      `Bridge fallback also failed: ${bridgeErr?.message}`
+    );
+  }
 }
 
-async function findChartTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
+// ─── Bridge connection: SIGUSR1 → V8 inspector → webContents.debugger ────────
+
+async function connectViaBridge() {
+  // Ensure V8 inspector is listening (send SIGUSR1 if needed)
+  await ensureInspectorListening();
+
+  // Connect to the main process V8 inspector
+  const targets = await fetchJsonTargets(INSPECTOR_PORT);
+  if (!targets.length) throw new Error('No V8 inspector targets on port ' + INSPECTOR_PORT);
+
+  mainClient = await CDP({ host: CDP_HOST, port: INSPECTOR_PORT, target: targets[0].id });
+  await mainClient.Runtime.enable();
+
+  // Find the chart webContents and attach the debugger
+  const setupResult = await mainClient.Runtime.evaluate({
+    expression: `
+      (function() {
+        var binding = process._linkedBinding('electron_browser_web_contents');
+        var all = binding.getAllWebContents();
+        var chart = null;
+        for (var i = 0; i < all.length; i++) {
+          var url = '';
+          try { url = all[i].getURL(); } catch(e) {}
+          if (url.indexOf('tradingview.com/chart') !== -1) { chart = all[i]; break; }
+        }
+        if (!chart) return JSON.stringify({ error: 'No chart webContents found. Is a chart tab open?' });
+        try { chart.debugger.attach('1.3'); } catch(e) { /* already attached */ }
+        global.__tvBridgeChart = chart;
+        return JSON.stringify({ ok: true, id: chart.id, url: chart.getURL() });
+      })()
+    `,
+    returnByValue: true,
+  });
+
+  const parsed = JSON.parse(setupResult.result?.value ?? '{"error":"No result"}');
+  if (parsed.error) throw new Error(parsed.error);
+
+  bridgeMode = true;
+  targetInfo = { id: 'bridge-' + parsed.id, url: parsed.url, type: 'page', title: 'TradingView (bridge)' };
+
+  // Create proxy client that all 68 tools can use transparently
+  client = {
+    Runtime: {
+      evaluate: (params) => bridgeRuntimeEvaluate(params),
+      enable: async () => {},
+      disable: async () => {},
+    },
+    Page: {
+      enable: async () => {},
+      disable: async () => {},
+      captureScreenshot: async (params) => bridgeCaptureScreenshot(params),
+    },
+    Input: {
+      dispatchKeyEvent: (params) => bridgeDebuggerCommand('Input.dispatchKeyEvent', params),
+      insertText: (params) => bridgeDebuggerCommand('Input.insertText', params),
+    },
+    DOM: {
+      enable: async () => {},
+      disable: async () => {},
+    },
+    close: async () => { await cleanupAll(); },
+  };
+
+  return client;
+}
+
+async function ensureInspectorListening() {
+  // Check if inspector is already up
+  try {
+    const targets = await fetchJsonTargets(INSPECTOR_PORT);
+    if (targets.length > 0) return;
+  } catch { /* not listening yet */ }
+
+  // Find the TradingView main process and send SIGUSR1
+  let pid;
+  try {
+    pid = execFileSync('pgrep', ['-f', '/Applications/TradingView.app/Contents/MacOS/TradingView$'], { encoding: 'utf8' }).trim();
+  } catch {
+    try {
+      pid = execFileSync('pgrep', ['-f', 'TradingView --type=browser'], { encoding: 'utf8' }).trim();
+    } catch {
+      throw new Error('Cannot find TradingView main process. Is TradingView running?');
+    }
+  }
+
+  if (!pid) throw new Error('No TradingView process found');
+
+  // SIGUSR1 toggles the V8 inspector
+  process.kill(parseInt(pid.split('\n')[0]), 'SIGUSR1');
+
+  // Wait for inspector to start (poll up to 5s)
+  for (let i = 0; i < 10; i++) {
+    await new Promise(r => setTimeout(r, 500));
+    try {
+      const targets = await fetchJsonTargets(INSPECTOR_PORT);
+      if (targets.length > 0) return;
+    } catch { /* keep waiting */ }
+  }
+  throw new Error('V8 inspector did not start on port ' + INSPECTOR_PORT + ' after SIGUSR1');
+}
+
+async function bridgeRuntimeEvaluate(params) {
+  if (!mainClient) throw new Error('Bridge not connected');
+
+  const expr = params.expression ?? '';
+  const returnByValue = params.returnByValue !== false;
+  const awaitPromise = params.awaitPromise ?? false;
+
+  // Pass expression safely via JSON.stringify — avoids all escaping issues
+  const safeExpr = JSON.stringify(expr);
+
+  // Electron 38+ uses Promise-based debugger.sendCommand (callback form deprecated)
+  const wrapper = `
+    global.__tvBridgeChart.debugger.sendCommand('Runtime.evaluate', {
+      expression: ${safeExpr},
+      returnByValue: ${returnByValue},
+      awaitPromise: ${awaitPromise}
+    })
+  `;
+
+  const result = await mainClient.Runtime.evaluate({
+    expression: wrapper,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+
+  if (result.exceptionDetails) {
+    const msg = result.exceptionDetails.exception?.description
+      || result.exceptionDetails.text
+      || 'Bridge evaluation error';
+    throw new Error(msg);
+  }
+
+  // The bridge returns the inner Runtime.evaluate result
+  const inner = result.result?.value;
+  if (inner && typeof inner === 'object') {
+    return inner;
+  }
+  return result;
+}
+
+async function bridgeDebuggerCommand(method, params = {}) {
+  if (!mainClient) throw new Error('Bridge not connected');
+
+  const safeMethod = JSON.stringify(method);
+  const safeParams = JSON.stringify(params || {});
+  const result = await mainClient.Runtime.evaluate({
+    expression: `global.__tvBridgeChart.debugger.sendCommand(${safeMethod}, ${safeParams})`,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+
+  if (result.exceptionDetails) {
+    const msg = result.exceptionDetails.exception?.description
+      || result.exceptionDetails.text
+      || `${method} bridge command failed`;
+    throw new Error(msg);
+  }
+
+  return result.result?.value ?? {};
+}
+
+// Liveness check for bridge mode
+async function evaluateViaBridge(expression) {
+  return bridgeRuntimeEvaluate({ expression, returnByValue: true });
+}
+
+async function bridgeCaptureScreenshot(_params) {
+  if (!mainClient) throw new Error('Bridge not connected');
+  const result = await mainClient.Runtime.evaluate({
+    expression: `
+      new Promise(function(resolve, reject) {
+        global.__tvBridgeChart.capturePage().then(function(img) {
+          resolve(img.toDataURL().replace('data:image/png;base64,', ''));
+        }).catch(reject);
+      })
+    `,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  return { data: result.result?.value ?? result?.value ?? '' };
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+async function fetchJsonTargets(port) {
+  const resp = await fetch(`http://${CDP_HOST}:${port}/json/list`);
+  return resp.json();
+}
+
+async function findChartTarget(port) {
+  const targets = await fetchJsonTargets(port);
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
     || null;
+}
+
+async function cleanupAll() {
+  if (client && !bridgeMode) {
+    try { await client.close(); } catch {}
+  }
+  if (mainClient) {
+    try {
+      await mainClient.Runtime.evaluate({
+        expression: `
+          (function() {
+            if (!global.__tvBridgeChart || !global.__tvBridgeChart.debugger) return false;
+            try {
+              if (global.__tvBridgeChart.debugger.isAttached()) {
+                global.__tvBridgeChart.debugger.detach();
+              }
+            } catch(e) {}
+            delete global.__tvBridgeChart;
+            return true;
+          })()
+        `,
+        returnByValue: true,
+      });
+    } catch {}
+    try { await mainClient.close(); } catch {}
+    mainClient = null;
+  }
+  client = null;
+  targetInfo = null;
+  bridgeMode = false;
 }
 
 export async function getTargetInfo() {
@@ -98,17 +330,10 @@ export async function evaluateAsync(expression) {
 }
 
 export async function disconnect() {
-  if (client) {
-    try { await client.close(); } catch {}
-    client = null;
-    targetInfo = null;
-  }
+  await cleanupAll();
 }
 
 // --- Direct API path helpers ---
-// Each returns the STRING expression path after verifying it exists.
-// Callers use the returned string in their own evaluate() calls.
-
 async function verifyAndReturn(path, name) {
   const exists = await evaluate(`typeof (${path}) !== 'undefined' && (${path}) !== null`);
   if (!exists) {

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { installLegacyToolSchemaSupport } from './tool-schema.js';
 import { registerHealthTools } from './tools/health.js';
 import { registerChartTools } from './tools/chart.js';
 import { registerPineTools } from './tools/pine.js';
@@ -64,6 +65,8 @@ CONTEXT MANAGEMENT:
 - Call chart_get_state ONCE at start, reuse entity IDs`,
   }
 );
+
+installLegacyToolSchemaSupport(server);
 
 // Register all tool groups
 registerHealthTools(server);

--- a/src/tool-schema.js
+++ b/src/tool-schema.js
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+function isZodSchema(value) {
+  return value && typeof value === 'object' && typeof value.safeParse === 'function';
+}
+
+function legacyFieldToZod(field) {
+  if (isZodSchema(field)) {
+    return field;
+  }
+
+  const spec = field && typeof field === 'object' ? field : {};
+  const type = spec.type || 'any';
+  let schema;
+
+  if (Array.isArray(spec.enum) && spec.enum.length > 0) {
+    schema = z.enum(spec.enum.map(String));
+  } else if (type === 'string') {
+    schema = z.string();
+  } else if (type === 'number') {
+    schema = z.number();
+  } else if (type === 'integer') {
+    schema = z.number().int();
+  } else if (type === 'boolean') {
+    schema = z.boolean();
+  } else if (type === 'array') {
+    schema = z.array(z.any());
+  } else if (type === 'object') {
+    schema = z.record(z.string(), z.any());
+  } else {
+    schema = z.any();
+  }
+
+  if (spec.description) {
+    schema = schema.describe(spec.description);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(spec, 'default')) {
+    if (spec.default === null) {
+      schema = schema.nullable();
+    }
+    schema = schema.optional().default(spec.default);
+  }
+
+  return schema;
+}
+
+export function legacyToolSchemaToZodShape(schema) {
+  if (!schema || typeof schema !== 'object' || isZodSchema(schema)) {
+    return schema;
+  }
+
+  return Object.fromEntries(
+    Object.entries(schema).map(([name, field]) => [name, legacyFieldToZod(field)])
+  );
+}
+
+export function installLegacyToolSchemaSupport(server) {
+  const originalTool = server.tool.bind(server);
+
+  server.tool = function patchedTool(name, description, inputSchema, callback) {
+    if (typeof inputSchema === 'function') {
+      return originalTool(name, description, inputSchema);
+    }
+
+    if (inputSchema && typeof inputSchema === 'object' && typeof callback === 'function') {
+      return originalTool(name, description, legacyToolSchemaToZodShape(inputSchema), callback);
+    }
+
+    return originalTool(...arguments);
+  };
+
+  return server;
+}

--- a/src/tools/chart.js
+++ b/src/tools/chart.js
@@ -3,6 +3,81 @@ import { waitForChartReady } from '../wait.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 
+function jsonResult(obj, isError = false) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(obj, null, 2) }],
+    ...(isError && { isError: true }),
+  };
+}
+
+export function normalizeTimeframe(value) {
+  if (value === undefined || value === null) {
+    throw new Error('timeframe is required. Examples: 1, 5, 15, 60, 1h, 4h, D, W, M.');
+  }
+
+  const raw = String(value).trim();
+  if (!raw) {
+    throw new Error('timeframe cannot be empty. Examples: 1, 5, 15, 60, 1h, 4h, D, W, M.');
+  }
+
+  const compact = raw.replace(/\s+/g, '');
+
+  if (/^\d+$/.test(compact)) {
+    return compact;
+  }
+
+  if (compact === 'D' || compact === '1D') return 'D';
+  if (compact === 'W' || compact === '1W') return 'W';
+  if (compact === 'M' || compact === '1M') return 'M';
+
+  const uppercasePeriod = compact.match(/^(\d+)([DWM])$/);
+  if (uppercasePeriod) {
+    const count = Number(uppercasePeriod[1]);
+    const unit = uppercasePeriod[2];
+    return count === 1 ? unit : `${count}${unit}`;
+  }
+
+  const lower = compact.toLowerCase();
+
+  const minuteMatch = lower.match(/^(\d+)(m|min|mins|minute|minutes)$/);
+  if (minuteMatch) {
+    return minuteMatch[1];
+  }
+
+  const hourMatch = lower.match(/^(\d+)(h|hr|hrs|hour|hours)$/);
+  if (hourMatch) {
+    return String(Number(hourMatch[1]) * 60);
+  }
+
+  const dayMatch = lower.match(/^(\d+)?(d|day|days)$/);
+  if (dayMatch) {
+    const count = Number(dayMatch[1] || 1);
+    return count === 1 ? 'D' : `${count}D`;
+  }
+
+  const weekMatch = lower.match(/^(\d+)?(w|wk|wks|week|weeks)$/);
+  if (weekMatch) {
+    const count = Number(weekMatch[1] || 1);
+    return count === 1 ? 'W' : `${count}W`;
+  }
+
+  const monthMatch = lower.match(/^(\d+)?(mo|mon|month|months)$/);
+  if (monthMatch) {
+    const count = Number(monthMatch[1] || 1);
+    return count === 1 ? 'M' : `${count}M`;
+  }
+
+  throw new Error(`Unsupported timeframe: ${raw}. Use minute counts, 1h/4h, D, W, or M.`);
+}
+
+function timeframesMatch(actual, expected) {
+  try {
+    return normalizeTimeframe(actual) === normalizeTimeframe(expected);
+  } catch {
+    return String(actual) === String(expected);
+  }
+}
+
 export function registerChartTools(server) {
 
   server.tool('chart_get_state', 'Get current chart state (symbol, timeframe, chart type, indicators)', {}, async () => {
@@ -41,11 +116,16 @@ export function registerChartTools(server) {
     symbol: { type: 'string', description: 'Symbol to set (e.g., BTCUSD, AAPL, ES1!, NYMEX:CL1!)' },
   }, async ({ symbol }) => {
     try {
+      if (!symbol || typeof symbol !== 'string') {
+        return jsonResult({ success: false, error: 'symbol is required.' }, true);
+      }
+
+      const symbolLiteral = JSON.stringify(symbol.trim());
       await evaluateAsync(`
         (function() {
           var chart = ${CHART_API};
           return new Promise(function(resolve) {
-            chart.setSymbol('${symbol.replace(/'/g, "\\'")}', {});
+            chart.setSymbol(${symbolLiteral}, {});
             // Give TV a moment to start the symbol change
             setTimeout(resolve, 500);
           });
@@ -53,47 +133,64 @@ export function registerChartTools(server) {
       `);
 
       const ready = await waitForChartReady(symbol);
+      const actual = await evaluate(`
+        (function() {
+          var chart = ${CHART_API};
+          return { symbol: chart.symbol(), resolution: chart.resolution(), chartType: chart.chartType() };
+        })()
+      `);
 
-      return {
-        content: [{ type: 'text', text: JSON.stringify({
-          success: true,
-          symbol,
-          chart_ready: ready,
-        }, null, 2) }],
-      };
+      const requested = symbol.trim().toUpperCase();
+      const actualSymbol = String(actual?.symbol || '').toUpperCase();
+      const success = actualSymbol.length > 0 && (actualSymbol.includes(requested) || requested.includes(actualSymbol));
+      return jsonResult({
+        success,
+        requested_symbol: symbol.trim(),
+        actual_symbol: actual?.symbol,
+        resolution: actual?.resolution,
+        chartType: actual?.chartType,
+        chart_ready: ready,
+        error: success ? undefined : `TradingView reported symbol ${actual?.symbol ?? 'unknown'} after setting ${symbol.trim()}.`,
+      }, !success);
     } catch (err) {
-      return {
-        content: [{ type: 'text', text: JSON.stringify({ success: false, error: err.message }, null, 2) }],
-        isError: true,
-      };
+      return jsonResult({ success: false, error: err.message }, true);
     }
   });
 
   server.tool('chart_set_timeframe', 'Change the chart timeframe/resolution', {
-    timeframe: { type: 'string', description: 'Timeframe (e.g., 1, 5, 15, 60, D, W, M)' },
+    timeframe: { type: 'string', description: 'Timeframe/resolution. Accepts minute counts or aliases like 1m, 5m, 1h, 4h, D, W, M.' },
   }, async ({ timeframe }) => {
     try {
+      const requested = normalizeTimeframe(timeframe);
+      const timeframeLiteral = JSON.stringify(requested);
       await evaluate(`
         (function() {
           var chart = ${CHART_API};
-          chart.setResolution('${timeframe.replace(/'/g, "\\'")}', {});
+          chart.setResolution(${timeframeLiteral}, {});
         })()
       `);
 
-      const ready = await waitForChartReady(null, timeframe);
+      const ready = await waitForChartReady(null, requested);
+      const actual = await evaluate(`
+        (function() {
+          var chart = ${CHART_API};
+          return { symbol: chart.symbol(), resolution: chart.resolution(), chartType: chart.chartType() };
+        })()
+      `);
 
-      return {
-        content: [{ type: 'text', text: JSON.stringify({
-          success: true,
-          timeframe,
-          chart_ready: ready,
-        }, null, 2) }],
-      };
+      const success = timeframesMatch(actual?.resolution, requested);
+      return jsonResult({
+        success,
+        input_timeframe: timeframe,
+        requested_resolution: requested,
+        actual_resolution: actual?.resolution,
+        symbol: actual?.symbol,
+        chartType: actual?.chartType,
+        chart_ready: ready,
+        error: success ? undefined : `TradingView reported resolution ${actual?.resolution ?? 'unknown'} after setting ${requested}.`,
+      }, !success);
     } catch (err) {
-      return {
-        content: [{ type: 'text', text: JSON.stringify({ success: false, error: err.message }, null, 2) }],
-        isError: true,
-      };
+      return jsonResult({ success: false, error: err.message }, true);
     }
   });
 
@@ -102,20 +199,25 @@ export function registerChartTools(server) {
   }, async ({ chart_type }) => {
     try {
       const typeMap = {
-        'Bars': 0, 'Candles': 1, 'Line': 2, 'Area': 3,
-        'Renko': 4, 'Kagi': 5, 'PointAndFigure': 6, 'LineBreak': 7,
-        'HeikinAshi': 8, 'HollowCandles': 9,
+        bars: 0,
+        candles: 1,
+        line: 2,
+        area: 3,
+        renko: 4,
+        kagi: 5,
+        pointandfigure: 6,
+        linebreak: 7,
+        heikinashi: 8,
+        hollowcandles: 9,
       };
-      const typeNum = typeMap[chart_type] ?? Number(chart_type);
+      const typeKey = String(chart_type).trim();
+      const typeNum = typeMap[typeKey.replace(/\s+/g, '').toLowerCase()] ?? Number(typeKey);
 
       if (isNaN(typeNum)) {
-        return {
-          content: [{ type: 'text', text: JSON.stringify({
-            success: false,
-            error: `Unknown chart type: ${chart_type}. Use a name (Candles, Line, etc.) or number (0-9).`,
-          }, null, 2) }],
-          isError: true,
-        };
+        return jsonResult({
+          success: false,
+          error: `Unknown chart type: ${chart_type}. Use a name (Candles, Line, etc.) or number (0-9).`,
+        }, true);
       }
 
       await evaluate(`
@@ -125,14 +227,10 @@ export function registerChartTools(server) {
         })()
       `);
 
-      return {
-        content: [{ type: 'text', text: JSON.stringify({ success: true, chart_type, type_num: typeNum }, null, 2) }],
-      };
+      const actual = await evaluate(`${CHART_API}.chartType()`);
+      return jsonResult({ success: actual === typeNum, chart_type, type_num: typeNum, actual_chart_type: actual }, actual !== typeNum);
     } catch (err) {
-      return {
-        content: [{ type: 'text', text: JSON.stringify({ success: false, error: err.message }, null, 2) }],
-        isError: true,
-      };
+      return jsonResult({ success: false, error: err.message }, true);
     }
   });
 

--- a/src/tools/indicators.js
+++ b/src/tools/indicators.js
@@ -40,26 +40,121 @@ export function registerIndicatorTools(server) {
           var study = chart.getStudyById('${escapedId}');
           if (!study) return { error: 'Study not found: ${escapedId}' };
 
-          var currentInputs = study.getInputValues();
           var overrides = ${inputsJson};
           var updatedKeys = {};
+          var path = 'unknown';
+          var unverified = false;
 
-          for (var i = 0; i < currentInputs.length; i++) {
-            if (overrides.hasOwnProperty(currentInputs[i].id)) {
-              currentInputs[i].value = overrides[currentInputs[i].id];
-              updatedKeys[currentInputs[i].id] = overrides[currentInputs[i].id];
+          function countUpdated() { return Object.keys(updatedKeys).length; }
+          function publicInputSummary(inputs) {
+            return (inputs || []).map(function(input) {
+              return { id: input.id, name: input.name, value: input.value };
+            });
+          }
+          function getInputInfoSummary() {
+            try {
+              var info = study.getInputsInfo ? study.getInputsInfo() : [];
+              return (info || []).map(function(input) {
+                return {
+                  id: input.id,
+                  name: input.name || input.title || input.displayName,
+                  value: input.value,
+                  type: input.type,
+                };
+              });
+            } catch(e) {
+              return [];
+            }
+          }
+          function getPropertyInputs() {
+            var props = study._study
+              ? study._study.properties().inputs
+              : (study.properties ? study.properties().inputs : null);
+            var summary = [];
+            if (props) {
+              summary = Object.keys(props).map(function(k) {
+                var p = props[k];
+                return { id: k, value: (p && typeof p.value === 'function') ? p.value() : (p ? p._value : undefined) };
+              });
+            }
+            return { props: props, summary: summary };
+          }
+
+          // ── Path A: public getInputValues/setInputValues (works for built-ins) ──
+          var currentInputs = study.getInputValues ? study.getInputValues() : [];
+          if (currentInputs && currentInputs.length > 0) {
+            path = 'setInputValues';
+            for (var i = 0; i < currentInputs.length; i++) {
+              if (overrides.hasOwnProperty(currentInputs[i].id)) {
+                currentInputs[i].value = overrides[currentInputs[i].id];
+                updatedKeys[currentInputs[i].id] = overrides[currentInputs[i].id];
+              }
+            }
+            if (countUpdated() === 0) {
+              return {
+                error: 'No matching input IDs found for requested overrides',
+                requested_inputs: Object.keys(overrides),
+                available_inputs: publicInputSummary(currentInputs),
+              };
+            }
+            study.setInputValues(currentInputs);
+
+          } else {
+            // ── Path B: custom Pine scripts — getInputValues() returns [] ──
+            // Prefer properties so we can reject unknown IDs instead of silently
+            // claiming success for keys TradingView ignored.
+            var propResult = getPropertyInputs();
+            if (propResult.props) {
+              path = 'properties';
+              var keys = Object.keys(overrides);
+              for (var k = 0; k < keys.length; k++) {
+                var key = keys[k];
+                if (propResult.props[key] && typeof propResult.props[key].setValue === 'function') {
+                  propResult.props[key].setValue(overrides[key]);
+                  updatedKeys[key] = overrides[key];
+                }
+              }
+              if (countUpdated() === 0) {
+                return {
+                  error: 'No matching input IDs found for requested overrides',
+                  requested_inputs: keys,
+                  available_inputs: propResult.summary.length > 0 ? propResult.summary : getInputInfoSummary(),
+                };
+              }
+              // Trigger recompute via modifyStudy with exact updated inputs.
+              try { chart.modifyStudy('${escapedId}', { inputs: updatedKeys }); } catch(e) {
+                try { chart.modifyStudy('${escapedId}', {}); } catch(_) {}
+              }
+            } else {
+              // ── Path C: final public modifyStudy fallback ──
+              // This path is useful for study types with hidden input property
+              // internals, but the result cannot be verified locally.
+              try {
+                chart.modifyStudy('${escapedId}', { inputs: overrides });
+                path = 'modifyStudy';
+                updatedKeys = overrides;
+                unverified = true;
+              } catch(modErr) {
+                return {
+                  error: 'No input path available for this study type',
+                  modifyStudyError: modErr.message,
+                  available_inputs: getInputInfoSummary(),
+                };
+              }
             }
           }
 
-          study.setInputValues(currentInputs);
+          // Enumerate available inputs from properties for diagnostics
+          var propInputs = getPropertyInputs().summary;
+          var infoInputs = getInputInfoSummary();
 
-          // Some complex studies recompile after setInputValues, making getInputValues()
-          // temporarily return []. Return the values we set instead.
-          var allInputs = study.getInputValues();
+          var allInputs = study.getInputValues ? study.getInputValues() : [];
           return {
             updated_inputs: updatedKeys,
-            all_inputs: allInputs.length > 0 ? allInputs : currentInputs,
-            note: allInputs.length === 0 ? 'Study is recompiling — inputs shown are the values set' : undefined,
+            path: path,
+            all_inputs: allInputs.length > 0 ? allInputs : (propInputs.length > 0 ? propInputs : infoInputs),
+            unverified: unverified,
+            note: allInputs.length === 0 ? 'Custom script: getInputValues() empty — used fallback path; prefer IDs shown in all_inputs.' : undefined,
           };
         })()
       `);
@@ -75,8 +170,11 @@ export function registerIndicatorTools(server) {
         content: [{ type: 'text', text: JSON.stringify({
           success: true,
           entity_id,
+          path: result.path,
           updated_inputs: result.updated_inputs,
           all_inputs: result.all_inputs,
+          unverified: result.unverified,
+          note: result.note,
         }, null, 2) }],
       };
     } catch (err) {

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -83,6 +83,17 @@ async function ensurePineEditorOpen() {
   return false;
 }
 
+function formatPineCompilerMessage(item) {
+  let message = item?.message || '';
+  const ctx = item?.ctx;
+  if (ctx && typeof ctx === 'object') {
+    for (const [key, value] of Object.entries(ctx)) {
+      message = message.replaceAll(`{${key}}`, String(value));
+    }
+  }
+  return message;
+}
+
 export function registerPineTools(server) {
 
   server.tool('pine_get_source', 'Get current Pine Script source code from the editor', {}, async () => {
@@ -796,7 +807,8 @@ export function registerPineTools(server) {
               column: e.start?.column,
               end_line: e.end?.line,
               end_column: e.end?.column,
-              message: e.message,
+              message: formatPineCompilerMessage(e),
+              code: e.code,
             });
           }
         }
@@ -807,7 +819,8 @@ export function registerPineTools(server) {
             warnings.push({
               line: w.start?.line,
               column: w.start?.column,
-              message: w.message,
+              message: formatPineCompilerMessage(w),
+              code: w.code,
             });
           }
         }

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -6,6 +6,22 @@ function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
 
+export function replayDateToUnixSeconds(date) {
+  if (!date) return null;
+
+  const raw = String(date).trim();
+  if (!raw) return null;
+  if (/^\d+$/.test(raw)) return Number(raw);
+
+  const parsed = raw.includes('T') ? new Date(raw) : new Date(`${raw}T00:00:00Z`);
+  const time = parsed.getTime();
+  if (Number.isNaN(time)) {
+    throw new Error(`Invalid replay date: ${date}. Use YYYY-MM-DD, ISO datetime, or a Unix timestamp in seconds.`);
+  }
+
+  return Math.floor(time / 1000);
+}
+
 export function registerReplayTools(server) {
 
   server.tool('replay_start', 'Start bar replay mode, optionally at a specific date', {
@@ -29,13 +45,21 @@ export function registerReplayTools(server) {
       await new Promise(r => setTimeout(r, 500));
 
       if (date) {
-        await evaluate(`${rp}.selectDate(new Date('${date}'))`);
+        // TradingView expects Unix timestamp in seconds for selectDate
+        const ts = replayDateToUnixSeconds(date);
+        await evaluate(`${rp}.selectDate(${ts})`);
       } else {
         await evaluate(`${rp}.selectFirstAvailableDate()`);
       }
-      await new Promise(r => setTimeout(r, 500));
+      await new Promise(r => setTimeout(r, 1000));
 
-      const started = await evaluate(wv(`${rp}.isReplayStarted()`));
+      // Check if replay actually started; if not, try startReplay()
+      let started = await evaluate(wv(`${rp}.isReplayStarted()`));
+      if (!started) {
+        try { await evaluate(`${rp}.startReplay()`); } catch { /* may not exist */ }
+        await new Promise(r => setTimeout(r, 500));
+        started = await evaluate(wv(`${rp}.isReplayStarted()`));
+      }
       const currentDate = await evaluate(wv(`${rp}.currentDate()`));
 
       return {

--- a/tests/chart_timeframe.test.js
+++ b/tests/chart_timeframe.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeTimeframe } from '../src/tools/chart.js';
+
+describe('normalizeTimeframe', () => {
+  it('keeps minute resolutions as TradingView minute counts', () => {
+    assert.equal(normalizeTimeframe('5'), '5');
+    assert.equal(normalizeTimeframe('5m'), '5');
+    assert.equal(normalizeTimeframe('15 minutes'), '15');
+  });
+
+  it('converts hour aliases to TradingView minute counts', () => {
+    assert.equal(normalizeTimeframe('1h'), '60');
+    assert.equal(normalizeTimeframe('4H'), '240');
+    assert.equal(normalizeTimeframe('2 hours'), '120');
+  });
+
+  it('normalizes daily, weekly, and monthly periods', () => {
+    assert.equal(normalizeTimeframe('D'), 'D');
+    assert.equal(normalizeTimeframe('1D'), 'D');
+    assert.equal(normalizeTimeframe('2D'), '2D');
+    assert.equal(normalizeTimeframe('W'), 'W');
+    assert.equal(normalizeTimeframe('1W'), 'W');
+    assert.equal(normalizeTimeframe('M'), 'M');
+    assert.equal(normalizeTimeframe('1M'), 'M');
+    assert.equal(normalizeTimeframe('3 months'), '3M');
+  });
+
+  it('rejects missing or unsupported resolutions with useful errors', () => {
+    assert.throws(() => normalizeTimeframe(undefined), /timeframe is required/);
+    assert.throws(() => normalizeTimeframe(''), /timeframe cannot be empty/);
+    assert.throws(() => normalizeTimeframe('quarterly'), /Unsupported timeframe/);
+  });
+});

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1,26 +1,21 @@
 /**
  * E2E tests for TradingView MCP tools.
- * Requires TradingView Desktop running with --remote-debugging-port=9222
+ * Requires TradingView Desktop running with a chart open. Uses the repo
+ * connection adapter, so it supports direct CDP or the Electron bridge
+ * fallback.
  *
  * Run: node --test tests/e2e.test.js
  */
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import CDP from 'chrome-remote-interface';
+import { disconnect, evaluate as tvEvaluate, getClient } from '../src/connection.js';
 
 let client;
-let Runtime;
 
 // Helper: evaluate JS in TradingView context
 async function evaluate(expr) {
-  const { result } = await Runtime.evaluate({
-    expression: expr,
-    returnByValue: true,
-    awaitPromise: true,
-  });
-  if (result.subtype === 'error') throw new Error(result.description);
-  return result.value;
+  return tvEvaluate(expr, { awaitPromise: true });
 }
 
 // Helper: check if a specific API path exists
@@ -34,31 +29,23 @@ async function apiExists(path) {
 describe('TradingView MCP E2E Tests', () => {
 
   before(async () => {
-    // Connect to TradingView via CDP
     try {
-      const targets = await CDP.List({ host: 'localhost', port: 9222 });
-      const chartTarget = targets.find(t => t.url && t.url.includes('tradingview.com/chart'));
-      if (!chartTarget) throw new Error('No TradingView chart target found');
-
-      client = await CDP({ host: 'localhost', port: 9222, target: chartTarget.id });
-      await client.Runtime.enable();
-      await client.Page.enable();
-      Runtime = client.Runtime;
+      client = await getClient();
     } catch (err) {
-      console.error('Cannot connect to TradingView. Make sure it is running with --remote-debugging-port=9222');
+      console.error(`Cannot connect to TradingView: ${err.message}`);
       process.exit(1);
     }
   });
 
   after(async () => {
-    if (client) try { await client.close(); } catch {}
+    await disconnect();
   });
 
   // ─── Health & Connection ─────────────────────────────────────────
 
   describe('Health & Connection', () => {
-    it('should connect via CDP', () => {
-      assert.ok(client, 'CDP client connected');
+    it('should connect through the TradingView connection adapter', () => {
+      assert.ok(client, 'TradingView client connected');
     });
 
     it('should find chart API', async () => {
@@ -448,7 +435,7 @@ describe('TradingView MCP E2E Tests', () => {
   // ─── Screenshots ─────────────────────────────────────────────────
 
   describe('Screenshots', () => {
-    it('should capture page screenshot via CDP', async () => {
+    it('should capture page screenshot', async () => {
       const { data } = await client.Page.captureScreenshot({ format: 'png' });
       assert.ok(data, 'Screenshot data returned');
       assert.ok(data.length > 100, 'Screenshot has content');

--- a/tests/pine_analyze.test.js
+++ b/tests/pine_analyze.test.js
@@ -293,7 +293,11 @@ this_function_does_not_exist()`;
     // API returns { success: true, result: { errors2: [...] } } for compile errors
     const errors = result?.result?.errors2 || [];
     assert.ok(errors.length > 0, `Should have compilation errors, got: ${JSON.stringify(result).slice(0, 200)}`);
-    assert.ok(errors[0].message.includes('this_function_does_not_exist'), 'Error should mention the bad function');
+    assert.ok(
+      errors[0].message.includes('this_function_does_not_exist') ||
+        errors[0]?.ctx?.fullName === 'this_function_does_not_exist',
+      'Error should identify the bad function'
+    );
   });
 
   it('should handle empty source gracefully', async () => {

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -1,0 +1,23 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { replayDateToUnixSeconds } from '../src/tools/replay.js';
+
+describe('replayDateToUnixSeconds', () => {
+  it('keeps unix second strings as numbers', () => {
+    assert.equal(replayDateToUnixSeconds('1711929600'), 1711929600);
+  });
+
+  it('parses YYYY-MM-DD as UTC midnight seconds', () => {
+    assert.equal(replayDateToUnixSeconds('2024-04-01'), 1711929600);
+  });
+
+  it('parses ISO datetime strings without appending a duplicate time suffix', () => {
+    assert.equal(replayDateToUnixSeconds('2024-04-01T12:30:00Z'), 1711974600);
+  });
+
+  it('returns null for omitted dates and rejects invalid dates', () => {
+    assert.equal(replayDateToUnixSeconds(''), null);
+    assert.throws(() => replayDateToUnixSeconds('not-a-date'), /Invalid replay date/);
+  });
+});

--- a/tests/tool_schema.test.js
+++ b/tests/tool_schema.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+
+import { legacyToolSchemaToZodShape } from '../src/tool-schema.js';
+
+describe('legacyToolSchemaToZodShape', () => {
+  it('converts legacy string fields into zod schemas', () => {
+    const shape = legacyToolSchemaToZodShape({
+      timeframe: { type: 'string', description: 'Timeframe' },
+    });
+
+    assert.equal(shape.timeframe.safeParse('60').success, true);
+    assert.equal(shape.timeframe.safeParse(60).success, false);
+  });
+
+  it('keeps existing zod schemas unchanged', () => {
+    const schema = z.string().describe('Pine source');
+    const shape = legacyToolSchemaToZodShape({ source: schema });
+
+    assert.equal(shape.source, schema);
+  });
+
+  it('makes defaulted legacy fields optional', () => {
+    const shape = legacyToolSchemaToZodShape({
+      filename: { type: 'string', default: '' },
+      options: { type: 'object', default: {} },
+      items: { type: 'array', default: [] },
+    });
+
+    assert.deepEqual(shape.filename.parse(undefined), '');
+    assert.deepEqual(shape.options.parse(undefined), {});
+    assert.deepEqual(shape.items.parse(undefined), []);
+  });
+
+  it('converts legacy object fields into JSON-schema-compatible records', () => {
+    const shape = legacyToolSchemaToZodShape({
+      inputs: { type: 'object', description: 'Input overrides' },
+    });
+
+    assert.equal(shape.inputs.safeParse({ length: 20, source: 'close' }).success, true);
+  });
+});


### PR DESCRIPTION
## Summary
- add legacy tool-schema conversion so argument-bearing MCP tools expose usable input schemas
- harden chart control, bridge fallback Input support, indicator input setting, replay date parsing, and Pine compiler message parsing
- update e2e tests to use the shared connection adapter and add unit tests for schema/timeframe/replay behavior
- document CDP plus Electron bridge operation and add a chart-control skill

## Verification
- npm test
- git diff --check
- live bridge check: chart_set_timeframe { timeframe: "1h" } returned actual_resolution "60"
- live bridge check: symbol_search ran through Input proxy without changing the chart symbol
- live fail-closed check: indicator_set_inputs with an invalid Warbird input key returned an error
