### PR TITLE
Fix: resolve evaluate/getChartApi via _resolve(_deps) across drawing + chart-nav functions

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,7 +115,8 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
-export async function getVisibleRange() {
+export async function getVisibleRange({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -157,7 +158,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
@@ -196,7 +198,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };


### PR DESCRIPTION
## Summary

`draw_list`, `draw_remove_one`, `draw_clear`, and the get-properties tool all fail at
runtime with:

```json
{ "success": false, "error": "getChartApi is not defined" }
```

`draw_shape` works fine, so you can *create* drawings but never list, inspect, remove,
or clear them. In practice this makes any draw-and-redraw workflow impossible (lines
accumulate with no way to clear stale ones).

## Repro

1. Connect to a chart.
2. Call `draw_shape` (horizontal_line) → succeeds.
3. Call `draw_list` (or `draw_clear` / `draw_remove_one`) → `getChartApi is not defined`.

## Root cause

In `src/core/drawing.js`, the module imports its helpers *aliased*:

```js
import { evaluate as _evaluate, getChartApi as _getChartApi, ... } from '../connection.js';
```

`drawShape` correctly resolves local `evaluate` / `getChartApi` via the DI helper:

```js
const { evaluate, getChartApi } = _resolve(_deps);
```

…but `listDrawings`, `getProperties`, `removeOne`, and `clearAll` were never updated to
do the same — they call **bare** `getChartApi()` / `evaluate()`, which don't exist in
module scope (only the `_`-prefixed aliases do). Hence the `ReferenceError`.

This looks like it slipped in when the `_resolve(_deps)` dependency-injection pattern was
introduced: `drawShape` got migrated to it, the other four functions did not.

## Fix

Resolve the locals in those four functions exactly like `drawShape` does (and add a
`_deps` param so they're testable the same way):

```js
export async function listDrawings({ _deps } = {}) {
  const { evaluate, getChartApi } = _resolve(_deps);
  ...
}
export async function getProperties({ entity_id, _deps }) {
  const { evaluate, getChartApi } = _resolve(_deps);
  ...
}
export async function removeOne({ entity_id, _deps }) {
  const { evaluate, getChartApi } = _resolve(_deps);
  ...
}
export async function clearAll({ _deps } = {}) {
  const { evaluate, getChartApi } = _resolve(_deps);
  ...
}
```

## Testing

- `node --check src/core/drawing.js` — clean.
- `node --test tests/sanitization.test.js` — **34/34 pass**.
- Verified live against a running TradingView Desktop: `draw_list`, `draw_remove_one`,
  and `draw_clear` now succeed where they previously threw.
- The two failures in `tests/e2e.test.js` (`ui_open_panel` → `hideWidget is not a
  function`; `replay_stop` → "Replay is not started") are **pre-existing and unrelated**
  to this change.

## Note

The removal/list/clear paths currently have no unit coverage — `sanitization.test.js`
exercises `draw_shape` but not these four — which is why the regression went unnoticed.
Happy to follow up with mockable unit tests for them if useful.

Also fixes the same _resolve(_deps) gap in src/core/chart.js: getVisibleRange, scrollToDate, and symbolInfo called evaluate by its bare (aliased) name → ReferenceError: evaluate is not defined. get_visible_range/scroll_to_date were dead; symbol_info had the same latent bug. symbolSearch is unaffected (uses fetch). Same one-line pattern as the drawing fns.