### PR TITLE
Add Windows 12hr update workflow, rules.json, and snapshot script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,40 @@ Claude Code ←→ MCP Server (stdio) ←→ CDP (localhost:9222) ←→ Trading
 ```
 
 Pine graphics path: `study._graphics._primitivesCollection.dwglines.get('lines').get(false)._primitivesDataById`
+
+## 12 Hr Update
+
+When asked to "run a 12 hr update", follow this workflow exactly:
+
+### Prerequisites
+1. Run `tv_health_check` — abort and report if `cdp_connected` is not `true`
+2. Load `rules.json` from the repo root for watchlist, timeframes, and bias criteria
+
+### Per-Symbol Analysis Loop
+For each `symbol` in `watchlist` × each `timeframe` in `timeframes`:
+1. `chart_set_symbol` → navigate to the symbol
+2. `chart_set_timeframe` → set timeframe
+3. Wait ~2 seconds for the chart to reload
+4. `chart_get_state` → confirm symbol and timeframe loaded correctly
+5. `data_get_study_values` → collect all indicator readings (EMA 20/50/200, RSI 14)
+6. `data_get_ohlcv` with `summary: true, count: 50` → price action summary
+7. `data_get_pine_lines` → key horizontal price levels from custom indicators
+8. `data_get_pine_labels` → labeled levels (PDH, PDL, session highs/lows, bias labels)
+9. Apply `bias_criteria` from rules.json → determine **BULLISH / BEARISH / NEUTRAL**
+10. `capture_screenshot` → save visual confirmation
+
+### Bias Determination Rules
+- **BULLISH** — price above EMA 20, RSI > 50 and rising, HH/HL structure (majority criteria agree)
+- **BEARISH** — price below EMA 20, RSI < 50 and falling, LH/LL structure (majority criteria agree)
+- **NEUTRAL** — mixed signals, consolidation, or criteria conflict
+- **Strong Bias** — all three criteria (trend + momentum + structure) fully aligned
+
+### Output
+1. Compile results into a timestamped JSON snapshot
+2. Save to `~/.tradingview-mcp/sessions/snapshot_YYYY-MM-DD_HHMM.json`
+3. Print a summary table in the console:
+   - Rows: symbols
+   - Columns: D / H4 / H1 / M15
+   - Cells: BULLISH / BEARISH / NEUTRAL
+4. Highlight **confluent setups** — same bias across 3 or more timeframes
+5. Highlight **strong bias** setups — all criteria aligned on a given timeframe

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,43 @@
+{
+  "watchlist": [
+    "OANDA:XAUUSD",
+    "OANDA:EURUSD",
+    "OANDA:GBPUSD",
+    "OANDA:USDJPY",
+    "OANDA:USDCHF",
+    "OANDA:AUDUSD",
+    "OANDA:NZDUSD",
+    "OANDA:USDCAD"
+  ],
+  "timeframes": ["D", "240", "60", "15"],
+  "bias_criteria": {
+    "trend": {
+      "indicators": ["EMA 20", "EMA 50", "EMA 200"],
+      "bullish": "Price above EMA 20; EMA 20 > EMA 50 > EMA 200",
+      "bearish": "Price below EMA 20; EMA 20 < EMA 50 < EMA 200",
+      "neutral": "Mixed EMA alignment or price between key EMAs"
+    },
+    "momentum": {
+      "indicators": ["RSI 14"],
+      "bullish": "RSI above 50 and rising",
+      "bearish": "RSI below 50 and falling",
+      "neutral": "RSI near 50 or flat"
+    },
+    "structure": {
+      "bullish": "Higher highs and higher lows (HH/HL)",
+      "bearish": "Lower highs and lower lows (LH/LL)",
+      "neutral": "Consolidation or choppy price action"
+    },
+    "confluence": {
+      "strong_bias": "All three criteria agree",
+      "moderate_bias": "Two of three criteria agree",
+      "no_bias": "Mixed or conflicting signals"
+    }
+  },
+  "report_settings": {
+    "output_dir": "~/.tradingview-mcp/sessions",
+    "format": "json",
+    "include_screenshot": true,
+    "ohlcv_count": 50
+  }
+}

--- a/scripts/12hr-snapshot.ps1
+++ b/scripts/12hr-snapshot.ps1
@@ -1,0 +1,57 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Scheduled 12hr snapshot — captures raw TradingView chart state via CDP.
+    Runs at 09:03 and 21:03 via Windows Scheduled Tasks.
+    Generates raw data only; bias analysis requires an in-session Claude request.
+
+.NOTES
+    Paths are derived at runtime from this script's location and $env:USERPROFILE
+    so the script works on any machine regardless of username or install path.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve paths relative to the repo root (script lives in <repo>\scripts\)
+$RepoRoot  = Split-Path -Parent $PSScriptRoot
+$NodeExe   = (Get-Command node -ErrorAction SilentlyContinue)?.Source ?? 'node'
+$CliJs     = Join-Path $RepoRoot 'src\cli\index.js'
+$RulesFile = Join-Path $RepoRoot 'rules.json'
+$OutDir    = Join-Path $env:USERPROFILE '.tradingview-mcp\sessions'
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+$timestamp = Get-Date -Format 'yyyy-MM-dd_HHmm'
+$outFile   = Join-Path $OutDir "snapshot_$timestamp.json"
+
+# Verify CDP is reachable
+try {
+    $health = Invoke-RestMethod 'http://localhost:9222/json/version' -TimeoutSec 5
+} catch {
+    @{
+        error     = 'CDP not reachable — TradingView not running with --remote-debugging-port=9222'
+        timestamp = $timestamp
+    } | ConvertTo-Json | Out-File $outFile -Encoding UTF8
+    Write-Warning "CDP unreachable. Snapshot written with error: $outFile"
+    exit 1
+}
+
+# Load rules
+$rules = Get-Content $RulesFile -Raw | ConvertFrom-Json
+
+# Run CLI status check
+$cliRaw    = & $NodeExe $CliJs status 2>&1
+$cliStatus = $cliRaw | ConvertFrom-Json -ErrorAction SilentlyContinue
+
+$snapshot = [ordered]@{
+    timestamp  = $timestamp
+    cdp_ok     = $true
+    cdp_target = $health.webSocketDebuggerUrl
+    cli_status = $cliStatus
+    watchlist  = $rules.watchlist
+    timeframes = $rules.timeframes
+    note       = 'Raw snapshot only. Open Claude Code and ask for a 12 Hr Update for bias analysis.'
+}
+
+$snapshot | ConvertTo-Json -Depth 10 | Out-File $outFile -Encoding UTF8
+Write-Host "Snapshot saved: $outFile"


### PR DESCRIPTION
﻿## Summary

- CLAUDE.md: adds 12 Hr Update workflow — Claude loops each symbol x timeframe from rules.json, reads EMA/RSI/structure via MCP tools, determines BULLISH/BEARISH/NEUTRAL bias, saves timestamped JSON snapshot to ~/.tradingview-mcp/sessions/
- rules.json: starter watchlist (XAUUSD, EURUSD, GBPUSD, USDJPY, USDCHF, AUDUSD, NZDUSD, USDCAD) x 4 timeframes (D/H4/H1/M15) with bias criteria definitions
- scripts/12hr-snapshot.ps1: Windows scheduled-task script for 09:03/21:03 CDP snapshots; paths resolved via $PSScriptRoot and $env:USERPROFILE — no hardcoded usernames

## Test plan
- [ ] Run tv_health_check in Claude Code — confirm cdp_connected: true
- [ ] Ask Claude to run a 12 hr update — confirm summary table and snapshot written to ~/.tradingview-mcp/sessions/
- [ ] Run scripts/12hr-snapshot.ps1 directly — confirm graceful error when CDP is down

Generated with Claude Code (https://claude.com/claude-code)
