### PR TITLE
Fix alert_create stale [class*=alert] selector after TV dialog refactor

### DIFF
--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -23,24 +23,22 @@ export async function create({ condition, price, message }) {
 
   const priceSet = await evaluate(`
     (function() {
-      var inputs = document.querySelectorAll('[class*="alert"] input[type="text"], [class*="alert"] input[type="number"]');
-      for (var i = 0; i < inputs.length; i++) {
-        var label = inputs[i].closest('[class*="row"]')?.querySelector('[class*="label"]');
-        if (label && /value|price/i.test(label.textContent)) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-          nativeSet.call(inputs[i], ${safeString(String(price))});
-          inputs[i].dispatchEvent(new Event('input', { bubbles: true }));
-          inputs[i].dispatchEvent(new Event('change', { bubbles: true }));
-          return true;
-        }
-      }
-      if (inputs.length > 0) {
-        var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-        nativeSet.call(inputs[0], ${safeString(String(price))});
-        inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
-        return true;
-      }
-      return false;
+      // The alert dialog wrapper has no data-name and no class fragment containing "alert"
+      // in current TradingView builds, so [class*="alert"] returns 0 inputs (see issue #168).
+      // Anchor on the "Create" submit button instead — its text is stable across releases —
+      // then find the price input as the first visible numeric-valued input in that dialog.
+      var createBtn = Array.from(document.querySelectorAll('button'))
+        .find(function(b) { return /^create$/i.test(b.textContent.trim()) && b.offsetParent !== null; });
+      var dialog = createBtn && createBtn.closest('div[class*="dialog"]');
+      if (!dialog) return false;
+      var inputs = Array.from(dialog.querySelectorAll('input')).filter(function(i) { return i.offsetParent !== null; });
+      var priceInput = inputs.find(function(i) { return !isNaN(parseFloat(i.value)); });
+      if (!priceInput) return false;
+      var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+      nativeSet.call(priceInput, ${safeString(String(price))});
+      priceInput.dispatchEvent(new Event('input', { bubbles: true }));
+      priceInput.dispatchEvent(new Event('change', { bubbles: true }));
+      return true;
     })()
   `);
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1276,6 +1276,44 @@ val = array.get(a, 5)`;
       const found = await evaluate(`!!document.querySelector('[data-name="alerts"]')`);
       assert.ok(typeof found === 'boolean', 'Alerts button detection works');
     });
+
+    it('alert_create — locate price input via Create-button anchor (issue #168)', async () => {
+      // Open the alert dialog
+      await evaluate(`(function() {
+        var btn = document.querySelector('[data-name="set-alert-button"]')
+          || document.querySelector('[data-name="alerts"]');
+        if (btn) btn.click();
+      })()`);
+      await sleep(800);
+
+      // Apply the same selector strategy used by core/alerts.js create()
+      const result = await evaluate(`(function() {
+        var createBtn = Array.from(document.querySelectorAll('button'))
+          .find(function(b) { return /^create$/i.test(b.textContent.trim()) && b.offsetParent !== null; });
+        var dialog = createBtn && createBtn.closest('div[class*="dialog"]');
+        if (!dialog) return { dialog_found: false };
+        var inputs = Array.from(dialog.querySelectorAll('input')).filter(function(i) { return i.offsetParent !== null; });
+        var priceInput = inputs.find(function(i) { return !isNaN(parseFloat(i.value)); });
+        return {
+          dialog_found: true,
+          price_input_found: !!priceInput,
+          price_input_value: priceInput ? priceInput.value : null,
+        };
+      })()`);
+
+      // Clean up: close the dialog before the next test runs
+      await Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+      await Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape' });
+      await sleep(200);
+
+      // Tolerate a TV plan/UX state where the dialog can't open (e.g. alert quota reached),
+      // but if it does open, the new selector strategy MUST find a numeric price input —
+      // that's the regression we're guarding against.
+      if (result.dialog_found) {
+        assert.ok(result.price_input_found, 'Create-button anchor located the price input in alert dialog');
+        assert.ok(!isNaN(parseFloat(result.price_input_value)), `Price input has numeric value (got: ${result.price_input_value})`);
+      }
+    });
   });
 
   // ─── 9. WATCHLIST (2 tools) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #168.

`alert_create` silently returned `success: false, price_set: false` against the current TradingView Desktop UI: the dialog opened with the symbol's current price pre-filled, the user-supplied `price` was never written, and no alert was created.

Root cause: `src/core/alerts.js:26` required the price input to live inside an ancestor whose class fragment contains `alert`, but a recent TV update changed the dialog wrapper so it has no `data-name` and no class fragment containing `alert`. `[class*="alert"] input` matches 0 nodes when the dialog is open.

## Fix

Anchor on the `Create` submit button (text-matched, stable across releases), walk up to its dialog ancestor, then find the price input as the first visible numeric-valued input inside the dialog. The native React `value` setter and submit-button click are unchanged.

```diff
- var inputs = document.querySelectorAll('[class*="alert"] input[type="text"], [class*="alert"] input[type="number"]');
- // ...label-text matching that no longer matches anything...
+ var createBtn = Array.from(document.querySelectorAll('button'))
+   .find(function(b) { return /^create$/i.test(b.textContent.trim()) && b.offsetParent !== null; });
+ var dialog = createBtn && createBtn.closest('div[class*="dialog"]');
+ if (!dialog) return false;
+ var inputs = Array.from(dialog.querySelectorAll('input')).filter(function(i) { return i.offsetParent !== null; });
+ var priceInput = inputs.find(function(i) { return !isNaN(parseFloat(i.value)); });
```

## Test plan

- [x] Added `tests/e2e.test.js` regression test in the `Alerts` describe block that opens the dialog and verifies the new selector strategy finds a numeric price input. Cleans up via Escape.
- [x] `npm test`: alert suite 4/4 passing (3 pre-existing + 1 new). The 2 unrelated failures in `ui_open_panel` and `replay_stop` exist on `main` (TV API drift / replay state) and are out of scope here.
- [x] Live-tested against TradingView Desktop on macOS — the same JS body now in `alerts.js` was used to successfully create alert `4734304563` (NVDA crossing 215) during diagnosis.

## Scope

One focused change. No behavior change beyond the selector swap. Sibling functions `list` and `deleteAlerts` use different code paths and are not touched.
