### PR TITLE
[codex] add verified strategy open workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ tv screenshot -r chart             # capture chart
 tv pine compile                    # compile Pine Script
 tv pane layout 2x2                 # 4-chart grid
 tv pane symbol 1 ES1!              # set pane symbol
+tv strategy open "8AM" --dry-run   # preview which saved layout would open
 tv stream quote | jq '.close'      # monitor price changes
 ```
 
@@ -172,6 +173,7 @@ tv alert list/create/delete
 tv watchlist get/add
 tv indicator add/remove/toggle/set/get
 tv layout list/switch
+tv strategy open
 tv pane list/layout/focus/symbol
 tv tab list/new/close/switch
 tv replay start/step/stop/status/autoplay/trade
@@ -305,7 +307,8 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `capture_screenshot` | Screenshot (regions: full, chart, strategy_tester) |
 | `batch_run` | Run action across multiple symbols/timeframes |
 | `watchlist_get` / `watchlist_add` | Read/modify watchlist |
-| `layout_list` / `layout_switch` | Manage saved layouts |
+| `layout_list` / `layout_switch` | Manage saved layouts with active-layout detection and switch verification |
+| `strategy_open` | Open a saved strategy/layout with optional dry-run, panel setup, and chart verification |
 | `ui_open_panel` / `ui_click` / `ui_evaluate` | UI automation |
 | `tv_launch` / `tv_health_check` / `tv_discover` | Connection management |
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
+    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/ui_layouts.test.js tests/strategy_open.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/ui_layouts.test.js tests/strategy_open.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/ui_layouts.test.js tests/strategy_open.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/cli/commands/strategy.js
+++ b/src/cli/commands/strategy.js
@@ -1,0 +1,27 @@
+import { register } from '../router.js';
+import * as core from '../../core/strategy.js';
+
+register('strategy', {
+  description: 'Strategy/workspace helpers',
+  subcommands: new Map([
+    ['open', {
+      description: 'Open a saved strategy/layout by name with optional verification',
+      options: {
+        symbol: { type: 'string', description: 'Expected active-chart symbol to verify after opening' },
+        timeframe: { type: 'string', description: 'Expected active-chart timeframe to verify after opening' },
+        panel: { type: 'string', multiple: true, description: 'Panel to open after switching (repeatable)' },
+        'dry-run': { type: 'boolean', description: 'Describe what would happen without changing TradingView' },
+      },
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Strategy/layout name required. Usage: tv strategy open "8AM Breakout Algo"');
+        return core.openStrategy({
+          name: positionals.join(' '),
+          symbol: opts.symbol,
+          timeframe: opts.timeframe,
+          panels: opts.panel,
+          dry_run: opts['dry-run'],
+        });
+      },
+    }],
+  ]),
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,6 +25,7 @@ import './commands/ui.js';
 import './commands/pane.js';
 import './commands/tab.js';
 import './commands/stream.js';
+import './commands/strategy.js';
 
 // Run
 import { run } from './router.js';

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -14,3 +14,4 @@ export * as batch from './batch.js';
 export * as watchlist from './watchlist.js';
 export * as indicators from './indicators.js';
 export * as ui from './ui.js';
+export * as strategy from './strategy.js';

--- a/src/core/strategy.js
+++ b/src/core/strategy.js
@@ -1,0 +1,136 @@
+/**
+ * Strategy/workspace orchestration helpers.
+ * Opens a named TradingView layout with optional verification and panel setup.
+ */
+import { getState as _getState } from './chart.js';
+import { layoutList as _layoutList, layoutSwitch as _layoutSwitch, openPanel as _openPanel } from './ui.js';
+
+function _resolve(deps) {
+  return {
+    getState: deps?.getState || _getState,
+    layoutList: deps?.layoutList || _layoutList,
+    layoutSwitch: deps?.layoutSwitch || _layoutSwitch,
+    openPanel: deps?.openPanel || _openPanel,
+  };
+}
+
+function _normalize(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function _resolveLayout(layouts, query) {
+  const raw = String(query || '').trim();
+  const normalized = _normalize(raw);
+  if (!normalized) throw new Error('Strategy/layout name is required');
+
+  const exactById = layouts.find(layout => String(layout.id) === raw);
+  if (exactById) return exactById;
+
+  const exactByName = layouts.find(layout => _normalize(layout.name) === normalized);
+  if (exactByName) return exactByName;
+
+  const partialMatches = layouts.filter(layout => _normalize(layout.name).includes(normalized));
+  if (partialMatches.length === 1) return partialMatches[0];
+  if (partialMatches.length > 1) {
+    const names = partialMatches.slice(0, 5).map(layout => layout.name).join(', ');
+    throw new Error(`Strategy/layout "${query}" is ambiguous. Matches: ${names}`);
+  }
+
+  throw new Error(`Strategy/layout "${query}" not found.`);
+}
+
+function _normalizeSymbol(symbol) {
+  return String(symbol || '').trim().toUpperCase();
+}
+
+function _normalizeTimeframe(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function _verifyChartState(state, { expectedSymbol, expectedTimeframe }) {
+  const issues = [];
+  if (expectedSymbol && _normalizeSymbol(state.symbol) !== _normalizeSymbol(expectedSymbol)) {
+    issues.push(`Expected symbol ${expectedSymbol} but active chart is ${state.symbol}`);
+  }
+  if (expectedTimeframe && _normalizeTimeframe(state.resolution) !== _normalizeTimeframe(expectedTimeframe)) {
+    issues.push(`Expected timeframe ${expectedTimeframe} but active chart is ${state.resolution}`);
+  }
+  return issues;
+}
+
+export async function openStrategy({ name, symbol, timeframe, panels, dry_run, _deps } = {}) {
+  const { layoutList, layoutSwitch, openPanel, getState } = _resolve(_deps);
+  const requestedPanels = Array.isArray(panels) ? panels : [];
+  const dryRun = !!dry_run;
+
+  const layouts = await layoutList();
+  const target = _resolveLayout(layouts.layouts || [], name);
+  const plan = {
+    strategy: name,
+    target_layout: {
+      id: target.id,
+      name: target.name,
+      url: target.url || null,
+      active: !!target.active,
+    },
+    current_layout: layouts.active_layout || null,
+    requested_symbol: symbol || null,
+    requested_timeframe: timeframe || null,
+    requested_panels: requestedPanels,
+    dry_run: dryRun,
+  };
+
+  if (dryRun) {
+    return {
+      success: true,
+      action: 'planned',
+      would_switch_layout: !target.active,
+      would_open_panels: requestedPanels,
+      plan,
+    };
+  }
+
+  const steps = [];
+  let switchResult;
+  if (target.active) {
+    switchResult = {
+      success: true,
+      action: 'already_active',
+      verified: true,
+      layout: target.name,
+      layout_id: target.id,
+      layout_url: target.url || null,
+    };
+  } else {
+    switchResult = await layoutSwitch({ name: target.name });
+  }
+  steps.push({ step: 'layout', result: switchResult });
+
+  const panelResults = [];
+  for (const panel of requestedPanels) {
+    const result = await openPanel({ panel, action: 'open' });
+    panelResults.push(result);
+  }
+  if (panelResults.length > 0) steps.push({ step: 'panels', result: panelResults });
+
+  const state = await getState();
+  const issues = _verifyChartState(state, { expectedSymbol: symbol, expectedTimeframe: timeframe });
+  if (issues.length > 0) {
+    throw new Error(`Strategy/layout opened but verification failed: ${issues.join('; ')}`);
+  }
+  steps.push({ step: 'chart_state', result: state });
+
+  return {
+    success: true,
+    action: 'opened',
+    verified: true,
+    strategy: name,
+    layout: switchResult.layout || target.name,
+    layout_id: switchResult.layout_id || target.id,
+    layout_url: switchResult.layout_url || target.url || null,
+    chart_state: state,
+    panels_opened: panelResults.map(result => result.panel),
+    steps,
+    plan,
+  };
+}

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -1,9 +1,229 @@
 /**
  * Core UI automation logic.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate as _evaluate, evaluateAsync as _evaluateAsync, getClient as _getClient } from '../connection.js';
 
-export async function click({ by, value }) {
+function _resolve(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    evaluateAsync: deps?.evaluateAsync || _evaluateAsync,
+    getClient: deps?.getClient || _getClient,
+  };
+}
+
+function _normalizeLayout(layout, currentSlug, currentName) {
+  const id = layout?.id ?? layout?.chartId ?? null;
+  const name = layout?.name || layout?.title || 'Untitled';
+  const url = layout?.url || layout?.chartUrl || null;
+  const symbol = layout?.symbol || null;
+  const resolution = layout?.interval || layout?.resolution || null;
+  const modified = layout?.timestamp || layout?.modified || null;
+  const active = currentName
+    ? _normalizeLayoutQuery(name) === _normalizeLayoutQuery(currentName)
+    : !!(url && currentSlug && url === currentSlug);
+
+  return {
+    id,
+    name,
+    url,
+    symbol,
+    resolution,
+    modified,
+    active,
+  };
+}
+
+function _normalizeLayoutQuery(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function _resolveLayoutMatch(layouts, query) {
+  const normalized = _normalizeLayoutQuery(query);
+  const rawQuery = String(query || '').trim();
+  if (!normalized) throw new Error('Layout name or ID is required');
+
+  const exactById = layouts.find(l => String(l.id) === rawQuery);
+  if (exactById) return exactById;
+
+  const exactByUrl = layouts.find(l => _normalizeLayoutQuery(l.url) === normalized);
+  if (exactByUrl) return exactByUrl;
+
+  const exactByName = layouts.find(l => _normalizeLayoutQuery(l.name) === normalized);
+  if (exactByName) return exactByName;
+
+  const partialMatches = layouts.filter(l => _normalizeLayoutQuery(l.name).includes(normalized));
+  if (partialMatches.length === 1) return partialMatches[0];
+  if (partialMatches.length > 1) {
+    const names = partialMatches.slice(0, 5).map(l => l.name).join(', ');
+    throw new Error(`Layout "${query}" is ambiguous. Matches: ${names}`);
+  }
+
+  throw new Error(`Layout "${query}" not found.`);
+}
+
+async function _getLayoutSnapshot({ evaluateAsync }) {
+  const snapshot = await evaluateAsync(`
+    new Promise(function(resolve) {
+      var done = false;
+      function finish(payload) {
+        if (done) return;
+        done = true;
+        resolve(payload);
+      }
+      function currentSlug() {
+        var match = location.pathname.match(/\\/chart\\/([^/?#]+)/i);
+        return match ? match[1] : null;
+      }
+      function currentName() {
+        try {
+          var attr = document.querySelector('[aria-label*="Aktives Layout:"], [aria-label*="Active layout:"]');
+          if (!attr) return null;
+          var label = attr.getAttribute('aria-label') || '';
+          var match = label.match(/(?:Aktives Layout|Active layout):\\s*([^\\n]+)/i);
+          return match ? match[1].trim() : null;
+        } catch (e) {
+          return null;
+        }
+      }
+      function build(rows, source, error) {
+        finish({
+          source: source,
+          error: error || null,
+          current_slug: currentSlug(),
+          current_name: currentName(),
+          current_href: location.href,
+          layouts: Array.isArray(rows) ? rows : [],
+        });
+      }
+
+      try {
+        var api = window.TradingViewApi || {};
+        try {
+          var stateWV = api._loadChartService && api._loadChartService._state;
+          var state = stateWV && typeof stateWV.value === 'function' ? stateWV.value() : null;
+          if (state && Array.isArray(state.chartList) && state.chartList.length > 0) {
+            build(state.chartList, 'load_chart_service');
+            return;
+          }
+        } catch (stateErr) {}
+
+        if (typeof api.getSavedCharts === 'function') {
+          api.getSavedCharts(function(charts) {
+            build(charts, 'getSavedCharts');
+          });
+          setTimeout(function() {
+            build([], 'getSavedCharts', 'getSavedCharts timed out');
+          }, 5000);
+          return;
+        }
+
+        build([], 'internal_api', 'No layout API available');
+      } catch (e) {
+        build([], 'internal_api', e.message);
+      }
+    })
+  `);
+
+  const currentSlug = snapshot?.current_slug || null;
+  const currentName = snapshot?.current_name || null;
+  const layouts = (snapshot?.layouts || []).map(layout => _normalizeLayout(layout, currentSlug, currentName));
+  return {
+    source: snapshot?.source || 'unknown',
+    error: snapshot?.error || null,
+    current_slug: currentSlug,
+    current_name: currentName,
+    current_href: snapshot?.current_href || null,
+    layouts,
+  };
+}
+
+function _findActiveLayout(layouts) {
+  return layouts.find(layout => layout.active) || null;
+}
+
+async function _dismissUnsavedLayoutDialog({ evaluate }) {
+  return evaluate(`
+    (function() {
+      var dialogPattern = /unsaved changes|last changes will be lost|nicht gespeicherte[nr]? änderungen|änderungen verloren gehen|neues layout öffnen/i;
+      var confirmPattern = /open anyway|don't save|do not save|discard|continue without saving|trotzdem öffnen|ohne speichern|nicht speichern|verwerfen|änderungen verwerfen|ja,? öffnen/i;
+
+      function tryButtons(root) {
+        var btns = root.querySelectorAll('button, [role="button"]');
+        for (var i = 0; i < btns.length; i++) {
+          var text = (btns[i].textContent || '').trim();
+          var aria = (btns[i].getAttribute('aria-label') || '').trim();
+          if (confirmPattern.test(text) || confirmPattern.test(aria)) {
+            btns[i].click();
+            return { dismissed: true, label: text || aria || null };
+          }
+        }
+        return null;
+      }
+
+      var dialogs = document.querySelectorAll('[role="dialog"], [data-dialog-name], [class*="dialog"]');
+      for (var j = 0; j < dialogs.length; j++) {
+        var text = (dialogs[j].textContent || '').trim();
+        if (!dialogPattern.test(text)) continue;
+        var scoped = tryButtons(dialogs[j]);
+        if (scoped) return scoped;
+      }
+
+      var fallback = tryButtons(document);
+      if (fallback) return fallback;
+      return { dismissed: false, label: null };
+    })()
+  `);
+}
+
+async function _waitForLayoutActivation(target, { evaluate, evaluateAsync, timeoutMs = 10000, intervalMs = 250 }) {
+  const started = Date.now();
+  let dismissed = false;
+  let attempts = 0;
+
+  while (Date.now() - started < timeoutMs) {
+    attempts += 1;
+    const dialog = await _dismissUnsavedLayoutDialog({ evaluate });
+    dismissed = dismissed || !!dialog?.dismissed;
+
+    const snapshot = await _getLayoutSnapshot({ evaluateAsync });
+    const active = _findActiveLayout(snapshot.layouts);
+    const slugMatches = target.url && snapshot.current_slug === target.url;
+    const idMatches = active && String(active.id) === String(target.id);
+    const nameMatches = active && _normalizeLayoutQuery(active.name) === _normalizeLayoutQuery(target.name);
+
+    if (slugMatches || idMatches || nameMatches) {
+      return {
+        success: true,
+        verified: true,
+        attempts,
+        source: snapshot.source,
+        current_slug: snapshot.current_slug,
+        current_name: snapshot.current_name,
+        current_href: snapshot.current_href,
+        active_layout: active,
+        unsaved_dialog_dismissed: dismissed,
+      };
+    }
+
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+
+  const finalSnapshot = await _getLayoutSnapshot({ evaluateAsync });
+  return {
+    success: false,
+    verified: false,
+    attempts,
+    source: finalSnapshot.source,
+    current_slug: finalSnapshot.current_slug,
+    current_name: finalSnapshot.current_name,
+    current_href: finalSnapshot.current_href,
+    active_layout: _findActiveLayout(finalSnapshot.layouts),
+    unsaved_dialog_dismissed: dismissed,
+  };
+}
+
+export async function click({ by, value, _deps }) {
+  const { evaluate } = _resolve(_deps);
   const escaped = JSON.stringify(value);
   const result = await evaluate(`
     (function() {
@@ -28,7 +248,8 @@ export async function click({ by, value }) {
   return { success: true, clicked: result };
 }
 
-export async function openPanel({ panel, action }) {
+export async function openPanel({ panel, action, _deps }) {
+  const { evaluate } = _resolve(_deps);
   const isBottomPanel = panel === 'pine-editor' || panel === 'strategy-tester';
   if (isBottomPanel) {
     const widgetName = panel === 'pine-editor' ? 'pine-editor' : 'backtesting';
@@ -88,7 +309,8 @@ export async function openPanel({ panel, action }) {
   }
 }
 
-export async function fullscreen() {
+export async function fullscreen({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var btn = document.querySelector('[data-name="header-toolbar-fullscreen"]');
@@ -101,66 +323,88 @@ export async function fullscreen() {
   return { success: true, action: 'fullscreen_toggled' };
 }
 
-export async function layoutList() {
-  const layouts = await evaluateAsync(`
-    new Promise(function(resolve) {
-      try {
-        window.TradingViewApi.getSavedCharts(function(charts) {
-          if (!charts || !Array.isArray(charts)) { resolve({layouts: [], source: 'internal_api', error: 'getSavedCharts returned no data'}); return; }
-          var result = charts.map(function(c) { return { id: c.id || c.chartId || null, name: c.name || c.title || 'Untitled', symbol: c.symbol || null, resolution: c.resolution || null, modified: c.timestamp || c.modified || null }; });
-          resolve({layouts: result, source: 'internal_api'});
-        });
-        setTimeout(function() { resolve({layouts: [], source: 'internal_api', error: 'getSavedCharts timed out'}); }, 5000);
-      } catch(e) { resolve({layouts: [], source: 'internal_api', error: e.message}); }
-    })
-  `);
-  return { success: true, layout_count: layouts?.layouts?.length || 0, source: layouts?.source, layouts: layouts?.layouts || [], error: layouts?.error };
+export async function layoutList({ _deps } = {}) {
+  const { evaluateAsync } = _resolve(_deps);
+  const snapshot = await _getLayoutSnapshot({ evaluateAsync });
+  const active = _findActiveLayout(snapshot.layouts);
+  return {
+    success: true,
+    layout_count: snapshot.layouts.length,
+    source: snapshot.source,
+    current_slug: snapshot.current_slug,
+    current_name: snapshot.current_name,
+    current_href: snapshot.current_href,
+    active_layout: active,
+    layouts: snapshot.layouts,
+    error: snapshot.error,
+  };
 }
 
-export async function layoutSwitch({ name }) {
-  const escaped = JSON.stringify(name);
+export async function layoutSwitch({ name, _deps }) {
+  const { evaluate, evaluateAsync } = _resolve(_deps);
+  const before = await _getLayoutSnapshot({ evaluateAsync });
+  if (before.error && before.layouts.length === 0) {
+    throw new Error(before.error);
+  }
+
+  const target = _resolveLayoutMatch(before.layouts, name);
+  if (target.active) {
+    return {
+      success: true,
+      action: 'already_active',
+      verified: true,
+      layout: target.name,
+      layout_id: target.id,
+      layout_url: target.url,
+      source: before.source,
+      current_slug: before.current_slug,
+      current_name: before.current_name,
+      current_href: before.current_href,
+      unsaved_dialog_dismissed: false,
+    };
+  }
+
+  const escaped = JSON.stringify(String(target.id));
   const result = await evaluateAsync(`
     new Promise(function(resolve) {
       try {
-        var target = ${escaped};
-        if (/^\\d+$/.test(target)) { window.TradingViewApi.loadChartFromServer(target); resolve({success: true, method: 'loadChartFromServer', id: target, source: 'internal_api'}); return; }
-        window.TradingViewApi.getSavedCharts(function(charts) {
-          if (!charts || !Array.isArray(charts)) { resolve({success: false, error: 'getSavedCharts returned no data', source: 'internal_api'}); return; }
-          var match = null;
-          for (var i = 0; i < charts.length; i++) { var cname = charts[i].name || charts[i].title || ''; if (cname === target || cname.toLowerCase() === target.toLowerCase()) { match = charts[i]; break; } }
-          if (!match) { for (var j = 0; j < charts.length; j++) { var cn = (charts[j].name || charts[j].title || '').toLowerCase(); if (cn.indexOf(target.toLowerCase()) !== -1) { match = charts[j]; break; } } }
-          if (!match) { resolve({success: false, error: 'Layout "' + target + '" not found.', source: 'internal_api'}); return; }
-          var chartId = match.id || match.chartId;
-          window.TradingViewApi.loadChartFromServer(chartId);
-          resolve({success: true, method: 'loadChartFromServer', id: chartId, name: match.name || match.title, source: 'internal_api'});
-        });
-        setTimeout(function() { resolve({success: false, error: 'getSavedCharts timed out', source: 'internal_api'}); }, 5000);
+        var targetId = ${escaped};
+        if (!window.TradingViewApi || typeof window.TradingViewApi.loadChartFromServer !== 'function') {
+          resolve({success: false, error: 'loadChartFromServer is not available', source: 'internal_api'});
+          return;
+        }
+        window.TradingViewApi.loadChartFromServer(targetId);
+        resolve({success: true, method: 'loadChartFromServer', id: targetId, source: 'internal_api'});
       } catch(e) { resolve({success: false, error: e.message, source: 'internal_api'}); }
     })
   `);
   if (!result?.success) throw new Error(result?.error || 'Unknown error switching layout');
 
-  // Handle "unsaved changes" confirmation dialog
-  await new Promise(r => setTimeout(r, 500));
-  const dismissed = await evaluate(`
-    (function() {
-      var btns = document.querySelectorAll('button');
-      for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (/open anyway|don't save|discard/i.test(text)) {
-          btns[i].click();
-          return true;
-        }
-      }
-      return false;
-    })()
-  `);
+  const verification = await _waitForLayoutActivation(target, { evaluate, evaluateAsync });
+  if (!verification.success) {
+    const current = verification.current_name || verification.active_layout?.name || verification.current_slug || 'unknown';
+    throw new Error(`Layout switch to "${target.name}" was not verified. Current layout appears to be "${current}".`);
+  }
 
-  if (dismissed) await new Promise(r => setTimeout(r, 1000));
-  return { success: true, layout: result.name || name, layout_id: result.id, source: result.source, action: 'switched', unsaved_dialog_dismissed: dismissed };
+  return {
+    success: true,
+    action: 'switched',
+    verified: true,
+    layout: target.name,
+    layout_id: target.id,
+    layout_url: target.url,
+    source: verification.source || result.source,
+    current_slug: verification.current_slug,
+    current_name: verification.current_name,
+    current_href: verification.current_href,
+    active_layout: verification.active_layout,
+    verification_attempts: verification.attempts,
+    unsaved_dialog_dismissed: verification.unsaved_dialog_dismissed,
+  };
 }
 
-export async function keyboard({ key, modifiers }) {
+export async function keyboard({ key, modifiers, _deps }) {
+  const { getClient } = _resolve(_deps);
   const c = await getClient();
   let mod = 0;
   if (modifiers) {
@@ -184,13 +428,15 @@ export async function keyboard({ key, modifiers }) {
   return { success: true, key, modifiers: modifiers || [] };
 }
 
-export async function typeText({ text }) {
+export async function typeText({ text, _deps }) {
+  const { getClient } = _resolve(_deps);
   const c = await getClient();
   await c.Input.insertText({ text });
   return { success: true, typed: text.substring(0, 100), length: text.length };
 }
 
-export async function hover({ by, value }) {
+export async function hover({ by, value, _deps }) {
+  const { evaluate, getClient } = _resolve(_deps);
   const coords = await evaluate(`
     (function() {
       var by = ${JSON.stringify(by)};
@@ -216,7 +462,8 @@ export async function hover({ by, value }) {
   return { success: true, hovered: { by, value, tag: coords.tag, x: coords.x, y: coords.y } };
 }
 
-export async function scroll({ direction, amount }) {
+export async function scroll({ direction, amount, _deps }) {
+  const { evaluate, getClient } = _resolve(_deps);
   const c = await getClient();
   const px = amount || 300;
   const center = await evaluate(`
@@ -234,7 +481,8 @@ export async function scroll({ direction, amount }) {
   return { success: true, direction, amount: px };
 }
 
-export async function mouseClick({ x, y, button, double_click }) {
+export async function mouseClick({ x, y, button, double_click, _deps }) {
+  const { getClient } = _resolve(_deps);
   const c = await getClient();
   const btn = button === 'right' ? 'right' : button === 'middle' ? 'middle' : 'left';
   const btnNum = btn === 'right' ? 2 : btn === 'middle' ? 1 : 0;
@@ -249,7 +497,8 @@ export async function mouseClick({ x, y, button, double_click }) {
   return { success: true, x, y, button: btn, double_click: !!double_click };
 }
 
-export async function findElement({ query, strategy }) {
+export async function findElement({ query, strategy, _deps }) {
+  const { evaluate } = _resolve(_deps);
   const strat = strategy || 'text';
   const results = await evaluate(`
     (function() {
@@ -287,7 +536,8 @@ export async function findElement({ query, strategy }) {
   return { success: true, query, strategy: strat, count: results?.length || 0, elements: results || [] };
 }
 
-export async function uiEvaluate({ expression }) {
+export async function uiEvaluate({ expression, _deps }) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(expression);
   return { success: true, result };
 }

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import { registerWatchlistTools } from './tools/watchlist.js';
 import { registerUiTools } from './tools/ui.js';
 import { registerPaneTools } from './tools/pane.js';
 import { registerTabTools } from './tools/tab.js';
+import { registerStrategyTools } from './tools/strategy.js';
 
 const server = new McpServer(
   {
@@ -59,6 +60,7 @@ Alerts: alert_create, alert_list, alert_delete
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch
+Strategies: strategy_open → open a saved strategy/layout with optional dry-run, panel setup, and chart verification
 
 CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv
@@ -84,6 +86,7 @@ registerWatchlistTools(server);
 registerUiTools(server);
 registerPaneTools(server);
 registerTabTools(server);
+registerStrategyTools(server);
 
 // Startup notice (stderr so it doesn't interfere with MCP stdio protocol)
 process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');

--- a/src/tools/strategy.js
+++ b/src/tools/strategy.js
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/strategy.js';
+
+export function registerStrategyTools(server) {
+  server.tool('strategy_open', 'Open a saved TradingView strategy/layout by name with optional verification and panel setup', {
+    name: z.string().describe('Strategy or saved layout name to open, e.g. "8AM Breakout Algo" or "Hit & Run Algo"'),
+    symbol: z.string().optional().describe('Optional expected active-chart symbol to verify after opening'),
+    timeframe: z.string().optional().describe('Optional expected active-chart timeframe/resolution to verify after opening'),
+    panels: z.array(z.enum(['pine-editor', 'strategy-tester', 'watchlist', 'alerts', 'trading'])).optional().describe('Optional panels to open after the layout is active'),
+    dry_run: z.coerce.boolean().optional().describe('If true, only resolve and describe what would happen without changing TradingView'),
+  }, async ({ name, symbol, timeframe, panels, dry_run }) => {
+    try { return jsonResult(await core.openStrategy({ name, symbol, timeframe, panels, dry_run })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+}

--- a/tests/strategy_open.test.js
+++ b/tests/strategy_open.test.js
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { openStrategy } from '../src/core/strategy.js';
+
+function deps(overrides = {}) {
+  return {
+    layoutList: async () => ({
+      success: true,
+      active_layout: { id: 2, name: 'Hit & Run Algo', url: 'xz2DdnNx', active: true },
+      layouts: [
+        { id: 1, name: '8AM Breakout Algo', url: 'hRmRbL7i', active: false },
+        { id: 2, name: 'Hit & Run Algo', url: 'xz2DdnNx', active: true },
+      ],
+    }),
+    layoutSwitch: async ({ name }) => ({
+      success: true,
+      action: 'switched',
+      verified: true,
+      layout: name,
+      layout_id: 1,
+      layout_url: 'hRmRbL7i',
+    }),
+    openPanel: async ({ panel, action }) => ({ success: true, panel, action, performed: 'opened' }),
+    getState: async () => ({ success: true, symbol: 'US500', resolution: '5', chartType: 1, studies: [] }),
+    ...overrides,
+  };
+}
+
+describe('strategy_open', () => {
+  it('returns a dry-run plan without touching TradingView', async () => {
+    let switched = false;
+    const result = await openStrategy({
+      name: '8AM',
+      dry_run: true,
+      _deps: deps({
+        layoutSwitch: async () => {
+          switched = true;
+          throw new Error('should not switch in dry_run');
+        },
+      }),
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.action, 'planned');
+    assert.equal(result.would_switch_layout, true);
+    assert.equal(result.plan.target_layout.name, '8AM Breakout Algo');
+    assert.equal(switched, false);
+  });
+
+  it('opens the layout, panels, and verifies chart state', async () => {
+    const panelCalls = [];
+    const result = await openStrategy({
+      name: '8AM Breakout Algo',
+      symbol: 'US500',
+      timeframe: '5',
+      panels: ['alerts', 'strategy-tester'],
+      _deps: deps({
+        openPanel: async ({ panel, action }) => {
+          panelCalls.push({ panel, action });
+          return { success: true, panel, action, performed: 'opened' };
+        },
+      }),
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.action, 'opened');
+    assert.equal(result.layout, '8AM Breakout Algo');
+    assert.deepEqual(result.panels_opened, ['alerts', 'strategy-tester']);
+    assert.equal(panelCalls.length, 2);
+    assert.equal(result.chart_state.symbol, 'US500');
+    assert.equal(result.chart_state.resolution, '5');
+  });
+
+  it('returns already_active behavior when target layout is active', async () => {
+    let switches = 0;
+    const result = await openStrategy({
+      name: 'Hit & Run Algo',
+      _deps: deps({
+        layoutSwitch: async () => {
+          switches += 1;
+          throw new Error('should not switch active layout');
+        },
+        getState: async () => ({ success: true, symbol: 'SOLUSD', resolution: '1D', chartType: 1, studies: [] }),
+      }),
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.steps[0].result.action, 'already_active');
+    assert.equal(switches, 0);
+  });
+
+  it('fails clearly on symbol or timeframe mismatch', async () => {
+    await assert.rejects(
+      () => openStrategy({
+        name: '8AM Breakout Algo',
+        symbol: 'BTCUSD',
+        timeframe: '1D',
+        _deps: deps(),
+      }),
+      /verification failed/i,
+    );
+  });
+
+  it('fails clearly on ambiguous partial matches', async () => {
+    await assert.rejects(
+      () => openStrategy({
+        name: 'hit',
+        dry_run: true,
+        _deps: deps({
+          layoutList: async () => ({
+            success: true,
+            active_layout: null,
+            layouts: [
+              { id: 2, name: 'Hit & Run Algo', url: 'xz2DdnNx', active: false },
+              { id: 3, name: 'Hit the Open Algo', url: 'abc123', active: false },
+            ],
+          }),
+        }),
+      }),
+      /ambiguous/i,
+    );
+  });
+});

--- a/tests/ui_layouts.test.js
+++ b/tests/ui_layouts.test.js
@@ -1,0 +1,121 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { layoutList, layoutSwitch } from '../src/core/ui.js';
+
+function createAsyncQueue(values) {
+  const calls = [];
+  const fn = async () => {
+    const next = values.shift();
+    calls.push(next);
+    return next;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function createEvalQueue(values) {
+  const calls = [];
+  const fn = async () => {
+    const next = values.length > 0 ? values.shift() : { dismissed: false, label: null };
+    calls.push(next);
+    return next;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('ui layouts', () => {
+  it('layoutList exposes active layout metadata', async () => {
+    const evaluateAsync = createAsyncQueue([{
+      source: 'load_chart_service',
+      current_slug: 'hRmRbL7i',
+      current_href: 'https://de.tradingview.com/chart/hRmRbL7i/',
+      layouts: [
+        { id: 186002420, name: '8AM Breakout Algo', url: 'hRmRbL7i', symbol: 'US500', interval: '5' },
+        { id: 186166925, name: 'Hit & Run Algo', url: 'xz2DdnNx', symbol: 'SOLUSD', interval: '1D' },
+      ],
+    }]);
+
+    const result = await layoutList({ _deps: { evaluateAsync } });
+    assert.equal(result.success, true);
+    assert.equal(result.layout_count, 2);
+    assert.equal(result.current_slug, 'hRmRbL7i');
+    assert.equal(result.active_layout?.name, '8AM Breakout Algo');
+    assert.equal(result.layouts[0].active, true);
+    assert.equal(result.layouts[1].active, false);
+    assert.equal(result.layouts[0].url, 'hRmRbL7i');
+  });
+
+  it('layoutSwitch rejects ambiguous partial matches', async () => {
+    const evaluateAsync = createAsyncQueue([{
+      source: 'load_chart_service',
+      current_slug: 'xz2DdnNx',
+      current_href: 'https://de.tradingview.com/chart/xz2DdnNx/',
+      layouts: [
+        { id: 186166925, name: 'Hit & Run Algo', url: 'xz2DdnNx' },
+        { id: 187748360, name: 'hit and run 2 US100', url: 'b2TXdUfn' },
+      ],
+    }]);
+    const evaluate = createEvalQueue([]);
+
+    await assert.rejects(
+      () => layoutSwitch({ name: 'hit', _deps: { evaluateAsync, evaluate } }),
+      /ambiguous/i,
+    );
+    assert.equal(evaluate.calls.length, 0, 'should not mutate UI when match is ambiguous');
+  });
+
+  it('layoutSwitch verifies the target layout and dismisses localized unsaved dialogs', async () => {
+    const evaluateAsync = createAsyncQueue([
+      {
+        source: 'load_chart_service',
+        current_slug: 'xz2DdnNx',
+        current_href: 'https://de.tradingview.com/chart/xz2DdnNx/',
+        layouts: [
+          { id: 186002420, name: '8AM Breakout Algo', url: 'hRmRbL7i', symbol: 'US500', interval: '5' },
+          { id: 186166925, name: 'Hit & Run Algo', url: 'xz2DdnNx', symbol: 'SOLUSD', interval: '1D' },
+        ],
+      },
+      { success: true, method: 'loadChartFromServer', id: '186002420', source: 'internal_api' },
+      {
+        source: 'load_chart_service',
+        current_slug: 'hRmRbL7i',
+        current_href: 'https://de.tradingview.com/chart/hRmRbL7i/',
+        layouts: [
+          { id: 186002420, name: '8AM Breakout Algo', url: 'hRmRbL7i', symbol: 'US500', interval: '5' },
+          { id: 186166925, name: 'Hit & Run Algo', url: 'xz2DdnNx', symbol: 'SOLUSD', interval: '1D' },
+        ],
+      },
+    ]);
+    const evaluate = createEvalQueue([
+      { dismissed: true, label: 'Nicht speichern' },
+    ]);
+
+    const result = await layoutSwitch({ name: '8AM Breakout Algo', _deps: { evaluateAsync, evaluate } });
+    assert.equal(result.success, true);
+    assert.equal(result.verified, true);
+    assert.equal(result.layout, '8AM Breakout Algo');
+    assert.equal(result.layout_id, 186002420);
+    assert.equal(result.layout_url, 'hRmRbL7i');
+    assert.equal(result.current_slug, 'hRmRbL7i');
+    assert.equal(result.unsaved_dialog_dismissed, true);
+    assert.equal(result.active_layout?.name, '8AM Breakout Algo');
+  });
+
+  it('layoutSwitch returns already_active when target is current layout', async () => {
+    const evaluateAsync = createAsyncQueue([{
+      source: 'load_chart_service',
+      current_slug: 'hRmRbL7i',
+      current_href: 'https://de.tradingview.com/chart/hRmRbL7i/',
+      layouts: [
+        { id: 186002420, name: '8AM Breakout Algo', url: 'hRmRbL7i', symbol: 'US500', interval: '5' },
+      ],
+    }]);
+
+    const result = await layoutSwitch({ name: '8AM Breakout Algo', _deps: { evaluateAsync, evaluate: async () => ({ dismissed: false }) } });
+    assert.equal(result.success, true);
+    assert.equal(result.action, 'already_active');
+    assert.equal(result.verified, true);
+    assert.equal(result.unsaved_dialog_dismissed, false);
+  });
+});


### PR DESCRIPTION
## Summary
This PR hardens saved-layout switching and adds a new `strategy_open` workflow for TradingView MCP.

## What Changed
- Added verified active-layout detection to `layout_list`
- Hardened `layout_switch` with post-switch verification and better German unsaved-dialog handling
- Added `strategy_open` as an MCP tool and CLI command (`tv strategy open`)
- Added dry-run support so strategy/layout resolution can be previewed without changing TradingView
- Added unit tests for layout verification and strategy opening flows
- Updated README command docs and examples

## Why
The old layout switch path could report success even when TradingView did not actually land on the intended saved layout. That makes higher-level automation unreliable. This PR makes the layout layer honest and then builds a safer strategy-opening abstraction on top of it.

## Validation
- `node --test tests/strategy_open.test.js tests/ui_layouts.test.js tests/pine_analyze.test.js`
- `node src/cli/index.js strategy --help`
- `node src/cli/index.js strategy open "8AM" --dry-run --symbol US500 --timeframe 5 --panel alerts --panel strategy-tester`

## Notes
- Existing local changes in `package-lock.json` and `tv_hitandrun_moc.json` were intentionally excluded from this PR.
- No live TradingView mutation was performed for the new strategy workflow; only dry-run verification was used.

## HANDOFF
- Summary: Layout switching is now verified instead of optimistic, and a new `strategy_open` workflow was added with dry-run support.
- Change type: MCP reliability improvement and new orchestration feature.
- Files changed: `src/core/ui.js`, `src/core/strategy.js`, `src/tools/strategy.js`, `src/cli/commands/strategy.js`, `src/server.js`, `src/cli/index.js`, `src/core/index.js`, `tests/ui_layouts.test.js`, `tests/strategy_open.test.js`, `package.json`, `README.md`.
- TradingView action required: no.
- MT5/VPS action required: no.
- Risks / unverified: Full live `strategy_open` execution was not run against the user's session to avoid unintended TradingView changes; `tests/cli.test.js` still has an existing Windows/Node assertion issue in unrelated `pine check` subprocess tests.
- Recommended next step: Run one controlled live `strategy_open` against a non-critical layout, then extend it with config-driven strategy aliases and optional post-open checks for alerts/panels.
