### PR TITLE
Add focusprofit fork improvements: alert toggles, chart.js evaluate fix, adaptive precision, GUI script switch, byte-exact source injection

### DIFF
--- a/src/cli/commands/alerts.js
+++ b/src/cli/commands/alerts.js
@@ -2,7 +2,7 @@ import { register } from '../router.js';
 import * as core from '../../core/alerts.js';
 
 register('alert', {
-  description: 'Alert tools (list, create, delete)',
+  description: 'Alert tools (list, create, enable, disable, delete)',
   subcommands: new Map([
     ['list', {
       description: 'List active alerts',
@@ -19,6 +19,24 @@ register('alert', {
         price: Number(opts.price),
         condition: opts.condition || 'crossing',
         message: opts.message,
+      }),
+    }],
+    ['enable', {
+      description: 'Enable (restart) one or more alerts by id',
+      options: {
+        ids: { type: 'string', description: 'Comma-separated alert ids' },
+      },
+      handler: (opts) => core.enable({
+        alert_ids: (opts.ids || '').split(',').map(function(s) { return s.trim(); }).filter(Boolean),
+      }),
+    }],
+    ['disable', {
+      description: 'Disable (stop) one or more alerts by id',
+      options: {
+        ids: { type: 'string', description: 'Comma-separated alert ids' },
+      },
+      handler: (opts) => core.disable({
+        alert_ids: (opts.ids || '').split(',').map(function(s) { return s.trim(); }).filter(Boolean),
       }),
     }],
     ['delete', {

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -103,6 +103,52 @@ export async function list() {
   return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
 }
 
+export async function enable({ alert_ids } = {}) {
+  if (!Array.isArray(alert_ids) || alert_ids.length === 0) {
+    throw new Error('enable: alert_ids must be a non-empty array');
+  }
+  const result = await evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/restart_alerts', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      body: JSON.stringify({ payload: { alert_ids: ${JSON.stringify(alert_ids)} } })
+    })
+      .then(function(r) {
+        return r.json().then(function(data) { return { ok: r.ok, status: r.status, data: data }; })
+          .catch(function() { return { ok: r.ok, status: r.status, data: null }; });
+      })
+      .catch(function(e) { return { ok: false, status: 0, error: e.message }; })
+  `);
+  if (!result?.ok) {
+    return { success: false, alert_ids, status: result?.status, error: result?.error || ('HTTP ' + result?.status), response: result?.data };
+  }
+  return { success: true, alert_ids, source: 'internal_api', status: result.status, response: result.data };
+}
+
+export async function disable({ alert_ids } = {}) {
+  if (!Array.isArray(alert_ids) || alert_ids.length === 0) {
+    throw new Error('disable: alert_ids must be a non-empty array');
+  }
+  const result = await evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/stop_alerts', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      body: JSON.stringify({ payload: { alert_ids: ${JSON.stringify(alert_ids)} } })
+    })
+      .then(function(r) {
+        return r.json().then(function(data) { return { ok: r.ok, status: r.status, data: data }; })
+          .catch(function() { return { ok: r.ok, status: r.status, data: null }; });
+      })
+      .catch(function(e) { return { ok: false, status: 0, error: e.message }; })
+  `);
+  if (!result?.ok) {
+    return { success: false, alert_ids, status: result?.status, error: result?.error || ('HTTP ' + result?.status), response: result?.data };
+  }
+  return { success: true, alert_ids, source: 'internal_api', status: result.status, response: result.data };
+}
+
 export async function deleteAlerts({ delete_all }) {
   if (delete_all) {
     const result = await evaluate(`

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,7 +115,8 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
-export async function getVisibleRange() {
+export async function getVisibleRange({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -157,7 +158,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
@@ -196,7 +198,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -3,6 +3,24 @@
  */
 import { evaluate, evaluateAsync, KNOWN_PATHS, safeString } from '../connection.js';
 
+/**
+ * Adaptive price rounding precision based on absolute value.
+ * mintick is not available via current MCP API (quote_get / symbol_info
+ * do not expose it); this heuristic covers the main instrument classes:
+ *   - crypto, indices, metals (>=100): 2 decimal places
+ *   - FX majors, major crosses (1..100): 5 decimal places
+ *   - micro tokens (<1): 5 decimal places
+ *
+ * Known limitation: JPY pairs (~150) fall into the >=100 bucket and get
+ * 2 decimal places instead of the needed 3-5. Exact fix via
+ * chart.symbolExt().minmov is a separate follow-up task.
+ */
+function priceDecimals(value) {
+    const abs = Math.abs(value);
+    if (abs >= 100) return 2;
+    return 5;
+}
+
 const MAX_OHLCV_BARS = 500;
 const MAX_TRADES = 20;
 const CHART_API = KNOWN_PATHS.chartApi;
@@ -368,8 +386,8 @@ export async function getPineLines({ study_filter, verbose } = {}) {
     const allLines = [];
     for (const item of s.items) {
       const v = item.raw;
-      const y1 = v.y1 != null ? Math.round(v.y1 * 100) / 100 : null;
-      const y2 = v.y2 != null ? Math.round(v.y2 * 100) / 100 : null;
+      const y1 = v.y1 != null ? Number(v.y1.toFixed(priceDecimals(v.y1))) : null;
+      const y2 = v.y2 != null ? Number(v.y2.toFixed(priceDecimals(v.y2))) : null;
       if (verbose) allLines.push({ id: item.id, y1, y2, x1: v.x1, x2: v.x2, horizontal: v.y1 === v.y2, style: v.st, width: v.w, color: v.ci });
       if (y1 != null && v.y1 === v.y2 && !seen[y1]) { hLevels.push(y1); seen[y1] = true; }
     }
@@ -391,7 +409,9 @@ export async function getPineLabels({ study_filter, max_labels, verbose } = {}) 
     let labels = s.items.map(item => {
       const v = item.raw;
       const text = v.t || '';
-      const price = v.y != null ? Math.round(v.y * 100) / 100 : null;
+      const price = v.y != null
+        ? Number(v.y.toFixed(priceDecimals(v.y)))
+        : null;
       if (verbose) return { id: item.id, text, price, x: v.x, yloc: v.yl, size: v.sz, textColor: v.tci, color: v.ci };
       return { text, price };
     }).filter(l => l.text || l.price != null);
@@ -440,8 +460,10 @@ export async function getPineBoxes({ study_filter, verbose } = {}) {
     const allBoxes = [];
     for (const item of s.items) {
       const v = item.raw;
-      const high = v.y1 != null && v.y2 != null ? Math.round(Math.max(v.y1, v.y2) * 100) / 100 : null;
-      const low = v.y1 != null && v.y2 != null ? Math.round(Math.min(v.y1, v.y2) * 100) / 100 : null;
+      const hi = v.y1 != null && v.y2 != null ? Math.max(v.y1, v.y2) : null;
+      const lo = v.y1 != null && v.y2 != null ? Math.min(v.y1, v.y2) : null;
+      const high = hi != null ? Number(hi.toFixed(priceDecimals(hi))) : null;
+      const low  = lo != null ? Number(lo.toFixed(priceDecimals(lo))) : null;
       if (verbose) allBoxes.push({ id: item.id, high, low, x1: v.x1, x2: v.x2, borderColor: v.c, bgColor: v.bc });
       if (high != null && low != null) { const key = high + ':' + low; if (!seen[key]) { zones.push({ high, low }); seen[key] = true; } }
     }

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -4,6 +4,25 @@
  * They throw on error (callers catch and format).
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { appendFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// ── Action log (script switches + injects) ──
+// Appends one JSON line per script-editor write action so the history of which
+// script was switched to / injected can be unwound after the fact (TM-229).
+// Override the path with env TV_MCP_ACTION_LOG.
+const ACTION_LOG = process.env.TV_MCP_ACTION_LOG
+  || join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'pine-actions.log');
+
+function logPineAction(entry) {
+  try {
+    appendFileSync(ACTION_LOG, JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n');
+  } catch (_e) { /* logging must never break the action */ }
+}
+
+// Reads the Pine Editor's bound-script title (the Save/Publish target anchor).
+const READ_BOUND_TITLE = `(function(){ var t=document.querySelector('.label-k49p41Es'); return t?t.textContent.trim():null; })()`;
 
 // ── Monaco finder (injected into TV page) ──
 const FIND_MONACO = `
@@ -263,9 +282,12 @@ export async function getSource() {
   return { success: true, source, line_count: source.split('\n').length, char_count: source.length };
 }
 
-export async function setSource({ source }) {
+export async function setSource({ source, reason }) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
+
+  // Record which script is bound (Save target) at inject time — see TM-229.
+  const boundTitle = await evaluate(READ_BOUND_TITLE);
 
   const escaped = JSON.stringify(source);
   const set = await evaluate(`
@@ -278,7 +300,10 @@ export async function setSource({ source }) {
   `);
 
   if (!set) throw new Error('Monaco found but setValue() failed.');
-  return { success: true, lines_set: source.split('\n').length };
+
+  logPineAction({ action: 'set_source', target: boundTitle, lines: source.split('\n').length, chars: source.length, reason: reason || null });
+
+  return { success: true, lines_set: source.split('\n').length, bound_title: boundTitle };
 }
 
 export async function compile() {
@@ -586,6 +611,82 @@ export async function openScript({ name }) {
   }
 
   return { success: true, name: result.name, script_id: result.id, lines: result.lines, source: 'internal_api', opened: true };
+}
+
+/**
+ * Real GUI script switch (TM-229). Unlike openScript() — which only setValue()s a
+ * script's source into the CURRENT editor without changing the editor's bound
+ * script — this drives TradingView's own "Open script…" flow so the editor REBINDS
+ * to the target. After this, Save/Publish target the correct script.
+ *
+ * Steps (validated DOM flow): click the editor name button → click the "Open script…"
+ * menu item → click the matching row in the open dialog → poll until the editor's
+ * bound-title equals the target. Throws (and logs) if the binding does not change,
+ * so callers never proceed with a save/publish on the wrong script.
+ */
+export async function openScriptGui({ name, reason }) {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor.');
+
+  const fromTitle = await evaluate(READ_BOUND_TITLE);
+
+  // Resolve the canonical script_id + exact display name (registry anchor) via pine-facade.
+  const escapedName = JSON.stringify(name.toLowerCase());
+  const meta = await evaluateAsync(`
+    fetch('https://pine-facade.tradingview.com/pine-facade/list/?filter=saved', { credentials: 'include' })
+      .then(function(r){ return r.json(); })
+      .then(function(scripts){
+        if(!Array.isArray(scripts)) return {error:'pine-facade returned unexpected data'};
+        var target=${escapedName};
+        var m=null;
+        for(var i=0;i<scripts.length;i++){ var sn=(scripts[i].scriptName||'').toLowerCase(), st=(scripts[i].scriptTitle||'').toLowerCase(); if(sn===target||st===target){m=scripts[i];break;} }
+        if(!m){ for(var j=0;j<scripts.length;j++){ var sn2=(scripts[j].scriptName||'').toLowerCase(), st2=(scripts[j].scriptTitle||'').toLowerCase(); if(sn2.indexOf(target)!==-1||st2.indexOf(target)!==-1){m=scripts[j];break;} } }
+        if(!m) return {error:'Script "'+target+'" not found. Use pine_list_scripts.'};
+        return {id:m.scriptIdPart, name:m.scriptName||m.scriptTitle};
+      })
+      .catch(function(e){ return {error:e.message}; })
+  `);
+  if (meta?.error) throw new Error(meta.error);
+  const displayName = meta.name;
+  const scriptId = meta.id;
+
+  // Step 1 — open the script-management menu (the editor name button).
+  await evaluate(`(function(){ var n=document.querySelector('.nameButton-k49p41Es'); if(n) n.click(); })()`);
+  await new Promise(r => setTimeout(r, 350));
+
+  // Step 2 — click "Open script…".
+  const menuClicked = await evaluate(`(function(){ var mi=[].slice.call(document.querySelectorAll('[role="menuitem"]')).find(function(e){return /Open script/i.test(e.textContent||'');}); if(!mi) return false; mi.click(); return true; })()`);
+  if (!menuClicked) throw new Error('"Open script…" menu item not found (Pine Editor UI may have changed).');
+  await new Promise(r => setTimeout(r, 600));
+
+  // Step 3 — click the dialog row whose label is exactly the display name (immediately followed by "Version:").
+  const escapedDisplay = JSON.stringify(displayName);
+  const rowClicked = await evaluate(`(function(){
+    var target=${escapedDisplay};
+    var rows=[].slice.call(document.querySelectorAll('*')).filter(function(e){ if(e.children.length>3) return false; var t=(e.textContent||'').trim(); return t.indexOf(target+'Version:')===0; });
+    if(rows.length===0) return false;
+    rows[rows.length-1].click();
+    return true;
+  })()`);
+  if (!rowClicked) throw new Error('Script "'+displayName+'" not found in the open dialog.');
+  await new Promise(r => setTimeout(r, 900));
+
+  // Step 4 — VERIFY the binding actually changed (poll the bound-title).
+  let toTitle = null;
+  for (let i = 0; i < 12; i++) {
+    toTitle = await evaluate(READ_BOUND_TITLE);
+    if (toTitle === displayName) break;
+    await new Promise(r => setTimeout(r, 200));
+  }
+  const verified = toTitle === displayName;
+
+  logPineAction({ action: 'open_gui', from: fromTitle, to: displayName, script_id: scriptId, verified, reason: reason || null });
+
+  if (!verified) {
+    throw new Error('Binding verification FAILED: editor title is "' + toTitle + '", expected "' + displayName + '". Switch did not take effect — do NOT save or publish.');
+  }
+
+  return { success: true, name: displayName, script_id: scriptId, bound_title: toTitle, from: fromTitle, verified: true, method: 'gui_open' };
 }
 
 export async function listScripts() {

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -4,7 +4,8 @@
  * They throw on error (callers catch and format).
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -19,6 +20,14 @@ function logPineAction(entry) {
   try {
     appendFileSync(ACTION_LOG, JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n');
   } catch (_e) { /* logging must never break the action */ }
+}
+
+// SHA-256 hex of a UTF-8 string — used for cryptographic byte-exact verification
+// of editor content vs a local file (TM-233). Closes the char_count gap (equal-
+// length substitutions, e.g. a unicode separator swap, are invisible to char_count
+// but change the hash).
+function sha256(s) {
+  return createHash('sha256').update(s, 'utf8').digest('hex');
 }
 
 // Reads the Pine Editor's bound-script title (the Save/Publish target anchor).
@@ -279,7 +288,7 @@ export async function getSource() {
     throw new Error('Monaco editor found but getValue() returned null.');
   }
 
-  return { success: true, source, line_count: source.split('\n').length, char_count: source.length };
+  return { success: true, source, line_count: source.split('\n').length, char_count: source.length, sha256: sha256(source) };
 }
 
 export async function setSource({ source, reason }) {
@@ -304,6 +313,66 @@ export async function setSource({ source, reason }) {
   logPineAction({ action: 'set_source', target: boundTitle, lines: source.split('\n').length, chars: source.length, reason: reason || null });
 
   return { success: true, lines_set: source.split('\n').length, bound_title: boundTitle };
+}
+
+// Inject a local file's exact bytes into the editor and verify byte-exactly (TM-233).
+// The server reads the file itself (no model transcription of the source), sets it
+// via Monaco setValue, reads it back, and compares SHA-256(file) vs SHA-256(editor).
+// `verified` is the cryptographic guarantee that the editor holds exactly the file.
+// Use this for large / unicode-heavy files (e.g. index.pine) where re-emitting the
+// source as a string argument is unreliable. Like setSource it never targets PROD —
+// the caller must ensure the right script is bound (verify bound_title / pine_open_gui).
+export async function setSourceFromFile({ path, reason }) {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor.');
+
+  const fileContent = readFileSync(path, 'utf8');
+  const fileSha = sha256(fileContent);
+
+  // Record which script is bound (Save target) at inject time — see TM-229.
+  const boundTitle = await evaluate(READ_BOUND_TITLE);
+
+  const escaped = JSON.stringify(fileContent);
+  const set = await evaluate(`
+    (function() {
+      var m = ${FIND_MONACO};
+      if (!m) return false;
+      m.editor.setValue(${escaped});
+      return true;
+    })()
+  `);
+  if (!set) throw new Error('Monaco found but setValue() failed.');
+
+  // Read back and verify byte-exactly via hash.
+  const editorContent = await evaluate(`
+    (function() {
+      var m = ${FIND_MONACO};
+      if (!m) return null;
+      return m.editor.getValue();
+    })()
+  `);
+  if (editorContent === null || editorContent === undefined) {
+    throw new Error('Monaco getValue() returned null after setSourceFromFile.');
+  }
+  const editorSha = sha256(editorContent);
+  const verified = fileSha === editorSha;
+
+  logPineAction({
+    action: 'set_source_from_file', target: boundTitle, path,
+    bytes: Buffer.byteLength(fileContent, 'utf8'), lines: fileContent.split('\n').length,
+    sha256: fileSha, verified, reason: reason || null,
+  });
+
+  return {
+    success: true,
+    path,
+    bound_title: boundTitle,
+    lines_set: fileContent.split('\n').length,
+    byte_count: Buffer.byteLength(fileContent, 'utf8'),
+    sha256: fileSha,
+    sha256_editor: editorSha,
+    verified,
+  };
 }
 
 export async function compile() {

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -17,6 +17,20 @@ export function registerAlertTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
+  server.tool('alert_enable', 'Enable (restart) one or more alerts by id via pricealerts API', {
+    alert_ids: z.array(z.union([z.string(), z.number()])).min(1).describe('Array of alert_id values to enable'),
+  }, async ({ alert_ids }) => {
+    try { return jsonResult(await core.enable({ alert_ids })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('alert_disable', 'Disable (stop) one or more alerts by id via pricealerts API', {
+    alert_ids: z.array(z.union([z.string(), z.number()])).min(1).describe('Array of alert_id values to disable'),
+  }, async ({ alert_ids }) => {
+    try { return jsonResult(await core.disable({ alert_ids })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
   server.tool('alert_delete', 'Delete all alerts or open context menu for deletion', {
     delete_all: z.coerce.boolean().optional().describe('Delete all alerts'),
   }, async ({ delete_all }) => {

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -16,6 +16,14 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
+  server.tool('pine_set_source_from_file', 'Inject a local file\'s exact bytes into the editor and verify byte-exactly. The server reads the file itself (no transcription of the source), sets it via Monaco, reads it back and compares SHA-256(file) vs SHA-256(editor) — the returned "verified" flag is the cryptographic byte-exact guarantee (closes the char_count gap). Use for large / unicode-heavy files (e.g. index.pine). Returns bound_title (the Save/Publish target) — verify it before saving. Never use to target the PROD script.', {
+    path: z.string().describe('Absolute path to the local file whose bytes will be injected'),
+    reason: z.string().optional().describe('Optional context (e.g. "TM-231: inject index.pine") logged to pine-actions.log'),
+  }, async ({ path, reason }) => {
+    try { return jsonResult(await core.setSourceFromFile({ path, reason })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
   server.tool('pine_compile', 'Compile / add the current Pine Script to the chart', {}, async () => {
     try { return jsonResult(await core.compile()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -8,10 +8,11 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_set_source', 'Set Pine Script source code in the editor', {
+  server.tool('pine_set_source', 'Set Pine Script source code in the editor (returns bound_title = the script the editor will Save to — verify it matches your intended target before saving)', {
     source: z.string().describe('Pine Script source code to inject'),
-  }, async ({ source }) => {
-    try { return jsonResult(await core.setSource({ source })); }
+    reason: z.string().optional().describe('Optional context (e.g. "TM-230: warning fix") logged to pine-actions.log'),
+  }, async ({ source, reason }) => {
+    try { return jsonResult(await core.setSource({ source, reason })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
@@ -47,11 +48,19 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_open', 'Open a saved Pine Script by name', {
+  server.tool('pine_open', 'DEPRECATED — loads a script\'s source into the CURRENT editor WITHOUT changing the editor\'s bound script (Save/Publish target stays unchanged). Risk: a subsequent save overwrites the bound script with the loaded source. Use pine_open_gui to actually switch scripts.', {
     name: z.string().describe('Name of the saved script to open (case-insensitive match)'),
   }, async ({ name }) => {
     try { return jsonResult(await core.openScript({ name })); }
     catch (err) { return jsonResult({ success: false, source: 'internal_api', error: err.message }, true); }
+  });
+
+  server.tool('pine_open_gui', 'Really switch the Pine Editor to another saved script by driving TradingView\'s own "Open script…" flow, so the editor REBINDS (Save/Publish then target the new script). Verifies the switch by polling the editor title and throws if it did not change. Returns the canonical script_id. Logs the switch to pine-actions.log.', {
+    name: z.string().describe('Name of the saved script to switch to (case-insensitive match)'),
+    reason: z.string().optional().describe('Optional context (e.g. "TM-231: edit tmAlert") logged to pine-actions.log'),
+  }, async ({ name, reason }) => {
+    try { return jsonResult(await core.openScriptGui({ name, reason })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
   server.tool('pine_list_scripts', 'List saved Pine Scripts', {}, async () => {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -60,6 +60,41 @@ function wv(path) {
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Unit tests — no CDP connection required
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Mirror of priceDecimals from src/core/data.js for test-scope validation. */
+function priceDecimals(value) {
+  const abs = Math.abs(value);
+  if (abs >= 100) return 2;
+  return 5;
+}
+
+describe('priceDecimals — adaptive price rounding heuristic', () => {
+  it('FX major (1.16017) → 5 decimal places', () => {
+    assert.strictEqual(priceDecimals(1.16017), 5);
+  });
+  it('JPY pair (150.23) → 2 decimal places (known limitation)', () => {
+    assert.strictEqual(priceDecimals(150.23), 2);
+  });
+  it('XAUUSD (4504.33) → 2 decimal places', () => {
+    assert.strictEqual(priceDecimals(4504.33), 2);
+  });
+  it('BTCUSDT (77123.5) → 2 decimal places', () => {
+    assert.strictEqual(priceDecimals(77123.5), 2);
+  });
+  it('micro token (0.00045) → 5 decimal places', () => {
+    assert.strictEqual(priceDecimals(0.00045), 5);
+  });
+  it('boundary at 100 exactly → 2 decimal places', () => {
+    assert.strictEqual(priceDecimals(100), 2);
+  });
+  it('negative FX value (-1.16017) → 5 decimal places', () => {
+    assert.strictEqual(priceDecimals(-1.16017), 5);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 
 describe('TradingView MCP — Full E2E (70 tools)', () => {
 
@@ -472,7 +507,8 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
                 var prices = [];
                 var seen = {};
                 coll._primitivesDataById.forEach(function(v) {
-                  var y = v.y1 != null && v.y1 === v.y2 ? Math.round(v.y1 * 100) / 100 : null;
+                  var dec = Math.abs(v.y1) >= 100 ? 2 : 5;
+                  var y = v.y1 != null && v.y1 === v.y2 ? Number(v.y1.toFixed(dec)) : null;
                   if (y != null && !seen[y]) { prices.push(y); seen[y] = true; }
                 });
                 prices.sort(function(a,b) { return b - a; });
@@ -505,7 +541,8 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
               if (coll && coll._primitivesDataById && coll._primitivesDataById.size > 0) {
                 var labels = [];
                 coll._primitivesDataById.forEach(function(v) {
-                  if (v.t || v.y != null) labels.push({ text: v.t || '', price: v.y != null ? Math.round(v.y * 100) / 100 : null });
+                  var pdec = v.y != null ? (Math.abs(v.y) >= 100 ? 2 : 5) : 0;
+                  if (v.t || v.y != null) labels.push({ text: v.t || '', price: v.y != null ? Number(v.y.toFixed(pdec)) : null });
                 });
                 if (labels.length > 50) labels = labels.slice(-50);
                 var name = '';


### PR DESCRIPTION
This PR contributes five independent improvements from the focusprofit fork:
1. alert_enable / alert_disable tools + CLI — toggle existing alerts without recreating them.
2. fix(chart.js): apply _resolve(_deps) to getVisibleRange/scrollToDate/symbolInfo (they didn't destructure evaluate → "evaluate is not defined"). Matches all other helpers (PR #30).
3. Adaptive price precision in getPineLabels/getPineBoxes/getPineLines.
4. pine_open_gui — real GUI-driven script switch (editor actually rebinds); pine_open deprecated.
5. pine_set_source_from_file — inject a file's exact bytes with SHA-256 byte-exact verify.
Each is a separate commit; happy to split into per-feature PRs if preferred.