### PR TITLE
Add Streamable HTTP transport alongside stdio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -427,12 +430,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -588,9 +591,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -639,9 +642,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "start": "node src/server.js",
+    "start:http": "node src/server-http.js",
     "tv": "node src/cli/index.js",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",

--- a/src/create-server.js
+++ b/src/create-server.js
@@ -1,0 +1,88 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerHealthTools } from './tools/health.js';
+import { registerChartTools } from './tools/chart.js';
+import { registerPineTools } from './tools/pine.js';
+import { registerDataTools } from './tools/data.js';
+import { registerCaptureTools } from './tools/capture.js';
+import { registerDrawingTools } from './tools/drawing.js';
+import { registerAlertTools } from './tools/alerts.js';
+import { registerBatchTools } from './tools/batch.js';
+import { registerReplayTools } from './tools/replay.js';
+import { registerIndicatorTools } from './tools/indicators.js';
+import { registerWatchlistTools } from './tools/watchlist.js';
+import { registerUiTools } from './tools/ui.js';
+import { registerPaneTools } from './tools/pane.js';
+import { registerTabTools } from './tools/tab.js';
+
+export function createMcpServer() {
+  const server = new McpServer(
+    {
+      name: 'tradingview',
+      version: '2.0.0',
+      description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
+    },
+    {
+      instructions: `TradingView MCP — 78 tools for reading and controlling a live TradingView Desktop chart.
+
+TOOL SELECTION GUIDE — use this to pick the right tool:
+
+Reading your chart:
+- chart_get_state → get symbol, timeframe, all indicator names + entity IDs (call first)
+- data_get_study_values → get current numeric values from ALL visible indicators (RSI, MACD, BB, EMA, etc.)
+- quote_get → get real-time price snapshot (last, OHLC, volume)
+- data_get_ohlcv → get price bars. ALWAYS pass summary=true unless you need individual bars
+
+Reading custom Pine indicator output (line.new/label.new/table.new/box.new drawings):
+- data_get_pine_lines → horizontal price levels from custom indicators (deduplicated, sorted)
+- data_get_pine_labels → text annotations with prices ("PDH 24550", "Bias Long", etc.)
+- data_get_pine_tables → table data formatted as rows (session stats, analytics dashboards)
+- data_get_pine_boxes → price zones as {high, low} pairs
+- ALWAYS pass study_filter to target a specific indicator by name (e.g., study_filter="Profiler")
+- Indicators must be VISIBLE on chart for these to work
+
+Changing the chart:
+- chart_set_symbol, chart_set_timeframe, chart_set_type → change ticker/resolution/style
+- chart_manage_indicator → add/remove studies. USE FULL NAMES: "Relative Strength Index" not "RSI"
+- chart_scroll_to_date → jump to a date (ISO format)
+- indicator_set_inputs → change indicator settings (length, source, etc.)
+
+Pine Script development:
+- pine_set_source → inject code, pine_smart_compile → compile + check errors
+- pine_get_errors → read errors, pine_get_console → read log output
+- WARNING: pine_get_source can return 200KB+ for complex scripts — avoid unless editing
+
+Screenshots: capture_screenshot → regions: "full", "chart", "strategy_tester"
+Replay: replay_start → replay_step → replay_trade → replay_status → replay_stop
+Batch: batch_run → run action across multiple symbols/timeframes
+Drawing: draw_shape → horizontal_line, trend_line, rectangle, text
+Alerts: alert_create, alert_list, alert_delete
+Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
+Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
+Tabs: tab_list, tab_new, tab_close, tab_switch
+
+CONTEXT MANAGEMENT:
+- ALWAYS use summary=true on data_get_ohlcv
+- ALWAYS use study_filter on pine tools when you know which indicator you want
+- NEVER use verbose=true unless user specifically asks for raw data
+- Prefer capture_screenshot for visual context over pulling large datasets
+- Call chart_get_state ONCE at start, reuse entity IDs`,
+    }
+  );
+
+  registerHealthTools(server);
+  registerChartTools(server);
+  registerPineTools(server);
+  registerDataTools(server);
+  registerCaptureTools(server);
+  registerDrawingTools(server);
+  registerAlertTools(server);
+  registerBatchTools(server);
+  registerReplayTools(server);
+  registerIndicatorTools(server);
+  registerWatchlistTools(server);
+  registerUiTools(server);
+  registerPaneTools(server);
+  registerTabTools(server);
+
+  return server;
+}

--- a/src/server-http.js
+++ b/src/server-http.js
@@ -1,0 +1,82 @@
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createMcpServer } from './create-server.js';
+
+const PORT = parseInt(process.env.MCP_HTTP_PORT || process.argv[2] || '3000');
+const HOST = process.env.MCP_HTTP_HOST || '127.0.0.1';
+
+// sessionId → StreamableHTTPServerTransport
+const sessions = new Map();
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  if (!chunks.length) return undefined;
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString());
+  } catch {
+    return undefined;
+  }
+}
+
+const httpServer = createServer(async (req, res) => {
+  if (req.url !== '/mcp') {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found — MCP endpoint is /mcp');
+    return;
+  }
+
+  try {
+    const sessionId = req.headers['mcp-session-id'];
+
+    if (req.method === 'POST') {
+      const body = await readBody(req);
+
+      if (!sessionId) {
+        // New session: client sending initialize (or first request)
+        const newId = randomUUID();
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => newId,
+        });
+        const mcpServer = createMcpServer();
+        await mcpServer.connect(transport);
+        sessions.set(newId, transport);
+        transport.onclose = () => sessions.delete(newId);
+        await transport.handleRequest(req, res, body);
+      } else {
+        const transport = sessions.get(sessionId);
+        if (!transport) {
+          res.writeHead(404, { 'Content-Type': 'text/plain' });
+          res.end('Session not found');
+          return;
+        }
+        await transport.handleRequest(req, res, body);
+      }
+    } else if (req.method === 'GET' || req.method === 'DELETE') {
+      const transport = sessions.get(sessionId);
+      if (!transport) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Session not found');
+        return;
+      }
+      await transport.handleRequest(req, res, undefined);
+    } else {
+      res.writeHead(405, { Allow: 'GET, POST, DELETE' });
+      res.end('Method not allowed');
+    }
+  } catch (err) {
+    process.stderr.write(`MCP HTTP error: ${err.message}\n`);
+    if (!res.headersSent) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal server error');
+    }
+  }
+});
+
+process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');
+process.stderr.write('   Ensure your usage complies with TradingView\'s Terms of Use.\n\n');
+
+httpServer.listen(PORT, HOST, () => {
+  process.stderr.write(`MCP HTTP server listening on http://${HOST}:${PORT}/mcp\n`);
+});

--- a/src/server.js
+++ b/src/server.js
@@ -1,94 +1,9 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { registerHealthTools } from './tools/health.js';
-import { registerChartTools } from './tools/chart.js';
-import { registerPineTools } from './tools/pine.js';
-import { registerDataTools } from './tools/data.js';
-import { registerCaptureTools } from './tools/capture.js';
-import { registerDrawingTools } from './tools/drawing.js';
-import { registerAlertTools } from './tools/alerts.js';
-import { registerBatchTools } from './tools/batch.js';
-import { registerReplayTools } from './tools/replay.js';
-import { registerIndicatorTools } from './tools/indicators.js';
-import { registerWatchlistTools } from './tools/watchlist.js';
-import { registerUiTools } from './tools/ui.js';
-import { registerPaneTools } from './tools/pane.js';
-import { registerTabTools } from './tools/tab.js';
+import { createMcpServer } from './create-server.js';
 
-const server = new McpServer(
-  {
-    name: 'tradingview',
-    version: '2.0.0',
-    description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
-  },
-  {
-    instructions: `TradingView MCP — 78 tools for reading and controlling a live TradingView Desktop chart.
-
-TOOL SELECTION GUIDE — use this to pick the right tool:
-
-Reading your chart:
-- chart_get_state → get symbol, timeframe, all indicator names + entity IDs (call first)
-- data_get_study_values → get current numeric values from ALL visible indicators (RSI, MACD, BB, EMA, etc.)
-- quote_get → get real-time price snapshot (last, OHLC, volume)
-- data_get_ohlcv → get price bars. ALWAYS pass summary=true unless you need individual bars
-
-Reading custom Pine indicator output (line.new/label.new/table.new/box.new drawings):
-- data_get_pine_lines → horizontal price levels from custom indicators (deduplicated, sorted)
-- data_get_pine_labels → text annotations with prices ("PDH 24550", "Bias Long", etc.)
-- data_get_pine_tables → table data as formatted rows (session stats, analytics dashboards)
-- data_get_pine_boxes → price zones as {high, low} pairs
-- ALWAYS pass study_filter to target a specific indicator by name (e.g., study_filter="Profiler")
-- Indicators must be VISIBLE on chart for these to work
-
-Changing the chart:
-- chart_set_symbol, chart_set_timeframe, chart_set_type → change ticker/resolution/style
-- chart_manage_indicator → add/remove studies. USE FULL NAMES: "Relative Strength Index" not "RSI"
-- chart_scroll_to_date → jump to a date (ISO format)
-- indicator_set_inputs → change indicator settings (length, source, etc.)
-
-Pine Script development:
-- pine_set_source → inject code, pine_smart_compile → compile + check errors
-- pine_get_errors → read errors, pine_get_console → read log output
-- WARNING: pine_get_source can return 200KB+ for complex scripts — avoid unless editing
-
-Screenshots: capture_screenshot → regions: "full", "chart", "strategy_tester"
-Replay: replay_start → replay_step → replay_trade → replay_status → replay_stop
-Batch: batch_run → run action across multiple symbols/timeframes
-Drawing: draw_shape → horizontal_line, trend_line, rectangle, text
-Alerts: alert_create, alert_list, alert_delete
-Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
-Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
-Tabs: tab_list, tab_new, tab_close, tab_switch
-
-CONTEXT MANAGEMENT:
-- ALWAYS use summary=true on data_get_ohlcv
-- ALWAYS use study_filter on pine tools when you know which indicator you want
-- NEVER use verbose=true unless user specifically asks for raw data
-- Prefer capture_screenshot for visual context over pulling large datasets
-- Call chart_get_state ONCE at start, reuse entity IDs`,
-  }
-);
-
-// Register all tool groups
-registerHealthTools(server);
-registerChartTools(server);
-registerPineTools(server);
-registerDataTools(server);
-registerCaptureTools(server);
-registerDrawingTools(server);
-registerAlertTools(server);
-registerBatchTools(server);
-registerReplayTools(server);
-registerIndicatorTools(server);
-registerWatchlistTools(server);
-registerUiTools(server);
-registerPaneTools(server);
-registerTabTools(server);
-
-// Startup notice (stderr so it doesn't interfere with MCP stdio protocol)
 process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');
 process.stderr.write('   Ensure your usage complies with TradingView\'s Terms of Use.\n\n');
 
-// Start stdio transport
+const server = createMcpServer();
 const transport = new StdioServerTransport();
 await server.connect(transport);


### PR DESCRIPTION
## Summary

- Extracts `McpServer` construction into `src/create-server.js` so both transports share the same tool registration
- `src/server.js` keeps the existing stdio path unchanged (no breaking change to existing Claude Code config)
- `src/server-http.js` adds a session-aware [MCP Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) server; sessions tracked by `Mcp-Session-Id` header, each session gets its own `McpServer` instance
- Port defaults to `3000`, configurable via `MCP_HTTP_PORT` env var or first CLI arg
- Adds `start:http` npm script

## Usage

```bash
npm run start:http           # http://127.0.0.1:3000/mcp
MCP_HTTP_PORT=8080 npm run start:http
```

Configure any MCP client that supports HTTP transport:
```json
{ "url": "http://127.0.0.1:3000/mcp" }
```

## Test plan

- [x] `npm run start` (stdio) still works
- [x] `npm run start:http` starts and responds `200 OK` to a well-formed `initialize` POST
- [x] Session ID returned in `Mcp-Session-Id` response header and usable in subsequent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)