### PR TITLE
fix: support Windows Store (MSIX) TradingView launch and patch npm vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -427,12 +430,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -451,9 +454,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -588,9 +591,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -639,9 +642,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -17,27 +17,23 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
-if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
-)
+REM Check MSIX / Windows Store installs via where
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
 )
 
+REM If still not found, try MSIX launch via COM ApplicationActivationManager (handles WindowsApps ACL restriction)
 if "%TV_EXE%"=="" (
-    echo Error: TradingView not found.
-    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps
-    echo.
-    echo If installed elsewhere, run manually:
-    echo   "C:\path\to\TradingView.exe" --remote-debugging-port=%PORT%
-    exit /b 1
+    echo TradingView.exe not found in standard paths. Attempting MSIX launch via COM...
+    powershell -NoProfile -NonInteractive -Command "$code='using System; using System.Runtime.InteropServices; namespace AppLauncher { [ComImport,Guid(\"2e941141-7f97-4756-ba1d-9decde894a3d\"),InterfaceType(ComInterfaceType.InterfaceIsIUnknown)] public interface IApplicationActivationManager { int ActivateApplication([MarshalAs(UnmanagedType.LPWStr)] string a,[MarshalAs(UnmanagedType.LPWStr)] string b,int c,out uint d); int ActivateForFile(string a,IntPtr b,string c,out uint d); int ActivateForProtocol(string a,IntPtr b,out uint c); } [ComImport,Guid(\"45BA127D-10A8-46EA-8AB7-56EA9078943C\"),ClassInterface(ClassInterfaceType.None)] public class AppActMgr {} public static class Launcher { public static int Launch(string aumid,string args,out uint pid){var m=(IApplicationActivationManager)new AppActMgr();return m.ActivateApplication(aumid,args,0,out pid);} } }'; Add-Type -TypeDefinition $code; $p=[uint32]0; $hr=[AppLauncher.Launcher]::Launch('TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop','--remote-debugging-port=%PORT%',[ref]$p); if($hr -eq 0){Write-Output \"MSIX launch OK PID=$p\"}else{Write-Output \"MSIX launch failed HRESULT=0x$($hr.ToString(\"X8\"))\"}"
+    goto :wait_cdp
 )
 
 echo Found TradingView at: %TV_EXE%
 echo Starting with --remote-debugging-port=%PORT%...
 start "" "%TV_EXE%" --remote-debugging-port=%PORT%
 
+:wait_cdp
 echo Waiting for CDP to become available...
 timeout /t 5 /nobreak >nul
 


### PR DESCRIPTION
## What changed

### scripts/launch_tv_debug.bat - MSIX launch fix
Windows Store installs of TradingView live under `C:\Program Files\WindowsApps`, which has ACL restrictions that silently block both direct exe execution and the existing `dir /s /b` discovery. The script was exiting without any visible error.

**Fix:** when TradingView.exe is not found in standard paths, fall back to launching via the COM `IApplicationActivationManager` interface (CLSID `45BA127D-10A8-46EA-8AB7-56EA9078943C`) through an inline PowerShell one-liner. This is the same mechanism the Windows Start Menu uses and correctly forwards `--remote-debugging-port` into the Electron process.

Verified working: CDP responds at `http://localhost:9222/json/version` with Electron 38 / Chrome 140.

### `package-lock.json` - security fixes
Ran `npm audit fix` to resolve 5 vulnerabilities (1 high, 4 moderate):
- `fast-uri` ?3.1.1 ? 3.1.2 (path traversal, host confusion)
- `hono` ?4.12.17 ? 4.12.18 (cookie handling, JSX injection, cache leakage, JWT validation)
- `@hono/node-server` <1.19.13 ? 1.19.14 (middleware bypass)
- `ip-address` ?10.1.0 ? 10.2.0 (XSS)
- `express-rate-limit` 8.3.1 ? 8.5.1 (depends on ip-address)

## Testing
- Launched TradingView Desktop (MSIX, Windows Store) via the updated script - CDP confirmed live at `ws://localhost:9222`
- `npm audit` reports 0 vulnerabilities after fix