### PR TITLE
Add CLI chart capture, watchlist update, and OHLCV helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,28 @@ Claude Code ←→ MCP Server (stdio) ←→ CDP (localhost:9222) ←→ Trading
 ```
 
 Pine graphics path: `study._graphics._primitivesCollection.dwglines.get('lines').get(false)._primitivesDataById`
+
+## 12 Hr Update — Custom Watchlist Scanner
+
+When the user asks for a "12 hr update" or "twelve hour update", follow this workflow:
+
+### Step-by-Step
+1. Read `rules.json` in the project root to get the watchlist symbols, timeframes, and bias criteria
+2. For each symbol in `watchlist`:
+   a. `chart_set_symbol` to switch to that symbol
+   b. For each timeframe in `timeframes` (e.g., "W", "D", "240"):
+      - `chart_set_timeframe` to switch
+      - `quote_get` for current price
+      - `data_get_study_values` for all indicator readings
+      - `data_get_ohlcv` with `summary: true` for price stats
+      - `data_get_pine_lines` for support/resistance levels
+   c. Apply `biasCriteria` from rules.json to determine: Bullish / Bearish / Neutral
+3. Compile all results into a structured report
+4. Save to `~/.tradingview-mcp/sessions/` as `YYYY-MM-DD_HH-mm.json`
+5. Display the formatted report to the user
+
+### Report Format
+Each asset should show: Symbol | Bias | Price | Key Level | Per-Timeframe Breakdown | Indicator Values | Watch Points
+
+### Summary Section
+End with a summary grouping assets by Bullish/Bearish/Neutral, plus any risk checklist items from `rules.json.riskRules`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,42 @@
+{
+  "watchlist": ["BTCUSD", "ETHUSD", "SOLUSD", "AAPL", "TSLA", "NVDA"],
+  "timeframes": ["1W", "1D", "4H"],
+  "biasCriteria": {
+    "bullish": [
+      "RSI(14) above 50 and rising",
+      "MACD histogram positive and increasing",
+      "Price above 21 EMA and 50 EMA",
+      "21 EMA above 50 EMA (golden alignment)"
+    ],
+    "bearish": [
+      "RSI(14) below 50 and falling",
+      "MACD histogram negative and decreasing",
+      "Price below 21 EMA and 50 EMA",
+      "21 EMA below 50 EMA (death alignment)"
+    ],
+    "neutral": [
+      "Mixed signals across indicators",
+      "Price choppy between 21 and 50 EMA",
+      "RSI between 45-55 with no clear trend"
+    ]
+  },
+  "riskRules": {
+    "maxPositionSize": "2% of portfolio per trade",
+    "stopLossRequired": true,
+    "riskRewardMinimum": 2.0,
+    "preSessionChecklist": [
+      "Check for major news events",
+      "Verify no earnings announcements today",
+      "Check overall market sentiment (SPX/VIX)"
+    ]
+  },
+  "twelveHrUpdate": {
+    "enabled": true,
+    "scheduleHours": [9, 21],
+    "reportFormat": "structured",
+    "includeKeyLevels": true,
+    "includeVolumeAnalysis": true,
+    "saveHistory": true,
+    "historyDir": "~/.tradingview-mcp/sessions"
+  }
+}

--- a/tv_capture.js
+++ b/tv_capture.js
@@ -16,6 +16,9 @@ import { evaluate, evaluateAsync, getClient, getTargetInfo } from './src/connect
 import { mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
+import { platform } from 'os';
+
+const IS_WIN = platform() === 'win32';
 
 const SCREENSHOT_DIR = '/Users/rattanon/tradingview-mcp/screenshots';
 
@@ -44,11 +47,25 @@ async function activateTarget() {
 
 async function bringToForeground() {
   try {
-    execSync(`osascript -e 'tell application "TradingView" to activate'`, { timeout: 3000 });
+    if (IS_WIN) {
+      // Windows: ใช้ PowerShell focus window ด้วย AppActivate
+      execSync(
+        `powershell -NoProfile -NonInteractive -Command "` +
+        `$proc = Get-Process -Name TradingView -ErrorAction SilentlyContinue | Select-Object -First 1; ` +
+        `if ($proc) { ` +
+        `  Add-Type -AssemblyName Microsoft.VisualBasic; ` +
+        `  [Microsoft.VisualBasic.Interaction]::AppActivate($proc.Id) ` +
+        `}"`,
+        { timeout: 5000 }
+      );
+    } else {
+      // macOS: AppleScript
+      execSync(`osascript -e 'tell application "TradingView" to activate'`, { timeout: 3000 });
+    }
     process.stderr.write(`[focus] TradingView activated\n`);
     await new Promise(r => setTimeout(r, 400));  // รอ focus transition
   } catch (e) {
-    process.stderr.write(`[focus] AppleScript failed: ${e.message}\n`);
+    process.stderr.write(`[focus] bringToForeground failed: ${e.message}\n`);
   }
 }
 

--- a/tv_capture.js
+++ b/tv_capture.js
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * tv_capture.js — CLI helper for screenshotter.py
+ * Usage: node tv_capture.js <symbol> <tf> <filename>
+ * Output: JSON { success, file_path, error }
+ *
+ * Strategy:
+ *  1. setSymbol()    — chart.setSymbol() API + waitForChartReady()
+ *  2. setTimeframe() — chart.setResolution() API + waitForChartReady()
+ *  3. Page.captureScreenshot (full page) → sips crop ด้วย physical pixels
+ *     (CDP clip coordinates ให้ผลผิดบน Retina — crop ด้วย sips แทน)
+ */
+
+import { setSymbol, setTimeframe } from './src/core/chart.js';
+import { evaluate, evaluateAsync, getClient, getTargetInfo } from './src/connection.js';
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+
+const SCREENSHOT_DIR = '/Users/rattanon/tradingview-mcp/screenshots';
+
+const [,, symbol, tf, filename] = process.argv;
+
+if (!symbol || !tf || !filename) {
+  process.stdout.write(JSON.stringify({ success: false, error: 'Usage: node tv_capture.js <symbol> <tf> <filename>' }) + '\n');
+  process.exit(1);
+}
+
+// ── Activate target (ป้องกัน rAF throttling สำหรับ background tabs) ──────────
+
+async function activateTarget() {
+  try {
+    const info = await getTargetInfo();
+    if (info && info.id) {
+      await fetch(`http://localhost:9222/json/activate/${info.id}`);
+      process.stderr.write(`[activate] Target ${info.id.substring(0, 8)}... activated\n`);
+    }
+  } catch (e) {
+    process.stderr.write(`[activate] Failed: ${e.message}\n`);
+  }
+}
+
+// ── Bring TradingView to OS foreground (เพื่อเปิด rAF) ───────────────────────
+
+async function bringToForeground() {
+  try {
+    execSync(`osascript -e 'tell application "TradingView" to activate'`, { timeout: 3000 });
+    process.stderr.write(`[focus] TradingView activated\n`);
+    await new Promise(r => setTimeout(r, 400));  // รอ focus transition
+  } catch (e) {
+    process.stderr.write(`[focus] AppleScript failed: ${e.message}\n`);
+  }
+}
+
+// ── รอให้ canvas repaint จริง (ผ่าน rAF) ─────────────────────────────────────
+
+async function waitForCanvasRepaint() {
+  // 1. Bring TradingView window to OS foreground → rAF ทำงานที่ full speed
+  await bringToForeground();
+
+  // 2. Dispatch resize เพื่อ trigger TradingView repaint schedule
+  try { await evaluate(`window.dispatchEvent(new Event('resize'))`); } catch {}
+
+  // 3. รอ 5 rAF cycles (ตอนนี้ rAF ทำงานได้เพราะ window อยู่ foreground)
+  //    TradingView render chart ผ่าน rAF → 5 cycles (~83ms@60fps) มากพอ
+  try {
+    await evaluateAsync(`new Promise(r => {
+      var n = 0;
+      function tick() { if (++n >= 5) r(); else requestAnimationFrame(tick); }
+      requestAnimationFrame(tick);
+    })`);
+    process.stderr.write(`[repaint] rAF cycles done\n`);
+  } catch {
+    await new Promise(r => setTimeout(r, 300));
+    process.stderr.write(`[repaint] rAF fallback setTimeout\n`);
+  }
+
+  // 4. Buffer เพิ่ม 200ms เผื่อ TradingView มี post-render processing
+  await new Promise(r => setTimeout(r, 200));
+}
+
+// ── Dismiss popups ────────────────────────────────────────────────────────────
+
+async function dismissPopups() {
+  await evaluate(`
+    (function() {
+      var evt = new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true });
+      document.dispatchEvent(evt);
+      var closeBtn = document.querySelector('[data-name="close"]') ||
+                     document.querySelector('[class*="closeButton"]') ||
+                     document.querySelector('[aria-label="Close"]');
+      if (closeBtn) closeBtn.click();
+    })()`);
+  await new Promise(r => setTimeout(r, 400));
+}
+
+// ── Get chart bounds รวม header (CSS pixels) ──────────────────────────────────
+
+async function getChartBoundsWithHeader() {
+  return await evaluate(`
+    (function() {
+      var panes = Array.from(document.querySelectorAll('[data-name="pane-canvas"]'));
+      if (!panes[0]) return null;
+
+      var firstR = panes[0].getBoundingClientRect();
+      var lastR  = panes[panes.length - 1].getBoundingClientRect();
+      var panesH = (lastR.top + lastR.height) - firstR.top + 16;
+
+      // หา header bar (symbol name + TF buttons)
+      var header = document.querySelector('[data-name="header-toolbar"]')
+                || document.querySelector('[data-name="legend"]')
+                || document.querySelector('[class*="headerWrapper"]')
+                || document.querySelector('[class*="chart-toolbar"]');
+
+      var headerH = 0;
+      if (header) {
+        var hRect = header.getBoundingClientRect();
+        if (hRect.bottom <= firstR.top + 5) {
+          headerH = firstR.top - hRect.top;
+        }
+      }
+      if (headerH <= 0) headerH = Math.min(firstR.top, 48);
+
+      var y = Math.max(0, firstR.top - headerH);
+      return {
+        x:      firstR.left,
+        y:      y,
+        width:  firstR.width,
+        height: panesH + (firstR.top - y),
+      };
+    })()`);
+}
+
+// ── Capture ด้วย Page.captureScreenshot + clip ───────────────────────────────
+// (ใช้ได้เพราะ waitForCanvasRepaint ทำให้ window อยู่ foreground + rAF render แล้ว)
+// ข้อดี: รวม header toolbar (symbol name + TF buttons) ด้วย
+
+async function captureAndCrop(filePath) {
+  const c = await getClient();
+
+  // Get chart bounds รวม header (CSS pixels)
+  const bounds = await getChartBoundsWithHeader();
+  if (!bounds) throw new Error('ไม่พบ chart bounds');
+
+  const dpr = (await evaluate(`window.devicePixelRatio || 1`)) || 2;
+
+  // Capture ด้วย CDP clip — DIP coordinates, scale=dpr สำหรับ Retina
+  const { data } = await c.Page.captureScreenshot({
+    format: 'png',
+    fromSurface: true,
+    clip: {
+      x:      bounds.x,
+      y:      bounds.y,
+      width:  bounds.width,
+      height: bounds.height,
+      scale:  dpr,
+    },
+  });
+
+  if (!data) throw new Error('Page.captureScreenshot คืน null');
+
+  const buf = Buffer.from(data, 'base64');
+  writeFileSync(filePath, buf);
+  process.stderr.write(`[capture] screenshot size=${buf.length}\n`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+try {
+  // 0. Dismiss popups ก่อนเริ่ม
+  await dismissPopups();
+
+  // 1. Switch symbol — API + waitForChartReady()
+  const symResult = await setSymbol({ symbol });
+  process.stderr.write(`[symbol] ${symResult.symbol} ready=${symResult.chart_ready}\n`);
+  await new Promise(r => setTimeout(r, 300));
+
+  // 2. Dismiss popup อีกรอบ
+  await dismissPopups();
+
+  // 2b. Activate target เพื่อให้ rAF ทำงานที่ full speed (ไม่ throttle background tab)
+  await activateTarget();
+
+  // 3. Switch TF — setResolution() API + waitForChartReady()
+  const tfResult = await setTimeframe({ timeframe: tf });
+  process.stderr.write(`[tf] ${tf} ready=${tfResult.chart_ready}\n`);
+
+  // 4. รอจนกว่า chart จะโหลด DATA จริง (ไม่ใช่แค่ toolbar update)
+  //    ตรวจสอบ mainSeries().bars().size() ให้ stable ก่อน capture
+  const SETTLE_TIMEOUT = 12000;
+  const SETTLE_POLL    = 300;
+  let settleElapsed = 0;
+  const symUpper = symbol.toUpperCase().replace(/USDT$/, '');  // "ALGOUSDT" → "ALGO"
+
+  let prevBarsSize = -1;
+  let stableCount  = 0;
+  const STABLE_NEEDED = 3;  // bars count ต้องเท่ากัน 3 รอบติดกัน = 900ms stable
+
+  while (settleElapsed < SETTLE_TIMEOUT) {
+    await new Promise(r => setTimeout(r, SETTLE_POLL));
+    settleElapsed += SETTLE_POLL;
+
+    const rawState = await evaluate(`
+      (function() {
+        try {
+          var api = window.TradingViewApi;
+          if (!api || !api._activeChartWidgetWV) return JSON.stringify({sym:'',res:'',bars:0,barDur:0});
+          var w = api._activeChartWidgetWV.value && api._activeChartWidgetWV.value();
+          if (!w) return JSON.stringify({sym:'',res:'',bars:0,barDur:0});
+          var sym = (w.symbol ? w.symbol() : '').toUpperCase();
+          var res = w.resolution ? w.resolution() : '';
+          var bars = 0, barDur = 0;
+          try {
+            var m = w._chartWidget && w._chartWidget.model();
+            if (m) {
+              var bs = m.mainSeries().bars();
+              bars = bs.size();
+              // ตรวจสอบ bar duration จาก timestamp diff ของ 2 bars ล่าสุด
+              var li = bs.lastIndex(), fi = bs.firstIndex();
+              if (li - fi >= 2) {
+                var t1 = bs.valueAt(li);
+                var t2 = bs.valueAt(li - 1);
+                if (t1 && t2) barDur = t1[0] - t2[0];
+              }
+            }
+          } catch {}
+          return JSON.stringify({sym:sym, res:res, bars:bars, barDur:barDur});
+        } catch(e) {
+          return JSON.stringify({sym:'',res:'',bars:0,barDur:0,err:e.message});
+        }
+      })()
+    `);
+
+    let chartSym = '', chartRes = '', barsSize = 0, barDur = 0;
+    try { const s = JSON.parse(rawState); chartSym=s.sym; chartRes=s.res; barsSize=s.bars; barDur=s.barDur; } catch {}
+
+    const symOk   = chartSym && chartSym.includes(symUpper);
+    const resOk   = chartRes === tf;
+    // ตรวจ bar duration: tf=30→1800s, tf=60→3600s, tf=240→14400s
+    const expectedDur = parseInt(tf) * 60;
+    const durOk   = barDur === expectedDur;
+
+    if (symOk && resOk && durOk && barsSize > 0) {
+      if (barsSize === prevBarsSize) {
+        stableCount++;
+      } else {
+        stableCount = 1;
+        prevBarsSize = barsSize;
+      }
+    } else {
+      stableCount  = 0;
+      prevBarsSize = barsSize;
+    }
+
+    process.stderr.write(`[settle] ${settleElapsed}ms sym="${chartSym}" res="${chartRes}" barDur=${barDur}(want=${expectedDur}) bars=${barsSize} stable=${stableCount}/${STABLE_NEEDED}\n`);
+
+    if (symOk && resOk && durOk && stableCount >= STABLE_NEEDED) {
+      process.stderr.write(`[settle] data ready — bars=${barsSize} barDur=${barDur}\n`);
+      break;
+    }
+  }
+  if (settleElapsed >= SETTLE_TIMEOUT) {
+    process.stderr.write(`[settle] timeout — capture anyway\n`);
+  }
+
+  // 4b. รอให้ canvas repaint จริง (ผ่าน rAF) ก่อน capture
+  await waitForCanvasRepaint();
+
+  // 5. Capture (retry ถ้าไฟล์เล็กเกินไป — อาจ canvas ยัง blank)
+  mkdirSync(SCREENSHOT_DIR, { recursive: true });
+  const filePath = join(SCREENSHOT_DIR, `${filename}.png`);
+
+  const MAX_ATTEMPTS = 3;
+  const MIN_SIZE_KB   = 60;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    await captureAndCrop(filePath);
+    const { statSync } = await import('fs');
+    const sizeKb = statSync(filePath).size / 1024;
+    process.stderr.write(`[capture] attempt ${attempt} size=${Math.round(sizeKb * 1024)}\n`);
+    if (sizeKb >= MIN_SIZE_KB) break;
+    if (attempt < MAX_ATTEMPTS) {
+      process.stderr.write(`[capture] too small (${Math.round(sizeKb)}KB < ${MIN_SIZE_KB}KB), retrying...\n`);
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  }
+
+  process.stdout.write(JSON.stringify({ success: true, file_path: filePath }) + '\n');
+  process.exit(0);
+} catch (err) {
+  process.stdout.write(JSON.stringify({ success: false, error: err.message }) + '\n');
+  process.exit(1);
+}

--- a/tv_capture.js
+++ b/tv_capture.js
@@ -49,9 +49,11 @@ async function bringToForeground() {
   try {
     if (IS_WIN) {
       // Windows: ใช้ PowerShell focus window ด้วย AppActivate
+      // หา Edge หรือ Chrome ที่เปิด TradingView อยู่ (มี MainWindowTitle)
       execSync(
-        `powershell -NoProfile -NonInteractive -Command "` +
-        `$proc = Get-Process -Name TradingView -ErrorAction SilentlyContinue | Select-Object -First 1; ` +
+        `powershell -NoProfile -NonInteractive -Command ` +
+        `"$proc = Get-Process -Name msedge,chrome,TradingView -ErrorAction SilentlyContinue ` +
+        `| Where-Object {$_.MainWindowTitle -ne ''} | Select-Object -First 1; ` +
         `if ($proc) { ` +
         `  Add-Type -AssemblyName Microsoft.VisualBasic; ` +
         `  [Microsoft.VisualBasic.Interaction]::AppActivate($proc.Id) ` +

--- a/tv_ohlcv.js
+++ b/tv_ohlcv.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * tv_ohlcv.js — ดึง OHLCV bars จาก TradingView Desktop ผ่าน CDP
+ * Usage: node tv_ohlcv.js <symbol> <timeframe> [count]
+ *   symbol    — เช่น BTCUSDT
+ *   timeframe — TradingView resolution: 1, 5, 15, 30, 60, 240, D
+ *   count     — จำนวน bars (default 200, max 500)
+ * Output: JSON to stdout
+ *   { success: true, symbol, timeframe, bars: [{time,open,high,low,close,volume},...] }
+ *   { success: false, error: "..." }
+ */
+
+import { setSymbol, setTimeframe } from './src/core/chart.js';
+import { evaluate, evaluateAsync, KNOWN_PATHS } from './src/connection.js';
+
+const BARS_PATH = KNOWN_PATHS.mainSeriesBars;
+
+const [,, symbol, timeframe, countArg] = process.argv;
+
+if (!symbol || !timeframe) {
+  process.stdout.write(JSON.stringify({
+    success: false,
+    error: 'Usage: node tv_ohlcv.js <symbol> <timeframe> [count]'
+  }) + '\n');
+  process.exit(1);
+}
+
+const count = Math.min(parseInt(countArg || '200', 10), 500);
+
+async function fetchBars() {
+  // สลับ symbol + timeframe แล้วรอ chart โหลด
+  await setSymbol({ symbol });
+  await setTimeframe({ timeframe });
+
+  // รอให้ bars โหลดเสร็จ (retry สูงสุด 10 ครั้ง x 500ms)
+  let bars = null;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await new Promise(r => setTimeout(r, 500));
+    try {
+      const result = await evaluate(`
+        (function() {
+          var bars = ${BARS_PATH};
+          if (!bars || typeof bars.lastIndex !== 'function') return null;
+          var end   = bars.lastIndex();
+          var start = Math.max(bars.firstIndex(), end - ${count} + 1);
+          var out   = [];
+          for (var i = start; i <= end; i++) {
+            var v = bars.valueAt(i);
+            if (v) out.push({ time: v[0], open: v[1], high: v[2], low: v[3], close: v[4], volume: v[5] || 0 });
+          }
+          return out.length > 0 ? out : null;
+        })()
+      `);
+      if (result && result.length > 0) {
+        bars = result;
+        break;
+      }
+    } catch { /* ยังโหลดไม่เสร็จ */ }
+  }
+
+  if (!bars) throw new Error(`No bars loaded for ${symbol} ${timeframe} after retries`);
+  return bars;
+}
+
+fetchBars()
+  .then(bars => {
+    process.stdout.write(JSON.stringify({ success: true, symbol, timeframe, bar_count: bars.length, bars }) + '\n');
+    process.exit(0);
+  })
+  .catch(err => {
+    process.stdout.write(JSON.stringify({ success: false, symbol, timeframe, error: err.message }) + '\n');
+    process.exit(1);
+  });

--- a/tv_watchlist.js
+++ b/tv_watchlist.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * tv_watchlist.js — CLI helper สำหรับ watchlist_tv.py
+ * Usage: node tv_watchlist.js <list_name> <symbols_json>
+ *   list_name    : ชื่อ watchlist เช่น "Focus", "Watch", "Accum"
+ *   symbols_json : JSON array เช่น '["BINANCE:BTCUSDT.P","BINANCE:ETHUSDT.P"]'
+ *
+ * Output: JSON { success, added, removed, total, error }
+ *
+ * Strategy: เรียก TradingView REST API ผ่าน fetch() ใน browser context
+ *   → ใช้ browser session cookies อัตโนมัติ (ไม่ต้องดึง cookies เอง)
+ *   → ทำงานได้แม้ TradingView เปิดใน Chrome แบบปกติ (ไม่ต้อง CDP port 9222)
+ */
+
+import { evaluate } from './src/connection.js';
+
+const [,, listName, symbolsJson] = process.argv;
+
+if (!listName || !symbolsJson) {
+  process.stdout.write(JSON.stringify({
+    success: false,
+    error: 'Usage: node tv_watchlist.js <list_name> <symbols_json>'
+  }) + '\n');
+  process.exit(1);
+}
+
+let targetSymbols;
+try {
+  targetSymbols = JSON.parse(symbolsJson);
+} catch (e) {
+  process.stdout.write(JSON.stringify({ success: false, error: `Invalid JSON: ${e.message}` }) + '\n');
+  process.exit(1);
+}
+
+// ── Evaluate helper (store result in window global, poll it back) ─────────────
+
+async function evalAsync(js) {
+  // เซ็ต sentinel ก่อน เพื่อรู้ว่า fetch เสร็จแล้ว
+  const key = `__tv_wl_${Date.now()}`;
+  await evaluate(`window['${key}'] = '__pending__'; ${js}.then(r => { window['${key}'] = r; }).catch(e => { window['${key}'] = {__error: e.message}; });`);
+
+  // Poll ทุก 200ms จนกว่าจะมีผล (timeout 15s)
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 200));
+    const raw = await evaluate(`JSON.stringify(window['${key}'])`);
+    if (raw && raw !== '"__pending__"') {
+      try { return JSON.parse(JSON.parse(raw)); } catch { return JSON.parse(raw); }
+    }
+  }
+  throw new Error('evalAsync timeout');
+}
+
+// ── TV REST API helpers ────────────────────────────────────────────────────────
+
+const TV_BASE = 'https://in.tradingview.com';
+
+async function getAllLists() {
+  return evalAsync(`fetch('${TV_BASE}/api/v1/symbols_list/custom/', {credentials:'include'}).then(r=>r.json())`);
+}
+
+function getCsrf() {
+  return evaluate(`document.cookie.match(/csrftoken=([^;]+)/)?.[1] || ''`);
+}
+
+async function apiPost(path, body) {
+  const csrf = await getCsrf();
+  return evalAsync(`fetch('${TV_BASE}${path}', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': ${JSON.stringify(csrf || '')}
+    },
+    body: JSON.stringify(${JSON.stringify(body)})
+  }).then(r => r.ok ? r.json().catch(()=>({ok:true,status:r.status})) : r.text().then(t=>({__httpError:r.status,body:t.slice(0,200)})))`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+try {
+  // 1. ดึง watchlists ทั้งหมด
+  const lists = await getAllLists();
+  if (!Array.isArray(lists)) {
+    throw new Error(`getAllLists returned: ${JSON.stringify(lists)}`);
+  }
+  process.stderr.write(`[wl] Found ${lists.length} lists: ${lists.map(l=>l.name).join(', ')}\n`);
+
+  // 2. หา list ที่ต้องการ (exact → partial)
+  let existing = lists.find(l => l.name === listName)
+                || lists.find(l => l.name.includes(listName));
+
+  let listId;
+  if (existing) {
+    listId = existing.id;
+    process.stderr.write(`[wl] Found '${existing.name}' (id=${listId})\n`);
+  } else {
+    // สร้างใหม่
+    process.stderr.write(`[wl] Creating new list '${listName}'...\n`);
+    const created = await evalAsync(`fetch('${TV_BASE}/api/v1/symbols_list/custom/', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {'Content-Type':'application/json','X-CSRFToken': document.cookie.match(/csrftoken=([^;]+)/)?.[1]||''},
+      body: JSON.stringify({name:${JSON.stringify(listName)}, symbols:[]})
+    }).then(r=>r.json())`);
+    if (!created || !created.id) throw new Error(`Create list failed: ${JSON.stringify(created)}`);
+    listId = created.id;
+    existing = { symbols: [] };
+    process.stderr.write(`[wl] Created '${listName}' (id=${listId})\n`);
+  }
+
+  // 3. เปรียบเทียบ current vs target
+  const currentSet  = new Set(existing.symbols || []);
+  const targetSet   = new Set(targetSymbols);
+  const toRemove    = [...currentSet].filter(s => !targetSet.has(s));
+  const toAdd       = targetSymbols.filter(s => !currentSet.has(s));
+
+  process.stderr.write(`[wl] current=${currentSet.size} target=${targetSet.size} remove=${toRemove.length} add=${toAdd.length}\n`);
+
+  // 4. Remove
+  if (toRemove.length > 0) {
+    const r = await apiPost(`/api/v1/symbols_list/custom/${listId}/remove/`, toRemove);
+    process.stderr.write(`[wl] remove result: ${JSON.stringify(r)}\n`);
+  }
+
+  // 5. Add
+  if (toAdd.length > 0) {
+    const r = await apiPost(`/api/v1/symbols_list/custom/${listId}/append/?source=web-tvd`, toAdd);
+    process.stderr.write(`[wl] add result: ${JSON.stringify(r)}\n`);
+  }
+
+  process.stdout.write(JSON.stringify({
+    success: true,
+    added:   toAdd.length,
+    removed: toRemove.length,
+    total:   targetSymbols.length,
+  }) + '\n');
+  process.exit(0);
+
+} catch (err) {
+  process.stdout.write(JSON.stringify({ success: false, error: err.message }) + '\n');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- **`tv_capture.js`** — CLI helper for capturing TradingView chart screenshots with correct symbol/TF verification
- **`tv_watchlist.js`** — CLI helper to update TradingView watchlists via `fetch()` in browser context
- **`tv_ohlcv.js`** — CLI helper to fetch OHLCV bars via CDP
- **`rules.json`** — watchlist symbols, timeframes, bias criteria, and risk rules for the 12-hour update workflow
- **`CLAUDE.md`** — document key design decisions and the 12-hour update workflow

## What changed and why

### tv_capture.js — Fix duplicate/stale chart screenshots and missing header

**Problem 1: Duplicate screenshots** — `canvas.toDataURL()` returned identical pixels across different symbols/timeframes because Electron throttles `requestAnimationFrame` for background tabs. The canvas never repainted.

**Fix:**
1. AppleScript `tell application "TradingView" to activate` — brings the Electron window to OS foreground, enabling rAF at full speed (60 fps)
2. `evaluateAsync` + 5 rAF cycles — waits for TradingView to actually repaint the canvas before capture
3. `Target.activateTarget` via `/json/activate/{id}` — ensures the correct CDP tab is active within TradingView

**Problem 2: Missing symbol name and TF in screenshots** — `canvas.toDataURL()` composites only `[data-name="pane-canvas"]` HTML5 Canvas elements. The header toolbar (symbol name, TF buttons) is HTML DOM and not part of those canvas elements.

**Fix:** Switch to `Page.captureScreenshot` with `clip` parameter — captures the full compositor frame including DOM. Works correctly now that AppleScript + rAF ensures the compositor has a fresh frame.

**Additional reliability improvements:**
- `barDur` stability poll via `mainSeries().bars().valueAt()` timestamp diff — confirms correct TF data is loaded (`bars.size()` always returns 300 from cache regardless of TF)
- Size-based retry (3 attempts, min 60 KB) — catches blank captures

### tv_watchlist.js — Update watchlists without manual cookie handling

Uses `fetch()` inside the TradingView browser context via `evaluate()`, so session cookies are used automatically. No need to extract cookies via CDP `Network.getCookies`.

### tv_ohlcv.js

New CLI script to fetch OHLCV bar data from TradingView Desktop via CDP.

### rules.json + CLAUDE.md

Configuration and documentation for the 12-hour update workflow.

## Test plan

- [x] Captured ARBUSDT.P 30m and ENAUSDT.P 4H — different MD5 hashes (no duplicate frames)
- [x] Both screenshots show symbol name + TF label in header
- [x] File sizes 300–330 KB (well above 60 KB blank threshold)
- [x] `barDur` check confirms correct TF data loaded before capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)