### PR TITLE
Fix Windows MSIX/Store install detection in launch script

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -17,9 +17,11 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
+REM Check MSIX / Windows Store installs via Get-AppxPackage
+REM (dir /s on WindowsApps fails with Access Denied for non-admin; Get-AppxPackage
+REM  resolves the current install location regardless of version suffix)
 if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+    for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$p = Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue; if ($p) { Join-Path $p.InstallLocation 'TradingView.exe' }"`) do set "TV_EXE=%%i"
 )
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"


### PR DESCRIPTION
## Summary

The Windows launch script (`scripts/launch_tv_debug.bat`) fails to find TradingView on machines where it was installed from the Microsoft Store / via MSIX — which is the default install channel on current Windows.

The existing detection walks `%PROGRAMFILES%\WindowsApps\TradingView*\` with `dir /s /b`. That folder has an ACL that denies *enumeration* to non-admin users, even though individual files inside are readable when accessed by exact path. So `dir /s` silently returns Access Denied, the `for /f` loop yields nothing, and the script bails with `TradingView not found` — forcing users to look up their MSIX path and launch manually.

## Fix

Resolve the install location via `Get-AppxPackage -Name 'TradingView.Desktop'` instead. This is the documented way to query MSIX install paths, works without elevation, and is version-agnostic (so TradingView auto-updates don''t break it).

```bat
for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$p = Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue; if ($p) { Join-Path $p.InstallLocation 'TradingView.exe' }"`) do set "TV_EXE=%%i"
```

The non-MSIX checks (`%LOCALAPPDATA%\TradingView`, `%PROGRAMFILES%\TradingView`, `where TradingView.exe`) are preserved as-is, so users with portable / non-Store installs are unaffected.

## Repro / verification

Tested on Windows 11 Home 26200 with TradingView Desktop 3.1.0.7818 installed from the Microsoft Store:

- **Before:** `Error: TradingView not found. Checked: %LOCALAPPDATA%\TradingView, %PROGRAMFILES%\TradingView, WindowsApps`
- **After:** `Found TradingView at: C:\Program Files\WindowsApps\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\TradingView.exe` → launches → CDP comes up on :9222 → `/json/version` returns the Electron 38.2.2 build.

## Test plan

- [ ] Run `scripts\launch_tv_debug.bat` on a Windows machine with TradingView installed from the Microsoft Store / MSIX. Confirm it locates `TradingView.exe` and CDP becomes available on :9222.
- [ ] Run on a Windows machine with a non-MSIX install (`%LOCALAPPDATA%\TradingView\TradingView.exe`). Confirm the existing path still wins (MSIX check is skipped because `TV_EXE` is already set).
- [ ] Run on a Windows machine with no TradingView installed. Confirm it still reports the "not found" error cleanly.

---

Note: the `ERROR: Input redirection is not supported` lines that appear when the script is invoked from PowerShell come from `taskkill`/`timeout` reacting to PowerShell''s non-interactive stdin — pre-existing, unrelated to this change. Running from `cmd` directly is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)