### PR TITLE
fix: correct tool count in CLAUDE.md from 68 to 78

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+78 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 


### PR DESCRIPTION
CLAUDE.md header said 68 tools but README, server.js and SETUP_GUIDE all say 78. This fixes the inconsistency.