### PR TITLE
Fix CDP chart-target selection for TradingView Desktop (Electron)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/connection.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/connection.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,13 +2,16 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
+let explicitTargetId = null;
+let _cdpFactory = CDP;
+let _fetchFn = (...args) => fetch(...args);
 // Overridable via TV_CDP_HOST/TV_CDP_PORT (or CDP_HOST/CDP_PORT) env vars.
 // Default is 127.0.0.1, not localhost: on some Windows machines localhost
 // resolves to ::1 first, and Electron's --remote-debugging-port only listens on IPv4.
 export const CDP_HOST = process.env.TV_CDP_HOST || process.env.CDP_HOST || '127.0.0.1';
 export const CDP_PORT = Number(process.env.TV_CDP_PORT || process.env.CDP_PORT) || 9222;
-const MAX_RETRIES = 5;
-const BASE_DELAY = 500;
+let MAX_RETRIES = 5;
+let BASE_DELAY = 500;
 
 // Known direct API paths discovered via live probing (see PROBE_RESULTS.md)
 const KNOWN_PATHS = {
@@ -53,18 +56,33 @@ export function requireFinite(value, name) {
 export async function getClient() {
   if (client) {
     try {
-      // Quick liveness check
-      await client.Runtime.evaluate({ expression: '1', returnByValue: true });
-      return client;
+      const probe = await client.Runtime.evaluate({
+        expression: "typeof window.TradingViewApi !== 'undefined' && !!(window.TradingViewApi && window.TradingViewApi._activeChartWidgetWV)",
+        returnByValue: true,
+      });
+      if (probe.result?.value === true) return client;
+      try { await client.close(); } catch { /* already gone */ }
+      client = null;
+      targetInfo = null;
     } catch {
+      try { await client.close(); } catch { /* already gone */ }
       client = null;
       targetInfo = null;
     }
+  }
+  if (explicitTargetId) {
+    try {
+      const still = await findTargetById(explicitTargetId);
+      if (still) return connect(explicitTargetId);
+    } catch { /* network error — fall through to connect() with retry */ }
+    explicitTargetId = null;
   }
   return connect();
 }
 
 export async function connect(targetId = null) {
+  if (targetId) explicitTargetId = targetId;
+  else explicitTargetId = null;
   let lastError;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
@@ -75,7 +93,7 @@ export async function connect(targetId = null) {
           : 'No TradingView chart target found. Is TradingView open with a chart?');
       }
       targetInfo = target;
-      client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
+      client = await _cdpFactory({ host: CDP_HOST, port: CDP_PORT, target: target.id });
 
       // Enable required domains
       await client.Runtime.enable();
@@ -108,16 +126,22 @@ export async function reconnectTo(targetId) {
 }
 
 async function findChartTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await _fetchFn(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
-    || null;
+  const pages = targets.filter(t => t.type === 'page');
+  // 1) Real chart page: web (tradingview.com/chart) or desktop (Electron) where the
+  //    loaded layout URL contains /chart/.
+  const chart = pages.find(t => /tradingview\.com\/chart|\/chart\//i.test(t.url));
+  if (chart) return chart;
+  // 2) Desktop fallback: every TradingView.app file:// page matches /tradingview/i,
+  //    so the old fallback grabbed the window shell / new-tab. Exclude known
+  //    non-chart shells/helpers instead of taking the first match blindly.
+  const NON_CHART = /new-tab|tooltip|browser-api-container|renderer-services|drag-service|\/window\/index\.html/i;
+  return pages.find(t => /tradingview/i.test(t.url) && !NON_CHART.test(t.url)) || null;
 }
 
 async function findTargetById(id) {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await _fetchFn(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
   return targets.find(t => t.id === id) || null;
 }
@@ -155,7 +179,18 @@ export async function disconnect() {
     try { await client.close(); } catch {}
     client = null;
     targetInfo = null;
+    explicitTargetId = null;
   }
+}
+
+export function _resetForTest({ cdpFactory, fetchFn, retries, delay } = {}) {
+  client = null;
+  targetInfo = null;
+  explicitTargetId = null;
+  if (cdpFactory) _cdpFactory = cdpFactory;
+  if (fetchFn) _fetchFn = fetchFn;
+  if (retries !== undefined) MAX_RETRIES = retries;
+  if (delay !== undefined) BASE_DELAY = delay;
 }
 
 // --- Direct API path helpers ---

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,0 +1,235 @@
+/**
+ * Tests for getClient() liveness probe, findChartTarget shell exclusion,
+ * and explicitTargetId stickiness with reconnectTo.
+ *
+ * Pure unit: uses _resetForTest DI to inject mock CDP factory, fetch,
+ * and retry settings so no real TradingView Desktop is needed.
+ *
+ * Run: node --test tests/connection.test.js
+ */
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getClient, connect, reconnectTo, disconnect,
+  _resetForTest,
+} from '../src/connection.js';
+
+// ── Mock targets ─────────────────────────────────────────────────────
+
+const CHART_TARGET = {
+  id: 'ABC123', type: 'page',
+  url: 'file:///Applications/TradingView.app/Contents/Resources/app/chart/index.html',
+  title: 'BTCUSD',
+};
+const SECOND_CHART = {
+  id: 'DEF456', type: 'page',
+  url: 'https://www.tradingview.com/chart/XyZ999/',
+  title: 'ETHUSD',
+};
+const SHELL_TARGET = {
+  id: 'SHELL1', type: 'page',
+  url: 'file:///Applications/TradingView.app/Contents/Resources/app/window/index.html',
+  title: 'TradingView',
+};
+const NEW_TAB_TARGET = {
+  id: 'NEWTAB1', type: 'page',
+  url: 'file:///Applications/TradingView.app/Contents/Resources/app/new-tab/index.html',
+  title: 'New tab',
+};
+
+let cdpTargets = [];
+let probeValue = true;
+let probeThrows = false;
+let connectedTargets = [];
+let fetchThrows = false;
+
+function makeMockClient() {
+  return {
+    Runtime: {
+      evaluate: async () => {
+        if (probeThrows) throw new Error('target crashed');
+        return { result: { value: probeValue } };
+      },
+      enable: async () => {},
+    },
+    Page: { enable: async () => {} },
+    DOM: { enable: async () => {} },
+    close: async () => {},
+  };
+}
+
+const mockCdpFactory = async (opts) => {
+  connectedTargets.push(opts.target);
+  return makeMockClient();
+};
+const mockFetch = async () => {
+  if (fetchThrows) throw new Error('fetch failed');
+  return { json: async () => [...cdpTargets] };
+};
+
+function resetAll() {
+  cdpTargets = [CHART_TARGET, SHELL_TARGET, NEW_TAB_TARGET];
+  probeValue = true;
+  probeThrows = false;
+  fetchThrows = false;
+  connectedTargets = [];
+  _resetForTest({
+    cdpFactory: mockCdpFactory,
+    fetchFn: mockFetch,
+    retries: 1,
+    delay: 0,
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('getClient() — chart-API liveness probe', () => {
+  beforeEach(resetAll);
+
+  it('returns cached client when probe passes', async () => {
+    const first = await getClient();
+    const second = await getClient();
+    assert.strictEqual(first, second);
+    assert.equal(connectedTargets.length, 1);
+  });
+
+  it('reconnects when probe returns false (non-chart page)', async () => {
+    const first = await getClient();
+    probeValue = false;
+    const second = await getClient();
+    assert.notStrictEqual(first, second);
+    assert.equal(connectedTargets.length, 2);
+  });
+
+  it('reconnects when probe throws (target crashed)', async () => {
+    const first = await getClient();
+    probeThrows = true;
+    const second = await getClient();
+    assert.notStrictEqual(first, second);
+    assert.equal(connectedTargets.length, 2);
+  });
+});
+
+describe('getClient() — explicitTargetId stickiness', () => {
+  beforeEach(resetAll);
+
+  it('reconnectTo sets explicitTargetId; probe failure retries same target', async () => {
+    cdpTargets = [CHART_TARGET, SECOND_CHART, SHELL_TARGET];
+    await reconnectTo(SECOND_CHART.id);
+    connectedTargets = [];
+    probeValue = false;
+    await getClient();
+    assert.equal(connectedTargets.length, 1);
+    assert.equal(connectedTargets[0], SECOND_CHART.id,
+      'should reconnect to the explicit target, not fall back to findChartTarget');
+  });
+
+  it('falls back to findChartTarget when explicit target disappears', async () => {
+    cdpTargets = [CHART_TARGET, SECOND_CHART, SHELL_TARGET];
+    await reconnectTo(SECOND_CHART.id);
+    connectedTargets = [];
+    probeValue = false;
+    cdpTargets = [CHART_TARGET, SHELL_TARGET];
+    await getClient();
+    assert.equal(connectedTargets.length, 1);
+    assert.equal(connectedTargets[0], CHART_TARGET.id);
+  });
+
+  it('connect() without targetId clears explicitTargetId', async () => {
+    cdpTargets = [CHART_TARGET, SECOND_CHART, SHELL_TARGET];
+    await reconnectTo(SECOND_CHART.id);
+    await connect();
+    connectedTargets = [];
+    probeValue = false;
+    await getClient();
+    assert.equal(connectedTargets.length, 1);
+    assert.equal(connectedTargets[0], CHART_TARGET.id,
+      'should use findChartTarget after bare connect(), not the previous explicit SECOND_CHART');
+  });
+
+  it('disconnect clears explicitTargetId', async () => {
+    cdpTargets = [CHART_TARGET, SECOND_CHART, SHELL_TARGET];
+    await reconnectTo(SECOND_CHART.id);
+    await disconnect();
+    connectedTargets = [];
+    probeValue = false;
+    await getClient();
+    assert.equal(connectedTargets.length, 1);
+    assert.equal(connectedTargets[0], CHART_TARGET.id,
+      'should use findChartTarget after disconnect, not the previous explicit SECOND_CHART');
+  });
+
+  it('explicit target fetch error falls back to connect with retry', async () => {
+    cdpTargets = [CHART_TARGET, SECOND_CHART, SHELL_TARGET];
+    _resetForTest({ retries: 2, delay: 0, cdpFactory: mockCdpFactory, fetchFn: mockFetch });
+    await reconnectTo(SECOND_CHART.id);
+    probeValue = false;
+    fetchThrows = true;
+    connectedTargets = [];
+    await assert.rejects(
+      () => getClient(),
+      { message: /CDP connection failed/ },
+    );
+  });
+
+  it('explicit target fetch error recovers when network returns', async () => {
+    cdpTargets = [CHART_TARGET, SECOND_CHART, SHELL_TARGET];
+    let fetchCallCount = 0;
+    _resetForTest({
+      retries: 3,
+      delay: 0,
+      cdpFactory: mockCdpFactory,
+      fetchFn: async () => {
+        fetchCallCount++;
+        if (fetchCallCount <= 1) throw new Error('fetch failed');
+        return { json: async () => [...cdpTargets] };
+      },
+    });
+    await reconnectTo(SECOND_CHART.id);
+    probeValue = false;
+    fetchCallCount = 0;
+    connectedTargets = [];
+    const c = await getClient();
+    assert.ok(c);
+    assert.equal(connectedTargets[0], CHART_TARGET.id,
+      'should fall back to findChartTarget after explicit target fetch error');
+  });
+});
+
+describe('findChartTarget — shell/helper exclusion', () => {
+  beforeEach(resetAll);
+
+  it('prefers chart URL over shell/helper pages', async () => {
+    cdpTargets = [SHELL_TARGET, NEW_TAB_TARGET, CHART_TARGET];
+    await connect();
+    assert.equal(connectedTargets[0], CHART_TARGET.id);
+  });
+
+  it('excludes shell and new-tab from fallback matching', async () => {
+    cdpTargets = [SHELL_TARGET, NEW_TAB_TARGET];
+    await assert.rejects(
+      () => connect(),
+      { message: /No TradingView chart target found/ },
+    );
+  });
+
+  it('matches desktop Electron chart URL with /chart/ path', async () => {
+    cdpTargets = [{
+      id: 'DESK1', type: 'page',
+      url: 'file:///Applications/TradingView.app/Contents/Resources/app/chart/ABC123.html',
+      title: 'Chart',
+    }];
+    await connect();
+    assert.equal(connectedTargets[0], 'DESK1');
+  });
+
+  it('matches tradingview.com web chart URL', async () => {
+    cdpTargets = [{
+      id: 'WEB1', type: 'page',
+      url: 'https://www.tradingview.com/chart/XyZ123/',
+      title: 'BTCUSD Chart',
+    }];
+    await connect();
+    assert.equal(connectedTargets[0], 'WEB1');
+  });
+});


### PR DESCRIPTION
## Problem

On TradingView **Desktop** (Electron), `findChartTarget()` often attaches to the wrong CDP target. Every `file://` page in the app matches the `/tradingview/i` fallback, so the first match is frequently the window shell, the "New tab" landing page, or a helper page (tooltip, browser-api-container, drag-service) instead of the actual chart. Once cached, the bare `'1'` liveness probe in `getClient()` keeps that wrong connection alive forever — every subsequent tool call fails with "TradingViewApi is not defined".

## Fix

- **`findChartTarget()`**: match real chart pages first (`tradingview.com/chart` for web, `/chart/` in the loaded layout URL for desktop), then fall back to TradingView pages **excluding** known non-chart shells/helpers, instead of blindly taking the first match.
- **`getClient()` liveness probe**: verify the cached connection is on an actual chart page (`window.TradingViewApi._activeChartWidgetWV` present), not just any live page. A connection to a non-chart target is closed and re-established to the chart page.
- **Plays nicely with `reconnectTo()` / `tab_switch`** (#319): an explicitly selected target is sticky — if the probe fails, we first try to reconnect to that same target, and only fall back to auto-discovery when it's gone. Network errors during the sticky lookup fall back to `connect()` so the full retry/backoff path still applies.

## Scope note

The original version of this PR also made the CDP port/host configurable via env vars; that part was since implemented upstream in #318 (more thoroughly — dual env names, exported constants, IPv4 default) and has been dropped from this PR. What remains is purely the desktop target-selection fix.

## Tests

13 unit tests for target selection, probe behavior, explicit-target stickiness, and network-error fallback (mutation-tested: removing the stickiness logic or the error handling turns them red). Full suite: 165/165 green, lint clean. Verified live against TradingView Desktop on macOS — shell/helper pages excluded, real chart page selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
