### PR TITLE
fix(launch): strip ELECTRON_RUN_AS_NODE from TV spawn env (closes #130)

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -219,7 +219,14 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* may not be running */ }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
+  // Strip ELECTRON_RUN_AS_NODE from the spawn env: when this MCP server is launched
+  // from a parent that runs as an Electron utility process (e.g. VSCode's Code Helper
+  // (Plugin), Claude Desktop), the var is set to '1' and inherited through the child
+  // chain. With it set, the TradingView binary boots in Node mode and rejects
+  // --remote-debugging-port at argv parsing ('bad option: --remote-debugging-port'),
+  // making it look like TV is broken when it is actually env contamination.
+  const { ELECTRON_RUN_AS_NODE: _stripped, ...spawnEnv } = process.env;
+  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore', env: spawnEnv });
   child.unref();
 
   for (let i = 0; i < 15; i++) {


### PR DESCRIPTION
## Summary

- Closes #130. The `bad option: --remote-debugging-port=9222` symptom is **not** a TradingView 3.1.0 vendor change — it's `ELECTRON_RUN_AS_NODE=1` leaking into the spawn env from an Electron parent process tree, causing the TV binary to boot in Node mode where Node rejects the flag.
- Strip the var from the env passed to `spawn()` in `src/core/health.js`. One-line fix.
- Verified end-to-end against the unchanged TV 3.1.0 binary (PID + `Chrome/140.0.7339.133` returned in <1s).

## Reproduction (without fix)

When `tradingview-mcp` is launched from a parent that runs as an Electron utility process (VSCode's `Code Helper (Plugin)` with `--type=utility --utility-sub-type=node.mojom.NodeService`, Claude Desktop, etc.), `ELECTRON_RUN_AS_NODE=1` is in the inherited environment. The current `spawn()` call in `health.js` passes `process.env` through unchanged, so the TV binary sees that var and boots as a Node.js runtime — Node then rejects the unknown CLI flag:

```
$ ELECTRON_RUN_AS_NODE=1 /Applications/TradingView.app/Contents/MacOS/TradingView --remote-debugging-port=9222
/Applications/TradingView.app/Contents/MacOS/TradingView: bad option: --remote-debugging-port=9222
```

The child exits in ~1s. `tv_launch` returns `success: true` (because `spawn` itself succeeded), but `tv_health_check` then fails repeatedly with `CDP connection failed`.

## Root cause vs. issue #130's hypothesis

Issue #130 currently attributes this to a TradingView 3.1.0 wrapper change that strips `--remote-debugging-port` before Electron sees it. That hypothesis is incorrect — at least on macOS. With a clean env:

```
$ env -u ELECTRON_RUN_AS_NODE /Applications/TradingView.app/Contents/MacOS/TradingView --remote-debugging-port=9222
DevTools listening on ws://127.0.0.1:9222/devtools/browser/...
```

CDP comes up at 1s on the **unchanged** 3.1.0 binary (`Chrome/140.0.7339.133`, `Protocol-Version: 1.3`). No vendor change required.

If Windows MSIX/UWP commenters in #130 are seeing the same symptom, it's worth them checking their environment for `ELECTRON_RUN_AS_NODE` before pursuing wrapper-strip / pipe-transport rewrites.

## Fix

In `src/core/health.js`, before:

```js
const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`],
    { detached: true, stdio: 'ignore' });
```

After:

```js
// Strip ELECTRON_RUN_AS_NODE from the spawn env: when this MCP server is
// launched from a parent that runs as an Electron utility process (e.g.
// VSCode's Code Helper (Plugin), Claude Desktop), the var is set to '1'
// and inherited through the child chain. With it set, the TradingView
// binary boots in Node mode and rejects --remote-debugging-port at argv
// parsing ('bad option: --remote-debugging-port'), making it look like
// TV is broken when it is actually env contamination.
const { ELECTRON_RUN_AS_NODE: _stripped, ...spawnEnv } = process.env;
const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`],
    { detached: true, stdio: 'ignore', env: spawnEnv });
```

## Verification

With `ELECTRON_RUN_AS_NODE=1` deliberately set in the calling shell (the contaminated case):

```
$ ELECTRON_RUN_AS_NODE=1 node --input-type=module -e '
    import { launch } from "./src/core/health.js";
    const r = await launch({ port: 9222, kill_existing: true });
    console.log(JSON.stringify(r));
'
{ "success": true, "pid": 25953, "cdp_ready": true, "browser": "Chrome/140.0.7339.133" }
```

CDP is up immediately and `quote_get`, `chart_get_state`, `data_get_pine_lines`, etc. all work normally afterward.

## Test plan

- [x] `tv_launch` succeeds and CDP responds when `ELECTRON_RUN_AS_NODE=1` is set in the calling env (regression for the bug).
- [x] `tv_launch` continues to work when the var is unset (no behavior change for users not affected).
- [ ] Existing tests still pass (`npm test` — to be run by maintainer).
- [x] No effect on non-launch tools (`chart_*`, `data_*`, `pine_*`, etc.) since they don't touch `process.env`.

## Why other open PRs don't cover this

- **#107** — fixes data extraction (`data_get_strategy_results` / `_trades` / `_equity`); assumes CDP is already up.
- **#108** — bridge-side compat (`127.0.0.1` swap, skip `Runtime/Page/DOM.enable()`, window-target fallback); useful only after CDP is up.
- **#147** — Windows MSIX launch (port 9222→9223, hardcoded path); doesn't address env contamination.

This PR is orthogonal and stacks cleanly with all three.
