### PR TITLE
Add Windows AppX/Store detection to tv_launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,33 @@
 
 68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
+## Quick-Connect (This Machine)
+
+TradingView Desktop is installed as a **Microsoft Store (AppX) package**.
+Node.js is at `%LOCALAPPDATA%\Programs\nodejs`.
+
+To connect in one shot, run these PowerShell commands in sequence:
+
+```powershell
+# 1. Kill any existing instance (optional)
+Stop-Process -Name "TradingView" -Force -ErrorAction SilentlyContinue
+
+# 2. Launch with CDP enabled
+$tvExe = (Get-AppxPackage -Name '*TradingView*').InstallLocation + '\TradingView.exe'
+Start-Process -FilePath $tvExe -ArgumentList "--remote-debugging-port=9222"
+
+# 3. Wait for CDP to be ready (poll up to 15s)
+for ($i = 0; $i -lt 15; $i++) {
+  Start-Sleep -Seconds 1
+  try { Invoke-WebRequest -Uri "http://localhost:9222/json/version" -UseBasicParsing -TimeoutSec 2 | Out-Null; break } catch {}
+}
+
+# 4. Verify health check
+node -e "import('./src/core/health.js').then(m => m.healthCheck()).then(r => console.log(JSON.stringify(r, null, 2))).catch(e => console.error(e.message))"
+```
+
+The `tv_launch` tool also handles this automatically (including AppX detection).
+
 ## Decision Tree — Which Tool When
 
 ### "What's on my chart right now?"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -189,6 +189,18 @@ export async function launch({ port, kill_existing } = {}) {
     if (p && existsSync(p)) { tvPath = p; break; }
   }
 
+  // Windows: detect Microsoft Store / AppX installations
+  if (!tvPath && platform === 'win32') {
+    try {
+      const psCmd = `powershell -NoProfile -Command "(Get-AppxPackage -Name '*TradingView*').InstallLocation"`;
+      const appxPath = execSync(psCmd, { timeout: 5000 }).toString().trim();
+      if (appxPath) {
+        const candidate = `${appxPath}\\TradingView.exe`;
+        if (existsSync(candidate)) tvPath = candidate;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath) {
     try {
       const cmd = platform === 'win32' ? 'where TradingView.exe' : 'which tradingview';


### PR DESCRIPTION
## Summary

- **`tv_launch` now auto-detects Microsoft Store (AppX) installs on Windows.** TradingView installed via the Microsoft Store lives under `C:\Program Files\WindowsApps` and is invisible to the existing path-based and `where` lookups. This adds a `Get-AppxPackage` fallback that resolves the install location automatically.
- **Added Quick-Connect section to CLAUDE.md** documenting the AppX launch sequence for faster session startup.

## Why

Users who install TradingView Desktop from the Microsoft Store (rather than the standalone installer) can't use `tv_launch` — it fails with "TradingView not found" because WindowsApps paths aren't in the standard search list and `where` can't find them.

## Changes

- `src/core/health.js`: Added AppX detection block between the static path search and the `where`/`which` fallback. Uses PowerShell `Get-AppxPackage` to resolve the install path.
- `CLAUDE.md`: Added Quick-Connect section with PowerShell commands for AppX launches.
- `package-lock.json`: Lockfile sync (bin entry from existing package.json).

## Test plan

- [ ] Verify `tv_launch` succeeds on a Windows machine with TradingView installed from the Microsoft Store
- [ ] Verify `tv_launch` still works on machines with the standalone installer (existing paths unchanged)
- [ ] Verify `tv_health_check` passes after AppX-detected launch

Generated with [Claude Code](https://claude.com/claude-code)
