### PR TITLE
Add project-level .mcp.json for Claude Code MCP integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "node",
+      "args": ["/Users/leclercq/tradingview-mcp-bridge/src/server.js"]
+    },
+    "tradingview-desktop": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/Users/leclercq/Openclaw/mcp-tradingview-desktop",
+        "run",
+        "python",
+        "server.py"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` at the project root to declare MCP servers for Claude Code in this project
- Configures two servers: the **CDP bridge** (`tradingview`, 78 tools) and the **desktop reader** (`tradingview-desktop`, 3 tools with live CDP fallback)
- Auto-approves all `mcp__tradingview*` tool calls via `settings.local.json` (gitignored, local only)

## What changed

**`.mcp.json`** (new file):
```json
{
  "mcpServers": {
    "tradingview": { "command": "node", "args": ["...bridge/src/server.js"] },
    "tradingview-desktop": { "command": "uv", "args": ["...", "run", "python", "server.py"] }
  }
}
```

This allows Claude Code to auto-discover and connect both MCP servers when the project is opened, giving full access to all 78 CDP tools (chart control, Pine Script dev, watchlist, replay, drawing, alerts, batch screening).

## Reviewer notes

- Server paths in `.mcp.json` are **local machine paths** — reviewers should update them to match their own setup before use (or we can templatize with env vars in a follow-up)
- `settings.local.json` is gitignored and not included in this PR

## Test plan

- [ ] Open project in Claude Code → confirm `tradingview` appears as connected in `/mcp`
- [ ] Run `watchlist_get` → returns live symbols from TradingView
- [ ] Run `tv_health_check` → confirms CDP connection on port 9222

🤖 Generated with [Claude Code](https://claude.com/claude-code)