### PR TITLE
Fix tab_switch to re-attach CDP client to the new target

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -61,13 +61,19 @@ export async function getClient() {
   return connect();
 }
 
-export async function connect() {
+export async function connect(targetId = null) {
   let lastError;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const target = await findChartTarget();
+      const target = targetId
+        ? await findTargetById(targetId)
+        : await findChartTarget();
       if (!target) {
-        throw new Error('No TradingView chart target found. Is TradingView open with a chart?');
+        throw new Error(
+          targetId
+            ? `CDP target ${targetId} not found.`
+            : 'No TradingView chart target found. Is TradingView open with a chart?'
+        );
       }
       targetInfo = target;
       client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
@@ -87,6 +93,19 @@ export async function connect() {
   throw new Error(`CDP connection failed after ${MAX_RETRIES} attempts: ${lastError?.message}`);
 }
 
+/**
+ * Re-attach the cached CDP client to a specific target id.
+ * Used by tab_switch so subsequent reads come from the chosen tab.
+ */
+export async function reconnectTo(targetId) {
+  if (client) {
+    try { await client.close(); } catch {}
+    client = null;
+    targetInfo = null;
+  }
+  return connect(targetId);
+}
+
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
@@ -94,6 +113,12 @@ async function findChartTarget() {
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
     || null;
+}
+
+async function findTargetById(id) {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  return targets.find(t => t.id === id) || null;
 }
 
 export async function getTargetInfo() {

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,7 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
+import { getClient, evaluate, reconnectTo } from '../connection.js';
 
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
@@ -95,12 +95,15 @@ export async function switchTab({ index }) {
 
   const target = tabs.tabs[idx];
 
-  // Use CDP Target.activateTarget to bring the tab to front
+  // 1) Bring the tab to front in the UI.
+  // 2) Re-attach the cached CDP client to this target so subsequent
+  //    reads (chart_get_state, data_get_*, quote_get) come from this tab,
+  //    not whichever tab we first connected to.
   try {
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
-    const text = await resp.text();
+    await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
+    await reconnectTo(target.id);
     return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
   } catch (e) {
-    throw new Error(`Failed to activate tab ${idx}: ${e.message}`);
+    throw new Error(`Failed to switch to tab ${idx}: ${e.message}`);
   }
 }


### PR DESCRIPTION
switchTab() previously only called /json/activate/{id}, which brings a tab to the front in the UI but does not change which target the CDP client is bound to. As a result, after switching tabs, all reads (chart_get_state, data_get_study_values, quote_get, etc.) still came from whichever tab was first connected to — making per-tab dashboards or cross-tab batch sweeps impossible.

This change adds an optional targetId to connect() and a new reconnectTo(targetId) helper. switchTab() now activates the tab and then re-attaches the cached CDP client to that target, so subsequent reads come from the switched-to tab.