### PR TITLE
Add MSIX/Store install detection for Windows

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -197,6 +197,16 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  // Windows MSIX / Store install: Get-AppxPackage is the reliable way to locate
+  // it because C:\Program Files\WindowsApps is ACL-restricted for directory listing.
+  if (!tvPath && platform === 'win32') {
+    try {
+      const psCmd = 'powershell -NoProfile -NonInteractive -Command "$p = Get-AppxPackage -Name *TradingView* | Select-Object -First 1; if ($p) { Join-Path $p.InstallLocation \'TradingView.exe\' }"';
+      const out = execSync(psCmd, { timeout: 6000 }).toString().trim();
+      if (out && existsSync(out)) tvPath = out;
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath && platform === 'darwin') {
     try {
       const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();


### PR DESCRIPTION
## Summary

TradingView Desktop installed via `winget install TradingView.TradingViewDesktop` or directly from the Microsoft Store lands in `C:\Program Files\WindowsApps\TradingView.Desktop_*\TradingView.exe`. That folder is ACL-restricted from directory listing for normal users, so `where TradingView.exe` and the existing static path candidates all fail. Result: `tv_launch` errors with *"TradingView not found on win32"* on any machine where TradingView was installed through the Store / winget path (which is now the default for many Windows users).

## Fix

Add a `Get-AppxPackage` fallback after the existing `where TradingView.exe` lookup. `Get-AppxPackage` is a user-mode PowerShell cmdlet that works without elevated permissions and does not require directory-listing access on `WindowsApps`.

```js
if (!tvPath && platform === 'win32') {
  try {
    const psCmd = 'powershell -NoProfile -NonInteractive -Command "$p = Get-AppxPackage -Name *TradingView* | Select-Object -First 1; if ($p) { Join-Path $p.InstallLocation \'TradingView.exe\' }"';
    const out = execSync(psCmd, { timeout: 6000 }).toString().trim();
    if (out && existsSync(out)) tvPath = out;
  } catch { /* ignore */ }
}
```

Placed after the `where` lookup so traditional installer paths (`%LOCALAPPDATA%\TradingView\TradingView.exe`, `%PROGRAMFILES%\TradingView\TradingView.exe`) still take precedence. No behavior change for macOS, Linux, or non-MSIX Windows installs.

## Test plan

- [x] Verified on Windows 11 24H2 with **TradingView Desktop 3.1.0.7818** installed via `winget install TradingView.TradingViewDesktop`
- [x] Resolves to `C:\Program Files\WindowsApps\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\TradingView.exe`
- [x] CDP endpoint comes up on `http://127.0.0.1:9222/json/version` after launch
- [x] `tv_health_check` reports `cdp_connected: true, api_available: true`
- [x] `npm run test:unit` — 16/16 `pine_analyze` tests pass; 2 pre-existing `cli.test.js` failures (libuv `UV_HANDLE_CLOSING` assertion under Node 24 + Windows subprocess piping — unrelated to this change)

## Notes

One thing worth flagging separately: `cli.test.js` lines 133 and 142 fail on Windows under Node 24 with exit code `3221226505` (`0xC0000139` "Entry Point Not Found") and a libuv `UV_HANDLE_CLOSING` assertion when piping stdin to the spawned `tv` CLI. Reproducible on a fresh winget Node.js LTS install. Happy to dig into this in a separate PR if it would be useful.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
