### PR TITLE
feat: authenticated market screener (screener_scan/screener_quote) + study/quote read fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -2,6 +2,7 @@
  * Core data access logic.
  */
 import { evaluate, evaluateAsync, KNOWN_PATHS, safeString } from '../connection.js';
+import { quoteSymbol } from './screener.js';
 
 const MAX_OHLCV_BARS = 500;
 const MAX_TRADES = 20;
@@ -243,6 +244,17 @@ export async function getEquity() {
 }
 
 export async function getQuote({ symbol } = {}) {
+  // Explicit symbol → authenticated scanner, which quotes ANY symbol without
+  // changing the chart (fixes the old behavior of ignoring `symbol` and always
+  // returning the charted symbol). Falls back to chart bars on failure.
+  if (symbol && String(symbol).trim()) {
+    try {
+      const q = await quoteSymbol(symbol);
+      return { ...q, symbol: q.ticker || symbol, last: q.last ?? q.close };
+    } catch (e) {
+      // fall through to chart-bars method (valid only for the charted symbol)
+    }
+  }
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
@@ -322,33 +334,67 @@ export async function getDepth() {
 }
 
 export async function getStudyValues() {
+  // Read LAST-BAR plot values via getAllStudies()/getStudyById() (the same path
+  // stream.js uses) instead of dataWindowView().items(), which only populates on
+  // crosshair-hover and returned the '∅' sentinel for RSI/MACD/EMA when no bar was
+  // hovered — the cause of "only 1 of 4 studies" / missing momentum indicators.
   const data = await evaluate(`
     (function() {
-      var chart = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget;
-      var model = chart.model();
-      var sources = model.model().dataSources();
+      var chart = ${CHART_API};
       var results = [];
-      for (var si = 0; si < sources.length; si++) {
-        var s = sources[si];
-        if (!s.metaInfo) continue;
+      var studies = [];
+      try { studies = chart.getAllStudies() || []; } catch(e) {}
+      for (var i = 0; i < studies.length; i++) {
+        var info = studies[i];
+        var name = (info && info.name) || '';
+        var values = {};
         try {
-          var meta = s.metaInfo();
-          var name = meta.description || meta.shortDescription || '';
-          if (!name) continue;
-          var values = {};
-          try {
-            var dwv = s.dataWindowView();
-            if (dwv) {
-              var items = dwv.items();
-              if (items) {
-                for (var i = 0; i < items.length; i++) {
-                  var item = items[i];
-                  if (item._value && item._value !== '∅' && item._title) values[item._title] = item._value;
+          var study = chart.getStudyById(info.id);
+          if (study) {
+            var src = study._study || study;
+            // Most-recent plot value via firstValue() — a real number, no
+            // crosshair-hover needed (dataWindowView returns '∅' without one).
+            // (firstValue() yields the study's primary plot; multi-line studies
+            // like MACD/Bollinger expose only their main line here — for named
+            // sub-plots, hover the last bar so the data-window merge below fills.)
+            try { var fv = src.firstValue(); if (typeof fv === 'number' && !isNaN(fv)) values['value'] = fv; } catch(e) {}
+            // Secondary: data-window view, covers some custom plot() studies.
+            try {
+              var realSource = study._source || src;
+              var dwv = realSource && realSource.dataWindowView && realSource.dataWindowView();
+              var items = dwv && dwv.items ? (dwv.items() || []) : [];
+              for (var j = 0; j < items.length; j++) {
+                var it = items[j];
+                if (it && it._title && it._value != null && it._value !== '∅' && !(it._title in values)) {
+                  values[it._title] = it._value;
                 }
               }
-            }
-          } catch(e) {}
-          if (Object.keys(values).length > 0) results.push({ name: name, values: values });
+            } catch(e) {}
+          }
+        } catch(e) {}
+        if (Object.keys(values).length > 0) results.push({ name: name, values: values });
+      }
+      // Fallback: original dataSources scan if getAllStudies yielded nothing.
+      if (results.length === 0) {
+        try {
+          var sources = chart._chartWidget.model().model().dataSources();
+          for (var si = 0; si < sources.length; si++) {
+            var s = sources[si];
+            if (!s.metaInfo) continue;
+            try {
+              var meta = s.metaInfo();
+              var nm = meta.description || meta.shortDescription || '';
+              if (!nm) continue;
+              var v = {};
+              var dwv2 = s.dataWindowView && s.dataWindowView();
+              var its = dwv2 && dwv2.items ? (dwv2.items() || []) : [];
+              for (var ii = 0; ii < its.length; ii++) {
+                var item = its[ii];
+                if (item && item._title && item._value != null && item._value !== '∅') v[item._title] = item._value;
+              }
+              if (Object.keys(v).length > 0) results.push({ name: nm, values: v });
+            } catch(e) {}
+          }
         } catch(e) {}
       }
       return results;

--- a/src/core/screener.js
+++ b/src/core/screener.js
@@ -1,0 +1,127 @@
+/**
+ * Market screener via an AUTHENTICATED in-page fetch to scanner.tradingview.com.
+ *
+ * The standalone data-API server scrapes this same endpoint ANONYMOUSLY and gets
+ * daily-rate-limited (empty body -> "Expecting value"). This module instead runs
+ * the fetch INSIDE the logged-in TradingView Desktop page over CDP, so the request
+ * carries the user's session cookies (credentials:'include') and is treated as an
+ * authenticated request — the same proven primitive the bridge already uses for
+ * alerts (core/alerts.js) and pine-facade (core/pine.js).
+ *
+ * NOTE: TradingView's scanner JSON schema (filter operators, column ids) is
+ * undocumented and changes occasionally — a renamed column breaks a query, not the
+ * transport. Responses are guarded defensively.
+ */
+import { evaluateAsync, safeString } from '../connection.js';
+
+// Map friendly market names to scanner.tradingview.com/{market}/scan path segments.
+const MARKET_ALIASES = {
+  us: 'america', usa: 'america', america: 'america', nasdaq: 'america', nyse: 'america', amex: 'america',
+  egx: 'egypt', egypt: 'egypt',
+  uae: 'uae', dfm: 'uae', adx: 'uae',
+  ksa: 'ksa', saudi: 'ksa', tadawul: 'ksa',
+  crypto: 'crypto', global: 'global',
+};
+
+const DEFAULT_COLUMNS = ['name', 'close', 'change', 'volume', 'market_cap_basic', 'RSI', 'EMA50', 'EMA200', 'ADX'];
+
+function resolveMarket(market) {
+  const m = String(market || 'america').trim().toLowerCase();
+  return MARKET_ALIASES[m] || m;
+}
+
+function inferMarket(symbol) {
+  const s = String(symbol).toUpperCase();
+  if (s.startsWith('EGX:')) return 'egypt';
+  if (s.startsWith('DFM:') || s.startsWith('ADX:')) return 'uae';
+  if (s.startsWith('TADAWUL:')) return 'ksa';
+  if (/(BINANCE|KUCOIN|BYBIT|COINBASE):/.test(s)) return 'crypto';
+  return 'america';
+}
+
+/**
+ * Run a scanner query.
+ * @param {object} opts
+ * @param {string} [opts.market='america']  friendly market name or scanner segment
+ * @param {string[]} [opts.columns]         column ids to return
+ * @param {Array} [opts.filters]            scanner filter clauses ({left,operation,right})
+ * @param {object} [opts.sort]              { sortBy, sortOrder }
+ * @param {number[]} [opts.range=[0,50]]    [offset, limit]
+ * @param {string[]} [opts.tickers]         explicit tickers (e.g. ['NASDAQ:AAPL']) — tickers mode
+ * @param {object} [opts.body]              raw scanner body override (advanced; ignores the above)
+ */
+export async function scan({ market = 'america', columns, filters, sort, range, tickers, body } = {}) {
+  const mkt = resolveMarket(market);
+  const cols = Array.isArray(columns) && columns.length ? columns : DEFAULT_COLUMNS;
+
+  let payload;
+  if (body && typeof body === 'object') {
+    payload = body;
+  } else if (Array.isArray(tickers) && tickers.length) {
+    payload = { symbols: { tickers, query: { types: [] } }, columns: cols };
+  } else {
+    payload = { symbols: { query: { types: [] } }, columns: cols };
+    const flt = Array.isArray(filters) ? filters : [];
+    if (flt.length) payload.filter = flt;
+    payload.range = Array.isArray(range) && range.length === 2 ? range : [0, 50];
+    if (sort && sort.sortBy) payload.sort = { sortBy: sort.sortBy, sortOrder: sort.sortOrder || 'desc' };
+  }
+
+  const url = `https://scanner.tradingview.com/${mkt}/scan`;
+  // NOTE: deliberately NO Content-Type header. Adding one triggers a CORS
+  // preflight (OPTIONS) that scanner.tradingview.com rejects from the chart-page
+  // origin ("Failed to fetch"). A header-less POST is a CORS "simple request"
+  // and succeeds with credentials:'include' (verified 2026-06-03, HTTP 200).
+  const result = await evaluateAsync(`
+    fetch(${safeString(url)}, {
+      method: 'POST',
+      credentials: 'include',
+      body: ${safeString(JSON.stringify(payload))}
+    })
+    .then(function(r) { return r.text(); })
+    .then(function(t) {
+      if (!t) return { __error: 'empty body (rate-limited or not logged in)' };
+      try { return JSON.parse(t); } catch(e) { return { __error: 'non-JSON response: ' + String(t).slice(0, 160) }; }
+    })
+    .catch(function(e) { return { __error: e && e.message ? e.message : String(e) }; })
+  `);
+
+  if (!result || result.__error) {
+    throw new Error('Scanner fetch failed: ' + (result?.__error || 'no response'));
+  }
+
+  const rawRows = Array.isArray(result.data) ? result.data : [];
+  const usedCols = payload.columns || cols;
+  const rows = rawRows.map((row) => {
+    const obj = { ticker: row.s };
+    const d = Array.isArray(row.d) ? row.d : [];
+    for (let i = 0; i < usedCols.length; i++) obj[usedCols[i]] = d[i];
+    return obj;
+  });
+
+  return {
+    success: true,
+    market: mkt,
+    total: typeof result.totalCount === 'number' ? result.totalCount : rows.length,
+    count: rows.length,
+    columns: usedCols,
+    rows,
+  };
+}
+
+/**
+ * Fetch a quote for ANY symbol without changing the chart — fixes quote_get's
+ * symbol param by routing through the authenticated scanner (tickers mode).
+ */
+export async function quoteSymbol(symbol) {
+  if (!symbol) throw new Error('symbol is required');
+  const ticker = String(symbol).includes(':') ? symbol : symbol; // pass through; caller may prefix
+  const r = await scan({
+    market: inferMarket(ticker),
+    tickers: [ticker],
+    columns: ['name', 'close', 'open', 'high', 'low', 'volume', 'change', 'RSI', 'EMA50', 'EMA200'],
+  });
+  const row = r.rows[0];
+  if (!row) throw new Error(`No scanner data for ${ticker} (check exchange prefix, e.g. NASDAQ:${ticker})`);
+  return { success: true, source: 'scanner_authenticated', ...row };
+}

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import { registerWatchlistTools } from './tools/watchlist.js';
 import { registerUiTools } from './tools/ui.js';
 import { registerPaneTools } from './tools/pane.js';
 import { registerTabTools } from './tools/tab.js';
+import { registerScreenerTools } from './tools/screener.js';
 
 const server = new McpServer(
   {
@@ -84,6 +85,7 @@ registerWatchlistTools(server);
 registerUiTools(server);
 registerPaneTools(server);
 registerTabTools(server);
+registerScreenerTools(server);
 
 // Startup notice (stderr so it doesn't interfere with MCP stdio protocol)
 process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');

--- a/src/tools/screener.js
+++ b/src/tools/screener.js
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/screener.js';
+
+export function registerScreenerTools(server) {
+  server.tool(
+    'screener_scan',
+    'Run a market screener via an AUTHENTICATED fetch to scanner.tradingview.com from inside your logged-in TradingView session (not anonymous, so not rate-limited). Discovers movers across a whole market — the one thing the chart tools cannot do. market: us/egypt/uae/ksa/crypto/global. Pass filters as scanner clauses, e.g. [{"left":"exchange","operation":"equal","right":"NASDAQ"},{"left":"RSI","operation":"in_range","right":[35,65]}].',
+    {
+      market: z.string().optional().describe('Market: us, egypt, uae, ksa, crypto, global (default us/america)'),
+      columns: z.array(z.string()).optional().describe('Column ids, e.g. ["name","close","change","volume","RSI","EMA50","EMA200","ADX"]'),
+      filters: z.array(z.object({
+        left: z.string(),
+        operation: z.string(),
+        right: z.any(),
+      })).optional().describe('Scanner filter clauses {left, operation, right}'),
+      sort_by: z.string().optional().describe('Column id to sort by (e.g. "change", "volume")'),
+      sort_order: z.enum(['asc', 'desc']).optional().describe('Sort order (default desc)'),
+      limit: z.coerce.number().optional().describe('Max rows (default 50)'),
+      tickers: z.array(z.string()).optional().describe('Explicit tickers (e.g. ["NASDAQ:AAPL"]) — tickers mode, ignores filters'),
+    },
+    async ({ market, columns, filters, sort_by, sort_order, limit, tickers }) => {
+      try {
+        return jsonResult(await core.scan({
+          market,
+          columns,
+          filters,
+          tickers,
+          sort: sort_by ? { sortBy: sort_by, sortOrder: sort_order } : undefined,
+          range: limit ? [0, Math.max(1, Math.floor(limit))] : undefined,
+        }));
+      } catch (err) {
+        return jsonResult({ success: false, error: err.message, hint: 'Ensure TradingView Desktop is logged in. Column/filter ids must match TradingView scanner schema.' }, true);
+      }
+    },
+  );
+
+  server.tool(
+    'screener_quote',
+    'Get a real-time quote for ANY symbol WITHOUT changing the chart, via the authenticated scanner. Use a fully-qualified ticker like "NASDAQ:AAPL" or "EGX:COMI" for reliable resolution.',
+    {
+      symbol: z.string().describe('Fully-qualified ticker, e.g. NASDAQ:NVDA, EGX:COMI, DFM:EMAAR'),
+    },
+    async ({ symbol }) => {
+      try { return jsonResult(await core.quoteSymbol(symbol)); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    },
+  );
+}


### PR DESCRIPTION
## What

Two new MCP tools plus two read-path fixes for the live-chart bridge.

### New: a market screener (the one thing the chart tools can't do)
- **`screener_scan`** — query `scanner.tradingview.com/{market}/scan` for market-wide discovery (movers, filters, sorting) across `us`/`egypt`/`uae`/`ksa`/`crypto`/`global`.
- **`screener_quote`** — quote ANY symbol without changing the chart.

Both fetch from **inside the logged-in TradingView page** via `evaluateAsync` with `credentials: 'include'` — the same authenticated-fetch pattern already used in `core/alerts.js` and `core/pine.js`. Because it rides the user's own session, it isn't the anonymous / rate-limited path, so it gives reliable discovery without the empty-body throttling that hits standalone scrapers.

**Key gotcha (documented inline):** the fetch must send **no `Content-Type` header**. Adding `application/json` triggers a CORS preflight (OPTIONS) that `scanner.tradingview.com` rejects from the chart-page origin → `Failed to fetch`. A header-less POST is a CORS "simple request" and succeeds.

### Fix: `data_get_study_values` returned the `∅` sentinel / only some studies
It read `dataWindowView().items()`, which only populates on crosshair-hover — without a hover, RSI/MACD/etc. return `∅` and were filtered out (often leaving just 1 study). It now reads the latest value via `getAllStudies()` + `getStudyById().firstValue()` (the same approach `core/stream.js` already uses), so every visible study returns its current value with no crosshair needed.

### Fix: `quote_get` ignored its `symbol` argument
It always returned the charted symbol regardless of the arg. Now, when `symbol` is passed it fetches that symbol via the screener (and falls back to the chart bars otherwise).

## Tested
Verified live against TradingView Desktop over CDP:
- `screener_scan` (NASDAQ, RSI 40–65, close > $5): ~2,400 matches, sorted by change.
- `screener_quote NASDAQ:NVDA`: returns close / RSI / EMA50 / EMA200.
- `data_get_study_values`: returns all visible studies with clean primary values.

## Notes
- Additive and backward compatible; no new dependencies.
- Scanner column/filter ids use TradingView's undocumented schema, so responses are guarded defensively — same risk class as the existing `pine-facade` / `pricealerts` calls.
