### PR TITLE
fix(cli): return exit codes without process.exit

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -28,4 +28,4 @@ import './commands/stream.js';
 
 // Run
 import { run } from './router.js';
-await run(process.argv);
+process.exitCode = await run(process.argv);

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -55,7 +55,7 @@ export async function run(argv) {
 
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     printHelp();
-    process.exit(0);
+    return 0;
   }
 
   const cmdName = args[0];
@@ -64,7 +64,7 @@ export async function run(argv) {
   if (!cmd) {
     console.error(`Unknown command: ${cmdName}`);
     console.error('Run "tv --help" for a list of commands.');
-    process.exit(1);
+    return 1;
   }
 
   // Handle subcommands (e.g., tv pine get)
@@ -73,13 +73,13 @@ export async function run(argv) {
     const subName = args[1];
     if (!subName || subName === '--help' || subName === '-h') {
       printCommandHelp(cmdName, cmd);
-      process.exit(0);
+      return 0;
     }
     const sub = cmd.subcommands.get(subName);
     if (!sub) {
       console.error(`Unknown subcommand: ${cmdName} ${subName}`);
       printCommandHelp(cmdName, cmd);
-      process.exit(1);
+      return 1;
     }
     handler = sub.handler;
     options = sub.options || {};
@@ -101,11 +101,11 @@ export async function run(argv) {
             console.log(`  ${flag.padEnd(20)}${v.description || ''}`);
           }
         }
-        process.exit(0);
+        return 0;
       }
-      await execute(handler, values, positionals);
+      return await execute(handler, values, positionals);
     } catch (err) {
-      handleError(err);
+      return handleError(err);
     }
   } else {
     handler = cmd.handler;
@@ -119,11 +119,11 @@ export async function run(argv) {
       });
       if (values.help) {
         printCommandHelp(cmdName, cmd);
-        process.exit(0);
+        return 0;
       }
-      await execute(handler, values, positionals);
+      return await execute(handler, values, positionals);
     } catch (err) {
-      handleError(err);
+      return handleError(err);
     }
   }
 }
@@ -132,9 +132,9 @@ async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
     console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    return 0;
   } catch (err) {
-    handleError(err);
+    return handleError(err);
   }
 }
 
@@ -143,8 +143,8 @@ function handleError(err) {
   // Connection failures get exit code 2
   if (/CDP|connection|ECONNREFUSED|not running/i.test(message)) {
     console.error(JSON.stringify({ success: false, error: message }, null, 2));
-    process.exit(2);
+    return 2;
   }
   console.error(JSON.stringify({ success: false, error: message }, null, 2));
-  process.exit(1);
+  return 1;
 }


### PR DESCRIPTION
## Summary
- return explicit numeric exit codes from the CLI router instead of calling process.exit() inside command handlers
- set process.exitCode at the top-level entrypoint so Node can exit cleanly after async work completes
- preserve current CLI behavior while avoiding the Windows native crash path tied to direct process.exit() usage

## Test Plan
- npm run test:cli