### PR TITLE
Allowlist read-only TradingView MCP tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__tradingview__data_get_ohlcv",
+      "mcp__tradingview__data_get_study_values",
+      "mcp__tradingview__chart_get_state",
+      "mcp__tradingview__quote_get",
+      "mcp__tradingview__tv_health_check",
+      "mcp__tradingview__alert_list",
+      "mcp__tradingview__data_get_pine_lines",
+      "mcp__tradingview__data_get_pine_labels"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` allowlisting 8 read-only TradingView MCP tools so Claude Code stops prompting for permission on every call
- Tools that mutate chart state (`draw_shape`, `chart_set_*`, `capture_screenshot`, indicator toggles, etc.) intentionally still require approval

## Allowlisted tools
| Tool | Why |
|---|---|
| `mcp__tradingview__data_get_ohlcv` | Read price bars |
| `mcp__tradingview__data_get_study_values` | Read current indicator values |
| `mcp__tradingview__chart_get_state` | Inspect symbol/timeframe/active studies |
| `mcp__tradingview__quote_get` | Real-time price snapshot |
| `mcp__tradingview__tv_health_check` | Verify CDP connection |
| `mcp__tradingview__alert_list` | List active alerts |
| `mcp__tradingview__data_get_pine_lines` | Read Pine `line.new()` levels |
| `mcp__tradingview__data_get_pine_labels` | Read Pine `label.new()` annotations |

Selected from a scan of ~500 tool calls across the 16 most recent local Claude Code transcripts; all 8 appeared 3+ times and are strictly read-only.

## Test plan
- [ ] Pull and verify `.claude/settings.json` is present and valid JSON
- [ ] Open repo in Claude Code, run a TradingView session, confirm no permission prompt appears for the 8 listed tools
- [ ] Confirm prompts still appear for mutating tools (e.g. `draw_shape`, `chart_set_symbol`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)