### PR TITLE
Fix ReferenceError in drawing list/clear/remove/properties helpers

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -3,6 +3,12 @@
  */
 import { evaluate as _evaluate, getChartApi as _getChartApi, safeString, requireFinite } from '../connection.js';
 
+// Module-level aliases so listDrawings/getProperties/removeOne/clearAll (which
+// reference bare `evaluate`/`getChartApi`) resolve correctly. drawShape uses its
+// own locals via _resolve(), which shadow these inside that function.
+const evaluate = _evaluate;
+const getChartApi = _getChartApi;
+
 function _resolve(deps) {
   return { evaluate: deps?.evaluate || _evaluate, getChartApi: deps?.getChartApi || _getChartApi };
 }


### PR DESCRIPTION
## What

`listDrawings`, `clearAll`, `removeOne`, and `getProperties` in `src/core/drawing.js` reference bare `evaluate` / `getChartApi`, but `connection.js` is imported under aliases (`_evaluate` / `_getChartApi`). As a result, every call to those four helpers throws `getChartApi is not defined`. Only `drawShape` works, because it resolves the functions via `_resolve()`.

In practice this breaks the `draw_list`, `draw_clear`, `draw_remove_one`, and `draw_get_properties` MCP tools.

## Fix

Add two module-level aliases so the read/clear/remove/properties helpers resolve correctly:

    const evaluate = _evaluate;
    const getChartApi = _getChartApi;

`drawShape()`'s function-local bindings (via `_resolve()`) still shadow these, so its behavior is unchanged.

## Testing

Verified against a live TradingView Desktop CDP session (3.1.0):

- `draw_list` -> `{ success: true, count: 9 }` (previously threw `getChartApi is not defined`)
- `draw_get_properties` -> `{ success: true, ... }`
- `draw_shape` -> unaffected (still creates shapes correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
