### PR TITLE
fix: wait for chart render before screenshot

### DIFF
--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -1,7 +1,8 @@
-/**
+﻿/**
  * Core screenshot/capture logic.
  */
 import { getClient, evaluate, getChartCollection } from '../connection.js';
+import { waitForChartRender } from '../wait.js';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -9,11 +10,15 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCREENSHOT_DIR = join(dirname(dirname(__dirname)), 'screenshots');
 
-export async function captureScreenshot({ region, filename, method } = {}) {
+export async function captureScreenshot({ region, filename, method, waitForRender = false } = {}) {
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
+  if (waitForRender) {
+    await waitForChartRender();
+  }
+
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_');
+  const fname = (filename || `tv_${region || 'full'}_${ts}`).replace(/[\\/]/g, '_');
   const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
 
   if (method === 'api') {
@@ -21,7 +26,9 @@ export async function captureScreenshot({ region, filename, method } = {}) {
       const colPath = await getChartCollection();
       await evaluate(`${colPath}.takeScreenshot()`);
       return {
-        success: true, method: 'api',
+        success: true,
+        method: 'api',
+        waited_for_render: !!waitForRender,
         note: 'takeScreenshot() triggered — TradingView will save/show the screenshot via its own UI',
       };
     } catch {
@@ -64,7 +71,11 @@ export async function captureScreenshot({ region, filename, method } = {}) {
   writeFileSync(filePath, Buffer.from(data, 'base64'));
 
   return {
-    success: true, method: 'cdp', file_path: filePath, region,
+    success: true,
+    method: 'cdp',
+    file_path: filePath,
+    region,
+    waited_for_render: !!waitForRender,
     size_bytes: Buffer.from(data, 'base64').length,
   };
 }

--- a/src/tools/capture.js
+++ b/src/tools/capture.js
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+﻿import { z } from 'zod';
 import { jsonResult } from './_format.js';
 import * as core from '../core/capture.js';
 
@@ -7,8 +7,17 @@ export function registerCaptureTools(server) {
     region: z.string().optional().describe('Region to capture: full, chart, strategy_tester (default full)'),
     filename: z.string().optional().describe('Custom filename (without extension)'),
     method: z.string().optional().describe('Capture method: cdp (Page.captureScreenshot) or api (chartWidgetCollection.takeScreenshot) (default cdp)'),
-  }, async ({ region, filename, method }) => {
-    try { return jsonResult(await core.captureScreenshot({ region, filename, method })); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    wait_for_render: z.boolean().optional().describe('Wait for the visible chart canvas to stabilize before capture. Useful after chart_set_symbol or chart_set_timeframe.'),
+  }, async ({ region, filename, method, wait_for_render }) => {
+    try {
+      return jsonResult(await core.captureScreenshot({
+        region,
+        filename,
+        method,
+        waitForRender: wait_for_render,
+      }));
+    } catch (err) {
+      return jsonResult({ success: false, error: err.message }, true);
+    }
   });
 }

--- a/src/wait.js
+++ b/src/wait.js
@@ -70,3 +70,71 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
   // Timeout — return true anyway, caller should verify
   return false;
 }
+
+export async function waitForChartRender(timeout = 5000) {
+  const start = Date.now();
+  let lastSignature = null;
+  let stableCount = 0;
+
+  while (Date.now() - start < timeout) {
+    const state = await evaluate(`
+      (function() {
+        var canvas = document.querySelector('[data-name="pane-canvas"] canvas')
+          || document.querySelector('[data-name="pane-canvas"]')
+          || document.querySelector('canvas');
+
+        var rect = canvas ? canvas.getBoundingClientRect() : null;
+
+        var chart = null;
+        var symbol = '';
+        var resolution = '';
+
+        try {
+          chart = window.TradingViewApi._activeChartWidgetWV.value();
+          symbol = chart.symbol();
+          resolution = chart.resolution();
+        } catch(e) {}
+
+        var spinner = document.querySelector('[class*="loader"]')
+          || document.querySelector('[class*="loading"]')
+          || document.querySelector('[data-name="loading"]');
+
+        return {
+          symbol: symbol,
+          resolution: resolution,
+          isLoading: !!(spinner && spinner.offsetParent !== null),
+          canvasWidth: rect ? Math.round(rect.width) : 0,
+          canvasHeight: rect ? Math.round(rect.height) : 0
+        };
+      })()
+    `);
+
+    if (!state || state.isLoading || !state.canvasWidth || !state.canvasHeight) {
+      stableCount = 0;
+      await new Promise(r => setTimeout(r, POLL_INTERVAL));
+      continue;
+    }
+
+    const signature = [
+      state.symbol,
+      state.resolution,
+      state.canvasWidth,
+      state.canvasHeight,
+    ].join('|');
+
+    if (signature === lastSignature) {
+      stableCount++;
+    } else {
+      stableCount = 0;
+      lastSignature = signature;
+    }
+
+    if (stableCount >= 3) {
+      return true;
+    }
+
+    await new Promise(r => setTimeout(r, POLL_INTERVAL));
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Fixes #144.

This adds an optional `wait_for_render` parameter to `capture_screenshot`.

When enabled, the screenshot tool waits for the visible chart canvas to stabilize before capturing. This helps avoid stale screenshots immediately after `chart_set_symbol` or `chart_set_timeframe`, where the data layer may already reflect the new symbol/timeframe but the visible chart canvas can still show the previous rendered frame.

## Changes

- Added `wait_for_render` option to `capture_screenshot`
- Added `waitForChartRender()` helper in `src/wait.js`
- Included `waited_for_render` in screenshot results for easier debugging
- Kept the existing default behavior unchanged

## Testing

Manual testing recommended:

1. Start on `BATS:MSTR`, resolution `60`
2. Call `chart_set_symbol` with `BITSTAMP:BTCUSD`
3. Call `chart_set_timeframe` with `D`
4. Call `capture_screenshot` with `region: "chart"` and `wait_for_render: true`
5. Confirm the screenshot shows BTCUSD daily chart rather than the previous MSTR 1H frame

AI assistance was used to inspect the issue and draft the fix, and the final changes were reviewed before submission.