### PR TITLE
Fix alert_create by using internal pricealerts REST API

### DIFF
--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,81 +1,127 @@
 /**
  * Core alert logic.
+ *
+ * create() and list() use TradingView's internal pricealerts.tradingview.com REST API
+ * (same backend the desktop UI uses). Discovered by intercepting the network call from
+ * the "Create alert" dialog. The DOM-fallback path that earlier shipped here never
+ * matched the real alert dialog selectors and silently no-op'd.
  */
-import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
+import { evaluate as _evaluate, evaluateAsync as _evaluateAsync, safeString, requireFinite } from '../connection.js';
 
-export async function create({ condition, price, message }) {
-  const opened = await evaluate(`
-    (function() {
-      var btn = document.querySelector('[aria-label="Create Alert"]')
-        || document.querySelector('[data-name="alerts"]');
-      if (btn) { btn.click(); return true; }
-      return false;
-    })()
-  `);
+const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
+const CREATE_URL = 'https://pricealerts.tradingview.com/create_alert';
+const LIST_URL = 'https://pricealerts.tradingview.com/list_alerts';
 
-  if (!opened) {
-    const client = await getClient();
-    await client.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 1, key: 'a', code: 'KeyA', windowsVirtualKeyCode: 65 });
-    await client.Input.dispatchKeyEvent({ type: 'keyUp', key: 'a', code: 'KeyA' });
-  }
-
-  await new Promise(r => setTimeout(r, 1000));
-
-  const priceSet = await evaluate(`
-    (function() {
-      var inputs = document.querySelectorAll('[class*="alert"] input[type="text"], [class*="alert"] input[type="number"]');
-      for (var i = 0; i < inputs.length; i++) {
-        var label = inputs[i].closest('[class*="row"]')?.querySelector('[class*="label"]');
-        if (label && /value|price/i.test(label.textContent)) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-          nativeSet.call(inputs[i], ${safeString(String(price))});
-          inputs[i].dispatchEvent(new Event('input', { bubbles: true }));
-          inputs[i].dispatchEvent(new Event('change', { bubbles: true }));
-          return true;
-        }
-      }
-      if (inputs.length > 0) {
-        var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-        nativeSet.call(inputs[0], ${safeString(String(price))});
-        inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
-        return true;
-      }
-      return false;
-    })()
-  `);
-
-  if (message) {
-    await evaluate(`
-      (function() {
-        var textarea = document.querySelector('[class*="alert"] textarea')
-          || document.querySelector('textarea[placeholder*="message"]');
-        if (textarea) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
-          nativeSet.call(textarea, ${JSON.stringify(message)});
-          textarea.dispatchEvent(new Event('input', { bubbles: true }));
-        }
-      })()
-    `);
-  }
-
-  await new Promise(r => setTimeout(r, 500));
-  const created = await evaluate(`
-    (function() {
-      var btns = document.querySelectorAll('button[data-name="submit"], button');
-      for (var i = 0; i < btns.length; i++) {
-        if (/^create$/i.test(btns[i].textContent.trim())) { btns[i].click(); return true; }
-      }
-      return false;
-    })()
-  `);
-
-  return { success: !!created, price, condition, message: message || '(none)', price_set: !!priceSet, source: 'dom_fallback' };
+function _resolve(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    evaluateAsync: deps?.evaluateAsync || _evaluateAsync,
+  };
 }
 
-export async function list() {
-  // Use pricealerts REST API — returns structured data with alert_id, symbol, price, conditions
+/**
+ * Build the alert payload shape the pricealerts service expects. Shape was reverse-engineered
+ * by hooking fetch in the page context and triggering the native Create-alert dialog.
+ */
+function buildPayload({ symbol, price, message, resolution, frequency, expirationDays }) {
+  const symbolWrapped = '=' + JSON.stringify({
+    adjustment: 'splits',
+    'currency-id': 'USD',
+    session: 'extended',
+    symbol,
+  });
+  return {
+    payload: {
+      conditions: [{
+        type: 'cross',
+        frequency,
+        series: [{ type: 'barset' }, { type: 'value', value: price }],
+        resolution,
+      }],
+      symbol: symbolWrapped,
+      resolution,
+      message: message || `${symbol} crossing ${price}`,
+      sound_file: 'alert/fired',
+      sound_duration: 0,
+      popup: true,
+      auto_deactivate: true,
+      email: false,
+      sms_over_email: false,
+      mobile_push: true,
+      web_hook: null,
+      name: null,
+      expiration: new Date(Date.now() + expirationDays * 86400 * 1000).toISOString(),
+      active: true,
+      ignore_warnings: true,
+    },
+  };
+}
+
+export async function create({ condition, price, message, symbol, resolution, frequency, expiration_days, _deps } = {}) {
+  const { evaluate, evaluateAsync } = _resolve(_deps);
+
+  const priceNum = requireFinite(price, 'price');
+  const expDays = expiration_days != null ? requireFinite(expiration_days, 'expiration_days') : 30;
+  const freq = frequency || 'on_first_fire';
+
+  let sym = symbol;
+  let res = resolution;
+  if (!sym || !res) {
+    const state = await evaluate(`
+      (function() {
+        try {
+          var chart = ${CHART_API};
+          return { symbol: chart.symbol(), resolution: chart.resolution() };
+        } catch(e) { return { error: e.message }; }
+      })()
+    `);
+    if (state?.error || !state?.symbol) throw new Error('Cannot read current chart symbol/resolution: ' + (state?.error || 'unknown'));
+    sym = sym || state.symbol;
+    res = res || state.resolution || '1';
+  }
+
+  // Note: `condition` is accepted for backwards compat but the underlying API uses
+  // type:cross + cross_interval which fires on any crossing in either direction.
+  void condition;
+
+  const payload = buildPayload({ symbol: sym, price: priceNum, message, resolution: res, frequency: freq, expirationDays: expDays });
+
   const result = await evaluateAsync(`
-    fetch('https://pricealerts.tradingview.com/list_alerts', { credentials: 'include' })
+    fetch(${safeString(CREATE_URL)}, {
+      method: 'POST',
+      credentials: 'include',
+      body: ${safeString(JSON.stringify(payload))}
+    })
+      .then(function(r) { return r.text().then(function(t) { return { status: r.status, body: t }; }); })
+      .catch(function(e) { return { error: e.message }; })
+  `);
+
+  if (result?.error) {
+    return { success: false, source: 'internal_api', error: result.error, price: priceNum, symbol: sym };
+  }
+
+  let parsed = null;
+  try { parsed = JSON.parse(result.body); } catch {}
+  const ok = parsed?.s === 'ok';
+
+  return {
+    success: ok,
+    source: 'internal_api',
+    symbol: sym,
+    resolution: res,
+    price: priceNum,
+    condition: 'crossing',
+    message: message || `${sym} crossing ${price}`,
+    expiration_days: expDays,
+    alert_id: parsed?.r?.id || null,
+    error: ok ? null : (parsed?.errmsg || result.body?.slice(0, 200)),
+  };
+}
+
+export async function list({ _deps } = {}) {
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    fetch(${safeString(LIST_URL)}, { credentials: 'include' })
       .then(function(r) { return r.json(); })
       .then(function(data) {
         if (data.s !== 'ok' || !Array.isArray(data.r)) return { alerts: [], error: data.errmsg || 'Unexpected response' };
@@ -103,7 +149,8 @@ export async function list() {
   return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
 }
 
-export async function deleteAlerts({ delete_all }) {
+export async function deleteAlerts({ delete_all, _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   if (delete_all) {
     const result = await evaluate(`
       (function() {

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -3,12 +3,16 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/alerts.js';
 
 export function registerAlertTools(server) {
-  server.tool('alert_create', 'Create a price alert via the TradingView alert dialog', {
-    condition: z.string().describe('Alert condition (e.g., "crossing", "greater_than", "less_than")'),
+  server.tool('alert_create', 'Create a price alert via the TradingView internal API (pricealerts.tradingview.com). Uses the current chart symbol + resolution unless overridden.', {
+    condition: z.string().describe('Alert condition (accepted for compat; underlying API fires on any crossing in either direction)'),
     price: z.coerce.number().describe('Price level for the alert'),
-    message: z.string().optional().describe('Alert message'),
-  }, async ({ condition, price, message }) => {
-    try { return jsonResult(await core.create({ condition, price, message })); }
+    message: z.string().optional().describe('Alert message (defaults to "<symbol> crossing <price>")'),
+    symbol: z.string().optional().describe('Symbol like "BATS:RDDT" (default: current chart symbol)'),
+    resolution: z.string().optional().describe('Resolution string like "1", "5", "60", "D" (default: current chart resolution)'),
+    frequency: z.enum(['on_first_fire', 'once_per_bar', 'once_per_bar_close', 'once_per_minute']).optional().describe('Fire frequency (default: on_first_fire)'),
+    expiration_days: z.coerce.number().optional().describe('Days until expiration (default: 30)'),
+  }, async (args) => {
+    try { return jsonResult(await core.create(args)); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 


### PR DESCRIPTION
## Summary

`alert_create` has been silently broken — every call returns `success: false` with `price_set: false` and no alert is created. Root cause: the DOM-fallback in `src/core/alerts.js` queries `[class*=\"alert\"] input[type=\"text\"|number]` but TV's real alert dialog uses scoped hash classes (e.g. `submitBtn-m9pp3wEB`), so neither the price input nor the Create button is matched.

This PR swaps the DOM scrape for a direct `POST https://pricealerts.tradingview.com/create_alert` — the same endpoint TV's own dialog hits when the user clicks **Create**.

## How the payload shape was found

Hooked `window.fetch` in the page context, then clicked the native **Create alert** button in the toolbar and captured the outgoing request. The wrapped envelope and field names didn't match what the previous code was trying:

```jsonc
{
  \"payload\": {
    \"conditions\": [{                                  // plural array, not \"condition\"
      \"type\": \"cross\",
      \"frequency\": \"on_first_fire\",
      \"series\": [{ \"type\": \"barset\" }, { \"type\": \"value\", \"value\": 140.65 }],
      \"resolution\": \"1\"
    }],
    \"symbol\": \"={\\\"adjustment\\\":\\\"splits\\\",\\\"currency-id\\\":\\\"USD\\\",\\\"session\\\":\\\"extended\\\",\\\"symbol\\\":\\\"BATS:RDDT\\\"}\",
    \"resolution\": \"1\",
    \"message\": \"...\",
    \"expiration\": \"2026-06-24T18:09:21.000Z\",       // ISO 8601 string, not unix
    \"active\": true,
    \"popup\": true,
    \"mobile_push\": true,
    \"sound_file\": \"alert/fired\",
    \"sound_duration\": 0,
    \"auto_deactivate\": true,
    \"email\": false,
    \"sms_over_email\": false,
    \"web_hook\": null,
    \"name\": null,
    \"ignore_warnings\": true
  }
}
```

Two gotchas worth flagging:
- Body is **raw JSON without `Content-Type: application/json`**. Setting that header triggers a CORS preflight that fails. The browser treats the unset Content-Type as `text/plain` → simple request → no preflight.
- The `symbol` field is `=` + `JSON.stringify({...})` with `adjustment`, `currency-id`, `session`, `symbol`. Plain `\"BATS:RDDT\"` is rejected with `invalid_request`.

## Behavior changes

- `alert_create` now actually creates alerts (verified against 4 levels on `BATS:RDDT`).
- Adds optional params: `symbol`, `resolution`, `frequency`, `expiration_days`. When omitted, symbol + resolution come from the current chart via `${CHART_API}.symbol()` / `.resolution()`.
- Returns `alert_id`, `expiration_days`, and `source: 'internal_api'` on success.
- Uses `safeString` + `requireFinite` for the same injection / NaN guards already used across the codebase.
- `list()` and `deleteAlerts()` are unchanged.
- `condition` param is still accepted for backwards compat but is a no-op — the underlying API uses `type:cross` + `cross_interval` which fires on any crossing in either direction.

## Test plan

- [x] `node -e \"import('./src/core/alerts.js')...\"` — module loads, exports `create`, `list`, `deleteAlerts`
- [x] Live: created 4 alerts on RDDT (140.65 / 145 / 150 / 153), confirmed via `alert_list` with returned `alert_id` matching
- [x] Live: omitting `symbol` / `resolution` correctly picks them up from the current chart
- [ ] Existing e2e tests in `tests/e2e.test.js` still pass (the existing alert tests only assert button existence — should not be affected)

## Not in scope

- `alert_delete` for individual alerts — pricealerts service does not expose `/remove_alert` / `/delete_alert` (returns `no_such_endpoint`). Would need a separate session of fetch-hooking to find the real delete endpoint. `delete_all` via context menu is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)