### PR TITLE
Add Windows MSIX launch support for tv_launch and /scan slash command

### DIFF
--- a/.claude/commands/scan.md
+++ b/.claude/commands/scan.md
@@ -1,0 +1,35 @@
+Run the full pre-session watchlist scan across all 5 permitted instruments using the trading methodology in memory.
+
+Instruments to scan in order: MES → M2K → MGC → MNQ → MBT
+
+For each instrument run the full sequence:
+1. Switch chart to that instrument (15m timeframe)
+2. Step 1 — Daily Bias (D1): switch to D timeframe, read RSI + RSI-based MA → LONG or SHORT bias
+3. Step 2 — 4H Signal: switch to 240 timeframe, read RSI gap (|RSI − MA|). Gap ≥ 10 = Swing candidate, 5–9 = Surgical only, < 5 = skip
+4. Step 3 — 15m Signal: switch to 15 timeframe, read RSI gap
+5. Step 4 — 5m Signal: switch to 5 timeframe, read RSI gap
+6. Step 4b — MACD Confirmation: read MACD histogram on 5m — confirm direction matches RSI gap
+7. Step 5 — OHLCV Momentum: data_get_ohlcv with summary=true, count=10
+8. Step 6 — Volume: check if last 3 bars show increasing volume in trade direction
+9. Step 7 — Quote: get current live price
+
+After scanning all 5, produce a ranked summary table:
+
+| Rank | Instrument | D1 Bias | 4H Gap | 15m Gap | 5m Gap | MACD | Mode | Grade |
+|------|-----------|---------|--------|---------|--------|------|------|-------|
+
+Then give a clear recommendation:
+- Which instrument to trade first (#1 priority)
+- Which mode (Swing or Surgical)
+- Direction (Long or Short)
+- What to watch for (entry trigger)
+- Any instruments to skip and why
+
+Apply all mode selection rules from the methodology:
+- 4H gap ≥ 10 → Swing Scalp
+- 4H gap 5–9 → Surgical only
+- 4H gap < 5 → skip
+- MNQ and MBT → Swing only regardless of gap
+- MGC Surgical → requires 5m gap ≥ 9
+- Midday (11:30–2:00 PM EST) → Surgical suspended
+- Major news within 30 min → no new trades

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__ccd_session__mark_chapter"
+    ]
+  }
+}

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -207,20 +207,62 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
-  if (!tvPath) {
+  // Windows MSIX (Store) version — executable lives in a protected WindowsApps folder;
+  // must be activated via IApplicationActivationManager COM interface with args support.
+  let msixPid = null;
+  if (!tvPath && platform === 'win32') {
+    try {
+      const { execFileSync } = await import('child_process');
+      // PowerShell inline C# to activate the MSIX package with --remote-debugging-port
+      const ps = `
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class _TvLauncher {
+  [ComImport, Guid("2e941141-7f97-4756-ba1d-9decde894a3d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  private interface IApplicationActivationManager {
+    int ActivateApplication([MarshalAs(UnmanagedType.LPWStr)] string appId, [MarshalAs(UnmanagedType.LPWStr)] string args, int opts, out uint pid);
+    int ActivateForFile([MarshalAs(UnmanagedType.LPWStr)] string appId, IntPtr items, [MarshalAs(UnmanagedType.LPWStr)] string verb, out uint pid);
+    int ActivateForProtocol([MarshalAs(UnmanagedType.LPWStr)] string appId, IntPtr items, out uint pid);
+  }
+  [ComImport, Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C"), ClassInterface(ClassInterfaceType.None)]
+  private class CAppActivationManager {}
+  public static uint Launch(string appId, string args) {
+    IApplicationActivationManager mgr = (IApplicationActivationManager)new CAppActivationManager();
+    uint pid = 0; int hr = mgr.ActivateApplication(appId, args, 0, out pid);
+    if (hr != 0) throw new System.Runtime.InteropServices.COMException("ActivateApplication failed", hr);
+    return pid;
+  }
+}
+'@
+$p = [_TvLauncher]::Launch("TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop", "--remote-debugging-port=${cdpPort}")
+Write-Output $p
+`.trim();
+      const result = execFileSync('powershell.exe', ['-NonInteractive', '-Command', ps], { timeout: 15000 }).toString().trim();
+      msixPid = parseInt(result, 10) || null;
+    } catch (e) { /* MSIX launch failed, will throw below */ }
+  }
+
+  if (!tvPath && !msixPid) {
     throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
   }
 
-  if (killFirst) {
+  if (killFirst && !msixPid) {
     try {
       if (platform === 'win32') execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
       else execSync('pkill -f TradingView', { timeout: 5000 });
       await new Promise(r => setTimeout(r, 1500));
     } catch { /* may not be running */ }
+  } else if (killFirst && msixPid === null) {
+    try { execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 }); } catch { /* ignore */ }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
-  child.unref();
+  let child = null;
+  if (tvPath) {
+    child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
+    child.unref();
+  }
+
+  const launchedPid = child ? child.pid : msixPid;
 
   for (let i = 0; i < 15; i++) {
     await new Promise(r => setTimeout(r, 1000));
@@ -236,7 +278,9 @@ export async function launch({ port, kill_existing } = {}) {
       if (ready) {
         const info = JSON.parse(ready);
         return {
-          success: true, platform, binary: tvPath, pid: child.pid,
+          success: true, platform,
+          binary: tvPath || 'MSIX (Windows Store)',
+          pid: launchedPid,
           cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
           browser: info.Browser, user_agent: info['User-Agent'],
         };
@@ -245,7 +289,9 @@ export async function launch({ port, kill_existing } = {}) {
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform,
+    binary: tvPath || 'MSIX (Windows Store)',
+    pid: launchedPid, cdp_port: cdpPort, cdp_ready: false,
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
 }


### PR DESCRIPTION
## Summary
- tv_launch Windows Store fix: TradingView MSIX installs now launch with CDP via IApplicationActivationManager COM interface
- /scan slash command: full pre-session watchlist scan (D1→4H→15m→5m→MACD→OHLCV→volume→quote) with ranked trade recommendation
- Settings allowlist: mcp__ccd_session__mark_chapter added

## Test plan
- [ ] Run tv_launch on Windows Store TradingView — confirm CDP connects on port 9222
- [ ] Type /scan in Claude Code session — confirm full scan runs and ranked table appears
- [ ] Confirm non-MSIX installs still launch correctly