### PR TITLE
launch: detect TradingView MSIX install on Windows

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -207,6 +207,20 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  // Windows: TradingView is distributed as MSIX (UWP) only; resolve the per-version
+  // install location dynamically via Get-AppxPackage. The exe runs FullTrust so
+  // spawning it directly with --remote-debugging-port works.
+  if (!tvPath && platform === 'win32') {
+    try {
+      const cmd = 'powershell.exe -NoProfile -NonInteractive -Command "(Get-AppxPackage -Name TradingView.Desktop).InstallLocation"';
+      const installLocation = execSync(cmd, { timeout: 5000 }).toString().trim();
+      if (installLocation) {
+        const candidate = `${installLocation}\\TradingView.exe`;
+        if (existsSync(candidate)) tvPath = candidate;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath) {
     throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
   }


### PR DESCRIPTION
## Problem

On Windows, `tv_launch` fails with `TradingView not found` even when TradingView Desktop is correctly installed, because the auto-detection in `launch()` only checks Win32 installer paths:

- `%LOCALAPPDATA%\TradingView\TradingView.exe`
- `%PROGRAMFILES%\TradingView\TradingView.exe`
- `%PROGRAMFILES(X86)%\TradingView\TradingView.exe`

TradingView is distributed for Windows **exclusively as an MSIX package** — the [official download page](https://www.tradingview.com/desktop/) serves a single `.msix` file, and `winget install TradingView.TradingViewDesktop` installs the same MSIX. None of the candidate paths ever resolve, so Windows users currently have to launch manually with a hardcoded `C:\Program Files\WindowsApps\TradingView.Desktop_<version>_x64__n534cwy3pjxzj\TradingView.exe` path — which itself breaks on every TradingView update because the version part changes.

## Solution

Add a Windows-specific fallback in `launch()` after the existing `where TradingView.exe` lookup that uses `Get-AppxPackage TradingView.Desktop` to resolve the install location dynamically. Survives MSIX version bumps.

The TradingView MSIX declares `EntryPoint="Windows.FullTrustApplication"`, so spawning its `TradingView.exe` with `--remote-debugging-port=9222` from outside the package container works exactly like a Win32 install: the exe accepts CLI args normally, and only directory enumeration (not read/execute on individual files) is restricted under the WindowsApps ACL.

The 14-line addition is purely a new code path after the existing fallbacks — it cannot affect other platforms or the existing Win32 lookups.

## Test plan

- [x] Manually verified on Windows 11 with TradingView Desktop 3.1.0.7818 installed from Microsoft Store:
  - `tv_launch` resolves to `C:\Program Files\WindowsApps\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\TradingView.exe`
  - TradingView boots, CDP responds on `http://127.0.0.1:9222/json/version`
  - `tv_health_check` returns `cdp_connected: true` with active chart info
- [x] `npm test` results unchanged vs `main` — pre-existing environment-dependent failures (`cli pine check`, replay e2e) reproduce on a clean checkout without this patch (verified via `git stash` of the patch and re-running). This change adds only new code; no existing path is modified.

## Notes

Happy to refactor if you'd prefer a different shape — e.g., extracting the PowerShell probe into its own helper, returning more diagnostic info, or adding a unit test that mocks the AppxPackage path resolution.
