### PR TITLE
Add 12hr watchlist scanner: rules.json + CLAUDE.md workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,28 @@ Claude Code ←→ MCP Server (stdio) ←→ CDP (localhost:9222) ←→ Trading
 ```
 
 Pine graphics path: `study._graphics._primitivesCollection.dwglines.get('lines').get(false)._primitivesDataById`
+
+## 12 Hr Update — Custom Watchlist Scanner
+
+When the user asks for a "12 hr update" or "twelve hour update", follow this workflow:
+
+### Step-by-Step
+1. Read `rules.json` in the project root to get the watchlist symbols, timeframes, and bias criteria
+2. For each symbol in `watchlist`:
+   a. `chart_set_symbol` to switch to that symbol
+   b. For each timeframe in `timeframes` (e.g., "W", "D", "240"):
+      - `chart_set_timeframe` to switch
+      - `quote_get` for current price
+      - `data_get_study_values` for all indicator readings
+      - `data_get_ohlcv` with `summary: true` for price stats
+      - `data_get_pine_lines` for support/resistance levels
+   c. Apply `biasCriteria` from rules.json to determine: Bullish / Bearish / Neutral
+3. Compile all results into a structured report
+4. Save to `C:\Users\kushd\.tradingview-mcp\sessions\` as `YYYY-MM-DD_HH-mm.json`
+5. Display the formatted report to the user
+
+### Report Format
+Each asset should show: Symbol | Bias | Price | Key Level | Per-Timeframe Breakdown | Indicator Values | Watch Points
+
+### Summary Section
+End with a summary grouping assets by Bullish/Bearish/Neutral, plus any risk checklist items from `rules.json.riskRules`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,42 @@
+{
+  "watchlist": ["BTCUSD", "ETHUSD", "SOLUSD", "AAPL", "TSLA", "NVDA"],
+  "timeframes": ["1W", "1D", "4H"],
+  "biasCriteria": {
+    "bullish": [
+      "RSI(14) above 50 and rising",
+      "MACD histogram positive and increasing",
+      "Price above 21 EMA and 50 EMA",
+      "21 EMA above 50 EMA (golden alignment)"
+    ],
+    "bearish": [
+      "RSI(14) below 50 and falling",
+      "MACD histogram negative and decreasing",
+      "Price below 21 EMA and 50 EMA",
+      "21 EMA below 50 EMA (death alignment)"
+    ],
+    "neutral": [
+      "Mixed signals across indicators",
+      "Price choppy between 21 and 50 EMA",
+      "RSI between 45-55 with no clear trend"
+    ]
+  },
+  "riskRules": {
+    "maxPositionSize": "2% of portfolio per trade",
+    "stopLossRequired": true,
+    "riskRewardMinimum": 2.0,
+    "preSessionChecklist": [
+      "Check for major news events",
+      "Verify no earnings announcements today",
+      "Check overall market sentiment (SPX/VIX)"
+    ]
+  },
+  "twelveHrUpdate": {
+    "enabled": true,
+    "scheduleHours": [9, 21],
+    "reportFormat": "structured",
+    "includeKeyLevels": true,
+    "includeVolumeAnalysis": true,
+    "saveHistory": true,
+    "historyDir": "~/.tradingview-mcp/sessions"
+  }
+}


### PR DESCRIPTION
## What changed
- `rules.json` — new file defining the watchlist (BTCUSD, ETHUSD, SOLUSD, AAPL, TSLA, NVDA), timeframes (1W/1D/4H), bullish/bearish/neutral bias criteria, and risk rules (2% max position, R:R >= 2.0, pre-session checklist)
- `CLAUDE.md` — appended the 12 Hr Update workflow section: how to iterate symbols x timeframes, apply bias criteria, compile a structured report, and save sessions to disk

## Why
Adds a repeatable, rule-driven market bias scanner that runs on demand ("12 hr update") and saves structured JSON session history for later review.

## Notes for reviewer
- `rules.json` is user-editable without touching code — watchlist, timeframes, and criteria are all configurable
- Session save path in CLAUDE.md references a Windows path; Mac/Linux users may want to adjust to `~/.tradingview-mcp/sessions/`