### PR TITLE
Fix path traversal vulnerability in screenshot filename sanitization

### DIFF
--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -13,7 +13,7 @@ export async function captureScreenshot({ region, filename, method } = {}) {
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_');
+  const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_').replace(/\.\./g, '_');
   const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
 
   if (method === 'api') {


### PR DESCRIPTION
Sanitize '..' sequences in the filename parameter to prevent writing screenshot files outside the intended screenshots/ directory.