### PR TITLE
fix(windows): detect MSIX (Microsoft Store) TradingView install in tv_launch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -197,6 +197,20 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  // Fallback: detect MSIX (Microsoft Store) install path via PowerShell
+  if (!tvPath && platform === 'win32') {
+    try {
+      const raw = execSync(
+        'powershell -NoProfile -Command "(Get-AppxPackage | Where-Object { $_.Name -like \'*TradingView*\' }).InstallLocation"',
+        { timeout: 5000 }
+      ).toString().trim();
+      if (raw) {
+        const msixExe = `${raw}\\TradingView.exe`;
+        if (existsSync(msixExe)) tvPath = msixExe;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath && platform === 'darwin') {
     try {
       const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();


### PR DESCRIPTION
## What

`tv_launch` now detects TradingView when installed via the **Microsoft Store (MSIX)** on Windows.

## Why

The Microsoft Store version installs into a versioned path under `C:\Program Files\WindowsApps\` - not the standard `%LOCALAPPDATA%\TradingView\` path that `tv_launch` checks. This caused `tv_launch` to throw "TradingView not found" even when the app was installed.

## How

Added a PowerShell-based fallback in `src/core/health.js` that runs `Get-AppxPackage` to resolve the actual install location at runtime. The fallback only runs on `win32` and only after all static path candidates fail - no performance impact for standard installs.

## Test

Verified on Windows 11 with TradingView from the Microsoft Store:
- `tv_launch` successfully locates and launches the exe
- CDP port 9222 opens and `tv_health_check` returns `cdp_connected: true`