### PR TITLE
DEV-607: Add explicit TradingView target selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "tv": "node src/cli/index.js",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/connection.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/connection.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/connection.js
+++ b/src/connection.js
@@ -90,6 +90,22 @@ export async function connect() {
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
+  return selectChartTarget(targets, process.env.TV_TARGET_ID || '');
+}
+
+export function selectChartTarget(targets, requestedTargetId = '') {
+  const requested = String(requestedTargetId || '').trim();
+  if (requested) {
+    const target = targets.find(t => t.id === requested);
+    if (!target) {
+      throw new Error(`TV_TARGET_ID ${requested} was not found in Chrome DevTools targets`);
+    }
+    if (target.type !== 'page') {
+      throw new Error(`TV_TARGET_ID ${requested} is not a page target`);
+    }
+    return target;
+  }
+
   // Prefer targets with tradingview.com/chart in the URL
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -158,6 +158,7 @@ export async function setVisibleRange({ from, to, _deps }) {
 }
 
 export async function scrollToDate({ date }) {
+  const { evaluate } = _resolve();
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectChartTarget } from '../src/connection.js';
+
+const targets = [
+  {
+    id: 'tab-a',
+    type: 'page',
+    url: 'https://www.tradingview.com/chart/AAA/?symbol=VANTAGE%3AEURUSD',
+  },
+  {
+    id: 'tab-b',
+    type: 'page',
+    url: 'https://www.tradingview.com/chart/BBB/?symbol=VANTAGE%3AGBPUSD',
+  },
+];
+
+describe('connection target selection', () => {
+  it('uses TV_TARGET_ID before falling back to first TradingView chart', () => {
+    const selected = selectChartTarget(targets, 'tab-b');
+    assert.equal(selected.id, 'tab-b');
+  });
+
+  it('fails loudly when TV_TARGET_ID does not exist', () => {
+    assert.throws(
+      () => selectChartTarget(targets, 'missing-tab'),
+      /TV_TARGET_ID missing-tab was not found/,
+    );
+  });
+
+  it('keeps legacy first-chart fallback when no target id is requested', () => {
+    const selected = selectChartTarget(targets);
+    assert.equal(selected.id, 'tab-a');
+  });
+});


### PR DESCRIPTION
## Summary
- Add TV_TARGET_ID support so callers can select a specific Chrome DevTools page target when multiple TradingView tabs are open
- Keep the existing first TradingView chart fallback when no target id is provided
- Resolve chart dependencies in scrollToDate before using evaluate
- Add unit coverage for target selection and include it in unit/all test scripts

## Verification
- npm run test:unit: 32 passing
- git diff --check: clean

## Notes
- Full live E2E suite was also run; unrelated TradingView UI/live-state cases failed in draw_clear, ui_open_panel, and replay_stop while the rest passed.