### PR TITLE
fix: restore drawing.js DI by adding _resolve() to all exports

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -8,7 +8,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
-import { drawShape } from '../src/core/drawing.js';
+import { drawShape, listDrawings, getProperties, removeOne, clearAll } from '../src/core/drawing.js';
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
 
@@ -281,6 +281,44 @@ describe('drawing.js — sanitized evaluate calls', () => {
     const call = evaluate.calls.find(c => c.includes('createMultipointShape'));
     assert.ok(call, 'createMultipointShape called');
     assert.ok(call.includes('"trend_line"'), 'shape name via safeString');
+  });
+
+  // Regression guard: listDrawings/getProperties/removeOne/clearAll previously
+  // referenced bare `evaluate`/`getChartApi` identifiers that don't exist after
+  // the DI refactor aliased the imports — every call threw ReferenceError at
+  // runtime. These tests would have caught it.
+  it('listDrawings resolves DI deps and calls getAllShapes via apiPath', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const result = await listDrawings({ _deps });
+    assert.equal(result.success, true);
+    const call = evaluate.calls.find(c => c.includes('getAllShapes'));
+    assert.ok(call, 'getAllShapes called');
+    assert.ok(call.includes('window.__api'), 'apiPath from injected getChartApi');
+  });
+
+  it('getProperties resolves DI deps and uses entity_id via safeString', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await getProperties({ entity_id: 'abc123', _deps });
+    const call = evaluate.calls.find(c => c.includes('getShapeById'));
+    assert.ok(call, 'getShapeById called');
+    assert.ok(call.includes('"abc123"'), 'entity_id via safeString');
+  });
+
+  it('removeOne resolves DI deps and uses entity_id via safeString', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await removeOne({ entity_id: 'abc123', _deps });
+    const call = evaluate.calls.find(c => c.includes('removeEntity'));
+    assert.ok(call, 'removeEntity callsite present');
+    assert.ok(call.includes('"abc123"'), 'entity_id via safeString');
+  });
+
+  it('clearAll resolves DI deps and calls removeAllShapes via apiPath', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const result = await clearAll({ _deps });
+    assert.equal(result.success, true);
+    const call = evaluate.calls.find(c => c.includes('removeAllShapes'));
+    assert.ok(call, 'removeAllShapes called');
+    assert.ok(call.includes('window.__api'), 'apiPath from injected getChartApi');
   });
 });
 


### PR DESCRIPTION
## Summary

Four of the five exports in `src/core/drawing.js` throw `ReferenceError: getChartApi is not defined` at runtime. Affects `draw_list`, `draw_get_properties`, `draw_remove_one`, and `draw_clear` MCP tools — only `draw_shape` works

## Root cause

Commit f23eb1b ("Add DI and full test coverage for chart.js and drawing.js sanitization") aliased the imports as `_evaluate` / `_getChartApi` so `drawShape` could call `_resolve(_deps)` and re-bind the original names into scope. The four other exports were never updated, they still reference the bare `getChartApi` / `evaluate` identifiers, which no longer exist after the alias rename.

```js
// drawShape (works) — line 11
const { evaluate, getChartApi } = _resolve(_deps);

// listDrawings / getProperties / removeOne / clearAll (broken)
const apiPath = await getChartApi();  // ← ReferenceError
```

The regression slipped through because `sanitization.test.js` only covered `drawShape`.

## Fix

- Add `_deps` parameter and `_resolve()` call to the four broken functions, mirroring `drawShape`
- Add regression tests for each of the four, asserting they execute through to `evaluate()` with the injected `apiPath`

## Test plan

- [x] `node --test tests/sanitization.test.js` → 70/70 pass (was 66/66 before)
- [x] Reproduced original error against `main`: `draw_list` returns `{success: false, error: "getChartApi is not defined"}`
- [ ] Verify `draw_list` returns shapes after this patch (requires running TradingView desktop + MCP)