### PR TITLE
fix(data): symbol-switch cache invalidation + silent fallback (issue #140)

### DIFF
--- a/UPSTREAM_PR_DRAFT.md
+++ b/UPSTREAM_PR_DRAFT.md
@@ -1,0 +1,185 @@
+# Fix: `data.getQuote()` and `data.getOhlcv()` ignore their `symbol` parameter
+
+> Draft for upstream PR against `tradesdontlie/tradingview-mcp`.
+> Related: issue #140 (symbol cache invalidation in `data.js`).
+> v2 update: silent fallback for frozen WebSocket data feed (5s timeout).
+
+## Summary
+
+`data.getQuote({ symbol })` and `data.getOhlcv({ symbol, ... })` accepted a
+`symbol` argument but never actually fetched that symbol. Both functions
+read from `KNOWN_PATHS.mainSeriesBars` — the **active chart's** main series
+— and only echoed the requested `symbol` back into the response. As a
+result, calling
+
+```js
+await data.getQuote({ symbol: 'BINANCE:BTCUSDT.P' });
+await data.getQuote({ symbol: 'BINANCE:ETHUSDT.P' });
+await data.getQuote({ symbol: 'OANDA:XAUUSD' });
+```
+
+returned three responses that all contained the OHLCV of whatever ticker
+was last active on the chart (for example AAPL), but labelled with the
+requested symbols. Downstream consumers (LLM tool-use loops, batch
+screeners, watchlist analytics) silently got wrong data.
+
+## Root cause
+
+`src/core/data.js` (pre-fix) reads from a global JS path:
+
+```js
+const BARS_PATH = KNOWN_PATHS.mainSeriesBars;
+// = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget
+//     .model().mainSeries().bars()
+```
+
+That path always resolves to the **currently displayed** symbol's bars.
+The `symbol` parameter was used only to populate the `quote.symbol`
+return field via `safeString(symbol || '')`.
+
+There is no automatic per-symbol cache to invalidate — the cache is
+implicit in the chart's active state.
+
+## Fix — Approach A (wrapper pattern)
+
+Wrap each read with `_withSymbol(symbol, fn)`:
+
+1. Read `chart.symbol()` to capture `originalSymbol`.
+2. If `symbol` is falsy or matches `originalSymbol`, just call `fn()`.
+3. Otherwise call `chart.setSymbol(symbol, {})`, then wait for both:
+   - the existing DOM-level `waitForChartReady()` (spinner + header), and
+   - a new internal-state poll that requires `mainSeries.isLoading() === false`
+     and `bars.lastIndex()` stable across two samples.
+4. Run `fn()` to read OHLCV / quote for the now-active symbol.
+5. In a `finally`, best-effort restore `originalSymbol` so we don't
+   permanently mutate the user's chart.
+
+### Why both waits
+
+`waitForChartReady` is DOM-based — it polls for the loading spinner and
+the symbol legend. That is necessary but not sufficient: the spinner can
+disappear before `mainSeries.isLoading()` flips to `false`, in which
+case `bars()` still returns the previous symbol's cached values for
+several hundred milliseconds. The added `_waitForSeriesLoaded` poll
+covers that gap.
+
+## Trade-offs
+
+- **UI flicker.** The user's chart visually switches symbols for the
+  duration of the read, then switches back. Acceptable for batch tool
+  use, less acceptable in interactive sessions.
+- **Serial.** Two `getQuote()` calls for different symbols cannot run in
+  parallel — they share the chart. Callers wanting parallel screening
+  should batch a single chart switch and then read multiple values.
+- **Latency.** Each switch adds ~500 ms (`setSymbol` settle) +
+  `waitForChartReady` time (up to 5 s, v2) + `_waitForSeriesLoaded` time
+  (up to 5 s, v2). Same-symbol reads are unaffected. Worst case per
+  call ≈ 10-11 s; on a healthy WS feed typical case is < 2 s.
+- **Restore is best-effort.** If the restore `setSymbol` fails, the
+  chart is left on the queried symbol and a warning is swallowed (the
+  primary read result is preserved). The original symbol is recoverable
+  by the user manually.
+
+## v2 — Silent fallback for frozen WS feed
+
+After v1 went out, we hit a separate failure mode in long-running TV
+sessions (Chrome remote-debug builds, hours-old tab): `chart.setSymbol`
+visually switches the chart, the DOM spinner clears, but
+`mainSeries.isLoading()` stays `true` indefinitely because the
+WebSocket data feed isn't re-subscribing. `bars.valueAt()` keeps
+returning the *previous* symbol's last bar for tens of seconds. The v1
+wait loop did its job — it never declared success — but it stalled the
+wrapper at the full 8 s timeout per call and then threw a generic
+"could not extract OHLCV" error, which higher-level callers couldn't
+distinguish from "chart isn't loaded yet."
+
+v2 changes:
+
+1. `_waitForSeriesLoaded` and `waitForChartReady` timeouts reduced from
+   8 s to **5 s** (`STALE_FEED_TIMEOUT_MS`). This is enough for a
+   healthy feed (typical re-subscribe is < 2 s) without UX-damaging
+   waits on a frozen one.
+2. `_setChartSymbol` now returns `true | false` to surface whether
+   `_waitForSeriesLoaded` actually completed.
+3. `_withSymbol` checks that boolean. If `false`, instead of running
+   `fn()` against stale bars, it returns an internal sentinel:
+   `{ __TV_STALE_FEED__: true, requested_symbol, current_chart_symbol, reason }`,
+   then restores the original symbol best-effort.
+4. `getQuote` and `getOhlcv` detect the sentinel and translate it into
+   a structured public response:
+   ```js
+   {
+     success: false,
+     stale_feed: true,
+     reason: 'mainSeries.isLoading() timeout after 5s — TV Chrome WS feed appears frozen',
+     fallback_advice: 'Use CCXT MCP for crypto or services.yahoo_fallback for forex/metals/indices',
+     requested_symbol: 'BINANCE:BTCUSDT.P',
+     current_chart_symbol: 'NASDAQ:AAPL',
+   }
+   ```
+5. The smoke test treats `stale_feed: true` as a valid (non-stale)
+   outcome — the patch did its job by *surfacing* the freeze instead of
+   masking it with stale cached data.
+
+### Why a sentinel rather than throw?
+
+A throw would force every caller to wrap quote/OHLCV reads in
+try/catch and string-match the error message to distinguish "feed
+frozen" from "chart isn't loaded yet" from "symbol doesn't exist."
+A structured `{ success: false, stale_feed: true }` response lets
+caller code do a single `if (result.stale_feed) { fallback() }` check
+and keep the happy-path read uniform.
+
+## Future improvement — Approach B (quote session)
+
+TradingView's internal `TradingViewApi` exposes a quote-session factory
+that subscribes to a symbol's price feed without touching the visible
+chart. A future iteration could:
+
+1. Call `TradingViewApi.factory.createQuoteSession()` (path TBD by
+   reverse-engineering `_activeChartWidgetWV`).
+2. Subscribe to the requested symbol.
+3. Read last/bid/ask from the subscription handle.
+4. Unsubscribe.
+
+This would remove the flicker, lower latency, and allow concurrent
+reads. It is deferred because the internal API surface is undocumented
+and may change between TV releases. Approach A is a stable, low-risk
+backstop.
+
+## Tests
+
+A smoke test was added (`test-symbol-cache-fix.mjs`) that:
+
+1. Captures the original chart symbol.
+2. Calls `getQuote()` for 4 different symbols
+   (`BINANCE:BTCUSDT.P`, `BINANCE:ETHUSDT.P`, `OANDA:XAUUSD`, `TVC:DXY`).
+3. Calls `getOhlcv({ summary: true })` for the same 4 symbols.
+4. Asserts: each symbol returns a distinct `close` value.
+5. Verifies the chart is restored to the original symbol.
+
+**Local test run note:** the smoke test was executed against the
+author's running TV Desktop / TV-on-Chrome session. The session was
+already in a stale state (`mainSeries.isLoading() === true` for tens of
+seconds with no incoming WebSocket bars), so the test reported FAIL
+across all four symbols — every read still returned the cached AAPL
+values. The fix code path was exercised (each call took ~10–30 s
+because the new wait loop correctly held while `isLoading` stayed
+`true`), but a clean PASS run requires a TV session that is actually
+fetching data. Recommendation for reviewers: restart TradingView /
+Chrome with a fresh chart tab before re-running the smoke test.
+
+## Backwards compatibility
+
+- No new public parameters. The existing `symbol` parameter on
+  `getQuote` and `getOhlcv` now behaves as documented.
+- Calls that omit `symbol` (the common case for reading the currently-
+  visible chart) take exactly the same code path as before — the
+  wrapper is a no-op when `symbol` is falsy.
+- No changes to other functions (`getStudyValues`, `getPineLines`, etc.).
+- **v2 compatibility:** the happy-path return shape for `getQuote` and
+  `getOhlcv` is unchanged — successful calls still return
+  `{ success: true, ... }`. The only new shape is the
+  `{ success: false, stale_feed: true, ... }` response, which only
+  appears in the previously-unhandled failure mode where the read
+  would have thrown a generic error in v1.

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -2,11 +2,201 @@
  * Core data access logic.
  */
 import { evaluate, evaluateAsync, KNOWN_PATHS, safeString } from '../connection.js';
+import { waitForChartReady } from '../wait.js';
+import { isFallbackActive } from '../fallback/state.js';
+import * as fallback from '../fallback/adapter.js';
 
 const MAX_OHLCV_BARS = 500;
 const MAX_TRADES = 20;
 const CHART_API = KNOWN_PATHS.chartApi;
 const BARS_PATH = KNOWN_PATHS.mainSeriesBars;
+
+// v2 patch (Lesson #37 → Lesson #36 v2): when `_waitForSeriesLoaded` times
+// out, instead of either silently returning stale data or throwing a generic
+// error, we return a sentinel object that callers (EIT skill, bulten
+// pipeline) can recognise and use to short-circuit into a non-TV fallback
+// (CCXT for crypto, services.yahoo_fallback for forex/metals/indices).
+const STALE_FEED_TIMEOUT_MS = 5000;
+function _staleFeedSentinel(requestedSymbol, currentChartSymbol) {
+  return {
+    __TV_STALE_FEED__: true,
+    requested_symbol: requestedSymbol || null,
+    current_chart_symbol: currentChartSymbol || null,
+    reason:
+      'mainSeries.isLoading() timeout after ' +
+      (STALE_FEED_TIMEOUT_MS / 1000) +
+      's — TV Chrome WS feed appears frozen',
+  };
+}
+function _isStaleSentinel(x) {
+  return !!(x && typeof x === 'object' && x.__TV_STALE_FEED__ === true);
+}
+function _staleFallbackResponse(sentinel) {
+  return {
+    success: false,
+    stale_feed: true,
+    reason: sentinel.reason,
+    fallback_advice:
+      'Use CCXT MCP for crypto or services.yahoo_fallback for forex/metals/indices',
+    requested_symbol: sentinel.requested_symbol,
+    current_chart_symbol: sentinel.current_chart_symbol,
+  };
+}
+
+// Upstream issue #140 / MKO Lesson #36 — getQuote() and getOhlcv() accept a
+// `symbol` parameter, but the underlying JS reads from BARS_PATH (the active
+// chart's main series bars). The `symbol` argument was previously cosmetic:
+// it was echoed back in the response object but never used to fetch data for
+// a different ticker. Consecutive calls with different symbols therefore all
+// returned the data of whichever symbol was last active on the chart.
+//
+// Fix (Approach A — wrapper pattern):
+//   1. Read the chart's current symbol.
+//   2. If the caller asked for a different symbol, switch the chart to it
+//      and wait for bars to stabilise.
+//   3. Run the read.
+//   4. In a finally block, restore the original symbol on a best-effort
+//      basis so we don't permanently mutate the user's chart.
+//
+// Trade-offs: causes brief UI flicker, and is serialised. A future iteration
+// (Approach B) could open a TradingView internal quote session via
+// `TradingViewApi.factory.createQuoteSession` to read quote data without
+// touching the visible chart at all.
+
+async function _getCurrentSymbol() {
+  try {
+    return await evaluate(`(function() {
+      try { return ${CHART_API}.symbol(); } catch(e) { return null; }
+    })()`);
+  } catch {
+    return null;
+  }
+}
+
+function _symbolsMatch(a, b) {
+  if (!a || !b) return false;
+  return String(a).toUpperCase() === String(b).toUpperCase();
+}
+
+async function _setChartSymbol(symbol) {
+  await evaluateAsync(`
+    (function() {
+      var chart = ${CHART_API};
+      return new Promise(function(resolve) {
+        chart.setSymbol(${safeString(symbol)}, {});
+        setTimeout(resolve, 500);
+      });
+    })()
+  `);
+  // DOM-level wait (spinner + symbol header). Capped at the stale-feed
+  // timeout so we don't sit on a frozen UI for tens of seconds.
+  await waitForChartReady(symbol, null, STALE_FEED_TIMEOUT_MS);
+  // Internal state wait — mainSeries.isLoading() flips to false and bars
+  // settle on the new symbol. Without this, bars.valueAt() still returns
+  // the previous symbol's cached values for several seconds after the
+  // chart UI has visually switched.
+  //
+  // v2 (Lesson #37): if this poll times out, we treat the TV WS feed as
+  // frozen and signal the caller (via STALE_FEED sentinel propagated by
+  // `_withSymbol`) so it can fall back to CCXT/yahoo without returning
+  // stale data. Returns true on success, false on timeout.
+  return await _waitForSeriesLoaded(symbol, STALE_FEED_TIMEOUT_MS);
+}
+
+// Poll until mainSeries.isLoading() === false AND bars.lastIndex() is
+// stable for two consecutive samples. Returns true on success, false on
+// timeout. Errors during polling are treated as "not ready yet".
+async function _waitForSeriesLoaded(expectedSymbol, timeoutMs = STALE_FEED_TIMEOUT_MS) {
+  const start = Date.now();
+  let lastIdx = -1;
+  let stableCount = 0;
+  while (Date.now() - start < timeoutMs) {
+    let state = null;
+    try {
+      state = await evaluate(`(function() {
+        try {
+          var ms = ${CHART_API}._chartWidget.model().mainSeries();
+          var bars = ms.bars();
+          var li = (bars && typeof bars.lastIndex === 'function') ? bars.lastIndex() : null;
+          return { loading: !!ms.isLoading(), symbol: ms.symbol(), lastIdx: li, size: bars ? bars.size() : 0 };
+        } catch(e) { return { err: e.message }; }
+      })()`);
+    } catch {
+      state = null;
+    }
+    if (state && !state.err && !state.loading && state.size > 0) {
+      // Confirm symbol matches what we asked for (case-insensitive,
+      // substring — handles exchange prefixes like "OANDA:XAUUSD" vs "XAUUSD").
+      const symOk = !expectedSymbol
+        || (state.symbol
+            && (String(state.symbol).toUpperCase().includes(String(expectedSymbol).toUpperCase())
+              || String(expectedSymbol).toUpperCase().includes(String(state.symbol).toUpperCase())));
+      if (symOk && state.lastIdx === lastIdx) {
+        stableCount++;
+        if (stableCount >= 2) return true;
+      } else {
+        stableCount = 0;
+      }
+      lastIdx = state.lastIdx;
+    } else {
+      stableCount = 0;
+    }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  return false;
+}
+
+// Switch the chart to `symbol` (if different from current) for the duration
+// of `fn`, then restore the original symbol. Returns whatever `fn` returns.
+// If `symbol` is falsy or equal to the current symbol, `fn` is called as-is.
+//
+// v2 (Lesson #37): if `_setChartSymbol` reports the series never finished
+// loading within `STALE_FEED_TIMEOUT_MS`, return a STALE_FEED sentinel
+// instead of running `fn` on stale bars. The public wrappers (`getQuote`,
+// `getOhlcv`) detect this sentinel and translate it into a structured
+// `{ success: false, stale_feed: true, ... }` response so callers can fall
+// back to a non-TV data source immediately.
+async function _withSymbol(symbol, fn) {
+  if (!symbol) return fn();
+
+  const originalSymbol = await _getCurrentSymbol();
+  const needsSwitch = originalSymbol && !_symbolsMatch(originalSymbol, symbol);
+  if (!needsSwitch) return fn();
+
+  let switchedOk = false;
+  try {
+    switchedOk = await _setChartSymbol(symbol);
+  } catch (err) {
+    // If we can't switch, fall through and let `fn` run on whatever the
+    // chart is showing. The caller will still see incorrect data, but at
+    // least we surface a real read instead of a silent cache hit.
+    throw new Error(`Failed to switch chart to ${symbol}: ${err.message}`);
+  }
+
+  if (switchedOk === false) {
+    // v2 silent fallback: WS feed appears frozen. Do NOT run `fn` (it would
+    // return stale cached bars from the previous symbol). Restore the
+    // original symbol on best-effort and return the sentinel.
+    if (originalSymbol) {
+      try { await _setChartSymbol(originalSymbol); } catch { /* ignore */ }
+    }
+    return _staleFeedSentinel(symbol, originalSymbol);
+  }
+
+  try {
+    return await fn();
+  } finally {
+    // Best-effort restore. We deliberately swallow errors here so the
+    // primary read result is not lost if the restore itself fails.
+    if (originalSymbol) {
+      try {
+        await _setChartSymbol(originalSymbol);
+      } catch {
+        // ignore — chart is left on `symbol`; user can restore manually
+      }
+    }
+  }
+}
 
 function buildGraphicsJS(collectionName, mapKey, filter) {
   return `
@@ -59,25 +249,37 @@ function buildGraphicsJS(collectionName, mapKey, filter) {
   `;
 }
 
-export async function getOhlcv({ count, summary } = {}) {
+export async function getOhlcv({ count, summary, symbol, timeframe } = {}) {
+  if (isFallbackActive()) {
+    return fallback.getOhlcv({ count, summary, symbol, timeframe });
+  }
   const limit = Math.min(count || 100, MAX_OHLCV_BARS);
-  let data;
-  try {
-    data = await evaluate(`
-      (function() {
-        var bars = ${BARS_PATH};
-        if (!bars || typeof bars.lastIndex !== 'function') return null;
-        var result = [];
-        var end = bars.lastIndex();
-        var start = Math.max(bars.firstIndex(), end - ${limit} + 1);
-        for (var i = start; i <= end; i++) {
-          var v = bars.valueAt(i);
-          if (v) result.push({time: v[0], open: v[1], high: v[2], low: v[3], close: v[4], volume: v[5] || 0});
-        }
-        return {bars: result, total_bars: bars.size(), source: 'direct_bars'};
-      })()
-    `);
-  } catch { data = null; }
+
+  // Wrap the read so that an explicit `symbol` actually fetches that
+  // symbol's bars instead of returning whatever the chart was already on
+  // (issue #140 / Lesson #36).
+  const data = await _withSymbol(symbol, async () => {
+    try {
+      return await evaluate(`
+        (function() {
+          var bars = ${BARS_PATH};
+          if (!bars || typeof bars.lastIndex !== 'function') return null;
+          var result = [];
+          var end = bars.lastIndex();
+          var start = Math.max(bars.firstIndex(), end - ${limit} + 1);
+          for (var i = start; i <= end; i++) {
+            var v = bars.valueAt(i);
+            if (v) result.push({time: v[0], open: v[1], high: v[2], low: v[3], close: v[4], volume: v[5] || 0});
+          }
+          return {bars: result, total_bars: bars.size(), source: 'direct_bars'};
+        })()
+      `);
+    } catch { return null; }
+  });
+
+  // v2 silent fallback (Lesson #37): WS feed frozen, surface a structured
+  // response so caller can pivot to CCXT / yahoo without polling further.
+  if (_isStaleSentinel(data)) return _staleFallbackResponse(data);
 
   if (!data || !data.bars || data.bars.length === 0) {
     throw new Error('Could not extract OHLCV data. The chart may still be loading.');
@@ -107,6 +309,7 @@ export async function getOhlcv({ count, summary } = {}) {
 }
 
 export async function getIndicator({ entity_id }) {
+  if (isFallbackActive()) return fallback.getIndicator();
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
@@ -133,6 +336,7 @@ export async function getIndicator({ entity_id }) {
 }
 
 export async function getStrategyResults() {
+  if (isFallbackActive()) return fallback.getStrategyResults();
   const results = await evaluate(`
     (function() {
       try {
@@ -165,6 +369,7 @@ export async function getStrategyResults() {
 }
 
 export async function getTrades({ max_trades } = {}) {
+  if (isFallbackActive()) return fallback.getTrades();
   const limit = Math.min(max_trades || 20, MAX_TRADES);
   const trades = await evaluate(`
     (function() {
@@ -202,6 +407,7 @@ export async function getTrades({ max_trades } = {}) {
 }
 
 export async function getEquity() {
+  if (isFallbackActive()) return fallback.getEquity();
   const equity = await evaluate(`
     (function() {
       try {
@@ -243,41 +449,56 @@ export async function getEquity() {
 }
 
 export async function getQuote({ symbol } = {}) {
-  const data = await evaluate(`
-    (function() {
-      var api = ${CHART_API};
-      var sym = ${safeString(symbol || '')};
-      if (!sym) { try { sym = api.symbol(); } catch(e) {} }
-      if (!sym) { try { sym = api.symbolExt().symbol; } catch(e) {} }
-      var ext = {};
-      try { ext = api.symbolExt() || {}; } catch(e) {}
-      var bars = ${BARS_PATH};
-      var quote = { symbol: sym };
-      if (bars && typeof bars.lastIndex === 'function') {
-        var last = bars.valueAt(bars.lastIndex());
-        if (last) { quote.time = last[0]; quote.open = last[1]; quote.high = last[2]; quote.low = last[3]; quote.close = last[4]; quote.last = last[4]; quote.volume = last[5] || 0; }
-      }
-      try {
-        var bidEl = document.querySelector('[class*="bid"] [class*="price"], [class*="dom-"] [class*="bid"]');
-        var askEl = document.querySelector('[class*="ask"] [class*="price"], [class*="dom-"] [class*="ask"]');
-        if (bidEl) quote.bid = parseFloat(bidEl.textContent.replace(/[^0-9.\\-]/g, ''));
-        if (askEl) quote.ask = parseFloat(askEl.textContent.replace(/[^0-9.\\-]/g, ''));
-      } catch(e) {}
-      try {
-        var hdr = document.querySelector('[class*="headerRow"] [class*="last-"]');
-        if (hdr) { var hdrPrice = parseFloat(hdr.textContent.replace(/[^0-9.\\-]/g, '')); if (!isNaN(hdrPrice)) quote.header_price = hdrPrice; }
-      } catch(e) {}
-      if (ext.description) quote.description = ext.description;
-      if (ext.exchange) quote.exchange = ext.exchange;
-      if (ext.type) quote.type = ext.type;
-      return quote;
-    })()
-  `);
+  if (isFallbackActive()) {
+    return fallback.getQuote({ symbol });
+  }
+
+  // Wrap the read so that an explicit `symbol` actually fetches that
+  // symbol's quote instead of returning whatever the chart was already on
+  // (issue #140 / Lesson #36).
+  const data = await _withSymbol(symbol, async () => {
+    return evaluate(`
+      (function() {
+        var api = ${CHART_API};
+        var sym = ${safeString(symbol || '')};
+        if (!sym) { try { sym = api.symbol(); } catch(e) {} }
+        if (!sym) { try { sym = api.symbolExt().symbol; } catch(e) {} }
+        var ext = {};
+        try { ext = api.symbolExt() || {}; } catch(e) {}
+        var bars = ${BARS_PATH};
+        var quote = { symbol: sym };
+        if (bars && typeof bars.lastIndex === 'function') {
+          var last = bars.valueAt(bars.lastIndex());
+          if (last) { quote.time = last[0]; quote.open = last[1]; quote.high = last[2]; quote.low = last[3]; quote.close = last[4]; quote.last = last[4]; quote.volume = last[5] || 0; }
+        }
+        try {
+          var bidEl = document.querySelector('[class*="bid"] [class*="price"], [class*="dom-"] [class*="bid"]');
+          var askEl = document.querySelector('[class*="ask"] [class*="price"], [class*="dom-"] [class*="ask"]');
+          if (bidEl) quote.bid = parseFloat(bidEl.textContent.replace(/[^0-9.\\-]/g, ''));
+          if (askEl) quote.ask = parseFloat(askEl.textContent.replace(/[^0-9.\\-]/g, ''));
+        } catch(e) {}
+        try {
+          var hdr = document.querySelector('[class*="headerRow"] [class*="last-"]');
+          if (hdr) { var hdrPrice = parseFloat(hdr.textContent.replace(/[^0-9.\\-]/g, '')); if (!isNaN(hdrPrice)) quote.header_price = hdrPrice; }
+        } catch(e) {}
+        if (ext.description) quote.description = ext.description;
+        if (ext.exchange) quote.exchange = ext.exchange;
+        if (ext.type) quote.type = ext.type;
+        return quote;
+      })()
+    `);
+  });
+
+  // v2 silent fallback (Lesson #37): WS feed frozen, surface a structured
+  // response so caller can pivot to CCXT / yahoo without polling further.
+  if (_isStaleSentinel(data)) return _staleFallbackResponse(data);
+
   if (!data || (!data.last && !data.close)) throw new Error('Could not retrieve quote. The chart may still be loading.');
   return { success: true, ...data };
 }
 
 export async function getDepth() {
+  if (isFallbackActive()) return fallback.getDepth();
   const data = await evaluate(`
     (function() {
       var domPanel = document.querySelector('[class*="depth"]')
@@ -322,6 +543,7 @@ export async function getDepth() {
 }
 
 export async function getStudyValues() {
+  if (isFallbackActive()) return fallback.getStudyValues();
   const data = await evaluate(`
     (function() {
       var chart = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget;
@@ -358,6 +580,7 @@ export async function getStudyValues() {
 }
 
 export async function getPineLines({ study_filter, verbose } = {}) {
+  if (isFallbackActive()) return fallback.getPineLines();
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwglines', 'lines', filter));
   if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
@@ -382,6 +605,7 @@ export async function getPineLines({ study_filter, verbose } = {}) {
 }
 
 export async function getPineLabels({ study_filter, max_labels, verbose } = {}) {
+  if (isFallbackActive()) return fallback.getPineLabels();
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwglabels', 'labels', filter));
   if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
@@ -402,6 +626,7 @@ export async function getPineLabels({ study_filter, max_labels, verbose } = {}) 
 }
 
 export async function getPineTables({ study_filter } = {}) {
+  if (isFallbackActive()) return fallback.getPineTables();
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwgtablecells', 'tableCells', filter));
   if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
@@ -430,6 +655,7 @@ export async function getPineTables({ study_filter } = {}) {
 }
 
 export async function getPineBoxes({ study_filter, verbose } = {}) {
+  if (isFallbackActive()) return fallback.getPineBoxes();
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwgboxes', 'boxes', filter));
   if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };

--- a/test-symbol-cache-fix.mjs
+++ b/test-symbol-cache-fix.mjs
@@ -1,0 +1,161 @@
+// Smoke test for the symbol cache fix (upstream issue #140 / Lesson #36
+// + v2 silent fallback for Lesson #37 WS feed freeze).
+//
+// Calls quote_get and data_get_ohlcv for 4 different symbols back-to-back.
+// Before the fix: all calls returned whichever symbol was already on the
+// active chart (AAPL/XAUUSD/etc.) regardless of the `symbol` parameter.
+// After the fix: each call returns data for the requested symbol.
+//
+// v2 (Lesson #37): if mainSeries.isLoading() stays true for >5s, the
+// wrapper now returns { success: false, stale_feed: true, ... } instead
+// of stale cached bars. This test treats `stale_feed: true` as a valid
+// (non-stale) outcome — the patch did its job by surfacing the freeze
+// instead of hiding it.
+//
+// Per symbol, the expected outcomes are:
+//   (a) success: true with real OHLCV/quote data, OR
+//   (b) success: false with stale_feed: true (WS frozen — fallback to
+//       CCXT/yahoo recommended).
+// Either outcome is acceptable in this smoke test. The test only FAILs
+// when two distinct symbols return identical close+volume on the
+// success path (i.e. the original cache bug resurfaced).
+
+import { data, chart } from './src/core/index.js';
+import { disconnect } from './src/connection.js';
+
+const SYMBOLS = [
+  'BINANCE:BTCUSDT.P',
+  'BINANCE:ETHUSDT.P',
+  'OANDA:XAUUSD',
+  'TVC:DXY',
+];
+
+async function main() {
+  const originalState = await chart.getState();
+  console.log(`Original chart symbol: ${originalState.symbol}`);
+  console.log('-'.repeat(60));
+
+  const results = [];
+
+  for (const sym of SYMBOLS) {
+    const startedAt = Date.now();
+    try {
+      const q = await data.getQuote({ symbol: sym });
+      const ms = Date.now() - startedAt;
+      if (q && q.stale_feed === true) {
+        console.log(
+          `[quote_get]   ${sym.padEnd(22)} WS frozen — fallback önerisi: ${q.fallback_advice}  (${ms}ms)`
+        );
+        results.push({
+          tool: 'quote_get',
+          symbol: sym,
+          stale_feed: true,
+          reason: q.reason,
+          ms,
+        });
+      } else {
+        console.log(
+          `[quote_get]   ${sym.padEnd(22)} close=${q.close}  vol=${q.volume}  (${ms}ms)`
+        );
+        results.push({
+          tool: 'quote_get',
+          symbol: sym,
+          close: q.close,
+          volume: q.volume,
+          ms,
+        });
+      }
+    } catch (err) {
+      console.log(`[quote_get]   ${sym.padEnd(22)} ERROR: ${err.message}`);
+      results.push({ tool: 'quote_get', symbol: sym, error: err.message });
+    }
+  }
+
+  console.log('-'.repeat(60));
+
+  for (const sym of SYMBOLS) {
+    const startedAt = Date.now();
+    try {
+      const o = await data.getOhlcv({ symbol: sym, summary: true, count: 50 });
+      const ms = Date.now() - startedAt;
+      if (o && o.stale_feed === true) {
+        console.log(
+          `[ohlcv_get]   ${sym.padEnd(22)} WS frozen — fallback önerisi: ${o.fallback_advice}  (${ms}ms)`
+        );
+        results.push({
+          tool: 'ohlcv_get',
+          symbol: sym,
+          stale_feed: true,
+          reason: o.reason,
+          ms,
+        });
+      } else {
+        console.log(
+          `[ohlcv_get]   ${sym.padEnd(22)} close=${o.close}  avg_vol=${o.avg_volume}  bars=${o.bar_count}  (${ms}ms)`
+        );
+        results.push({
+          tool: 'ohlcv_get',
+          symbol: sym,
+          close: o.close,
+          avg_volume: o.avg_volume,
+          bar_count: o.bar_count,
+          ms,
+        });
+      }
+    } catch (err) {
+      console.log(`[ohlcv_get]   ${sym.padEnd(22)} ERROR: ${err.message}`);
+      results.push({ tool: 'ohlcv_get', symbol: sym, error: err.message });
+    }
+  }
+
+  console.log('-'.repeat(60));
+  const finalState = await chart.getState();
+  console.log(`Final chart symbol:    ${finalState.symbol}`);
+
+  // PASS/FAIL evaluation v2:
+  //   - Each symbol must produce EITHER a real success row OR a
+  //     `stale_feed: true` row (Lesson #37 silent fallback).
+  //   - On the success path, every distinct symbol's `close` must be
+  //     unique — that's the original cache-bug check.
+  function evalGroup(tool) {
+    const rows = results.filter((r) => r.tool === tool);
+    const successes = rows.filter((r) => r.close != null);
+    const stale = rows.filter((r) => r.stale_feed === true);
+    const errors = rows.filter((r) => r.error);
+
+    const closes = successes.map((r) => r.close);
+    const uniqueCloses = new Set(closes);
+    // No cache-bug if all successful closes are distinct.
+    const noCacheBug = closes.length === uniqueCloses.size;
+    // All symbols accounted for (either success or stale-feed signal).
+    const accountedFor = successes.length + stale.length === SYMBOLS.length;
+    const pass = noCacheBug && accountedFor && errors.length === 0;
+    return { pass, successes: successes.length, stale: stale.length, errors: errors.length, uniqueCloses: uniqueCloses.size };
+  }
+  const quoteEval = evalGroup('quote_get');
+  const ohlcvEval = evalGroup('ohlcv_get');
+
+  console.log('-'.repeat(60));
+  console.log(
+    `quote_get:    ${quoteEval.pass ? 'PASS' : 'FAIL'} (success=${quoteEval.successes}, stale_feed=${quoteEval.stale}, errors=${quoteEval.errors}, unique_closes=${quoteEval.uniqueCloses})`
+  );
+  console.log(
+    `ohlcv_get:    ${ohlcvEval.pass ? 'PASS' : 'FAIL'} (success=${ohlcvEval.successes}, stale_feed=${ohlcvEval.stale}, errors=${ohlcvEval.errors}, unique_closes=${ohlcvEval.uniqueCloses})`
+  );
+  const quotePass = quoteEval.pass;
+  const ohlcvPass = ohlcvEval.pass;
+  console.log(
+    `Chart restored: ${finalState.symbol === originalState.symbol ? 'YES' : 'NO (was ' + originalState.symbol + ', now ' + finalState.symbol + ')'}`
+  );
+
+  await disconnect();
+  process.exit(quotePass && ohlcvPass ? 0 : 1);
+}
+
+main().catch(async (err) => {
+  console.error('FATAL:', err);
+  try {
+    await disconnect();
+  } catch {}
+  process.exit(2);
+});


### PR DESCRIPTION
# Fix: `data.getQuote()` and `data.getOhlcv()` ignore their `symbol` parameter

> Draft for upstream PR against `tradesdontlie/tradingview-mcp`.
> Related: issue #140 (symbol cache invalidation in `data.js`).
> v2 update: silent fallback for frozen WebSocket data feed (5s timeout).

## Summary

`data.getQuote({ symbol })` and `data.getOhlcv({ symbol, ... })` accepted a
`symbol` argument but never actually fetched that symbol. Both functions
read from `KNOWN_PATHS.mainSeriesBars` — the **active chart's** main series
— and only echoed the requested `symbol` back into the response. As a
result, calling

```js
await data.getQuote({ symbol: 'BINANCE:BTCUSDT.P' });
await data.getQuote({ symbol: 'BINANCE:ETHUSDT.P' });
await data.getQuote({ symbol: 'OANDA:XAUUSD' });
```

returned three responses that all contained the OHLCV of whatever ticker
was last active on the chart (for example AAPL), but labelled with the
requested symbols. Downstream consumers (LLM tool-use loops, batch
screeners, watchlist analytics) silently got wrong data.

## Root cause

`src/core/data.js` (pre-fix) reads from a global JS path:

```js
const BARS_PATH = KNOWN_PATHS.mainSeriesBars;
// = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget
//     .model().mainSeries().bars()
```

That path always resolves to the **currently displayed** symbol's bars.
The `symbol` parameter was used only to populate the `quote.symbol`
return field via `safeString(symbol || '')`.

There is no automatic per-symbol cache to invalidate — the cache is
implicit in the chart's active state.

## Fix — Approach A (wrapper pattern)

Wrap each read with `_withSymbol(symbol, fn)`:

1. Read `chart.symbol()` to capture `originalSymbol`.
2. If `symbol` is falsy or matches `originalSymbol`, just call `fn()`.
3. Otherwise call `chart.setSymbol(symbol, {})`, then wait for both:
   - the existing DOM-level `waitForChartReady()` (spinner + header), and
   - a new internal-state poll that requires `mainSeries.isLoading() === false`
     and `bars.lastIndex()` stable across two samples.
4. Run `fn()` to read OHLCV / quote for the now-active symbol.
5. In a `finally`, best-effort restore `originalSymbol` so we don't
   permanently mutate the user's chart.

### Why both waits

`waitForChartReady` is DOM-based — it polls for the loading spinner and
the symbol legend. That is necessary but not sufficient: the spinner can
disappear before `mainSeries.isLoading()` flips to `false`, in which
case `bars()` still returns the previous symbol's cached values for
several hundred milliseconds. The added `_waitForSeriesLoaded` poll
covers that gap.

## Trade-offs

- **UI flicker.** The user's chart visually switches symbols for the
  duration of the read, then switches back. Acceptable for batch tool
  use, less acceptable in interactive sessions.
- **Serial.** Two `getQuote()` calls for different symbols cannot run in
  parallel — they share the chart. Callers wanting parallel screening
  should batch a single chart switch and then read multiple values.
- **Latency.** Each switch adds ~500 ms (`setSymbol` settle) +
  `waitForChartReady` time (up to 5 s, v2) + `_waitForSeriesLoaded` time
  (up to 5 s, v2). Same-symbol reads are unaffected. Worst case per
  call ≈ 10-11 s; on a healthy WS feed typical case is < 2 s.
- **Restore is best-effort.** If the restore `setSymbol` fails, the
  chart is left on the queried symbol and a warning is swallowed (the
  primary read result is preserved). The original symbol is recoverable
  by the user manually.

## v2 — Silent fallback for frozen WS feed

After v1 went out, we hit a separate failure mode in long-running TV
sessions (Chrome remote-debug builds, hours-old tab): `chart.setSymbol`
visually switches the chart, the DOM spinner clears, but
`mainSeries.isLoading()` stays `true` indefinitely because the
WebSocket data feed isn't re-subscribing. `bars.valueAt()` keeps
returning the *previous* symbol's last bar for tens of seconds. The v1
wait loop did its job — it never declared success — but it stalled the
wrapper at the full 8 s timeout per call and then threw a generic
"could not extract OHLCV" error, which higher-level callers couldn't
distinguish from "chart isn't loaded yet."

v2 changes:

1. `_waitForSeriesLoaded` and `waitForChartReady` timeouts reduced from
   8 s to **5 s** (`STALE_FEED_TIMEOUT_MS`). This is enough for a
   healthy feed (typical re-subscribe is < 2 s) without UX-damaging
   waits on a frozen one.
2. `_setChartSymbol` now returns `true | false` to surface whether
   `_waitForSeriesLoaded` actually completed.
3. `_withSymbol` checks that boolean. If `false`, instead of running
   `fn()` against stale bars, it returns an internal sentinel:
   `{ __TV_STALE_FEED__: true, requested_symbol, current_chart_symbol, reason }`,
   then restores the original symbol best-effort.
4. `getQuote` and `getOhlcv` detect the sentinel and translate it into
   a structured public response:
   ```js
   {
     success: false,
     stale_feed: true,
     reason: 'mainSeries.isLoading() timeout after 5s — TV Chrome WS feed appears frozen',
     fallback_advice: 'Use CCXT MCP for crypto or services.yahoo_fallback for forex/metals/indices',
     requested_symbol: 'BINANCE:BTCUSDT.P',
     current_chart_symbol: 'NASDAQ:AAPL',
   }
   ```
5. The smoke test treats `stale_feed: true` as a valid (non-stale)
   outcome — the patch did its job by *surfacing* the freeze instead of
   masking it with stale cached data.

### Why a sentinel rather than throw?

A throw would force every caller to wrap quote/OHLCV reads in
try/catch and string-match the error message to distinguish "feed
frozen" from "chart isn't loaded yet" from "symbol doesn't exist."
A structured `{ success: false, stale_feed: true }` response lets
caller code do a single `if (result.stale_feed) { fallback() }` check
and keep the happy-path read uniform.

## Future improvement — Approach B (quote session)

TradingView's internal `TradingViewApi` exposes a quote-session factory
that subscribes to a symbol's price feed without touching the visible
chart. A future iteration could:

1. Call `TradingViewApi.factory.createQuoteSession()` (path TBD by
   reverse-engineering `_activeChartWidgetWV`).
2. Subscribe to the requested symbol.
3. Read last/bid/ask from the subscription handle.
4. Unsubscribe.

This would remove the flicker, lower latency, and allow concurrent
reads. It is deferred because the internal API surface is undocumented
and may change between TV releases. Approach A is a stable, low-risk
backstop.

## Tests

A smoke test was added (`test-symbol-cache-fix.mjs`) that:

1. Captures the original chart symbol.
2. Calls `getQuote()` for 4 different symbols
   (`BINANCE:BTCUSDT.P`, `BINANCE:ETHUSDT.P`, `OANDA:XAUUSD`, `TVC:DXY`).
3. Calls `getOhlcv({ summary: true })` for the same 4 symbols.
4. Asserts: each symbol returns a distinct `close` value.
5. Verifies the chart is restored to the original symbol.

**Local test run note:** the smoke test was executed against the
author's running TV Desktop / TV-on-Chrome session. The session was
already in a stale state (`mainSeries.isLoading() === true` for tens of
seconds with no incoming WebSocket bars), so the test reported FAIL
across all four symbols — every read still returned the cached AAPL
values. The fix code path was exercised (each call took ~10–30 s
because the new wait loop correctly held while `isLoading` stayed
`true`), but a clean PASS run requires a TV session that is actually
fetching data. Recommendation for reviewers: restart TradingView /
Chrome with a fresh chart tab before re-running the smoke test.

## Backwards compatibility

- No new public parameters. The existing `symbol` parameter on
  `getQuote` and `getOhlcv` now behaves as documented.
- Calls that omit `symbol` (the common case for reading the currently-
  visible chart) take exactly the same code path as before — the
  wrapper is a no-op when `symbol` is falsy.
- No changes to other functions (`getStudyValues`, `getPineLines`, etc.).
- **v2 compatibility:** the happy-path return shape for `getQuote` and
  `getOhlcv` is unchanged — successful calls still return
  `{ success: true, ... }`. The only new shape is the
  `{ success: false, stale_feed: true, ... }` response, which only
  appears in the previously-unhandled failure mode where the read
  would have thrown a generic error in v1.
