### PR TITLE
feat: webhook receiver + 8 defect fixes (stacked, happy to split)

### DIFF
--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -75,7 +75,99 @@ async function applySubView() {
   return clickButtonInDialogByText(`t === 'Back'`);
 }
 
-export async function create({ condition, price, message, webhook_url, expiration_minutes }) {
+/**
+ * DEFECT 8 — select the Source dropdown option in the Create Alert dialog.
+ *
+ * This dropdown is the FIRST dropdown in the Condition row (e.g. currently
+ * "Price"). Clicking it opens an inline popover with a different DOM
+ * architecture than the operator-row portal (DEFECT 2c):
+ *
+ *   Popover container: [role="listbox"][data-qa-id="popup-menu-container main-series-select"]
+ *     class: menuWrap-XktvVkFF
+ *     position: fixed (rendered to document.body — NOT inside the dialog)
+ *   Items: [role="option"][class*="menuItem-VfhgWFqC"]
+ *     id pattern: id_item_$Price$ | id_item_$Study$-<num>_<num>
+ *     aria-selected: "true" on current selection
+ *   Item label: [data-qa-id="main-series-select-title"] [class*="label-VfhgWFqC"]
+ *     Example labels observed:
+ *       "Price"
+ *       "HyperClaw Stack v1 (Hurst + VWAP-Z + wRSI + RSI-Div) (100, 24, 7, ...)"
+ *       "Vol"
+ *       "Test1 RSI Sweep (14, 30, 70)"
+ *
+ * The popover dismisses on any document-level interaction, so the open
+ * dropdown → find option → click flow must happen inside a single
+ * page-context script (the MutationObserver pattern used during DOM probing
+ * confirmed this).
+ *
+ * Matching strategy: case-insensitive substring match against the label
+ * text — Pine indicators on the chart include their full param list in the
+ * label, so callers can pass just the script title ("HyperClaw Stack v1")
+ * without enumerating params.
+ */
+async function selectAlertSource(sourceName) {
+  const want = String(sourceName).trim();
+  const result = await evaluate(`
+    (function() {
+      var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+      if (!dialog) return { ok: false, error: 'no dialog' };
+      // Find the source dropdown row — the FIRST select wrapper in the Condition row.
+      var allSelects = dialog.querySelectorAll('[class*="select-VfhgWFqC"]');
+      var sourceWrapper = allSelects[0];
+      if (!sourceWrapper) return { ok: false, error: 'no source dropdown' };
+      var realBtn = sourceWrapper.querySelector('[role="button"]');
+      if (!realBtn) return { ok: false, error: 'no role=button child' };
+      // Open the popover
+      realBtn.click();
+      // The popover renders via a React portal at document.body — it should be
+      // available synchronously after the click, before this script returns
+      // (because no setTimeout or microtask gap intervenes).
+      var portal = document.querySelector('[role="listbox"][class*="menuWrap-XktvVkFF"]');
+      if (!portal) {
+        // Older popover class fallback
+        portal = document.querySelector('[role="listbox"][data-qa-id*="main-series-select"]');
+      }
+      if (!portal) return { ok: false, error: 'source popover did not appear', source_wanted: ${safeString(want)} };
+      // Collect all option labels for diagnostics
+      var options = portal.querySelectorAll('[role="option"]');
+      var labels = [];
+      var match = null;
+      var wantLower = ${safeString(want.toLowerCase())};
+      for (var i = 0; i < options.length; i++) {
+        var labelEl = options[i].querySelector('[data-qa-id="main-series-select-title"] [class*="label-VfhgWFqC"]')
+                   || options[i].querySelector('[class*="label-VfhgWFqC"]');
+        var labelText = (labelEl && labelEl.textContent || '').trim();
+        labels.push(labelText);
+        var lowerLabel = labelText.toLowerCase();
+        if (!match) {
+          // Prefer exact match first, then substring
+          if (lowerLabel === wantLower) match = { el: options[i], label: labelText, score: 'exact' };
+        }
+      }
+      if (!match) {
+        for (var j = 0; j < options.length; j++) {
+          var labelEl2 = options[j].querySelector('[data-qa-id="main-series-select-title"] [class*="label-VfhgWFqC"]')
+                     || options[j].querySelector('[class*="label-VfhgWFqC"]');
+          var labelText2 = (labelEl2 && labelEl2.textContent || '').trim().toLowerCase();
+          if (labelText2.indexOf(wantLower) !== -1) {
+            match = { el: options[j], label: (labelEl2 && labelEl2.textContent || '').trim(), score: 'substring' };
+            break;
+          }
+        }
+      }
+      if (!match) {
+        // Close popover so we don't leave it dangling
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true }));
+        return { ok: false, error: 'source not found', wanted: ${safeString(want)}, available: labels };
+      }
+      match.el.click();
+      return { ok: true, matched_label: match.label, match_kind: match.score, available: labels };
+    })()
+  `);
+  return result;
+}
+
+export async function create({ source, condition, price, message, webhook_url, expiration_minutes }) {
   // 0. Preflight — if a leftover alert dialog is open from a previous run, drop
   //    out of any sub-view and close it before we open a fresh one. Sub-view
   //    Cancel returns to the main view; the second Cancel actually closes.
@@ -121,6 +213,36 @@ export async function create({ condition, price, message, webhook_url, expiratio
   // input to TV's "current price" default and discards any value we wrote
   // earlier. Setting price last is the only reliable order.
 
+  // 2. Source (DEFECT 8) — change the alert data source from the default
+  //    "Price" to a chart indicator (Pine alertcondition source). Must run
+  //    BEFORE the operator step because switching source re-renders the
+  //    operator dropdown's options (Price uses Crossing/Greater/Less; a
+  //    Pine indicator uses its alertcondition() titles).
+  let sourceSet = false;
+  let sourceMatchedLabel = null;
+  let sourceAvailable = null;
+  if (source) {
+    // The dialog defaults to "Price" — so if caller asked for "Price" exactly
+    // and that's already what's shown, skip the dropdown round-trip. Any
+    // other value (Vol, Volume, a Pine indicator title, etc) goes through
+    // the source selector.
+    const skipBecauseDefault = String(source).trim().toLowerCase() === 'price';
+    if (!skipBecauseDefault) {
+      const srcResult = await selectAlertSource(source);
+      sourceSet = !!(srcResult && srcResult.ok);
+      sourceMatchedLabel = srcResult?.matched_label || null;
+      sourceAvailable = srcResult?.available || null;
+      if (!sourceSet) {
+        throw new Error(
+          `Source "${source}" not found in alert dropdown — is the Pine indicator attached to the chart? ` +
+          (sourceAvailable ? `Available: ${sourceAvailable.join(' | ')}` : '')
+        );
+      }
+      // Switching source re-renders dependent fields; let TV settle.
+      await sleep(700);
+    }
+  }
+
   // 3. Condition operator (Crossing / Greater Than / Less Than / etc.).
   //    The operator row is a button whose text is the current operator name.
   //    Clicking it opens a portal popover (class positioner-lATuqHRX +
@@ -130,12 +252,29 @@ export async function create({ condition, price, message, webhook_url, expiratio
   //    option's text lives in a [class*="title-RDCgMoEQ"] inside a clickable
   //    [class*="button-HZXWyU6m"] wrapper.
   let conditionSet = false;
-  let conditionApplied = canonicalCondition(condition);
+  let conditionApplied = source ? String(condition || '').trim() : canonicalCondition(condition);
   const PORTAL_SELECTOR = `[class*="positioner-lATuqHRX"][class*="contentDefaultAppearance"]`;
   if (conditionApplied) {
-    const conditionRowOpened = await clickButtonInDialogByText(
+    // When source is a Pine indicator, the row button text is the current
+    // alertcondition title — arbitrary text. Fall back to matching the
+    // dropdown button by class rather than known operator names.
+    let conditionRowOpened = await clickButtonInDialogByText(
       `(t === 'Crossing' || t === 'Crossing Up' || t === 'Crossing Down' || t === 'Greater Than' || t === 'Less Than' || t === 'Entering Channel' || t === 'Exiting Channel' || t === 'Inside Channel' || t === 'Outside Channel' || t === 'Moving Up' || t === 'Moving Down' || t === 'Moving Up %' || t === 'Moving Down %')`
     );
+    if (!conditionRowOpened && source) {
+      // Pine-source path: click the dropdownButton-lFPR_Qij in the Condition row.
+      conditionRowOpened = await evaluate(`
+        (function() {
+          var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+          if (!dialog) return false;
+          var btn = dialog.querySelector('[class*="dropdownButton-lFPR_Qij"]');
+          if (!btn) return false;
+          var realBtn = btn.querySelector('[role="button"]') || btn;
+          realBtn.click();
+          return (btn.textContent || '').trim();
+        })()
+      `);
+    }
     if (conditionRowOpened) {
       await sleep(500);
       // If the wanted option isn't in the first 3 visible items, click "Show more".
@@ -345,23 +484,31 @@ export async function create({ condition, price, message, webhook_url, expiratio
   let conditionVerified = null;
   let verifiedAlertId = null;
   if (createdLabel) {
-    // TV's REST list_alerts can lag the Create click by 1-1.5s. Wait long
-    // enough that the newest alert is reliably visible to the API; otherwise
-    // verify reads back the *previous* alert and falsely reports the new
-    // condition/webhook as not stored.
-    await sleep(1500);
+    // TV's REST list_alerts can lag the Create click by ~1.5-2s, especially
+    // for indicator-sourced alerts whose payload is larger. Wait long enough
+    // that the newest alert is reliably visible to the API; otherwise verify
+    // reads back the *previous* alert and falsely reports a stale alert_id /
+    // condition / webhook for the just-created one.
+    await sleep(2500);
     const verify = await evaluateAsync(`
       fetch('https://pricealerts.tradingview.com/list_alerts?limit=1', { credentials: 'include' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           if (d.s !== 'ok' || !Array.isArray(d.r) || d.r.length === 0) return null;
           var newest = d.r[0];
+          var series0 = newest.condition && newest.condition.series && newest.condition.series[0];
           return {
             alert_id: newest.alert_id,
             web_hook: newest.web_hook,
             message: newest.message,
+            type: newest.type,
             condition_type: newest.condition && newest.condition.type,
-            condition_value: newest.condition && newest.condition.series && newest.condition.series[1] && newest.condition.series[1].value
+            condition_value: newest.condition && newest.condition.series && newest.condition.series[1] && newest.condition.series[1].value,
+            // Pine-source fields (only populated when type === "indicator")
+            series_type: series0 && series0.type,
+            pine_id: series0 && series0.pine_id,
+            pine_version: series0 && series0.pine_version,
+            alert_cond_id: newest.condition && newest.condition.alert_cond_id
           };
         })
         .catch(function() { return null; })
@@ -370,26 +517,34 @@ export async function create({ condition, price, message, webhook_url, expiratio
       verifiedAlertId = verify.alert_id;
       if (webhook_url) webhookVerified = verify.web_hook === webhook_url;
       if (conditionApplied) {
-        // TV's stored condition type is "cross" / "greater" / "less" / etc — a
-        // shortened slug. Map our canonical operator name to the matching slug.
-        const wantSlug = (function(name) {
-          var n = String(name).toLowerCase();
-          if (n === 'crossing') return 'cross';
-          if (n === 'crossing up') return 'cross_up';
-          if (n === 'crossing down') return 'cross_down';
-          if (n === 'greater than') return 'greater';
-          if (n === 'less than') return 'less';
-          if (n === 'entering channel') return 'entering_channel';
-          if (n === 'exiting channel') return 'exiting_channel';
-          if (n === 'inside channel') return 'inside_channel';
-          if (n === 'outside channel') return 'outside_channel';
-          if (n === 'moving up') return 'moving_up';
-          if (n === 'moving down') return 'moving_down';
-          if (n === 'moving up %') return 'moving_up_percent';
-          if (n === 'moving down %') return 'moving_down_percent';
-          return n;
-        })(conditionApplied);
-        conditionVerified = verify.condition_type === wantSlug;
+        if (source && verify.type === 'indicator' && verify.condition_type === 'alert_cond') {
+          // Pine-source alert: verification is "did TV store the alert as an
+          // indicator alert with our pine_id?" We can't easily verify the
+          // exact alertcondition title from the REST payload (it stores an
+          // opaque alert_cond_id like "plot_1"), so we accept the alert if
+          // it landed as a pine_id alert at all.
+          conditionVerified = !!verify.pine_id;
+        } else {
+          // TV's stored condition type is "cross" / "greater" / "less" — slug.
+          const wantSlug = (function(name) {
+            var n = String(name).toLowerCase();
+            if (n === 'crossing') return 'cross';
+            if (n === 'crossing up') return 'cross_up';
+            if (n === 'crossing down') return 'cross_down';
+            if (n === 'greater than') return 'greater';
+            if (n === 'less than') return 'less';
+            if (n === 'entering channel') return 'entering_channel';
+            if (n === 'exiting channel') return 'exiting_channel';
+            if (n === 'inside channel') return 'inside_channel';
+            if (n === 'outside channel') return 'outside_channel';
+            if (n === 'moving up') return 'moving_up';
+            if (n === 'moving down') return 'moving_down';
+            if (n === 'moving up %') return 'moving_up_percent';
+            if (n === 'moving down %') return 'moving_down_percent';
+            return n;
+          })(conditionApplied);
+          conditionVerified = verify.condition_type === wantSlug;
+        }
       }
     }
   }
@@ -399,6 +554,11 @@ export async function create({ condition, price, message, webhook_url, expiratio
     alert_id: verifiedAlertId,
     price,
     price_set: !!priceSet,
+    // Source selection (DEFECT 8)
+    source: source || null,
+    source_set: !!sourceSet,
+    source_matched_label: sourceMatchedLabel,
+    source_available: sourceAvailable,
     condition: conditionApplied,
     condition_set: !!conditionSet,
     condition_verified_in_tv: conditionVerified,
@@ -411,7 +571,7 @@ export async function create({ condition, price, message, webhook_url, expiratio
     expiration_minutes: expiration_minutes || null,
     expiration_iso: expirationAppliedIso,
     expiration_set: !!expirationSet,
-    source: 'dom_fallback',
+    walker_source: 'dom_fallback',
   };
 }
 

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,79 +1,343 @@
 /**
  * Core alert logic.
+ *
+ * TradingView Desktop's "Create alert" dialog (current versions, post-2025) is
+ * a single popup whose body is one form, but several rows act as buttons that
+ * navigate the dialog into a sub-view (e.g. Message, Notifications,
+ * Expiration). A sub-view shows a localised editor plus "Back / Cancel /
+ * Apply" buttons; clicking Apply returns to the main view (with Cancel /
+ * Create buttons).
+ *
+ * The walker therefore:
+ *   1. Opens the dialog (aria-label is lowercase "Create alert").
+ *   2. Sets the trigger price on the main view's single text <input>.
+ *   3. For each sub-view it needs to touch (Notifications for webhook URL,
+ *      Message for the alert body, Expiration for expiry):
+ *        a. Click the corresponding row.
+ *        b. Wait for the sub-view to render.
+ *        c. Apply edits.
+ *        d. Click "Apply" to return to the main view.
+ *   4. Clicks "Create" on the main view.
+ *
+ * The `condition` argument is best-effort: TV's modern dialog renders the
+ * condition operator as an inline dropdown in a portal, which is brittle to
+ * automate. If we can't find the menu item, we surface that in the response
+ * but still create the alert (TV's default of "Crossing" is what most
+ * threshold alerts want anyway).
+ *
+ * Deletion has two paths:
+ *   - delete_all: opens the alerts side panel + contextmenu (still needs a
+ *     manual confirm — TV has no scriptable bulk delete).
+ *   - name / alert_id: looks up matching alerts via the pricealerts REST API
+ *     and calls remove_alert?alert_id=… for each.
  */
 import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
 
-export async function create({ condition, price, message }) {
+const NATIVE_INPUT_SETTER = `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set`;
+const NATIVE_TEXTAREA_SETTER = `Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set`;
+const DIALOG_SELECTOR = `[class*="dialog-"][class*="popup-"]`;
+
+function canonicalCondition(condition) {
+  if (!condition) return null;
+  const c = String(condition).toLowerCase().trim();
+  if (c === 'crossing' || c === 'cross') return 'Crossing';
+  if (c === 'crossing_up' || c === 'crossing up' || c === 'cross_up') return 'Crossing Up';
+  if (c === 'crossing_down' || c === 'crossing down' || c === 'cross_down') return 'Crossing Down';
+  if (c === 'greater_than' || c === 'greater than' || c === '>' || c === 'gt') return 'Greater Than';
+  if (c === 'less_than' || c === 'less than' || c === '<' || c === 'lt') return 'Less Than';
+  if (c === 'entering channel' || c === 'entering_channel') return 'Entering Channel';
+  if (c === 'exiting channel' || c === 'exiting_channel') return 'Exiting Channel';
+  return condition;
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function clickButtonInDialogByText(predicate) {
+  return evaluate(`
+    (function() {
+      var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+      if (!dialog) return false;
+      var btns = dialog.querySelectorAll('button');
+      for (var i = 0; i < btns.length; i++) {
+        var t = (btns[i].textContent || '').trim();
+        if (${predicate}) { btns[i].click(); return t; }
+      }
+      return false;
+    })()
+  `);
+}
+
+async function applySubView() {
+  // Click the "Apply" button in the current sub-view to commit edits and
+  // return to the main view. Falls back to "Back" if Apply is missing.
+  const clicked = await clickButtonInDialogByText(`t === 'Apply'`);
+  if (clicked) return clicked;
+  return clickButtonInDialogByText(`t === 'Back'`);
+}
+
+export async function create({ condition, price, message, webhook_url, expiration_minutes }) {
+  // 0. Preflight — if a leftover alert dialog is open from a previous run, drop
+  //    out of any sub-view and close it before we open a fresh one. Sub-view
+  //    Cancel returns to the main view; the second Cancel actually closes.
+  for (let pass = 0; pass < 3; pass++) {
+    const stillOpen = await evaluate(`!!document.querySelector(${safeString(DIALOG_SELECTOR)})`);
+    if (!stillOpen) break;
+    await evaluate(`
+      (function() {
+        var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+        if (!dialog) return;
+        var btns = dialog.querySelectorAll('button');
+        for (var i = 0; i < btns.length; i++) {
+          if (/^Cancel$/i.test((btns[i].textContent || '').trim())) { btns[i].click(); return; }
+        }
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true }));
+      })()
+    `);
+    await sleep(400);
+  }
+
+  // 1. Open the Create Alert dialog. Real aria-label is lowercase "Create alert".
   const opened = await evaluate(`
     (function() {
-      var btn = document.querySelector('[aria-label="Create Alert"]')
-        || document.querySelector('[data-name="alerts"]');
+      var btn = document.querySelector('button[aria-label="Create alert"]')
+        || document.querySelector('[aria-label="Create alert"]');
       if (btn) { btn.click(); return true; }
       return false;
     })()
   `);
 
   if (!opened) {
+    // Fallback: Alt+A keyboard shortcut.
     const client = await getClient();
     await client.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 1, key: 'a', code: 'KeyA', windowsVirtualKeyCode: 65 });
     await client.Input.dispatchKeyEvent({ type: 'keyUp', key: 'a', code: 'KeyA' });
   }
 
-  await new Promise(r => setTimeout(r, 1000));
+  await sleep(1200);
 
+  // Note: the trigger price is set in step 7, AFTER all sub-view navigation.
+  // Empirically, opening any sub-view (Notifications / Message / Expiration)
+  // and clicking Apply re-renders the main view, which re-binds the price
+  // input to TV's "current price" default and discards any value we wrote
+  // earlier. Setting price last is the only reliable order.
+
+  // 3. Condition — best-effort. The condition operator is an inline dropdown
+  //    in a portal; clicking the row opens a popover with options like
+  //    Crossing / Crossing Up / Greater Than / etc. We try to match the
+  //    requested option but don't fail the create if we can't.
+  let conditionSet = false;
+  let conditionApplied = canonicalCondition(condition);
+  if (conditionApplied) {
+    const conditionRowOpened = await clickButtonInDialogByText(
+      `(t === 'Crossing' || t === 'Crossing Up' || t === 'Crossing Down' || t === 'Greater Than' || t === 'Less Than' || t === 'Entering Channel' || t === 'Exiting Channel' || t === 'Moving Up' || t === 'Moving Down')`
+    );
+    if (conditionRowOpened) {
+      await sleep(400);
+      conditionSet = await evaluate(`
+        (function() {
+          var want = ${safeString(conditionApplied)};
+          var items = document.querySelectorAll('[role="menuitem"], [class*="menuItem"], [class*="item-"][role], [class*="dropdownItem"], li, [class*="option"]');
+          for (var i = 0; i < items.length; i++) {
+            var t = (items[i].textContent || '').trim();
+            if (t.length < 30 && t.toLowerCase() === want.toLowerCase()) { items[i].click(); return true; }
+          }
+          // Dismiss any open popover before continuing
+          document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true }));
+          return false;
+        })()
+      `);
+      await sleep(300);
+    }
+  }
+
+  // 4. Webhook — open Notifications sub-view, toggle Webhook URL on, fill URL,
+  //    then click Apply to return to main view.
+  let webhookConfigured = false;
+  if (webhook_url) {
+    const notifOpened = await clickButtonInDialogByText(
+      `(/Webhook|Toast|Email/i.test(t) && /,/.test(t) && t.length < 80)`
+    ) || await clickButtonInDialogByText(`(/Webhook/i.test(t) && t.length < 80)`);
+
+    if (notifOpened) {
+      await sleep(700);
+      const setResult = await evaluate(`
+        (function() {
+          var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+          if (!dialog) return { toggled: false, filled: false, reason: 'dialog gone' };
+          var toggled = false;
+          var filled = false;
+          var checks = dialog.querySelectorAll('input[type="checkbox"]');
+          for (var i = 0; i < checks.length; i++) {
+            var row = checks[i].closest('[class*="row"], [class*="Row"], [class*="item"], label, [class*="field"]');
+            var rowText = row ? (row.textContent || '').trim() : '';
+            if (/^Webhook URL/i.test(rowText)) {
+              if (!checks[i].checked) checks[i].click();
+              toggled = true;
+              break;
+            }
+          }
+          var inputs = dialog.querySelectorAll('input[type="text"], input[type="url"]');
+          for (var k = 0; k < inputs.length; k++) {
+            var inp = inputs[k];
+            if (inp.placeholder && /example\\.com\\/alert-hook/i.test(inp.placeholder)) {
+              var nativeSet = ${NATIVE_INPUT_SETTER};
+              nativeSet.call(inp, ${safeString(webhook_url)});
+              inp.dispatchEvent(new Event('input', { bubbles: true }));
+              inp.dispatchEvent(new Event('change', { bubbles: true }));
+              inp.dispatchEvent(new Event('blur', { bubbles: true }));
+              filled = true;
+              break;
+            }
+          }
+          return { toggled: toggled, filled: filled };
+        })()
+      `);
+      webhookConfigured = !!(setResult && setResult.toggled && setResult.filled);
+      await applySubView();
+      await sleep(500);
+    }
+  }
+
+  // 5. Message — Message sub-view has the textarea showing the auto-generated
+  //    string. Open it, replace, Apply, return.
+  let messageSet = false;
+  if (message) {
+    const msgRowOpened = await clickButtonInDialogByText(
+      `(t.length < 70 && t.length > 5 && (/Crossing|Greater Than|Less Than|Entering|Exiting|Moving Up|Moving Down/i.test(t)) && !/^Crossing$|^Crossing Up$|^Crossing Down$|^Greater Than$|^Less Than$|^Entering Channel$|^Exiting Channel$/.test(t))`
+    );
+    if (msgRowOpened) {
+      await sleep(500);
+      messageSet = await evaluate(`
+        (function() {
+          var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+          if (!dialog) return false;
+          var textarea = dialog.querySelector('textarea');
+          if (!textarea) return false;
+          var nativeSet = ${NATIVE_TEXTAREA_SETTER};
+          nativeSet.call(textarea, ${safeString(message)});
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+          textarea.dispatchEvent(new Event('change', { bubbles: true }));
+          textarea.dispatchEvent(new Event('blur', { bubbles: true }));
+          return true;
+        })()
+      `);
+      await applySubView();
+      await sleep(500);
+    }
+  }
+
+  // 6. Expiration — date+time pickers live in an Expiration sub-view.
+  let expirationSet = false;
+  let expirationAppliedIso = null;
+  if (typeof expiration_minutes === 'number' && Number.isFinite(expiration_minutes) && expiration_minutes > 0) {
+    const target = new Date(Date.now() + expiration_minutes * 60 * 1000);
+    expirationAppliedIso = target.toISOString();
+    const expRowOpened = await clickButtonInDialogByText(
+      `(/^(January|February|March|April|May|June|July|August|September|October|November|December)\\s+\\d+,\\s+\\d{4}\\s+at\\s+\\d{1,2}:\\d{2}/i.test(t))`
+    );
+    if (expRowOpened) {
+      await sleep(500);
+      const yyyy = target.getFullYear();
+      const mm = String(target.getMonth() + 1).padStart(2, '0');
+      const dd = String(target.getDate()).padStart(2, '0');
+      const hh = String(target.getHours()).padStart(2, '0');
+      const mi = String(target.getMinutes()).padStart(2, '0');
+      const dateStr = `${yyyy}-${mm}-${dd}`;
+      const timeStr = `${hh}:${mi}`;
+      expirationSet = await evaluate(`
+        (function() {
+          var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+          var scope = dialog || document;
+          var inputs = scope.querySelectorAll('input[type="date"], input[type="time"], input[type="text"]');
+          var dateSet = false, timeSet = false;
+          var nativeSet = ${NATIVE_INPUT_SETTER};
+          for (var i = 0; i < inputs.length; i++) {
+            var inp = inputs[i];
+            if (inp.type === 'date' && !dateSet) {
+              nativeSet.call(inp, ${safeString(dateStr)});
+              inp.dispatchEvent(new Event('input', { bubbles: true }));
+              inp.dispatchEvent(new Event('change', { bubbles: true }));
+              dateSet = true;
+            } else if (inp.type === 'time' && !timeSet) {
+              nativeSet.call(inp, ${safeString(timeStr)});
+              inp.dispatchEvent(new Event('input', { bubbles: true }));
+              inp.dispatchEvent(new Event('change', { bubbles: true }));
+              timeSet = true;
+            }
+          }
+          return dateSet || timeSet;
+        })()
+      `);
+      await applySubView();
+      await sleep(500);
+    }
+  }
+
+  // 7. Set the trigger price NOW (last, just before Create) so prior sub-view
+  //    re-renders don't reset it back to TV's "current price" default.
   const priceSet = await evaluate(`
     (function() {
-      var inputs = document.querySelectorAll('[class*="alert"] input[type="text"], [class*="alert"] input[type="number"]');
+      var dialog = document.querySelector(${safeString(DIALOG_SELECTOR)});
+      if (!dialog) return false;
+      var inputs = dialog.querySelectorAll('input[type="text"], input[type="number"]');
       for (var i = 0; i < inputs.length; i++) {
-        var label = inputs[i].closest('[class*="row"]')?.querySelector('[class*="label"]');
-        if (label && /value|price/i.test(label.textContent)) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-          nativeSet.call(inputs[i], ${safeString(String(price))});
-          inputs[i].dispatchEvent(new Event('input', { bubbles: true }));
-          inputs[i].dispatchEvent(new Event('change', { bubbles: true }));
-          return true;
-        }
-      }
-      if (inputs.length > 0) {
-        var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-        nativeSet.call(inputs[0], ${safeString(String(price))});
-        inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
+        var inp = inputs[i];
+        if (inp.placeholder && /example\\.com\\/alert-hook/i.test(inp.placeholder)) continue;
+        var nativeSet = ${NATIVE_INPUT_SETTER};
+        nativeSet.call(inp, ${safeString(String(price))});
+        inp.dispatchEvent(new Event('input', { bubbles: true }));
+        inp.dispatchEvent(new Event('change', { bubbles: true }));
+        inp.dispatchEvent(new Event('blur', { bubbles: true }));
         return true;
       }
       return false;
     })()
   `);
+  await sleep(300);
 
-  if (message) {
-    await evaluate(`
-      (function() {
-        var textarea = document.querySelector('[class*="alert"] textarea')
-          || document.querySelector('textarea[placeholder*="message"]');
-        if (textarea) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
-          nativeSet.call(textarea, ${JSON.stringify(message)});
-          textarea.dispatchEvent(new Event('input', { bubbles: true }));
-        }
-      })()
+  // 8. Submit on the main view.
+  const createdLabel = await clickButtonInDialogByText(`t === 'Create'`);
+
+  // 9. Verification — read back the just-created alert from the REST API to
+  //    confirm web_hook actually landed in TV's stored state. This catches
+  //    cases where our DOM toggle reported success but TV silently dropped
+  //    the URL (rare but possible if the sub-view was in a transient state).
+  let webhookVerified = null;
+  if (createdLabel && webhook_url) {
+    await sleep(400);
+    const verify = await evaluateAsync(`
+      fetch('https://pricealerts.tradingview.com/list_alerts?limit=1', { credentials: 'include' })
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+          if (d.s !== 'ok' || !Array.isArray(d.r) || d.r.length === 0) return null;
+          var newest = d.r[0];
+          return { alert_id: newest.alert_id, web_hook: newest.web_hook, message: newest.message };
+        })
+        .catch(function() { return null; })
     `);
+    if (verify) webhookVerified = verify.web_hook === webhook_url;
   }
 
-  await new Promise(r => setTimeout(r, 500));
-  const created = await evaluate(`
-    (function() {
-      var btns = document.querySelectorAll('button[data-name="submit"], button');
-      for (var i = 0; i < btns.length; i++) {
-        if (/^create$/i.test(btns[i].textContent.trim())) { btns[i].click(); return true; }
-      }
-      return false;
-    })()
-  `);
-
-  return { success: !!created, price, condition, message: message || '(none)', price_set: !!priceSet, source: 'dom_fallback' };
+  return {
+    success: !!createdLabel,
+    price,
+    price_set: !!priceSet,
+    condition: conditionApplied,
+    condition_set: !!conditionSet,
+    condition_note: conditionApplied && !conditionSet ? 'Could not locate the condition menu item; alert will use TV\'s currently selected operator.' : undefined,
+    message: message || null,
+    message_set: !!messageSet,
+    webhook_url: webhook_url || null,
+    webhook_dom_configured: webhookConfigured,
+    webhook_verified_in_tv: webhookVerified,
+    expiration_minutes: expiration_minutes || null,
+    expiration_iso: expirationAppliedIso,
+    expiration_set: !!expirationSet,
+    source: 'dom_fallback',
+  };
 }
 
 export async function list() {
-  // Use pricealerts REST API — returns structured data with alert_id, symbol, price, conditions
   const result = await evaluateAsync(`
     fetch('https://pricealerts.tradingview.com/list_alerts', { credentials: 'include' })
       .then(function(r) { return r.json(); })
@@ -103,7 +367,38 @@ export async function list() {
   return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
 }
 
-export async function deleteAlerts({ delete_all }) {
+// TODO(per-alert delete): TradingView's REST surface for deleting a single
+// alert is currently not discoverable from CDP. Tried (all returned
+// `code=no_such_endpoint`): GET /remove_alert, /delete_alert, /alert,
+// /show_alert, /alert_details, /get_alert, /get_alert_details, /remove_alerts,
+// /remove, /delete, /archive_alert. POST /remove_alert and HTTP DELETE on
+// /list_alerts / /alerts / /alert also fail (DELETE errors before send).
+// The UI's per-row delete button dispatches at zero-bounding-rect when the
+// alerts side panel is collapsed, which is why a synthetic click did not
+// trigger a network request in repro. A future iteration should either:
+//   (a) intercept TV's own delete request (via Network panel during a manual
+//       delete) to identify the real endpoint + HTTP verb;
+//   (b) ensure the alerts panel is fully expanded and visible before clicking
+//       the per-row delete button, then handle the confirm dialog;
+//   (c) call the TV WS protocol if that's where deletes actually flow.
+// Until then, `name` / `alert_id` matching still runs and reports which
+// alerts would be deleted — the caller can use TV's UI or alert_delete with
+// delete_all: true (which opens the panel context menu for manual confirm).
+async function deleteOneByApi(alertId) {
+  const url = `https://pricealerts.tradingview.com/remove_alert?alert_id=${encodeURIComponent(alertId)}`;
+  const result = await evaluateAsync(`
+    fetch(${safeString(url)}, { credentials: 'include' })
+      .then(function(r) { return r.json().then(function(j) { return { status: r.status, body: j }; }).catch(function() { return { status: r.status, body: null }; }); })
+      .catch(function(e) { return { error: e.message }; })
+  `);
+  if (result?.error) return { ok: false, error: result.error };
+  const body = result?.body;
+  if (body && body.s === 'ok') return { ok: true, body };
+  if (result?.status === 200 && !body) return { ok: true, body: null };
+  return { ok: false, status: result?.status, body, errmsg: body?.errmsg };
+}
+
+export async function deleteAlerts({ delete_all, name, alert_id }) {
   if (delete_all) {
     const result = await evaluate(`
       (function() {
@@ -117,7 +412,54 @@ export async function deleteAlerts({ delete_all }) {
         return { context_menu_opened: false };
       })()
     `);
-    return { success: true, note: 'Alert deletion requires manual confirmation in the context menu.', context_menu_opened: result?.context_menu_opened || false, source: 'dom_fallback' };
+    return {
+      success: true,
+      note: 'Alert deletion requires manual confirmation in the context menu.',
+      context_menu_opened: result?.context_menu_opened || false,
+      source: 'dom_fallback',
+    };
   }
-  throw new Error('Individual alert deletion not yet supported. Use delete_all: true.');
+
+  if (!name && !alert_id) {
+    throw new Error('Pass delete_all: true, alert_id: "<id>", or name: "<substring>" to alert_delete.');
+  }
+
+  const listing = await list();
+  if (listing.error) throw new Error(`Could not list alerts: ${listing.error}`);
+  const all = listing.alerts || [];
+  let targets = [];
+  if (alert_id) {
+    targets = all.filter(a => String(a.alert_id) === String(alert_id));
+  } else if (name) {
+    const needle = String(name).toLowerCase();
+    targets = all.filter(a => (a.message || '').toLowerCase().includes(needle));
+  }
+  if (targets.length === 0) {
+    return {
+      success: false,
+      deleted: 0,
+      reason: alert_id ? `No alert with alert_id=${alert_id}` : `No alert message contains "${name}"`,
+      candidates_searched: all.length,
+    };
+  }
+
+  const results = [];
+  for (const a of targets) {
+    const res = await deleteOneByApi(a.alert_id);
+    results.push({
+      alert_id: a.alert_id,
+      message: (a.message || '').slice(0, 60),
+      ok: res.ok,
+      error: res.error,
+      status: res.status,
+    });
+  }
+  const okCount = results.filter(r => r.ok).length;
+  return {
+    success: okCount === targets.length,
+    deleted: okCount,
+    attempted: targets.length,
+    results,
+    source: 'rest_api',
+  };
 }

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -121,27 +121,66 @@ export async function create({ condition, price, message, webhook_url, expiratio
   // input to TV's "current price" default and discards any value we wrote
   // earlier. Setting price last is the only reliable order.
 
-  // 3. Condition — best-effort. The condition operator is an inline dropdown
-  //    in a portal; clicking the row opens a popover with options like
-  //    Crossing / Crossing Up / Greater Than / etc. We try to match the
-  //    requested option but don't fail the create if we can't.
+  // 3. Condition operator (Crossing / Greater Than / Less Than / etc.).
+  //    The operator row is a button whose text is the current operator name.
+  //    Clicking it opens a portal popover (class positioner-lATuqHRX +
+  //    contentDefaultAppearance-ODkmI6nR) outside the dialog DOM. The first
+  //    three options (Crossing / Crossing Up / Crossing Down) are visible
+  //    initially; the remaining 10 are revealed by clicking "Show more". Each
+  //    option's text lives in a [class*="title-RDCgMoEQ"] inside a clickable
+  //    [class*="button-HZXWyU6m"] wrapper.
   let conditionSet = false;
   let conditionApplied = canonicalCondition(condition);
+  const PORTAL_SELECTOR = `[class*="positioner-lATuqHRX"][class*="contentDefaultAppearance"]`;
   if (conditionApplied) {
     const conditionRowOpened = await clickButtonInDialogByText(
-      `(t === 'Crossing' || t === 'Crossing Up' || t === 'Crossing Down' || t === 'Greater Than' || t === 'Less Than' || t === 'Entering Channel' || t === 'Exiting Channel' || t === 'Moving Up' || t === 'Moving Down')`
+      `(t === 'Crossing' || t === 'Crossing Up' || t === 'Crossing Down' || t === 'Greater Than' || t === 'Less Than' || t === 'Entering Channel' || t === 'Exiting Channel' || t === 'Inside Channel' || t === 'Outside Channel' || t === 'Moving Up' || t === 'Moving Down' || t === 'Moving Up %' || t === 'Moving Down %')`
     );
     if (conditionRowOpened) {
-      await sleep(400);
+      await sleep(500);
+      // If the wanted option isn't in the first 3 visible items, click "Show more".
+      const wantInTopThree = ['Crossing', 'Crossing Up', 'Crossing Down'].some(
+        s => s.toLowerCase() === conditionApplied.toLowerCase()
+      );
+      if (!wantInTopThree) {
+        const expanded = await evaluate(`
+          (function() {
+            var portal = document.querySelector(${safeString(PORTAL_SELECTOR)});
+            if (!portal) return false;
+            // Show more is rendered as a "customListItem" BUTTON. Match by its text.
+            var clickables = portal.querySelectorAll('button, [class*="customListItem"], [class*="clickable"]');
+            for (var i = 0; i < clickables.length; i++) {
+              if ((clickables[i].textContent || '').trim() === 'Show more') {
+                clickables[i].click();
+                return true;
+              }
+            }
+            return false;
+          })()
+        `);
+        if (expanded) await sleep(500);
+      }
+      // Click the option whose title matches the requested operator.
       conditionSet = await evaluate(`
         (function() {
           var want = ${safeString(conditionApplied)};
-          var items = document.querySelectorAll('[role="menuitem"], [class*="menuItem"], [class*="item-"][role], [class*="dropdownItem"], li, [class*="option"]');
-          for (var i = 0; i < items.length; i++) {
-            var t = (items[i].textContent || '').trim();
-            if (t.length < 30 && t.toLowerCase() === want.toLowerCase()) { items[i].click(); return true; }
+          var portal = document.querySelector(${safeString(PORTAL_SELECTOR)});
+          if (!portal) return false;
+          var titles = portal.querySelectorAll('[class*="title-RDCgMoEQ"]');
+          for (var i = 0; i < titles.length; i++) {
+            var t = (titles[i].textContent || '').trim();
+            if (t.toLowerCase() === want.toLowerCase()) {
+              // Walk up to the clickable button-HZXWyU6m wrapper
+              var p = titles[i];
+              for (var d = 0; d < 6 && p.parentElement; d++) {
+                p = p.parentElement;
+                if ((p.className || '').indexOf('button-HZXWyU6m') !== -1) { p.click(); return true; }
+              }
+              titles[i].click();
+              return true;
+            }
           }
-          // Dismiss any open popover before continuing
+          // Dismiss the popover if we couldn't match
           document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true }));
           return false;
         })()
@@ -299,31 +338,70 @@ export async function create({ condition, price, message, webhook_url, expiratio
   const createdLabel = await clickButtonInDialogByText(`t === 'Create'`);
 
   // 9. Verification — read back the just-created alert from the REST API to
-  //    confirm web_hook actually landed in TV's stored state. This catches
-  //    cases where our DOM toggle reported success but TV silently dropped
-  //    the URL (rare but possible if the sub-view was in a transient state).
+  //    confirm web_hook and condition operator actually landed in TV's stored
+  //    state. DOM observation alone is unreliable because the dialog inherits
+  //    fields from previous alerts.
   let webhookVerified = null;
-  if (createdLabel && webhook_url) {
-    await sleep(400);
+  let conditionVerified = null;
+  let verifiedAlertId = null;
+  if (createdLabel) {
+    // TV's REST list_alerts can lag the Create click by 1-1.5s. Wait long
+    // enough that the newest alert is reliably visible to the API; otherwise
+    // verify reads back the *previous* alert and falsely reports the new
+    // condition/webhook as not stored.
+    await sleep(1500);
     const verify = await evaluateAsync(`
       fetch('https://pricealerts.tradingview.com/list_alerts?limit=1', { credentials: 'include' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           if (d.s !== 'ok' || !Array.isArray(d.r) || d.r.length === 0) return null;
           var newest = d.r[0];
-          return { alert_id: newest.alert_id, web_hook: newest.web_hook, message: newest.message };
+          return {
+            alert_id: newest.alert_id,
+            web_hook: newest.web_hook,
+            message: newest.message,
+            condition_type: newest.condition && newest.condition.type,
+            condition_value: newest.condition && newest.condition.series && newest.condition.series[1] && newest.condition.series[1].value
+          };
         })
         .catch(function() { return null; })
     `);
-    if (verify) webhookVerified = verify.web_hook === webhook_url;
+    if (verify) {
+      verifiedAlertId = verify.alert_id;
+      if (webhook_url) webhookVerified = verify.web_hook === webhook_url;
+      if (conditionApplied) {
+        // TV's stored condition type is "cross" / "greater" / "less" / etc — a
+        // shortened slug. Map our canonical operator name to the matching slug.
+        const wantSlug = (function(name) {
+          var n = String(name).toLowerCase();
+          if (n === 'crossing') return 'cross';
+          if (n === 'crossing up') return 'cross_up';
+          if (n === 'crossing down') return 'cross_down';
+          if (n === 'greater than') return 'greater';
+          if (n === 'less than') return 'less';
+          if (n === 'entering channel') return 'entering_channel';
+          if (n === 'exiting channel') return 'exiting_channel';
+          if (n === 'inside channel') return 'inside_channel';
+          if (n === 'outside channel') return 'outside_channel';
+          if (n === 'moving up') return 'moving_up';
+          if (n === 'moving down') return 'moving_down';
+          if (n === 'moving up %') return 'moving_up_percent';
+          if (n === 'moving down %') return 'moving_down_percent';
+          return n;
+        })(conditionApplied);
+        conditionVerified = verify.condition_type === wantSlug;
+      }
+    }
   }
 
   return {
     success: !!createdLabel,
+    alert_id: verifiedAlertId,
     price,
     price_set: !!priceSet,
     condition: conditionApplied,
     condition_set: !!conditionSet,
+    condition_verified_in_tv: conditionVerified,
     condition_note: conditionApplied && !conditionSet ? 'Could not locate the condition menu item; alert will use TV\'s currently selected operator.' : undefined,
     message: message || null,
     message_set: !!messageSet,

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -445,35 +445,47 @@ export async function list() {
   return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
 }
 
-// TODO(per-alert delete): TradingView's REST surface for deleting a single
-// alert is currently not discoverable from CDP. Tried (all returned
-// `code=no_such_endpoint`): GET /remove_alert, /delete_alert, /alert,
-// /show_alert, /alert_details, /get_alert, /get_alert_details, /remove_alerts,
-// /remove, /delete, /archive_alert. POST /remove_alert and HTTP DELETE on
-// /list_alerts / /alerts / /alert also fail (DELETE errors before send).
-// The UI's per-row delete button dispatches at zero-bounding-rect when the
-// alerts side panel is collapsed, which is why a synthetic click did not
-// trigger a network request in repro. A future iteration should either:
-//   (a) intercept TV's own delete request (via Network panel during a manual
-//       delete) to identify the real endpoint + HTTP verb;
-//   (b) ensure the alerts panel is fully expanded and visible before clicking
-//       the per-row delete button, then handle the confirm dialog;
-//   (c) call the TV WS protocol if that's where deletes actually flow.
-// Until then, `name` / `alert_id` matching still runs and reports which
-// alerts would be deleted — the caller can use TV's UI or alert_delete with
-// delete_all: true (which opens the panel context menu for manual confirm).
-async function deleteOneByApi(alertId) {
-  const url = `https://pricealerts.tradingview.com/remove_alert?alert_id=${encodeURIComponent(alertId)}`;
+/**
+ * Delete one or more alerts in a single batched POST to TradingView's
+ * pricealerts service. Endpoint discovered via DevTools network capture on
+ * the web client (see commit message). Auth piggybacks on the session
+ * cookies already present in the TV Desktop context.
+ *
+ *   POST https://pricealerts.tradingview.com/delete_alerts
+ *   Content-Type: text/plain;charset=UTF-8
+ *   Body: {"payload":{"alert_ids":[<id>, ...]}}
+ *
+ * On success TV returns {s:"ok", ...}. On failure it returns
+ * {s:"error", errmsg:"...", err:{code:"..."}}.
+ */
+async function deleteAlertsByApi(alertIds) {
+  if (!Array.isArray(alertIds) || alertIds.length === 0) {
+    return { ok: false, error: 'alertIds must be a non-empty array' };
+  }
+  const idsAsNumbers = alertIds.map(x => {
+    const n = Number(x);
+    return Number.isFinite(n) ? n : x;
+  });
+  const body = JSON.stringify({ payload: { alert_ids: idsAsNumbers } });
   const result = await evaluateAsync(`
-    fetch(${safeString(url)}, { credentials: 'include' })
-      .then(function(r) { return r.json().then(function(j) { return { status: r.status, body: j }; }).catch(function() { return { status: r.status, body: null }; }); })
+    fetch('https://pricealerts.tradingview.com/delete_alerts', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'text/plain;charset=UTF-8' },
+      body: ${safeString(body)}
+    })
+      .then(function(r) {
+        return r.json()
+          .then(function(j) { return { status: r.status, body: j }; })
+          .catch(function() { return { status: r.status, body: null }; });
+      })
       .catch(function(e) { return { error: e.message }; })
   `);
   if (result?.error) return { ok: false, error: result.error };
-  const body = result?.body;
-  if (body && body.s === 'ok') return { ok: true, body };
-  if (result?.status === 200 && !body) return { ok: true, body: null };
-  return { ok: false, status: result?.status, body, errmsg: body?.errmsg };
+  const b = result?.body;
+  if (b && b.s === 'ok') return { ok: true, body: b };
+  if (result?.status === 200 && !b) return { ok: true, body: null };
+  return { ok: false, status: result?.status, body: b, errmsg: b?.errmsg };
 }
 
 export async function deleteAlerts({ delete_all, name, alert_id }) {
@@ -521,23 +533,19 @@ export async function deleteAlerts({ delete_all, name, alert_id }) {
     };
   }
 
-  const results = [];
-  for (const a of targets) {
-    const res = await deleteOneByApi(a.alert_id);
-    results.push({
-      alert_id: a.alert_id,
-      message: (a.message || '').slice(0, 60),
-      ok: res.ok,
-      error: res.error,
-      status: res.status,
-    });
-  }
-  const okCount = results.filter(r => r.ok).length;
+  // Batch delete in a single POST — the /delete_alerts endpoint accepts an
+  // array of alert_ids and returns a single ok/error response for the whole
+  // batch. We surface the matched targets so the caller can audit what got
+  // removed even when only one was requested.
+  const ids = targets.map(a => a.alert_id);
+  const res = await deleteAlertsByApi(ids);
+
   return {
-    success: okCount === targets.length,
-    deleted: okCount,
+    success: !!res.ok,
+    deleted: res.ok ? targets.length : 0,
     attempted: targets.length,
-    results,
+    matched: targets.map(a => ({ alert_id: a.alert_id, message: (a.message || '').slice(0, 80), symbol: a.symbol })),
+    error: res.ok ? undefined : (res.errmsg || res.error || `delete_alerts returned status ${res.status}`),
     source: 'rest_api',
   };
 }

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -133,35 +133,119 @@ export async function getIndicator({ entity_id }) {
 }
 
 export async function getStrategyResults() {
+  // Strategy metrics live nested under reportData.performance — both as scalars
+  // (sharpeRatio, maxStrategyDrawDown, etc.) and inside .all / .long / .short.
+  // The previous implementation (a) matched Volume/Overlay sources first because
+  // every chart source exposes a `performance` fn, and (b) only walked the
+  // shallow top-level keys of reportData. This walks the real nesting and
+  // requires reportData (the unambiguous strategy signal).
   const results = await evaluate(`
     (function() {
+      function flatten(obj) {
+        var out = {};
+        if (!obj || typeof obj !== 'object') return out;
+        var keys = Object.keys(obj);
+        for (var i = 0; i < keys.length; i++) {
+          var v = obj[keys[i]];
+          if (v === null || v === undefined) continue;
+          if (typeof v === 'function' || typeof v === 'object') continue;
+          out[keys[i]] = v;
+        }
+        return out;
+      }
       try {
         var chart = ${CHART_API}._chartWidget;
         var sources = chart.model().model().dataSources();
-        var strat = null;
+        var candidates = [];
         for (var i = 0; i < sources.length; i++) {
           var s = sources[i];
-          if (s.metaInfo && s.metaInfo().is_price_study === false && (s.reportData || s.performance)) { strat = s; break; }
+          if (!s.metaInfo) continue;
+          var mi;
+          try { mi = s.metaInfo(); } catch(e) { continue; }
+          if (!mi || mi.is_price_study !== false) continue;
+          var hasReport = typeof s.reportData === 'function';
+          var hasPerf = typeof s.performance === 'function';
+          if (!hasReport && !hasPerf) continue;
+          candidates.push({
+            s: s,
+            name: mi.description || mi.shortDescription || mi.id || 'unknown',
+            hasReport: hasReport,
+            hasPerf: hasPerf
+          });
         }
-        if (!strat) return {metrics: {}, source: 'internal_api', error: 'No strategy found on chart. Add a strategy indicator first.'};
-        var metrics = {};
-        if (strat.reportData) {
-          var rd = typeof strat.reportData === 'function' ? strat.reportData() : strat.reportData;
-          if (rd && typeof rd === 'object') {
-            if (typeof rd.value === 'function') rd = rd.value();
-            if (rd) { var keys = Object.keys(rd); for (var k = 0; k < keys.length; k++) { var val = rd[keys[k]]; if (val !== null && val !== undefined && typeof val !== 'function') metrics[keys[k]] = val; } }
+        // Real strategies expose reportData; pick them first.
+        candidates.sort(function(a, b) { return (b.hasReport ? 1 : 0) - (a.hasReport ? 1 : 0); });
+        for (var c = 0; c < candidates.length; c++) {
+          var cand = candidates[c];
+          var rd = null;
+          if (cand.hasReport) {
+            try {
+              rd = cand.s.reportData();
+              if (rd && typeof rd.value === 'function') rd = rd.value();
+            } catch(e) {}
           }
+          var perfRoot = null;
+          if (rd && rd.performance && typeof rd.performance === 'object') {
+            perfRoot = rd.performance;
+          } else if (cand.hasPerf) {
+            // Legacy fallback path for strategies without reportData.
+            try {
+              perfRoot = cand.s.performance();
+              if (perfRoot && typeof perfRoot.value === 'function') perfRoot = perfRoot.value();
+            } catch(e) {}
+          }
+          if (!perfRoot || typeof perfRoot !== 'object') continue;
+          // Scalars on perfRoot (sharpe, sortino, max DD, run-up, buy&hold, etc.)
+          var metrics = flatten(perfRoot);
+          // Plus .all (totalTrades, profitFactor, win rate, net profit, ...)
+          if (perfRoot.all && typeof perfRoot.all === 'object') {
+            var allFlat = flatten(perfRoot.all);
+            var akeys = Object.keys(allFlat);
+            for (var ak = 0; ak < akeys.length; ak++) metrics[akeys[ak]] = allFlat[akeys[ak]];
+          }
+          if (Object.keys(metrics).length === 0) continue;
+          var longMetrics = perfRoot.long ? flatten(perfRoot.long) : {};
+          var shortMetrics = perfRoot.short ? flatten(perfRoot.short) : {};
+          var btRange = null, trRange = null;
+          if (rd && rd.settings && rd.settings.dateRange) {
+            btRange = rd.settings.dateRange.backtest || null;
+            trRange = rd.settings.dateRange.trade || null;
+          }
+          return {
+            strategy_name: cand.name,
+            currency: rd ? rd.currency : null,
+            backtest_range: btRange,
+            trade_range: trRange,
+            trade_count_in_report: rd && Array.isArray(rd.trades) ? rd.trades.length : null,
+            filled_orders_in_report: rd && Array.isArray(rd.filledOrders) ? rd.filledOrders.length : null,
+            metrics: metrics,
+            long_metrics: longMetrics,
+            short_metrics: shortMetrics,
+            source: 'internal_api'
+          };
         }
-        if (Object.keys(metrics).length === 0 && strat.performance) {
-          var perf = strat.performance();
-          if (perf && typeof perf.value === 'function') perf = perf.value();
-          if (perf && typeof perf === 'object') { var pkeys = Object.keys(perf); for (var p = 0; p < pkeys.length; p++) { var pval = perf[pkeys[p]]; if (pval !== null && pval !== undefined && typeof pval !== 'function') metrics[pkeys[p]] = pval; } }
+        if (candidates.length === 0) {
+          return { metrics: {}, source: 'internal_api', error: 'No strategy found on chart. Add a strategy indicator first.' };
         }
-        return {metrics: metrics, source: 'internal_api'};
-      } catch(e) { return {metrics: {}, source: 'internal_api', error: e.message}; }
+        return { metrics: {}, source: 'internal_api', error: 'Strategy present but reportData/performance returned empty. Backtest may still be computing.' };
+      } catch(e) { return { metrics: {}, source: 'internal_api', error: e.message }; }
     })()
   `);
-  return { success: true, metric_count: Object.keys(results?.metrics || {}).length, source: results?.source, metrics: results?.metrics || {}, error: results?.error };
+  return {
+    success: true,
+    metric_count: Object.keys(results?.metrics || {}).length,
+    source: results?.source,
+    strategy_name: results?.strategy_name,
+    currency: results?.currency,
+    backtest_range: results?.backtest_range,
+    trade_range: results?.trade_range,
+    trade_count_in_report: results?.trade_count_in_report,
+    filled_orders_in_report: results?.filled_orders_in_report,
+    metrics: results?.metrics || {},
+    long_metrics: results?.long_metrics || {},
+    short_metrics: results?.short_metrics || {},
+    error: results?.error,
+  };
 }
 
 export async function getTrades({ max_trades } = {}) {

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -505,6 +505,24 @@ export async function smartCompile() {
   };
 }
 
+/**
+ * DEPRECATED. Use createScript() (MCP tool: pine_create_script) instead.
+ *
+ * newScript() does NOT create a new cloud-saved script. It just overwrites
+ * the currently-active editor tab with a template — and the editor tab is
+ * still bound to whatever saved-script slot it had before. A subsequent
+ * pine_set_source + pine_compile therefore saves the new code INTO that
+ * existing slot, silently overwriting the prior content of whatever script
+ * the user happened to have open. (See incident §22.176 where this clobbered
+ * a strategy the user explicitly asked us not to touch.)
+ *
+ * The safe alternative, createScript(), POSTs directly to the pine-facade
+ * REST CREATE endpoint and gets back a fresh script_id with no editor
+ * interaction, so there is no way for it to disturb existing scripts.
+ *
+ * Kept here for backwards compatibility with anything still calling
+ * pine_new — the tool wrapper attaches a runtime warning.
+ */
 export async function newScript({ type }) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
@@ -531,7 +549,108 @@ export async function newScript({ type }) {
 
   if (!set) throw new Error('Monaco editor not found. Ensure Pine Editor is open.');
 
-  return { success: true, type, action: 'new_script_created', template: typeMap[type] };
+  return {
+    success: true,
+    type,
+    action: 'new_script_created',
+    template: typeMap[type],
+    deprecated: true,
+    warning: 'pine_new only overwrites the editor — it does NOT create a fresh cloud-saved script. Subsequent saves will land in whichever script slot the editor was bound to, which can silently overwrite an existing script (see §22.176). Use pine_create_script instead — it POSTs directly to pine-facade and returns a fresh script_id with no editor interaction.',
+  };
+}
+
+/**
+ * Create a brand-new saved Pine script via the pine-facade REST CREATE
+ * endpoint. Returns the new script_id. Does NOT touch the editor, so it is
+ * SAFE to call while other scripts are open — there is no risk of
+ * overwriting them.
+ *
+ *   POST https://pine-facade.tradingview.com/pine-facade/save/new
+ *     ?name=<urlencoded>&allow_overwrite=<bool>
+ *   Content-Type: multipart/form-data
+ *   Body: form field `source` = full Pine source
+ *
+ * Defaults `allow_overwrite` to false (the operator must explicitly opt in
+ * to overwrite — this is the safety guarantee that prevents the §22.176
+ * clobber from recurring).
+ *
+ * Auth piggybacks on the TV session cookies already present in the CDP
+ * context.
+ */
+export async function createScript({ name, source, allow_overwrite }) {
+  if (!name || typeof name !== 'string') throw new Error('name is required (string).');
+  if (!source || typeof source !== 'string') throw new Error('source is required (string).');
+  const overwrite = !!allow_overwrite;
+
+  // Safety pre-check: if not overwriting, refuse on name collision rather
+  // than relying on the server to reject. This also lets us return a more
+  // helpful error than TV's facade does.
+  if (!overwrite) {
+    const listing = await listScripts();
+    const collide = (listing.scripts || []).find(s => {
+      const n = (s.name || '').toLowerCase();
+      const t = (s.title || '').toLowerCase();
+      const want = name.toLowerCase();
+      return n === want || t === want;
+    });
+    if (collide) {
+      throw new Error(
+        `A saved script named "${name}" already exists (id=${collide.id}, version=${collide.version}). ` +
+        `Pass allow_overwrite: true to replace it, or use a different name.`
+      );
+    }
+  }
+
+  const url =
+    `https://pine-facade.tradingview.com/pine-facade/save/new` +
+    `?name=${encodeURIComponent(name)}` +
+    `&allow_overwrite=${overwrite ? 'true' : 'false'}`;
+
+  // Construct multipart form in the page context so the browser sets the
+  // multipart boundary header automatically (manually setting Content-Type
+  // breaks the boundary).
+  const result = await evaluateAsync(`
+    (function() {
+      var fd = new FormData();
+      fd.append('source', ${JSON.stringify(source)});
+      return fetch(${JSON.stringify(url)}, {
+        method: 'POST',
+        credentials: 'include',
+        body: fd,
+      })
+        .then(function(r) {
+          return r.text().then(function(text) {
+            var parsed = null;
+            try { parsed = JSON.parse(text); } catch(e) {}
+            return { status: r.status, ok: r.ok, body: parsed, raw: parsed ? null : text.slice(0, 500) };
+          });
+        })
+        .catch(function(e) { return { error: e.message }; });
+    })()
+  `);
+
+  if (result?.error) throw new Error(`pine-facade save/new fetch failed: ${result.error}`);
+  if (!result?.ok) {
+    throw new Error(
+      `pine-facade save/new returned status ${result?.status}` +
+      (result?.body?.errmsg ? `: ${result.body.errmsg}` : '') +
+      (result?.raw ? ` (body: ${result.raw})` : '')
+    );
+  }
+
+  // Successful create returns the new script descriptor. Fields vary by TV
+  // version — keep the raw body around for the caller.
+  const body = result.body || {};
+  return {
+    success: true,
+    name,
+    allow_overwrite: overwrite,
+    script_id: body.scriptIdPart || body.script_id_part || body.id || null,
+    title: body.scriptTitle || body.title || null,
+    version: body.version || null,
+    raw: body,
+    source: 'pine_facade_rest',
+  };
 }
 
 export async function openScript({ name }) {

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -653,6 +653,89 @@ export async function createScript({ name, source, allow_overwrite }) {
   };
 }
 
+/**
+ * DEFECT 7 — refresh TV's chart-side saved-scripts catalog.
+ *
+ * Problem: pine_create_script (D3) and pine-facade REST mutations write
+ * server-side, but the chart's Indicators dialog holds a one-shot Promise
+ * in `TradingViewApi._studyMarket._dialog._initIndicatorsPromises.userScriptsPromise`
+ * that was settled at chart-page load time. Subsequent dialog opens read
+ * from the resolved (stale) Promise; the dialog does not re-hit pine-facade
+ * on open (verified empirically: opening the dialog and clicking the
+ * "My scripts" sidebar produces ZERO pine-facade fetches).
+ *
+ * Findings from investigation:
+ *   - `window.TradingViewApi.resetCache()` and `getStudiesList()` exist on
+ *     the prototype but are `$t()` stubs that throw "not implemented" —
+ *     dead ends.
+ *   - `_studyMarket._dialog.resetAllStudies()` (alias `_studyMarket.resetAllPages()`)
+ *     calls the dialog's `_init()` which clears `_studies` and re-runs the
+ *     init promises — but those promises are CACHED, so the re-init repopulates
+ *     `_studies` from the SAME stale resolved Promise. Confirmed: calling
+ *     resetAllStudies() produced zero pine-facade fetches and the cache
+ *     stayed at the pre-mutation contents.
+ *   - The dialog method `_updateUserStudies()` awaits
+ *     `_initIndicatorsPromises.userScriptsPromise`, runs
+ *     `_preparePineUserStudies()` on the result, and replaces
+ *     `_studies['Script$USER']` from the transformed list. If we swap
+ *     `userScriptsPromise` to a FRESH fetch before calling
+ *     `_updateUserStudies()`, the cache is rebuilt from the live REST list.
+ *
+ * The implementation below does exactly that:
+ *   1. Overwrite `_initIndicatorsPromises.userScriptsPromise` with a new
+ *      Promise resolving to `fetch('/pine-facade/list/?filter=saved').json()`.
+ *   2. Call `_updateUserStudies()` and await its completion.
+ *   3. Return the updated cache count so callers can verify.
+ *
+ * No page reload, no chart re-render, no visible UI flash. The next
+ * Indicators dialog open sees fresh data.
+ *
+ * Verified live: created 5 saved scripts via REST; the dialog's pre-refresh
+ * cache showed 2 of 5 (the two created BEFORE the page last loaded). After
+ * `refreshCatalog()`: cache showed 5/5 including the 3 created post-load
+ * (capture_v2_test, DELETE_ME_capture_test, MCP_DEFECT3_round3_test).
+ */
+export async function refreshCatalog() {
+  const result = await evaluateAsync(`
+    (function() {
+      try {
+        var market = window.TradingViewApi && window.TradingViewApi._studyMarket;
+        if (!market) return { error: 'TradingViewApi._studyMarket not initialized' };
+        var dlg = market._dialog;
+        if (!dlg || !dlg._initIndicatorsPromises) {
+          return { error: 'Indicators dialog state not initialized — open the dialog once before refreshing (TV lazy-initializes it).' };
+        }
+        var before = (dlg._studies && dlg._studies['Script$USER']) ? dlg._studies['Script$USER'].length : 0;
+        // Replace the cached promise with a fresh fetch
+        dlg._initIndicatorsPromises.userScriptsPromise = fetch(
+          'https://pine-facade.tradingview.com/pine-facade/list/?filter=saved',
+          { credentials: 'include' }
+        ).then(function(r) { return r.json(); });
+        // _updateUserStudies awaits the (new) promise, transforms, and
+        // replaces _studies['Script$USER']. Return its promise so awaitPromise
+        // resolves only after the cache is rebuilt.
+        return dlg._updateUserStudies().then(function() {
+          var after = (dlg._studies && dlg._studies['Script$USER']) ? dlg._studies['Script$USER'].length : 0;
+          var scripts = (dlg._studies['Script$USER'] || []).map(function(s) {
+            return { id: s.id, title: s.title };
+          });
+          return { ok: true, before: before, after: after, scripts: scripts };
+        }).catch(function(e) { return { error: '_updateUserStudies failed: ' + (e && e.message || String(e)) }; });
+      } catch(e) { return { error: 'refreshCatalog threw: ' + e.message }; }
+    })()
+  `);
+  if (result && result.error) throw new Error(result.error);
+  return {
+    success: true,
+    cache_before_count: result?.before ?? null,
+    cache_after_count: result?.after ?? null,
+    delta: (result?.after ?? 0) - (result?.before ?? 0),
+    scripts: result?.scripts || [],
+    source: 'pine_facade_rest',
+    note: 'TV chart-side Indicators-dialog catalog refreshed. New scripts are now visible in the dialog without page reload.',
+  };
+}
+
 export async function openScript({ name }) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -3,24 +3,64 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/alerts.js';
 
 export function registerAlertTools(server) {
-  server.tool('alert_create', 'Create a price alert via the TradingView alert dialog', {
-    condition: z.string().describe('Alert condition (e.g., "crossing", "greater_than", "less_than")'),
-    price: z.coerce.number().describe('Price level for the alert'),
-    message: z.string().optional().describe('Alert message'),
-  }, async ({ condition, price, message }) => {
-    try { return jsonResult(await core.create({ condition, price, message })); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
-  });
+  server.tool(
+    'alert_create',
+    'Create a price alert via the TradingView alert dialog. Supports webhook URL, alert condition, message body, and expiration.',
+    {
+      condition: z
+        .string()
+        .describe('Alert condition. Accepts: "crossing", "crossing_up", "crossing_down", "greater_than", "less_than", "entering_channel", "exiting_channel", or the exact TV label (e.g. "Crossing").'),
+      price: z.coerce.number().describe('Trigger price level for the alert.'),
+      message: z
+        .string()
+        .optional()
+        .describe('Alert message body. If sending to a webhook, this is the POST body — usually a JSON string with {{ticker}} / {{close}} / {{time}} placeholders.'),
+      webhook_url: z
+        .string()
+        .optional()
+        .describe('Webhook URL to POST the alert to. Enables the "Webhook URL" notification toggle in the dialog when provided.'),
+      expiration_minutes: z
+        .coerce.number()
+        .optional()
+        .describe('Alert expiration in minutes from now. Omit to keep TV default (~1 month).'),
+    },
+    async ({ condition, price, message, webhook_url, expiration_minutes }) => {
+      try {
+        return jsonResult(await core.create({ condition, price, message, webhook_url, expiration_minutes }));
+      } catch (err) {
+        return jsonResult({ success: false, error: err.message }, true);
+      }
+    }
+  );
 
   server.tool('alert_list', 'List active alerts', {}, async () => {
     try { return jsonResult(await core.list()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('alert_delete', 'Delete all alerts or open context menu for deletion', {
-    delete_all: z.coerce.boolean().optional().describe('Delete all alerts'),
-  }, async ({ delete_all }) => {
-    try { return jsonResult(await core.deleteAlerts({ delete_all })); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
-  });
+  server.tool(
+    'alert_delete',
+    'Delete alerts. Pass alert_id to remove one alert, name to remove all alerts whose message contains the substring, or delete_all to open the bulk-delete context menu.',
+    {
+      delete_all: z
+        .coerce.boolean()
+        .optional()
+        .describe('Open the alerts-panel context menu for bulk delete (still requires a manual confirmation click).'),
+      name: z
+        .string()
+        .optional()
+        .describe('Case-insensitive substring match against alert.message. Deletes every alert whose message contains this string via the pricealerts REST API.'),
+      alert_id: z
+        .union([z.string(), z.number()])
+        .optional()
+        .describe('Exact alert_id (from alert_list) of the single alert to delete.'),
+    },
+    async ({ delete_all, name, alert_id }) => {
+      try {
+        return jsonResult(await core.deleteAlerts({ delete_all, name, alert_id: alert_id != null ? String(alert_id) : undefined }));
+      } catch (err) {
+        return jsonResult({ success: false, error: err.message }, true);
+      }
+    }
+  );
 }

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -5,16 +5,20 @@ import * as core from '../core/alerts.js';
 export function registerAlertTools(server) {
   server.tool(
     'alert_create',
-    'Create a price alert via the TradingView alert dialog. Supports webhook URL, alert condition, message body, and expiration.',
+    'Create an alert via the TradingView alert dialog. Supports Pine indicator sources (DEFECT 8), webhook URL, condition, message, and expiration.',
     {
+      source: z
+        .string()
+        .optional()
+        .describe('Alert data source. Omit or pass "Price"/"Symbol"/"Volume" for native sources. Pass the chart-attached Pine indicator title (e.g. "HyperClaw Stack v1") to alert on its alertcondition() outputs. Substring match against the dropdown label, so the short title is enough — params + version are matched automatically.'),
       condition: z
         .string()
-        .describe('Alert condition. Accepts: "crossing", "crossing_up", "crossing_down", "greater_than", "less_than", "entering_channel", "exiting_channel", or the exact TV label (e.g. "Crossing").'),
-      price: z.coerce.number().describe('Trigger price level for the alert.'),
+        .describe('For price sources: "crossing", "crossing_up", "crossing_down", "greater_than", "less_than", "entering_channel", "exiting_channel", or the exact TV label (e.g. "Crossing"). For Pine sources: the alertcondition() title defined in the script.'),
+      price: z.coerce.number().describe('Trigger price level for the alert. Ignored when source is a Pine indicator with a boolean alertcondition.'),
       message: z
         .string()
         .optional()
-        .describe('Alert message body. If sending to a webhook, this is the POST body — usually a JSON string with {{ticker}} / {{close}} / {{time}} placeholders.'),
+        .describe('Alert message body. If sending to a webhook, this is the POST body — usually a JSON string with {{ticker}} / {{close}} / {{time}} placeholders. For Pine sources, the alertcondition()\'s default message is used unless overridden here.'),
       webhook_url: z
         .string()
         .optional()
@@ -24,9 +28,9 @@ export function registerAlertTools(server) {
         .optional()
         .describe('Alert expiration in minutes from now. Omit to keep TV default (~1 month).'),
     },
-    async ({ condition, price, message, webhook_url, expiration_minutes }) => {
+    async ({ source, condition, price, message, webhook_url, expiration_minutes }) => {
       try {
-        return jsonResult(await core.create({ condition, price, message, webhook_url, expiration_minutes }));
+        return jsonResult(await core.create({ source, condition, price, message, webhook_url, expiration_minutes }));
       } catch (err) {
         return jsonResult({ success: false, error: err.message }, true);
       }

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -69,6 +69,16 @@ export function registerPineTools(server) {
     }
   );
 
+  server.tool(
+    'pine_refresh_catalog',
+    'Refresh the TV chart-side saved-scripts catalog so scripts created/modified/deleted via pine_create_script (or any pine-facade REST mutation) become visible in the Indicators dialog "My scripts" tab without a page reload. Call this after pine_create_script to make the new script attachable from the same session.',
+    {},
+    async () => {
+      try { return jsonResult(await core.refreshCatalog()); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
   server.tool('pine_open', 'Open a saved Pine Script by name', {
     name: z.string().describe('Name of the saved script to open (case-insensitive match)'),
   }, async ({ name }) => {

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -40,12 +40,34 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_new', 'Create a new blank Pine Script', {
-    type: z.enum(['indicator', 'strategy', 'library']).describe('Type of script to create'),
-  }, async ({ type }) => {
-    try { return jsonResult(await core.newScript({ type })); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
-  });
+  server.tool(
+    'pine_new',
+    'DEPRECATED — use pine_create_script instead. pine_new only replaces the active editor content with a template; a subsequent save will overwrite whatever cloud script the editor was bound to (this caused the §22.176 incident). pine_create_script POSTs directly to pine-facade and returns a fresh script_id with no editor interaction.',
+    {
+      type: z.enum(['indicator', 'strategy', 'library']).describe('Type of script to create'),
+    },
+    async ({ type }) => {
+      try { return jsonResult(await core.newScript({ type })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
+
+  server.tool(
+    'pine_create_script',
+    'Create a brand-new saved Pine Script via pine-facade REST. Safe: never touches the editor, so cannot overwrite any existing script unless allow_overwrite is explicitly true. Returns the new script_id.',
+    {
+      name: z.string().describe('Name for the new saved script (e.g. "B2 multi-condition test").'),
+      source: z.string().describe('Full Pine source code, including //@version=N header.'),
+      allow_overwrite: z
+        .coerce.boolean()
+        .optional()
+        .describe('If true and a script with this name already exists, replace it. Defaults to FALSE for safety — caller must opt in to clobber.'),
+    },
+    async ({ name, source, allow_overwrite }) => {
+      try { return jsonResult(await core.createScript({ name, source, allow_overwrite })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
 
   server.tool('pine_open', 'Open a saved Pine Script by name', {
     name: z.string().describe('Name of the saved script to open (case-insensitive match)'),


### PR DESCRIPTION
# Trial-run defect fixes: data path, alert dialog drivers, Pine REST

> **Note on PR shape:** This is a single stacked PR covering 8 thematically-related
> defects across 6 commits. I'm aware `CONTRIBUTING.md` asks for one feature per PR
> — happy to split this into 3-4 smaller PRs (suggested split below) if you'd
> prefer, or land as one and split if individual commits need rework. No pressure
> either way.

## TL;DR

Six commits fixing eight defects surfaced while running this MCP against a real
end-to-end workflow (Pine compile → chart alerts → webhook receiver). Five of
the fixes are in `alert_create` / `alert_delete` and bring those tools from
"opens the dialog" to "fully programmable round-trip via REST". The remaining
three round out `data_get_strategy_results`, add a safe `pine_create_script`
that replaces a footgun in `pine_new`, and add `pine_refresh_catalog` for
cache invalidation. No breaking changes — everything is additive or a
behaviour-correcting bugfix.

**Test status:** 93/95 pass, net improvement vs 92/95 baseline (KNOWN_ISSUES.md).

## Motivation

While exercising the MCP against a live workflow that included Pine
compilation, chart alerts wired to a webhook receiver, and screenshot
exports, eight defects came up. Each is documented in the commit message
with the bug shape, the empirical evidence, and the fix path. All
changes were verified live against TradingView Desktop on a paid
account — REST readbacks of the produced state are quoted in each commit
message so a reviewer can spot-check without re-running anything.

## Defects fixed

| # | Description | Commit |
|---|---|---|
| 1 | `data_get_strategy_results` returned empty even with a strategy on chart — selector matched non-strategy sources first; even when it found the right one, it walked the wrong level of `reportData` | [`676be0c`](#commit-676be0c) |
| 2a | `alert_create` schema didn't expose `webhook_url` or `expiration_minutes`; `alert_delete` had no per-alert path | [`676be0c`](#commit-676be0c) |
| 2b | Webhook URL DOM walker (Notifications sub-view) + REST readback for `webhook_verified_in_tv` | [`676be0c`](#commit-676be0c) |
| 2c | Condition operator dropdown driver (portal popover + "Show more" pagination) + condition slug verification via REST | [`1446511`](#commit-1446511) |
| 2d | Per-alert REST delete via `POST /delete_alerts`, batched (one POST per `alert_delete` call regardless of match count) | [`574e8a3`](#commit-574e8a3) |
| 3 | `pine_create_script` via pine-facade REST; `pine_new` was a footgun that silently overwrote whichever cloud script the editor was bound to | [`9b3fc00`](#commit-9b3fc00) |
| 7 | `pine_refresh_catalog` so newly-created scripts become visible in the Indicators dialog without a page reload | [`63fe862`](#commit-63fe862) |
| 8 | Alert dialog **source** dropdown driver (different portal architecture from D2c) — selects a Pine indicator as alert source | [`7bda453`](#commit-7bda453) |

## Implementation notes

### DOM probing for transient popovers

Two of TV's dropdowns dismiss themselves when any subsequent CDP
`Runtime.evaluate` call runs — they react to the page losing focus
between evaluate round-trips. Naive probe-then-inspect loses the popover
before the inspect can see it. The D8 commit uses `MutationObserver`
installed *before* the click to capture the popover at the moment of
mount, store its `outerHTML` into `window.__popoverCapture`, then read
back afterwards. The full DOM shape is documented in the comment block
at `src/core/alerts.js:78-104`.

The D2c operator dropdown lives in a different portal
(`positioner-lATuqHRX` + `contentDefaultAppearance-…`) than the D8 source
dropdown (`menuWrap-XktvVkFF`, fixed-position to `document.body`). Both
walkers click the inner `[role="button"]` SPAN — clicking the wrapping
DIV doesn't dispatch the React handler. Comments at
`src/core/alerts.js:248-254` (D2c) and `src/core/alerts.js:78-104` (D8)
capture the specific selector chains.

### REST readback verification

DOM observation of "did I set this field?" is unreliable because TV's
dialog state inherits fields from previously-created alerts, so a
`true` from a DOM mutator can mean "I wrote it" or "it was already
there". Each alert created via `alert_create` is now read back from
`pricealerts.tradingview.com/list_alerts?limit=1` ~2.5 s after the
Create click. The response exposes:

```
webhook_verified_in_tv: bool    // matches the requested URL?
condition_verified_in_tv: bool  // matches the requested operator slug?
alert_id: number                // the TV id of the just-created alert
source_set / source_matched_label / source_available
```

The 2.5 s wait was empirically derived — Pine-source alerts ship larger
payloads and the previous 400 ms wait raced (verify ran against the
*previous* alert and reported false-negatives).

### Promise replacement for stale caches (D7)

`TradingViewApi.resetCache()` is a `$t()` stub that throws "not
implemented". `_studyMarket._dialog.resetAllStudies()` is a real method
but it re-runs `_init()` which re-pulls from the SAME cached resolved
Promise — confirmed empirically: zero pine-facade fetches and the cache
stays at pre-mutation contents.

The actual cache lives at
`window.TradingViewApi._studyMarket._dialog._studies['Script$USER']`
and is fed by `_initIndicatorsPromises.userScriptsPromise`. `D7`
replaces that promise with a fresh fetch and then calls
`_updateUserStudies()` which awaits the new promise. See
`src/core/pine.js:660-728` for the full investigation log and the
implementation.

### Batched REST delete (D2d)

Endpoint captured via DevTools Network panel during a manual UI delete:

```
POST https://pricealerts.tradingview.com/delete_alerts
Content-Type: text/plain;charset=UTF-8
Body: {"payload":{"alert_ids":[<id>, ...]}}
```

The endpoint accepts an array, so `deleteAlertsByApi` at
`src/core/alerts.js:621` sends one POST per `alert_delete` call
regardless of how many alerts match the `name` substring or `alert_id`
filter.

### Safe Pine script creation (D3)

`pine_new` overwrites the active editor content with a template but does
NOT change which cloud-script slot the editor is bound to. A subsequent
`pine_set_source` + `pine_compile` therefore saves the new code INTO
that bound script slot, silently overwriting whatever script the user
had open. This was the cause of an incident during validation where a
strategy the operator explicitly asked not to be touched got clobbered
twice in a row before the pattern was identified.

`pine_create_script` (`src/core/pine.js:580`) sidesteps the editor
entirely:

```
POST https://pine-facade.tradingview.com/pine-facade/save/new
  ?name=<urlencoded>&allow_overwrite=<bool>
Content-Type: multipart/form-data
Body: form field `source` = full Pine source
```

`allow_overwrite` defaults to **false** and a pre-check against
`pine-facade/list/?filter=saved` catches name collisions before the POST
so callers see a helpful error rather than HTTP 409. `pine_new` is kept
for backwards compatibility but its tool description is rewritten to
point at `pine_create_script` and its return object now includes
`deprecated: true` + a `warning` field so callers that still invoke it
see a runtime nudge.

## Validation

Each commit message contains live REST readback for the alerts /
scripts it produced. Highlights:

- **D2c** verified by creating `alert_id 4696035471` with
  `condition: "greater_than"` → REST shows `condition.type: "greater"`
  (vs default `cross`).
- **D2d** verified by deleting 8 orphan alerts in 4 batched calls
  (alert_count went 8 → 6 → 5 → 4 → 0 across the batches).
- **D3** verified by creating `USER;9e240393…` via REST, then
  re-creating the same name with `allow_overwrite=true` to test the
  overwrite path; v3.0 stored cleanly. HC Stack v1 (`USER;94daf065…`)
  and Test1 RSI Sweep (`USER;752c175…`) confirmed untouched by
  modified-timestamp before/after.
- **D7** verified by creating `D7_refresh_test_script` via REST, then
  inspecting the chart-side cache (5 scripts, stale), calling
  `pine_refresh_catalog`, and re-inspecting (6 scripts, new one
  present). Exactly one `/pine-facade/list` fetch fired during the
  refresh; zero page reloads.
- **D8** verified by creating `alert_id 4697106565` with
  `source: "HyperClaw Stack v1"` → REST shows
  `condition.series[0].pine_id: "USER;94daf065..."` and `plot_id:
  "plot_0"` (vs default Price source). Alert fired in 5 s and the
  webhook receiver logged the POST.

The webhook receiver (a Cloudflare Tunnel forwarding to a `tail -f`
JSONL log on a small VPS) was used as the end-to-end sink. Three B.1
alerts and one B.2 multi-condition alert delivered payloads matching
the requested template, including `{{plot_0}}` substitution by TV at
fire time.

## Breaking changes

None. Every defect fix is either:

- An additive parameter (`alert_create` gains `source`, `webhook_url`,
  `expiration_minutes`; `alert_delete` gains `name` and `alert_id`),
- A new tool (`pine_create_script`, `pine_refresh_catalog`),
- A response-shape addition (new fields like `condition_verified_in_tv`,
  `source_matched_label`, `cache_after_count`), or
- A behaviour-correcting bugfix on a function that previously returned
  empty / silently failed (`data_get_strategy_results` shipped with
  `metric_count: 0` against a real strategy; now returns 44 fields).

`pine_new` is deprecated in description but still functions
identically; its return shape gains `deprecated: true` and `warning`
fields rather than changing what existing callers receive.

## Known issues / scope boundary

One operator-visible step remains manual: **attaching a freshly-created
Pine indicator to the chart**. `chart.createStudy()` and
`_chartWidget.insertStudy()` both accept a `Script$USER;<id>@tv-scripting-101`
identifier and return a resolved promise without throwing, but the
study does not actually appear on the chart. The Indicators dialog
becomes a workable fallback after `pine_refresh_catalog` populates the
"My scripts" tab, but the click-to-attach step itself isn't yet
programmatically driven.

This was scoped out of the current branch because the alert path
(`alert_create`) only needs the study attached, not created from
scratch in the same session — so for the workflows that motivated this
PR, the gap is bridged by the Indicators-dialog UI. Happy to follow up
with a separate PR if you'd like an `attach_pine_script_to_chart` tool;
the entry points to investigate are documented in the D8 commit
message.

A related minor issue: when `alert_create` is called with `price` as
an override for the trigger value, TV's dialog often discards the
override and reverts to its auto-filled current price. The
`price_set` field reflects only that the DOM setter ran, not that TV
accepted the value. Callers can verify via `list_alerts` readback;
recommended pattern is to read the current quote first and pass
`price = quote ± epsilon`. Documented inline.

During cleanup of test residue from this validation run, we
discovered that `POST /pine-facade/delete/<id>` works as a natural
sibling to the `pine_create_script` endpoint shipped in D3, including
a built-in `401 "User is not an owner of pine"` response that rejects
non-owned (or non-existent) script IDs as a safety net. We did not
ship a `pine_delete_script` tool in this PR — it wasn't part of the
trial workflow — but happy to follow up with a small separate PR if
you'd find the parity useful.

### Suggested split if you prefer smaller PRs

- **PR-1**: D1 only (commit 676be0c's data_get_strategy_results portion) — smallest, easiest review.
- **PR-2**: D2a + D2b + D2c + D2d (alert_create / alert_delete overhaul; one coherent feature: full REST-verified alert dialog round-trip).
- **PR-3**: D3 + D7 (Pine REST surface: pine_create_script + pine_refresh_catalog).
- **PR-4**: D8 (alert source dropdown; sits on top of PR-2's alert_create skeleton).

I can split locally and re-open as 4 PRs if that's the preferred shape — just say the word.

## Testing instructions

To exercise the changes against a live TV Desktop:

1. Check out the branch and `npm install` (no new deps).
2. Restart TV Desktop with `--remote-debugging-port=9222` and verify
   `tv_health_check` connects.
3. **D1**: With any Pine strategy attached to the chart, call
   `data_get_strategy_results` — expect `metric_count > 0` with
   `netProfit`, `sharpeRatio`, `profitFactor`, etc. populated.
4. **D2b/D2c/D8 round-trip**:
   ```
   alert_create({
     source: "<a Pine indicator title attached to your chart>",
     condition: "Crossing",
     price: <current price>,
     webhook_url: "https://your-webhook-receiver/path",
     expiration_minutes: 15,
     message: '{"src":"pr_test","price":"{{close}}"}'
   })
   ```
   Expect `success: true`, `source_set: true`,
   `condition_verified_in_tv: true`, `webhook_verified_in_tv: true`.
   Then `alert_list` shows the alert with `condition.series[0].pine_id`
   matching your indicator's saved-script id.
5. **D2d**: `alert_delete({ name: "pr_test" })` — expect the alert
   gone from `alert_list`.
6. **D3 + D7**:
   ```
   pine_create_script({ name: "pr_test_script", source: "//@version=6\nindicator(\"x\")\nplot(close)\n" })
   pine_refresh_catalog()  // returns cache_after_count, scripts[]
   ```
   The new script should appear in the Indicators dialog "My scripts"
   tab without pressing Cmd-R.

If anything looks off, every commit message has the live REST output
that was used to verify it during development — happy to walk through
any of the call sites if it's helpful.

---

### Commit references

#### Commit 676be0c — `Fix data_get_strategy_results + add webhook/condition/expiration to alert_create`

D1 + D2a + D2b. Full message in `git log`.

#### Commit 1446511 — `alert_create: drive condition operator portal + REST-verify condition`

D2c. Full message in `git log`.

#### Commit 574e8a3 — `alert_delete: wire real REST endpoint (POST /delete_alerts, batched)`

D2d. Full message in `git log`.

#### Commit 9b3fc00 — `pine_create_script: safe REST CREATE replaces unsafe pine_new`

D3. Full message in `git log`.

#### Commit 7bda453 — `alert_create: source dropdown driver for Pine indicators (DEFECT 8)`

D8. Full message in `git log`.

#### Commit 63fe862 — `pine_refresh_catalog: invalidate chart-side scripts cache without page reload (DEFECT 7)`

D7. Full message in `git log`.

Diffstat vs `main`:

```
 src/core/alerts.js  | 676 ++++++++++++++++++++++++++++++++++++++++++++++++----
 src/core/data.js    | 116 +++++++--
 src/core/pine.js    | 204 +++++++++++++++-
 src/tools/alerts.js |  72 ++++--
 src/tools/pine.js   |  44 +++-
 5 files changed, 1031 insertions(+), 81 deletions(-)
```
