### PR TITLE
fix(win32): launch MSIX/Store TradingView via ApplicationActivationManager

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -2,8 +2,10 @@
  * Core health/discovery/launch logic.
  */
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
+import { existsSync, writeFileSync, unlinkSync } from 'fs';
 import { execSync, spawn } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 export async function healthCheck() {
   await getClient();
@@ -159,10 +161,100 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
+async function waitForCdp(cdpPort) {
+  for (let i = 0; i < 15; i++) {
+    await new Promise(r => setTimeout(r, 1000));
+    try {
+      const http = await import('http');
+      const ready = await new Promise((resolve) => {
+        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+          let data = '';
+          res.on('data', (chunk) => data += chunk);
+          res.on('end', () => resolve(data));
+        }).on('error', () => resolve(null));
+      });
+      if (ready) return JSON.parse(ready);
+    } catch { /* retry */ }
+  }
+  return null;
+}
+
+// Launch TradingView Desktop installed as an MSIX/Microsoft Store package.
+// The exe lives under WindowsApps (ACL-locked), so spawn() fails with EACCES.
+// IApplicationActivationManager is Windows' supported way to pass arguments
+// (here: --remote-debugging-port) to packaged apps. Returns null if not MSIX.
+export function tryLaunchMsixWindows(cdpPort, killFirst, _execSync = execSync) {
+  const ps = `
+$ErrorActionPreference = 'Stop'
+$pkg = Get-AppxPackage -Name TradingView.Desktop -ErrorAction SilentlyContinue
+if (-not $pkg) { Write-Output 'NOT_INSTALLED'; exit 0 }
+$manifest = [xml](Get-Content (Join-Path $pkg.InstallLocation 'AppxManifest.xml') -Raw)
+$appId = $manifest.Package.Applications.Application.Id
+$aumid = "$($pkg.PackageFamilyName)!$appId"
+if (${killFirst ? '$true' : '$false'}) {
+  Get-Process TradingView -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  Start-Sleep -Milliseconds 1500
+}
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+[Guid("2e941141-7f97-4756-ba1d-9decde894a3d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IApplicationActivationManager {
+  IntPtr ActivateApplication([In] String aumid, [In] String args, [In] int opts, [Out] out UInt32 pid);
+}
+[ComImport, Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+public class ApplicationActivationManager : IApplicationActivationManager {
+  [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType=MethodCodeType.Runtime)]
+  public extern IntPtr ActivateApplication([In] String aumid, [In] String args, [In] int opts, [Out] out UInt32 pid);
+}
+"@
+$mgr = New-Object ApplicationActivationManager
+$procId = 0
+[void]$mgr.ActivateApplication($aumid, "--remote-debugging-port=${cdpPort}", 0, [ref]$procId)
+Write-Output "OK $procId $aumid"
+`;
+  const scriptPath = join(tmpdir(), `tv-msix-launch-${process.pid}-${Date.now()}.ps1`);
+  writeFileSync(scriptPath, ps, 'utf8');
+  try {
+    const out = _execSync(
+      `powershell -NoProfile -ExecutionPolicy Bypass -File "${scriptPath}"`,
+      { timeout: 15000 }
+    ).toString().trim();
+    if (out.includes('NOT_INSTALLED')) return null;
+    const m = out.match(/^OK\s+(\d+)\s+(\S+)/m);
+    if (!m) return null;
+    return { pid: parseInt(m[1], 10), aumid: m[2] };
+  } catch {
+    return null;
+  } finally {
+    try { unlinkSync(scriptPath); } catch { /* ignore */ }
+  }
+}
+
 export async function launch({ port, kill_existing } = {}) {
   const cdpPort = port || 9222;
   const killFirst = kill_existing !== false;
   const platform = process.platform;
+
+  if (platform === 'win32') {
+    const msix = tryLaunchMsixWindows(cdpPort, killFirst);
+    if (msix) {
+      const info = await waitForCdp(cdpPort);
+      if (info) {
+        return {
+          success: true, platform, binary: `msix:${msix.aumid}`, pid: msix.pid,
+          cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
+          browser: info.Browser, user_agent: info['User-Agent'],
+        };
+      }
+      return {
+        success: true, platform, binary: `msix:${msix.aumid}`, pid: msix.pid,
+        cdp_port: cdpPort, cdp_ready: false,
+        warning: 'TradingView (MSIX) launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
+      };
+    }
+  }
 
   const pathMap = {
     darwin: [
@@ -208,7 +300,10 @@ export async function launch({ port, kill_existing } = {}) {
   }
 
   if (!tvPath) {
-    throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
+    const hint = platform === 'win32'
+      ? ` If installed from the Microsoft Store, the MSIX detection above should have caught it — open an issue at https://github.com/tradesdontlie/tradingview-mcp/issues with the output of "Get-AppxPackage TradingView.Desktop".`
+      : '';
+    throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}.${hint}`);
   }
 
   if (killFirst) {
@@ -222,26 +317,13 @@ export async function launch({ port, kill_existing } = {}) {
   const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
   child.unref();
 
-  for (let i = 0; i < 15; i++) {
-    await new Promise(r => setTimeout(r, 1000));
-    try {
-      const http = await import('http');
-      const ready = await new Promise((resolve) => {
-        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
-          let data = '';
-          res.on('data', (chunk) => data += chunk);
-          res.on('end', () => resolve(data));
-        }).on('error', () => resolve(null));
-      });
-      if (ready) {
-        const info = JSON.parse(ready);
-        return {
-          success: true, platform, binary: tvPath, pid: child.pid,
-          cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
-          browser: info.Browser, user_agent: info['User-Agent'],
-        };
-      }
-    } catch { /* retry */ }
+  const info = await waitForCdp(cdpPort);
+  if (info) {
+    return {
+      success: true, platform, binary: tvPath, pid: child.pid,
+      cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
+      browser: info.Browser, user_agent: info['User-Agent'],
+    };
   }
 
   return {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -142,12 +142,38 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
     it('tv_launch — auto-detect binary (verify path resolution only)', async () => {
       // tv_launch is destructive (kills TradingView), so we only test path detection
       const { existsSync } = await import('fs');
-      const paths = [
-        '/Applications/TradingView.app/Contents/MacOS/TradingView',
-        `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
-      ];
-      const found = paths.some(p => existsSync(p));
-      assert.ok(found, 'TradingView binary found on disk');
+      const { execSync } = await import('child_process');
+      const pathsByPlatform = {
+        darwin: [
+          '/Applications/TradingView.app/Contents/MacOS/TradingView',
+          `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
+        ],
+        win32: [
+          `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
+          `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
+          `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+        ],
+        linux: [
+          '/opt/TradingView/tradingview',
+          '/opt/TradingView/TradingView',
+          `${process.env.HOME}/.local/share/TradingView/TradingView`,
+          '/usr/bin/tradingview',
+          '/snap/tradingview/current/tradingview',
+        ],
+      };
+      const paths = pathsByPlatform[process.platform] || [];
+      let found = paths.some(p => existsSync(p));
+      // Windows also installs via the Microsoft Store as an MSIX package.
+      if (!found && process.platform === 'win32') {
+        try {
+          const out = execSync(
+            'powershell -NoProfile -Command "if (Get-AppxPackage -Name TradingView.Desktop -ErrorAction SilentlyContinue) { \'YES\' } else { \'NO\' }"',
+            { timeout: 5000 }
+          ).toString().trim();
+          if (out.includes('YES')) found = true;
+        } catch { /* ignore */ }
+      }
+      assert.ok(found, 'TradingView binary found on disk (or MSIX on Windows)');
     });
   });
 

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -1,0 +1,54 @@
+/**
+ * Tests for the Windows MSIX launcher fallback used by tv_launch.
+ * The real activation can only run on a Windows machine with TradingView
+ * installed from the Microsoft Store, so we stub execSync and assert
+ * tryLaunchMsixWindows() parses both outcomes correctly.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { tryLaunchMsixWindows } from '../src/core/health.js';
+
+function fakeExecSync(stdout) {
+  return () => Buffer.from(stdout);
+}
+
+function throwingExecSync(message) {
+  return () => { throw new Error(message); };
+}
+
+describe('tryLaunchMsixWindows()', () => {
+  it('returns null when TradingView is not installed as an MSIX package', () => {
+    const result = tryLaunchMsixWindows(9222, true, fakeExecSync('NOT_INSTALLED\n'));
+    assert.equal(result, null);
+  });
+
+  it('parses { pid, aumid } from a successful activation', () => {
+    const stdout = 'OK 17188 TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop\n';
+    const result = tryLaunchMsixWindows(9222, true, fakeExecSync(stdout));
+    assert.deepEqual(result, {
+      pid: 17188,
+      aumid: 'TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop',
+    });
+  });
+
+  it('returns null when PowerShell errors (e.g. COM activation fails)', () => {
+    const result = tryLaunchMsixWindows(9222, true, throwingExecSync('Access denied'));
+    assert.equal(result, null);
+  });
+
+  it('returns null on unexpected stdout that does not match either pattern', () => {
+    const result = tryLaunchMsixWindows(9222, true, fakeExecSync('weird unparseable output'));
+    assert.equal(result, null);
+  });
+
+  it('respects the killFirst flag in the generated PowerShell (smoke check)', () => {
+    let captured = null;
+    const exec = (cmd, opts) => {
+      captured = { cmd, opts };
+      return Buffer.from('NOT_INSTALLED');
+    };
+    tryLaunchMsixWindows(9222, false, exec);
+    assert.ok(captured, 'execSync was called');
+    assert.match(captured.cmd, /powershell .* -File /, 'invokes powershell with a script file');
+  });
+});


### PR DESCRIPTION
## Summary

`tv_launch` currently fails for any user who installed TradingView Desktop from the Microsoft Store / .msix. The exe lives under `C:\Program Files\WindowsApps\TradingView.Desktop_<ver>_x64__<hash>\`, which is ACL-locked — `child_process.spawn()` returns `EACCES` ("Access is denied"). The existing launcher only checks three classic exe paths and throws *TradingView not found on win32*.

This PR adds a Windows fallback that:

1. Probes for the MSIX install via `Get-AppxPackage -Name TradingView.Desktop`.
2. If found, launches it through Windows' `IApplicationActivationManager` COM interface — the **documented** way to pass arguments (here `--remote-debugging-port=9222`) to packaged apps. `Start-Process`, `spawn`, and `ShellExecute` on the WindowsApps exe all fail or strip args; `ActivateApplication` works.
3. Falls through to the existing classic-exe search if no MSIX package is found. Non-MSIX installs and non-Windows platforms are untouched.

## Verification

Tested on `TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj` (Microsoft Store, Electron 38 / Chrome 140):

```
{
  "success": true,
  "platform": "win32",
  "binary": "msix:TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop",
  "cdp_port": 9222,
  "browser": "Chrome/140.0.7339.133",
  "user_agent": "... TradingView/3.1.0 ... Electron/38.2.2 ..."
}
```

`tv_health_check` then returns `cdp_connected: true` with the expected `chart_symbol` and `api_available: true`.

> Note: this directly contradicts PR #114, which claims the Store sandbox *"ignores `--remote-debugging-port=9222` and does not propagate `ELECTRON_REMOTE_DEBUGGING_PORT`, so CDP port 9222 never opens."* That's not true for current 3.1.0 — the flag is honored when delivered via `ActivateApplication`. The reason direct `spawn()` fails is WindowsApps ACLs, not flag suppression. A code fix is feasible; the docs-only workaround in #114 isn't needed.

## Why this approach vs. other open MSIX PRs

There are several open PRs in this area (#52, #73, #76, #79, #93, #100, #103, #110, #135, #153, #159). Most use `Get-AppxPackage` to **locate** the exe but then still try to `spawn()` it from `WindowsApps`, which fails on a properly ACL'd Store install (or only works if the user disabled WindowsApps ACLs). `ApplicationActivationManager` is the supported path; this is the only one I've seen tested end-to-end against a current build.

## Test changes

- `tests/launch.test.js` (new): unit tests for `tryLaunchMsixWindows()` with stubbed `execSync` covering the `NOT_INSTALLED` branch, successful activation parse, PowerShell error, unparseable stdout, and the `killFirst` smoke check. **5/5 pass.**
- `tests/e2e.test.js` "tv_launch — auto-detect binary": made platform-aware. The existing test only checked macOS paths and therefore failed unconditionally on Windows and Linux on `main` (regardless of any launcher logic). Now checks the correct paths per platform and falls back to `Get-AppxPackage` on Windows.

## Refactor

The CDP-ready polling loop is now a `waitForCdp(cdpPort)` helper so the classic and MSIX paths share it instead of duplicating ~25 lines.

## Scope

Per `CONTRIBUTING.md`: this is "improving reliability of existing tools (better selectors, error handling, timeouts)." It does not connect directly to TradingView's servers, scrape data, or enable automated trading. No new runtime dependencies — only `child_process.execSync` (already imported).

## Test plan

- [x] `npm test` (`tests/pine_analyze.test.js` and unaffected suites still pass on Windows)
- [x] `node --test tests/launch.test.js` → 5/5 pass
- [x] `node --test --test-name-pattern="tv_launch" tests/e2e.test.js` → pass on Windows MSIX install
- [x] Manual end-to-end against TradingView.Desktop 3.1.0.7818 from the Microsoft Store → `tv_health_check` returns `cdp_connected: true`
- [ ] Reviewer to verify against a classic (non-MSIX) Windows install that the fallthrough still works (should be unchanged — code path untouched)