### PR TITLE
Fix pine_open to rebind active-script slot via pineEditorTestApi (D9)

### DIFF
--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -535,8 +535,28 @@ export async function newScript({ type }) {
 }
 
 export async function openScript({ name }) {
-  const editorReady = await ensurePineEditorOpen();
-  if (!editorReady) throw new Error('Could not open Pine Editor.');
+  // D9 FIX: skip the FIND_MONACO-based ensurePineEditorOpen gate when
+  // pineEditorTestApi is available. testApi.openEditor() is itself a
+  // panel-opener (dispatches the same Redux action TV's own UI uses)
+  // and works on builds where the Monaco container is mounted detached
+  // without React fibers — a state that breaks the fiber-walk in
+  // FIND_MONACO. Only fall back to the legacy gate for pre-testApi
+  // TV builds where the JS payload below would also need to use
+  // m.editor.setValue.
+  const testApiAvailable = await evaluate(`
+    (function() {
+      try {
+        return typeof window.TradingViewApi !== 'undefined'
+          && typeof window.TradingViewApi.pineEditorTestApi === 'function'
+          && typeof window.TradingViewApi.pineEditorTestApi().openScript === 'function'
+          && typeof window.TradingViewApi.pineEditorTestApi().openEditor === 'function';
+      } catch (e) { return false; }
+    })()
+  `);
+  if (!testApiAvailable) {
+    const editorReady = await ensurePineEditorOpen();
+    if (!editorReady) throw new Error('Could not open Pine Editor.');
+  }
 
   const escapedName = JSON.stringify(name.toLowerCase());
 
@@ -569,12 +589,43 @@ export async function openScript({ name }) {
             .then(function(data) {
               var source = data.source || '';
               if (!source) return {error: 'Script source is empty', name: match.scriptName || match.scriptTitle};
+              // D9 FIX: route through TV's pineEditorTestApi instead of bare
+              // m.editor.setValue(source). setValue only touches Monaco's
+              // text buffer — it does NOT rebind the Pine Editor's active
+              // script slot (a Redux store entry: state.script.scriptIdPart).
+              // A subsequent pine_save / pine_compile then dispatches its
+              // save action against the PREVIOUS slot, silently clobbering
+              // an unrelated cloud script. testApi.openScript() dispatches
+              // the fetchAndOpenScript Redux action, which is the same path
+              // TV's own File → Open UI takes; the store's script slice is
+              // updated atomically so subsequent saves target the correct
+              // slot. Empirically verified end-to-end: two throwaway
+              // scripts D9_test_A/B; openScript(A) → openScript(B) →
+              // setEditorText(B + marker) → saveScript → A unchanged at
+              // v1.0, B bumped to v2.0 with marker. See PR description.
+              var testApi = window.TradingViewApi && typeof window.TradingViewApi.pineEditorTestApi === 'function'
+                ? window.TradingViewApi.pineEditorTestApi()
+                : null;
+              if (testApi && typeof testApi.openScript === 'function' && typeof testApi.openEditor === 'function') {
+                return testApi.openEditor()
+                  .then(function() { return testApi.openScript({scriptIdPart: id, version: ver}); })
+                  .then(function() {
+                    return {success: true, name: match.scriptName || match.scriptTitle, id: id, version: ver, lines: source.split('\\n').length, slot_rebound: true};
+                  })
+                  .catch(function(e) {
+                    return {error: 'pineEditorTestApi.openScript failed: ' + (e && e.message || String(e)), name: match.scriptName || match.scriptTitle};
+                  });
+              }
+              // Fallback: pre-pineEditorTestApi TV builds. Use the legacy
+              // setValue path but flag slot_rebound: false so callers can
+              // detect they are on the unsafe path and avoid a subsequent
+              // pine_save / pine_compile that would clobber the prior slot.
               var m = ${FIND_MONACO};
               if (m) {
                 m.editor.setValue(source);
-                return {success: true, name: match.scriptName || match.scriptTitle, id: id, lines: source.split('\\n').length};
+                return {success: true, name: match.scriptName || match.scriptTitle, id: id, lines: source.split('\\n').length, slot_rebound: false, warning: 'pineEditorTestApi unavailable on this TV build; fell back to setValue. Saving from this editor state may clobber the previously-bound script. See D9.'};
               }
-              return {error: 'Monaco editor not found to inject source', name: match.scriptName || match.scriptTitle};
+              return {error: 'Monaco editor not found to inject source and pineEditorTestApi unavailable', name: match.scriptName || match.scriptTitle};
             });
         })
         .catch(function(e) { return {error: e.message}; });
@@ -585,7 +636,17 @@ export async function openScript({ name }) {
     throw new Error(result.error);
   }
 
-  return { success: true, name: result.name, script_id: result.id, lines: result.lines, source: 'internal_api', opened: true };
+  return {
+    success: true,
+    name: result.name,
+    script_id: result.id,
+    version: result.version,
+    lines: result.lines,
+    slot_rebound: result.slot_rebound,   // D9: true when testApi path took, false on legacy-setValue fallback
+    warning: result.warning,             // populated only on the unsafe fallback path
+    source: 'internal_api',
+    opened: true,
+  };
 }
 
 export async function listScripts() {


### PR DESCRIPTION
# Fix `pine_open` editor-slot binding to prevent silent clobber of saved Pine scripts

> **Status:** code fix shipped and validated end-to-end. Option A from the
> "Proposed fix" section below was taken — see §0 "Resolution" for the
> confirmed mechanism, the actual diff applied to `src/core/pine.js`, and
> the empirical proof that pre-existing slots are no longer clobbered.
> The analysis sections (1–6) are preserved as the diagnostic trail that
> led to the fix.

## 0. Resolution — Option A taken, mechanism confirmed

### The TV-internal API that rebinds the slot

`window.TradingViewApi.pineEditorTestApi()` exposes a stable surface with
the methods needed for slot-aware script loading. Probed via
`Object.getOwnPropertyNames(Object.getPrototypeOf(testApi))`:

```
destroy · addOpenedScript · removeOpenedScript · openEditor · openNewScript
· openScript · saveScript · addScriptOnChart · updateScriptOnChart
· setEditorText · focusEditor
```

The two that matter for D9:

- **`openEditor()`** — Promise. Opens the Pine Editor panel via the same
  Redux dispatch path as TV's UI button. Works even on builds where the
  Monaco container is mounted detached with no React fibers attached
  (which breaks `FIND_MONACO`'s fiber-walk).
- **`openScript({scriptIdPart, version})`** — Promise. Dispatches the
  `fetchAndOpenScript` Redux action — the same action TV's own
  File → Open Pine Script UI fires. Result: `state.script.scriptIdPart`
  / `state.script.version` / `state.script.scriptSource` are all
  updated atomically. Subsequent `saveScript()` targets the correct
  slot.

Trace through the Pine Editor singleton:

```
testApi.openScript({scriptIdPart, version})
  → testApi._pineEditor.open(...)
    → testApi._pineEditor._scriptManager.showEditor(...)
      → testApi._pineEditor._storeProvider.dispatch(fetchAndOpenScript({...}))
```

The active slot can be read back via
`testApi._pineEditor._storeProvider.getEditorActiveScript()` which returns
`{ scriptIdPart, version, scriptName, scriptTitle, scriptSource, ... }`.

### What the fix does

`src/core/pine.js` `openScript()` now:

1. Detects whether `pineEditorTestApi` exists with `openScript` +
   `openEditor` methods. If yes, **skips** the legacy
   `ensurePineEditorOpen` gate (which depends on a `FIND_MONACO`
   fiber-walk that's brittle on the current TV build).
2. Resolves the requested name → `scriptIdPart` + `version` via the
   existing `/pine-facade/list/?filter=saved` GET (unchanged), then
   fetches source via `/pine-facade/get/<id>/<ver>` (unchanged — kept
   for the line-count return field and the legacy fallback).
3. Invokes `testApi.openEditor().then(() => testApi.openScript({scriptIdPart, version}))`.
   This is the slot-rebinding path.
4. Returns `{ ..., slot_rebound: true, version }` so callers can
   detect they're on the safe path.
5. Falls back to the legacy `m.editor.setValue(source)` only if
   `pineEditorTestApi` is unavailable (pre-API TV builds). In that
   case the response includes `slot_rebound: false` and a `warning`
   field explicitly naming the clobber risk.

### Empirical verification

Two-phase test on cloud-side throwaways `D9_test_A` (USER;56c8e8f1...)
and `D9_test_B` (USER;59b0674a...):

**Phase 1 — manual API probe (proves the testApi mechanism works):**
After `testApi.openScript(A)` → `testApi.openScript(B)` →
`testApi.setEditorText(B's source + marker)` → `testApi.saveScript()`:

- D9_test_A: REST GET shows **version 1.0 unchanged** ← no clobber
- D9_test_B: REST GET shows **version 2.0, marker present** ← save
  correctly targeted the rebound slot

**Phase 2 — patched MCP end-to-end (proves the production code path):**
Set fixture: Redux active = D9_test_A (verified via
`getEditorActiveScript()`). Called `pine_open` MCP tool with
`name: "D9_test_B"`. Result:

```json
{
  "success": true,
  "name": "D9_test_B",
  "script_id": "USER;59b0674a4dcb4adeb22c804e497bca4d",
  "version": "2.0",
  "lines": 6,
  "slot_rebound": true,
  "source": "internal_api",
  "opened": true
}
```

Post-call Redux: `getEditorActiveScript()` returns
`{scriptName: "D9_test_B", scriptIdPart: "USER;59b0674a4dcb4adeb22c804e497bca4d", version: "2.0"}`.
Post-call REST: D9_test_A still at version 1.0 (no clobber from the
rebind operation).

**Phase 3 — production safety check on HyperClaw Stack v1 (the
slot from Incident 3):**

| | scriptIdPart | version | modified |
|---|---|---|---|
| Pre-`pine_open` REST snapshot | USER;94daf065... | 5.0 | 1776894087 |
| After patched `pine_open("HyperClaw Stack v1")` | USER;94daf065... | 5.0 | 1776894087 |

Identical. Patched `pine_open` is non-destructive on real production
scripts. Tool response included `slot_rebound: true`, confirming the
testApi path took.

### CRLF normalization hypothesis — still relevant but bypassed

The CRLF→LF normalization analysis in §3 ("Why `pine_compile` triggers
the clobber") remains accurate as a root-cause description of the
old setValue-only path. The testApi path bypasses the Monaco dirty
check entirely — the source is loaded via Redux dispatch, not
`setValue`, so the editor's dirty flag is set/cleared based on TV's
own state-versus-source comparison rather than Monaco's normalize-then-diff.
We did not need to fix CRLF normalization separately; the slot-rebind
path makes it moot for the clobber scenario.

### The actual diff (≤30 LOC of behavior change)

`src/core/pine.js`:

```js
export async function openScript({ name }) {
  // D9 FIX: skip the FIND_MONACO-based ensurePineEditorOpen gate when
  // pineEditorTestApi is available. testApi.openEditor() handles
  // panel opening itself via the same Redux action TV's UI fires.
  const testApiAvailable = await evaluate(`
    (function() {
      try {
        return typeof window.TradingViewApi !== 'undefined'
          && typeof window.TradingViewApi.pineEditorTestApi === 'function'
          && typeof window.TradingViewApi.pineEditorTestApi().openScript === 'function'
          && typeof window.TradingViewApi.pineEditorTestApi().openEditor === 'function';
      } catch (e) { return false; }
    })()
  `);
  if (!testApiAvailable) {
    const editorReady = await ensurePineEditorOpen();
    if (!editorReady) throw new Error('Could not open Pine Editor.');
  }
  // ... existing /pine-facade/list + /pine-facade/get fetch chain ...
  // then inside the .then():
  var testApi = window.TradingViewApi && typeof window.TradingViewApi.pineEditorTestApi === 'function'
    ? window.TradingViewApi.pineEditorTestApi()
    : null;
  if (testApi && typeof testApi.openScript === 'function' && typeof testApi.openEditor === 'function') {
    return testApi.openEditor()
      .then(function() { return testApi.openScript({scriptIdPart: id, version: ver}); })
      .then(function() {
        return {success: true, name: ..., id, version: ver, lines, slot_rebound: true};
      })
      .catch(function(e) { return {error: 'pineEditorTestApi.openScript failed: ' + ...}; });
  }
  // legacy setValue fallback retained, now returns slot_rebound: false + warning
}
```

### Counter-evidence revisited (§ "Counter-evidence" below)

- **"TV internal API brittleness"** — partly mitigated by the fallback
  branch: if `pineEditorTestApi` ever disappears from a future TV
  build, the tool falls back to the original `setValue` path with an
  explicit `slot_rebound: false` + `warning` field rather than failing
  silently. The fallback path is the same code that's been shipping
  for months, so worst-case the behavior reverts to the pre-D9 state,
  with observability that the caller can act on.
- **"Niche workflow legitimacy"** — left unresolved. If any caller
  actually relied on the broken "save into the previously-bound slot"
  behavior, they will see slot targeting change. We have no evidence
  of such a caller; the original docstring did not describe this
  pattern; and the new return field `slot_rebound` lets callers
  detect the difference.
- **"Recommended path collision"** — orthogonal. D3's
  `pine_create_script(allow_overwrite=true)` remains the safer choice
  for REST-style edit-and-resave. D9 fixes the in-editor pattern for
  the use cases (debug/inspect/compile-attach) that legitimately need
  Monaco.

---

## Original draft (preserved as diagnostic trail) →

## 1. Summary

`pine_open(name)` calls `m.editor.setValue(source)` to swap the Monaco
editor's *displayed text* to the requested script's source, but it does
NOT rebind the editor's internal **active-script slot identity**. So a
subsequent `pine_save` / `pine_compile`'s Save button / `pine_smart_compile`
that triggers a Save will save the *displayed text* into the *previously-bound
slot* — silently overwriting whichever script the editor was bound to before
the `pine_open` call.

In our usage, this has caused a Pine indicator being created to silently
replace the source of an unrelated previously-attached strategy. The chart
study's compiled code auto-updates from the cloud script (live-linked), so
the active backtest is also corrupted, not just the cloud script.

## 2. Evidence — three reproductions in two days of downstream work

All three reproductions happened during separate downstream tasks, were
caught via `pine_list_scripts` showing the unexpected title/version drift,
and were recovered via REST `save/new?allow_overwrite=true` with the
original source. The cloud-side incident details are documented in the
commit messages of:

| Reproduction | Documented in | Trigger sequence |
|---|---|---|
| Incident 1 | commit message of `9b3fc00` (`pine_create_script: safe REST CREATE replaces unsafe pine_new`, "Operational notes / Sweet trap" paragraph) | Editor was bound to *Test1 RSI Sweep*. Workflow set new code in editor for a different script, called `pine_compile`. Save fired, clobbered Test1 RSI Sweep's cloud slot with the new code. Title flipped to the new strategy's `strategy("…")` name; version incremented. |
| Incident 2 | commit message of `9b3fc00` (same paragraph, "twice in a row before the pattern was identified") | Same workflow, same victim slot, second time within the same session. The first clobber's restoration had succeeded but the editor binding was still pointed at *Test1 RSI Sweep* because the restore went via REST `save/new` rather than `pine_open`, so the next `pine_compile` re-clobbered. |
| Incident 3 | commit message of `d6cedd5` ("DOM-attach hazard recurred during Phase 2b…"; full V2 Ray DCA backtest deliverable in `docs/ray_dca_pine_v6_backtest_may15.md`) | New session, new chart, **fresh `pine_open("Ray DCA v1")` call followed by `pine_compile`** to attach a freshly-created Pine indicator to the chart. The editor was bound to *Test1 RSI Sweep* from a prior session. `pine_open` swapped the displayed source. `pine_compile` clicked "Save" (Monaco's CRLF normalization marked the just-loaded content as dirty) — saved the Ray DCA source into *Test1 RSI Sweep*'s slot. Title flipped, version bumped 5.0 → 6.0. Restored via REST to v7.0 with the original Test1 source. |

Pattern in all three: editor's bound-slot ≠ the script whose source is currently displayed. The bug is independent of which scripts are involved; it depends only on whether the editor's prior binding was set to a *different* script than the user just opened.

### Why this is hard to notice as a user

- The displayed source after `pine_open` looks correct (it is the requested script's content).
- The TV UI may show a script-name indicator in the editor title bar that *also* updates to the opened script's name — masking the binding mismatch.
- The actual clobber only manifests on a *subsequent* save action, which may happen later in a longer workflow.
- The clobbered cloud script's chart-attached study (if any) **silently recompiles** from the new source on TV's next sync, contaminating any running backtest without any error or warning.

### Severity argument

Data-loss class. The clobber overwrites the cloud-saved Pine source, which may be the only copy of a user's work (some users edit only inside TV's web UI without an external backup). TV does retain version history server-side (you can restore via the version dropdown in TV's UI), but the chart-side backtest is corrupted during the window before a restore.

## 3. Root cause analysis

### Current implementation (`src/core/pine.js:537-589`)

```js
export async function openScript({ name }) {
  // ... resolves `name` → scriptIdPart + version via /pine-facade/list ...
  // ... GET /pine-facade/get/<id>/<ver> to fetch source ...
  var m = FIND_MONACO;
  if (m) {
    m.editor.setValue(source);       // ← ONLY edits the displayed text
    return { success: true, ... };
  }
}
```

`m.editor.setValue(source)` is Monaco's standalone-code-editor API. It replaces the text content of the editor's current model. Crucially: in TV's Pine Editor, this is **not** the same as "open the saved script named X". TV's Pine Editor maintains a separate piece of state — call it the *active-script slot* — that tracks which cloud script the editor's Save button will write to. `setValue` doesn't touch this state.

Concretely, the active-script slot is determined by:
- Which script was last opened via TV's own "Open script" UI flow (File → Open → click script), OR
- Which script was last created via TV's own "Save as" or "Save script" flow, OR
- Default to last-opened script on chart session start

When `openScript` only calls `setValue`, the editor stays bound to whichever script most recently went through one of TV's own UI flows.

### What "saving into the wrong slot" looks like internally

Inside TV's Save button click handler, the flow is roughly:
1. Read current Monaco editor text
2. Read the active-script slot (script id, version)
3. POST to `/pine-facade/save?id=<active_slot_id>&version=<next_version>` with the editor text

Step 3's target id is the *bound* slot, not the displayed-source's origin. Hence the clobber.

### Why `pine_compile` triggers the clobber rather than just `pine_save`

`pine_compile` clicks the Pine Editor's primary action button. TV shows that button as:
- **"Save"** — if the displayed text differs from what's currently stored in the active-script slot's saved version (i.e. the editor is "dirty")
- **"Add to chart"** — if the displayed text matches the active-script slot's stored version

Right after `openScript`'s `setValue`, the displayed text matches what we just loaded from the cloud — but TV's dirty-check apparently triggers on `setValue` regardless of content equality, or compares text with normalization differences (LF vs CRLF — TV stores with CRLF, Monaco normalizes to LF on `setValue`, so equality fails). So the button shows "Save", `pine_compile` clicks it, and the clobber lands.

Our verification of the CRLF hypothesis: `GET /pine-facade/get/<id>/<ver>` returns sources with `\r\n` line endings (visible in the response JSON's `source` field). Monaco's `setValue` does not preserve `\r\n`; it normalizes. So the cycle is:

```
cloud source (CRLF) → fetch → setValue → Monaco buffer (LF) → diff against cloud (CRLF) → "dirty" → Save button shown
```

## 4. Proposed fix

There are three reasonable directions. Listed in increasing scope / risk.

### Option A (minimal): also call TV's `openSavedScript` (or equivalent internal API) in `openScript`

After `setValue`, additionally call TV's internal "open this script id in the editor" method to rebind the active-script slot. We have not yet identified the exact method name on the TV Pine Editor object — discovery required. Candidate paths to probe via `ui_evaluate`:

```js
// On the Pine Editor singleton (location TBD via Object.getOwnPropertyNames walk
// during fix implementation):
pineEditor.openScript(scriptIdPart, version)
pineEditor.setActiveScript({ id, version, source })
pineEditor._scriptManager.load(scriptIdPart)
pineEditor.scriptModel.setCurrentScript(scriptIdPart)
```

The discovery procedure: install a fetch+XHR interceptor (same pattern documented in commit message of `574e8a3`/D2d), trigger TV's own File → Open Script UI flow, capture the JS call stack via Chrome DevTools (Performance / Call Stack tab) during the click. The interceptor likely won't see anything (the UI flow probably doesn't go through pine-facade for "open", only for fetch+save), so call-stack tracing is the primary tool.

Estimated discovery: 30-60 min if TV's Pine Editor object is accessible from `window`; longer if it's a closure-private singleton requiring source-map inspection.

### Option B (defensive): rebuild `openScript` as a "switch-by-source-replacement-only" doc warning + add explicit `pine_close_active_slot()`

Keep `openScript`'s current behavior unchanged but rewrite its tool description to be brutally clear:

> ⚠️ `pine_open` ONLY swaps the editor's displayed text to match the
> opened script's source. It does NOT rebind the editor to the opened
> script's slot. Any subsequent `pine_save` / `pine_compile` will write
> the displayed text into whichever slot the editor was bound to BEFORE
> this call. If you intend to actually edit the opened script, follow up
> by clicking the script in TV's UI (File → Open) to rebind, OR use
> `pine_create_script(allow_overwrite=true)` for an explicit slot-targeted
> save.

Plus add a `pine_close_active_slot()` MCP tool that detaches the editor from any bound slot (so subsequent saves prompt for a name via TV's "Save As" dialog, rather than silently clobbering).

Pro: zero risk of regression because the buggy code path is unchanged.
Con: bug persists for callers who don't read the warning; muscle memory from existing usage patterns will continue producing incidents.

### Option C (clean replacement): deprecate `pine_open` and recommend the REST `save/new` pattern

`pine_create_script` (D3, commit `9b3fc00`) already provides a safe path to PUT a script into TV's cloud without touching the editor. For users who want to actually EDIT an existing script, the safer pattern is:
1. `pine_list_scripts` → identify the script
2. Fetch its source via the pine-facade `get` endpoint (already used internally by `openScript`)
3. Edit the source in their preferred editor (file system, IDE, etc.)
4. `pine_create_script(name="...", source="...", allow_overwrite=true)` to push back

This sidesteps the Monaco editor entirely. Add a `pine_get_script_source(name)` tool that returns the cloud source as a string (without touching the editor), and document the round-trip pattern.

Pro: eliminates the bug class entirely; no Monaco state to manage; aligns with the D3 REST-first approach.
Con: changes the recommended workflow; some users may have IDE preferences tied to TV's in-browser Monaco (autocomplete, Pine syntax highlighting); breaks the "edit in TV's UI for free Pine intellisense" expectation.

### Recommended path

**Option A first, fall back to Option B if Option A's discovery proves too brittle.** Option C is a longer-arc workflow change worth doing eventually but separable from this PR.

For Option A specifically:
- Spend ≤60 min on TV-internal-API discovery via `ui_evaluate` probing during a manual File → Open click
- If a clean rebind method is found, ship the 2-line `openScript` fix
- If not, ship Option B (doc warning + `pine_close_active_slot`) as a defensive intermediate

## 5. Testing plan

### Manual reproduction (pre-fix verification)

Setup:
1. Use a TV account where you control the saved Pine scripts (any account works; just don't run on a slot you care about).
2. Create two throwaway scripts via REST or TV UI:
   - `D9_test_A` — content: `//@version=6\nindicator("A")\nplot(close)`
   - `D9_test_B` — content: `//@version=6\nindicator("B")\nplot(close*2)`
3. Note both scripts' `scriptIdPart` from `pine_list_scripts`.

Repro:
1. In TV's UI, open `D9_test_A` via File → Open Pine Script → click `D9_test_A`. This rebinds the editor's active slot to A.
2. Verify via `pine_get_source` that the editor shows A's source.
3. Call `pine_open(name: "D9_test_B")` via MCP.
4. Verify via `pine_get_source` that the editor now shows B's source.
5. Call `pine_compile`. The button clicked should be reported as "Pine Save" (not "Add to chart") due to the CRLF dirty-check.
6. Call `pine_list_scripts`.
7. **Expected (current buggy behavior)**: `D9_test_A`'s `version` has incremented (e.g. 1.0 → 2.0) and its `scriptTitle` may have changed to "B" (the `indicator()` declaration name). `D9_test_B` is unchanged. → confirms clobber.

### Verification after fix (post-fix)

Same setup. Same repro steps 1-3. Then:

4. Verify via `pine_get_source` that the editor shows B's source.
5. Probe via `ui_evaluate` that the editor's active-script slot now reads `D9_test_B`'s id (not A's). The exact probe call depends on which internal method Option A's discovery surfaces; sketch:

```js
window.TradingViewApi._pineEditorService?.getActiveScript?.()
// or equivalent — should return { id: <D9_test_B id>, version: <ver> }
```

6. Call `pine_compile`. Acceptable outcomes:
   - Saves into `D9_test_B`'s slot (slot rebind worked → version increments on B, A unchanged), OR
   - Button reports "Add to chart" not "Save" (CRLF normalization fixed → not flagged as dirty → no save attempt on B either — also acceptable because no clobber occurs).
7. Call `pine_list_scripts`. `D9_test_A`'s version is unchanged. `D9_test_B`'s version may or may not be incremented depending on the outcome in step 6.

### Cleanup

Both throwaway scripts can be deleted via `POST /pine-facade/delete/<scriptIdPart>` (endpoint discovered during V2.1 work, documented at end of `docs/ray_dca_pine_v6_backtest_may15.md`). This endpoint has a built-in 401 owner-check that prevents accidental deletion of someone else's scripts.

### Automation feasibility

The repro can be mostly automated via MCP after the fix lands. The one step that can't trivially be automated is **step 1 of the setup** (TV's UI File → Open flow to establish a known initial slot binding). That step is the one this PR's fix is designed to make automatable — so the repro automation arrives as a side effect of the fix.

Suggested test coverage: add a `tests/e2e/pine_open_slot_binding.test.js` that runs the repro after operator has manually performed step 1, asserts step 7's `pine_list_scripts` returns the expected versions. Won't fit the current "no TradingView needed" offline test suite (`npm test` 29/29), but fits as a separate e2e suite that documents the expected behavior even if it's gated on manual TV setup.

## 6. Breaking change assessment

### Behavioral changes

- **Option A fix:** the only visible behavior change is that `pine_save` / `pine_compile` after a `pine_open` will target the *opened* script's slot, not the *previously-bound* slot. For any caller that was relying on the buggy "save my edits back to the previously-bound script" pattern, this is a breaking change. We have no public evidence of such a caller — the pattern is unintuitive and the docs don't suggest it — but it's *possible* a workflow somewhere does:
  1. `pine_open(A)` — open A as a reference
  2. `pine_set_source(modified content)` — modify
  3. `pine_save` — save back to... whatever was bound before A? Unclear if any user actually relies on this.

  If such a user exists, their fix is to use `pine_create_script(name="...", allow_overwrite=true)` instead, which targets a slot by name explicitly. Worth flagging in the release notes.

- **Option B fix:** zero behavioral change. Pure documentation + a new opt-in tool (`pine_close_active_slot`). Strictly additive.

- **Option C fix:** explicit deprecation of `pine_open` in favor of the REST pattern. Breaking change in the "we recommend you stop using this tool" sense, not the "this tool no longer works" sense.

### API surface changes

- **Option A:** none. Existing `pine_open` schema unchanged.
- **Option B:** adds `pine_close_active_slot` tool.
- **Option C:** adds `pine_get_script_source(name)` tool; marks `pine_open` deprecated.

### Risk of regression introduced by the fix itself

Option A is the highest-risk option because it depends on TV's internal Pine Editor object having a stable "rebind active script" method. TV's internal APIs are explicitly not contract-stable (the project's README and CONTRIBUTING acknowledge "TV's internal Electron structure" as a moving target). A future TV update could break the rebind call without warning, returning the codebase to the current state silently.

Mitigation: wrap the rebind call in a try/catch; on failure, log a console warning AND fall back to the current `setValue`-only behavior, with a return-value field like `slot_rebound: false, fallback_to_set_value_only: true` so callers can detect when they're operating in the unsafe-fallback mode.

## Counter-evidence: reasons this fix might not be welcomed upstream

1. **TV internal API brittleness.** The maintainer (per CONTRIBUTING.md) explicitly warns that TV's internal Electron interfaces "can change or break without notice in any TradingView update." A fix that depends on additional internal-API surface (Option A) increases the codebase's coupling to TV's internals — opposite the project's stated maintenance preference. The maintainer may prefer Option B (pure documentation) on the principle "if we can't safely fix it, document it loudly and recommend the safer adjacent path."

2. **Niche workflow legitimacy.** Some users may *intentionally* use `pine_open` as a "show me script X's source without changing my saved slot binding" inspection pattern. For those users, the current behavior is the *desired* behavior. The breaking-change risk in §6 isn't zero. The maintainer may want to gate the fix on a new parameter — `pine_open(name, rebind_slot=true)` — to preserve both call shapes, increasing scope.

3. **Recommended path collision.** Our use of `pine_create_script` (D3, also from this contributor) already obviates `pine_open` for most modify-and-resave workflows. The maintainer might prefer to consolidate: rather than fix `pine_open`'s slot-binding, deprecate it entirely (Option C). That conversation belongs in an issue, not a fix PR — so this PR might land more cleanly as a *report* (this document, opened as an issue) than as a *patch* (the eventual code change).

## Acceptance criteria self-check (operator's V2.1-style gate applied to this draft)

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | Summary present (one sentence) | ✅ PASS | §1, the entire single-sentence opening of the Summary section. |
| 2 | Evidence references ≥3 documented incidents | ✅ PASS | §2 table with 3 rows citing commit messages `9b3fc00` (×2) and `d6cedd5` for the 3 reproductions, plus the V2 deliverable doc. |
| 3 | Proposed fix names specific TV internal API or DOM action | ✅ PASS (resolved) | §0 names the confirmed API: `window.TradingViewApi.pineEditorTestApi().openScript({scriptIdPart, version})` dispatching the `fetchAndOpenScript` Redux action via `_pineEditor._storeProvider`. Trace through Pine Editor singleton documented. |
| 4 | Testing plan reproducible | ✅ PASS (executed) | §5 plan was executed; §0 documents the 3-phase empirical proof (manual API probe with throwaway D9_test_A/B + patched-MCP end-to-end + HyperClaw Stack v1 read-only non-destructive check). Throwaways cleaned up via `POST /pine-facade/delete/`. |
| 5 | Breaking change assessment present | ✅ PASS | §6 enumerates behavioral changes; §0 documents the fallback branch (`slot_rebound: false` + `warning`) that keeps the pre-D9 path live for any TV build lacking `pineEditorTestApi`. |
| 6 | Counter-evidence: 1+ reason fix might not be welcomed | ✅ PASS | "Counter-evidence" section + §0 revisit address brittleness, niche-workflow, and consolidation-with-D3 concerns. |
| 7 | Confirmed mechanism end-to-end | ✅ PASS | §0 phase 2 + 3: patched MCP `pine_open` rebinds Redux slot atomically; HyperClaw Stack v1 metadata unchanged across the open call. |