### PR TITLE
docs: fix MCP config path (Claude Code does not read ~/.claude/.mcp.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Gives your AI assistant eyes and hands on your own chart:
 
 Paste this into Claude Code and it will handle the rest:
 
-> Install the TradingView MCP server. Clone https://github.com/tradesdontlie/tradingview-mcp.git, run npm install, add it to my MCP config at ~/.claude/.mcp.json, and launch TradingView with the debug port. Then verify the connection with tv_health_check.
+> Install the TradingView MCP server. Clone https://github.com/tradesdontlie/tradingview-mcp.git, run npm install, register it with `claude mcp add` (or add it to my user-scope MCP config at ~/.claude.json), and launch TradingView with the debug port. Then verify the connection with tv_health_check.
 
 Or follow the manual steps below.
 
@@ -115,20 +115,41 @@ scripts\launch_tv_debug.bat
 
 ### 3. Add to Claude Code
 
-Add to your Claude Code MCP config (`~/.claude/.mcp.json` or project `.mcp.json`):
+The simplest path is the `claude mcp add` CLI:
 
-```json
-{
-  "mcpServers": {
-    "tradingview": {
-      "command": "node",
-      "args": ["/path/to/tradingview-mcp/src/server.js"]
-    }
-  }
-}
+```bash
+claude mcp add tradingview --scope user -- node /path/to/tradingview-mcp/src/server.js
 ```
 
-Replace `/path/to/tradingview-mcp` with your actual path.
+That writes a top-level `mcpServers` entry into `~/.claude.json` (user scope, available in every project). Replace `/path/to/tradingview-mcp` with your actual clone path.
+
+If you'd rather edit a config by hand, you have two options. Note: **`~/.claude/.mcp.json` is not a path Claude Code reads** — don't use it.
+
+- **User scope** — top-level `mcpServers` in `~/.claude.json` (available everywhere):
+  ```json
+  {
+    "mcpServers": {
+      "tradingview": {
+        "command": "node",
+        "args": ["/path/to/tradingview-mcp/src/server.js"]
+      }
+    }
+  }
+  ```
+
+- **Project scope** — a `.mcp.json` at the root of a specific project (committed, shared with teammates):
+  ```json
+  {
+    "mcpServers": {
+      "tradingview": {
+        "command": "node",
+        "args": ["/path/to/tradingview-mcp/src/server.js"]
+      }
+    }
+  }
+  ```
+
+Restart Claude Code after editing either file so it picks up the new server.
 
 ### 4. Verify
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -14,7 +14,15 @@ If the user specifies a different install path, use that instead of `~/tradingvi
 
 ## Step 2: Add to MCP Config
 
-Add the server to the user's Claude Code MCP configuration. The config file is at `~/.claude/.mcp.json` (global) or `.mcp.json` (project-level).
+Register the server with the Claude Code MCP CLI (preferred — it edits the right file with the right structure):
+
+```bash
+claude mcp add tradingview --scope user -- node <INSTALL_PATH>/src/server.js
+```
+
+`--scope user` writes a top-level `mcpServers` entry into `~/.claude.json` so the server is available in every project. Use `--scope project` instead to write a `.mcp.json` at the project root (committed, shared).
+
+If editing config by hand, the file is `~/.claude.json` (user scope) or `<project>/.mcp.json` (project scope). **Do not use `~/.claude/.mcp.json` — Claude Code does not read that path.** The entry to add (under top-level `mcpServers` for user scope, or top-level for project scope):
 
 ```json
 {
@@ -96,7 +104,7 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 |---------|----------|
 | `cdp_connected: false` | Launch TradingView with `--remote-debugging-port=9222` |
 | `ECONNREFUSED` | TradingView isn't running or port 9222 is blocked |
-| MCP server not showing in Claude Code | Check `~/.claude/.mcp.json` syntax, restart Claude Code |
+| MCP server not showing in Claude Code | Confirm entry is in `~/.claude.json` (user scope) or `<project>/.mcp.json` (project scope) — not `~/.claude/.mcp.json`. Validate JSON, then restart Claude Code |
 | `tv` command not found | Run `npm link` from the project directory |
 | Tools return stale data | TradingView may still be loading — wait a few seconds |
 | Pine Editor tools fail | Open the Pine Editor panel first (`ui_open_panel pine-editor open`) |


### PR DESCRIPTION
## Summary

The README and `SETUP_GUIDE.md` both tell users to install the MCP server by editing `~/.claude/.mcp.json`. Claude Code does not read that path — installs following the docs silently fail to load the server.

The actual paths Claude Code reads:

- **User scope**: top-level `mcpServers` in `~/.claude.json`
- **Project scope**: `<project-root>/.mcp.json`

The "paste this prompt into Claude Code" install snippet at the top of the README inherits the same path, so the one-shot install also produces a broken setup. (I hit this firsthand — pasted the prompt, Claude Code dutifully wrote `~/.claude/.mcp.json`, then `tv_health_check` was nowhere to be found after restart.)

## Changes

- README install snippet: recommend `claude mcp add tradingview --scope user -- node <path>/src/server.js`, with manual JSON shown for both user (`~/.claude.json`) and project (`<project>/.mcp.json`) scope. Explicitly call out that `~/.claude/.mcp.json` is not a valid path.
- `SETUP_GUIDE.md` (the doc agents are pointed at): same correction, plus updated the troubleshooting row about "MCP server not showing".

No code changes.

## Test plan

- [x] Manually verified `claude mcp add tradingview --scope user -- node ~/dev/tradingview-mcp/src/server.js` writes to top-level `mcpServers` in `~/.claude.json` and the server loads after restart
- [x] Confirmed `~/.claude/.mcp.json` is not in Claude Code's MCP config search path (servers placed there don't load)
- [x] `tv_health_check` reachable from Claude Code once the entry is in `~/.claude.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)