### PR TITLE
Fix CDP bridge: target picker, liveness probe, symbol resolution

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -53,13 +53,19 @@ export function requireFinite(value, name) {
 export async function getClient() {
   if (client) {
     try {
-      // Quick liveness check
-      await client.Runtime.evaluate({ expression: '1', returnByValue: true });
-      return client;
-    } catch {
-      client = null;
-      targetInfo = null;
-    }
+      // Strict liveness: cached tab must be alive AND expose chart APIs.
+      // Plain `Runtime.evaluate('1')` passes on any TradingView page
+      // (news-flow, watchlist, symbols) and used to lock the picker to
+      // whichever tab was attached first — silently breaking every
+      // chart-API tool when a chart tab opened later.
+      const probe = await client.Runtime.evaluate({
+        expression: 'typeof window.TradingViewApi !== "undefined" && window.TradingViewApi._activeChartWidgetWV !== undefined',
+        returnByValue: true,
+      });
+      if (probe?.result?.value === true) return client;
+    } catch {}
+    client = null;
+    targetInfo = null;
   }
   return connect();
 }
@@ -69,10 +75,10 @@ export async function connect(targetId = null) {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const target = targetId ? await findTargetById(targetId) : await findChartTarget();
-      if (!target) {
-        throw new Error(targetId
-          ? `CDP target ${targetId} not found — is the tab still open?`
-          : 'No TradingView chart target found. Is TradingView open with a chart?');
+      // findChartTarget now throws explicit errors with actionable hints (no
+      // chart tab vs no TV at all), so only findTargetById can still return null.
+      if (targetId && !target) {
+        throw new Error(`CDP target ${targetId} not found — is the tab still open?`);
       }
       targetInfo = target;
       client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
@@ -85,6 +91,11 @@ export async function connect(targetId = null) {
       return client;
     } catch (err) {
       lastError = err;
+      // Don't retry actionable user-facing errors; they won't fix themselves
+      // by waiting (need user to open a chart tab).
+      if (err.message && /No TradingView chart tab found/.test(err.message)) {
+        throw err;
+      }
       const delay = Math.min(BASE_DELAY * Math.pow(2, attempt), 30000);
       await new Promise(r => setTimeout(r, delay));
     }
@@ -110,10 +121,26 @@ export async function reconnectTo(targetId) {
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
-    || null;
+  // Strict: only attach to actual chart tabs. Previously fell back to any
+  // tradingview tab (news-flow, watchlist, symbols pages) which silently
+  // broke every chart-API tool because _activeChartWidgetWV was undefined.
+  const chart = targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url));
+  if (chart) return chart;
+  const otherTV = targets.filter(t => t.type === 'page' && /tradingview/i.test(t.url));
+  if (otherTV.length > 0) {
+    const paths = otherTV.slice(0, 3).map(t => {
+      try { return new URL(t.url).pathname; } catch { return t.url; }
+    });
+    throw new Error(
+      `No TradingView chart tab found. Detected ${otherTV.length} non-chart ` +
+      `TradingView tab(s): ${paths.join(', ')}. Open a chart in TV Desktop ` +
+      `(Cmd+T then a ticker, or click a saved layout) and retry.`
+    );
+  }
+  throw new Error(
+    'No TradingView chart target found. Is TradingView open with a chart? ' +
+    'Launch with: /Applications/TradingView.app/Contents/MacOS/TradingView --remote-debugging-port=9222'
+  );
 }
 
 async function findTargetById(id) {

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,6 +2,10 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
+// Set when the caller pinned a specific tab via reconnectTo (tab_switch), so
+// recovery from a dead client returns to that tab instead of re-picking the
+// first chart tab findChartTarget() happens to see.
+let pinnedTargetId = null;
 // Overridable via TV_CDP_HOST/TV_CDP_PORT (or CDP_HOST/CDP_PORT) env vars.
 // Default is 127.0.0.1, not localhost: on some Windows machines localhost
 // resolves to ::1 first, and Electron's --remote-debugging-port only listens on IPv4.
@@ -53,21 +57,27 @@ export function requireFinite(value, name) {
 export async function getClient() {
   if (client) {
     try {
-      // Strict liveness: cached tab must be alive AND expose chart APIs.
-      // Plain `Runtime.evaluate('1')` passes on any TradingView page
-      // (news-flow, watchlist, symbols) and used to lock the picker to
-      // whichever tab was attached first — silently breaking every
-      // chart-API tool when a chart tab opened later.
-      const probe = await client.Runtime.evaluate({
-        expression: 'typeof window.TradingViewApi !== "undefined" && window.TradingViewApi._activeChartWidgetWV !== undefined',
-        returnByValue: true,
-      });
-      if (probe?.result?.value === true) return client;
+      // A pinned tab (tab_switch) only needs to be alive. Both of today's
+      // reconnectTo() callers pin chart tabs, so this is defensive: the
+      // function is exported and takes any target id, and a non-chart pin
+      // would fail the strict probe below and be silently dropped.
+      const expression = pinnedTargetId
+        ? '1'
+        // Strict liveness for auto-picked tabs: must be alive AND expose chart
+        // APIs. Plain `Runtime.evaluate('1')` passes on any TradingView page
+        // (news-flow, watchlist, symbols) and used to lock the picker to
+        // whichever tab was attached first — silently breaking every
+        // chart-API tool when a chart tab opened later.
+        : 'typeof window.TradingViewApi !== "undefined" && window.TradingViewApi._activeChartWidgetWV !== undefined';
+      const probe = await client.Runtime.evaluate({ expression, returnByValue: true });
+      if (pinnedTargetId || probe?.result?.value === true) return client;
     } catch {}
     client = null;
     targetInfo = null;
   }
-  return connect();
+  // Reconnect to the pinned tab if there is one, so a dead-client recovery does
+  // not silently migrate the session back to an auto-picked chart tab.
+  return connect(pinnedTargetId);
 }
 
 export async function connect(targetId = null) {
@@ -78,8 +88,12 @@ export async function connect(targetId = null) {
       // findChartTarget now throws explicit errors with actionable hints (no
       // chart tab vs no TV at all), so only findTargetById can still return null.
       if (targetId && !target) {
+        // Drop the pin so a closed tab does not wedge every later call on a
+        // target that no longer exists; the next call auto-picks a chart tab.
+        pinnedTargetId = null;
         throw new Error(`CDP target ${targetId} not found — is the tab still open?`);
       }
+      pinnedTargetId = targetId;
       targetInfo = target;
       client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
 
@@ -183,6 +197,8 @@ export async function disconnect() {
     client = null;
     targetInfo = null;
   }
+  // An explicit disconnect ends the session, so the tab_switch pin ends with it.
+  pinnedTargetId = null;
 }
 
 // --- Direct API path helpers ---

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -287,8 +287,15 @@ export async function symbolSearch({ query, type }) {
   if (!resp.ok) throw new Error(`Symbol search API returned ${resp.status}`);
   const data = await resp.json();
 
+  // Defensive array extraction. The previous `data.symbols || data || []`
+  // evaluated `{}` as truthy and let `.slice()` throw if the API ever
+  // returned an object without a `symbols` field (schema drift).
+  const arr = Array.isArray(data) ? data
+    : Array.isArray(data && data.symbols) ? data.symbols
+    : [];
+
   const strip = s => (s || '').replace(/<\/?em>/g, '');
-  const results = (data.symbols || data || []).slice(0, 15).map(r => ({
+  const results = arr.slice(0, 15).map(r => ({
     symbol: strip(r.symbol),
     description: strip(r.description),
     exchange: r.exchange || r.prefix || '',

--- a/src/wait.js
+++ b/src/wait.js
@@ -17,17 +17,29 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
           || document.querySelector('[data-name="loading"]');
         var isLoading = spinner && spinner.offsetParent !== null;
 
-        // Try to get bar count from data window or chart
+        // Bar count via TV's internal model (canonical, not DOM scraping).
+        // [class*="bar"] previously matched toolbars/sidebars/scrollbars and
+        // produced a near-constant signal that returned false-positive readiness.
         var barCount = -1;
         try {
-          var bars = document.querySelectorAll('[class*="bar"]');
-          barCount = bars.length;
+          var chart = window.TradingViewApi && window.TradingViewApi._activeChartWidgetWV
+            && window.TradingViewApi._activeChartWidgetWV.value();
+          var bars = chart && chart._chartWidget.model().mainSeries().bars();
+          if (bars) barCount = bars.lastIndex() - bars.firstIndex() + 1;
         } catch {}
 
-        // Get current symbol from header
-        var symbolEl = document.querySelector('[data-name="legend-source-title"]')
-          || document.querySelector('[class*="title"] [class*="apply-common-tooltip"]');
-        var currentSymbol = symbolEl ? symbolEl.textContent.trim() : '';
+        // Get current symbol — first try internal API, fall back to DOM legend.
+        var currentSymbol = '';
+        try {
+          var c = window.TradingViewApi && window.TradingViewApi._activeChartWidgetWV
+            && window.TradingViewApi._activeChartWidgetWV.value();
+          if (c && typeof c.symbol === 'function') currentSymbol = String(c.symbol() || '');
+        } catch {}
+        if (!currentSymbol) {
+          var symbolEl = document.querySelector('[data-name="legend-source-title"]')
+            || document.querySelector('[class*="title"] [class*="apply-common-tooltip"]');
+          currentSymbol = symbolEl ? symbolEl.textContent.trim() : '';
+        }
 
         return { isLoading: !!isLoading, barCount: barCount, currentSymbol: currentSymbol };
       })()
@@ -45,11 +57,27 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
       continue;
     }
 
-    // Check symbol match if expected
-    if (expectedSymbol && state.currentSymbol && !state.currentSymbol.toUpperCase().includes(expectedSymbol.toUpperCase())) {
-      stableCount = 0;
-      await new Promise(r => setTimeout(r, POLL_INTERVAL));
-      continue;
+    // Symbol match check — requires a non-empty currentSymbol.
+    // Previously: if expectedSymbol set but currentSymbol was empty (legend not
+    // yet rendered), the && short-circuit treated that as "matched" and let
+    // readiness proceed. Now we wait until the legend or API reports something.
+    //
+    // We compare against the *bare ticker* (segment after the last `:`)
+    // because TV resolves caller's exchange prefix to its preferred feed:
+    // a request for "NASDAQ:IREN" lands as "BATS:IREN" in chart.symbol(),
+    // and the previous strict `.includes(expectedSymbol)` would never match.
+    if (expectedSymbol) {
+      if (!state.currentSymbol) {
+        stableCount = 0;
+        await new Promise(r => setTimeout(r, POLL_INTERVAL));
+        continue;
+      }
+      const bareExpected = expectedSymbol.split(':').pop().toUpperCase();
+      if (!state.currentSymbol.toUpperCase().includes(bareExpected)) {
+        stableCount = 0;
+        await new Promise(r => setTimeout(r, POLL_INTERVAL));
+        continue;
+      }
     }
 
     // Check bar count stability
@@ -67,7 +95,7 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
     await new Promise(r => setTimeout(r, POLL_INTERVAL));
   }
 
-  // Timeout — return true anyway, caller should verify
+  // Timeout — caller must treat false as "not confirmed ready, verify before proceeding"
   return false;
 }
 


### PR DESCRIPTION
## Summary

Cluster of bugs in the CDP bridge that produced inconsistent attach behavior, false readiness signals, and wrong-tab screenshots. All issues were diagnosed and live-validated against TradingView Desktop on macOS.

The bugs compounded silently — `chart_set_symbol` would error out on the wrong tab, `capture_screenshot` would return non-chart content, and `waitForChartReady` could either false-positive (wrong tab, fragile DOM signal) or false-negative timeout (TV resolving exchange prefix). User-facing symptom: the TV chart appeared "blank" or operations seemed to silently no-op when in fact the picker had attached to a news-flow / watchlist / symbols tab.

### 1. `findChartTarget` silent fallback to non-chart tabs (`src/connection.js`)

Previously fell back to any TradingView page if no `/chart/` URL existed:
```js
return targets.find(t => /tradingview\.com\/chart/i.test(t.url))
  || targets.find(t => /tradingview/i.test(t.url))   // ← attaches to anything
  || null;
```
Result: every chart-API tool throws `TypeError: Cannot read properties of undefined (reading 'value')` because `_activeChartWidgetWV` is `undefined` on news-flow / watchlist / symbols pages. Worse: `capture_screenshot` returns the wrong page's content.

**Fix:** fail loud with an actionable error listing the non-chart tabs detected.

### 2. `getClient` cached client never invalidated when stale (`src/connection.js`)

`Runtime.evaluate('1')` passes on any TradingView page with a live JS engine. Once the picker attached to a non-chart tab, opening a chart tab afterward did not refresh the cache.

**Fix:** strict liveness probe checks `window.TradingViewApi._activeChartWidgetWV !== undefined`. Cached clients on tabs without chart APIs are invalidated, forcing reconnect through the (now strict) picker.

### 3. `symbolSearch` `.slice()` throws on `{}` response (`src/core/chart.js`)

`(data.symbols || data || []).slice(0, 15)` evaluates `{}` as truthy and lets `.slice()` throw if the API ever returns an object without a `symbols` field (schema drift / no matches). 

**Fix:** explicit `Array.isArray` checks.

### 4. `waitForChartReady` three readiness bugs (`src/wait.js`)

a. `[class*="bar"]` matched toolbars / sidebars / scrollbars producing a near-constant bar counter; `stableCount` reached threshold in ~400ms regardless of actual chart load. **Fix:** use TV's internal `mainSeries().bars()` API (already known via `KNOWN_PATHS.mainSeriesBars`).

b. Symbol match short-circuited when the legend was empty (legend not yet rendered after symbol change), letting readiness pass before the new symbol was confirmed. **Fix:** wait for non-empty `currentSymbol`.

c. `.includes(expectedSymbol)` is one-way — when caller passes `"NASDAQ:IREN"` but TV resolves to `"BATS:IREN"` (preferred feed), the match never succeeds and timeout fires. **Fix:** compare against bare ticker (segment after last `:`).

## Test plan

Validated end-to-end on TradingView Desktop on macOS:

- [x] `tv_health_check` reports the correct chart tab + `api_available: true` even when other TradingView tabs (news-flow, watchlist) are also open
- [x] `chart_set_symbol("AAPL")` returns `chart_ready: true`; subsequent `chart_get_state` and `quote_get` reflect the new symbol
- [x] `chart_set_symbol("NASDAQ:IREN")` returns `chart_ready: true` (previously timed out due to TV resolving to `BATS:IREN`)
- [x] `capture_screenshot` returns the actual chart, not whatever non-chart tab the old picker happened to attach to
- [x] `symbol_search("ZZZQQQNOTAREALSYMBOL")` returns `count: 0` gracefully
- [x] `node --check` passes on all 3 modified files

Existing automated e2e tests (`tests/e2e.test.js`) not run against this branch — they require a maintainer's test harness configuration. Happy to adapt if there's a CI pattern you'd like me to follow.