### PR TITLE
Fix strategy detection + getTrades mapping (data.js) and Pine add-to-chart button (locale-safe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
+    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/strategy_results.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/strategy_results.test.js",
     "test:cli": "node --test tests/cli.test.js",
     "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/strategy_results.test.js",
+    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/strategy_results.test.js tests/pine_compile_button.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/strategy_results.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/strategy_results.test.js tests/pine_compile_button.test.js",
     "test:cli": "node --test tests/cli.test.js",
     "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -198,6 +198,30 @@ export function flattenStrategyReport(raw) {
   return metrics;
 }
 
+// Maps TradingView's minified order-leg keys (from ordersData()) to readable
+// names. Meanings verified live against a real backtest on TV 3.2.0:
+//   b  -> isBuy   (true on a long entry / buy, false when closing a long / sell)
+//   e  -> isEntry (true for entry orders, false for exit/close orders)
+//   tm -> seq     (order sequence index 0..n-1; NOT a bar index or timestamp —
+//                  tm matched the array position across all sampled orders and
+//                  avgBarsInTrade was ~27, ruling out a per-bar index)
+// Note: ordersData() carries no timestamp; the richer paired-trade data with
+// P&L lives in reportData().trades (cp/dd/rn fields) — a future getTrades source.
+const ORDER_KEY_MAP = { b: 'isBuy', c: 'comment', e: 'isEntry', id: 'id', p: 'price', q: 'qty', tm: 'seq', tp: 'type' };
+
+export function normalizeOrder(o) {
+  const out = {};
+  if (!o || typeof o !== 'object') return out;
+  for (const k of Object.keys(o)) {
+    const v = o[k];
+    if (v === null || v === undefined) continue;
+    const t = typeof v;
+    if (t !== 'number' && t !== 'string' && t !== 'boolean') continue;
+    out[ORDER_KEY_MAP[k] || k] = v;
+  }
+  return out;
+}
+
 export async function getStrategyResults({ _deps } = {}) {
   const { evaluate } = _resolve(_deps);
   const raw = await evaluate(`
@@ -257,7 +281,8 @@ export async function getTrades({ max_trades } = {}) {
       } catch(e) { return {trades: [], source: 'internal_api', error: e.message}; }
     })()
   `);
-  return { success: true, trade_count: trades?.trades?.length || 0, source: trades?.source, trades: trades?.trades || [], error: trades?.error };
+  const normalized = (trades?.trades || []).map(normalizeOrder);
+  return { success: true, trade_count: normalized.length, source: trades?.source, trades: normalized, error: trades?.error };
 }
 
 export async function getEquity() {

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -132,36 +132,98 @@ export async function getIndicator({ entity_id }) {
   return { success: true, entity_id, visible: data?.visible, inputs };
 }
 
-export async function getStrategyResults() {
-  const results = await evaluate(`
+function _resolve(deps) {
+  return { evaluate: deps?.evaluate || evaluate };
+}
+
+/**
+ * Locate the strategy among the chart's data sources.
+ *
+ * A strategy is the ONLY data source that exposes reportData()/ordersData().
+ * The old heuristic `is_price_study === false && (reportData || performance)`
+ * was wrong on two counts in TradingView 3.2.0's new strategy tester:
+ *   1. `performance` exists on EVERY study, so it matched the first non-overlay
+ *      indicator (Volume/RSI/MACD) instead of the strategy.
+ *   2. `is_price_study === true` for overlay strategies, so the filter excluded
+ *      them entirely.
+ *
+ * Defined as an exported function so it can be unit-tested in Node AND embedded
+ * verbatim into the in-page IIFE via toString() — keep it self-contained (no
+ * closures / outer references / non-ES2015 syntax).
+ */
+export function findStrategySource(sources) {
+  for (var i = 0; i < sources.length; i++) {
+    var s = sources[i];
+    if (s && (s.reportData || s.ordersData)) return s;
+  }
+  return null;
+}
+
+/**
+ * Flatten a strategy report payload into a flat scalar metrics map.
+ *
+ * In the new tester the metrics live in `reportData().performance`, NOT in
+ * `dataSource.performance()` (which returns null). Shape:
+ *   performance = { <top-level scalars: sharpeRatio, maxStrategyDrawDown, ...>,
+ *                   all: {...}, long: {...}, short: {...} }
+ * The `all` bucket (net profit, profit factor, win rate, total trades, ...) is
+ * emitted unprefixed as the headline; long/short are prefixed long_/short_.
+ */
+export function flattenStrategyReport(raw) {
+  const metrics = {};
+  if (!raw || typeof raw !== 'object') return metrics;
+  const perf = raw.performance;
+  if (perf && typeof perf === 'object') {
+    for (const k of Object.keys(perf)) {
+      const v = perf[k];
+      if (typeof v === 'number' || typeof v === 'string' || typeof v === 'boolean') metrics[k] = v;
+    }
+    // 'all' is emitted unprefixed AFTER the top-level scalars, so on a key
+    // collision the 'all' (headline) value intentionally wins. The two key sets
+    // are disjoint in TradingView 3.2.0; this ordering just makes the precedence
+    // explicit if that ever changes.
+    for (const bucket of ['all', 'long', 'short']) {
+      const b = perf[bucket];
+      if (b && typeof b === 'object') {
+        const prefix = bucket === 'all' ? '' : bucket + '_';
+        for (const k of Object.keys(b)) {
+          const v = b[k];
+          if (typeof v === 'number' || typeof v === 'string' || typeof v === 'boolean') metrics[prefix + k] = v;
+        }
+      }
+    }
+  }
+  if (raw.currency !== null && raw.currency !== undefined) metrics.currency = raw.currency;
+  if (raw.tradesCount !== null && raw.tradesCount !== undefined) metrics.tradesCount = raw.tradesCount;
+  return metrics;
+}
+
+export async function getStrategyResults({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  const raw = await evaluate(`
     (function() {
       try {
         var chart = ${CHART_API}._chartWidget;
         var sources = chart.model().model().dataSources();
-        var strat = null;
-        for (var i = 0; i < sources.length; i++) {
-          var s = sources[i];
-          if (s.metaInfo && s.metaInfo().is_price_study === false && (s.reportData || s.performance)) { strat = s; break; }
-        }
-        if (!strat) return {metrics: {}, source: 'internal_api', error: 'No strategy found on chart. Add a strategy indicator first.'};
-        var metrics = {};
-        if (strat.reportData) {
-          var rd = typeof strat.reportData === 'function' ? strat.reportData() : strat.reportData;
-          if (rd && typeof rd === 'object') {
-            if (typeof rd.value === 'function') rd = rd.value();
-            if (rd) { var keys = Object.keys(rd); for (var k = 0; k < keys.length; k++) { var val = rd[keys[k]]; if (val !== null && val !== undefined && typeof val !== 'function') metrics[keys[k]] = val; } }
-          }
-        }
-        if (Object.keys(metrics).length === 0 && strat.performance) {
-          var perf = strat.performance();
-          if (perf && typeof perf.value === 'function') perf = perf.value();
-          if (perf && typeof perf === 'object') { var pkeys = Object.keys(perf); for (var p = 0; p < pkeys.length; p++) { var pval = perf[pkeys[p]]; if (pval !== null && pval !== undefined && typeof pval !== 'function') metrics[pkeys[p]] = pval; } }
-        }
-        return {metrics: metrics, source: 'internal_api'};
-      } catch(e) { return {metrics: {}, source: 'internal_api', error: e.message}; }
+        var findStrategy = ${findStrategySource.toString()};
+        var strat = findStrategy(sources);
+        if (!strat) return {error: 'No strategy found on chart. Add a strategy indicator first.'};
+        var rd = typeof strat.reportData === 'function' ? strat.reportData() : strat.reportData;
+        if (rd && typeof rd.value === 'function') rd = rd.value();
+        if (!rd || typeof rd !== 'object') return {error: 'Strategy found but report data is unavailable.'};
+        var perf = rd.performance;
+        if (perf && typeof perf.value === 'function') perf = perf.value();
+        var tradesCount = null;
+        try { if (rd.trades && typeof rd.trades.length === 'number') tradesCount = rd.trades.length; } catch(e) {}
+        return { currency: rd.currency, performance: (perf && typeof perf === 'object') ? perf : null, tradesCount: tradesCount };
+      } catch(e) { return {error: e.message}; }
     })()
   `);
-  return { success: true, metric_count: Object.keys(results?.metrics || {}).length, source: results?.source, metrics: results?.metrics || {}, error: results?.error };
+  if (raw && raw.error) {
+    return { success: true, metric_count: 0, source: 'internal_api', metrics: {}, error: raw.error };
+  }
+  const metrics = flattenStrategyReport(raw);
+  return { success: true, metric_count: Object.keys(metrics).length, source: 'internal_api', metrics };
 }
 
 export async function getTrades({ max_trades } = {}) {
@@ -171,11 +233,8 @@ export async function getTrades({ max_trades } = {}) {
       try {
         var chart = ${CHART_API}._chartWidget;
         var sources = chart.model().model().dataSources();
-        var strat = null;
-        for (var i = 0; i < sources.length; i++) {
-          var s = sources[i];
-          if (s.metaInfo && s.metaInfo().is_price_study === false && (s.ordersData || s.reportData)) { strat = s; break; }
-        }
+        var findStrategy = ${findStrategySource.toString()};
+        var strat = findStrategy(sources);
         if (!strat) return {trades: [], source: 'internal_api', error: 'No strategy found on chart.'};
         var orders = null;
         if (strat.ordersData) { orders = typeof strat.ordersData === 'function' ? strat.ordersData() : strat.ordersData; if (orders && typeof orders.value === 'function') orders = orders.value(); }
@@ -207,11 +266,8 @@ export async function getEquity() {
       try {
         var chart = ${CHART_API}._chartWidget;
         var sources = chart.model().model().dataSources();
-        var strat = null;
-        for (var i = 0; i < sources.length; i++) {
-          var s = sources[i];
-          if (s.metaInfo && s.metaInfo().is_price_study === false && (s.reportData || s.performance)) { strat = s; break; }
-        }
+        var findStrategy = ${findStrategySource.toString()};
+        var strat = findStrategy(sources);
         if (!strat) return {data: [], source: 'internal_api', error: 'No strategy found on chart.'};
         var data = [];
         if (strat.equityData) {

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -281,29 +281,52 @@ export async function setSource({ source }) {
   return { success: true, lines_set: source.split('\n').length };
 }
 
+/**
+ * Classify a Pine-editor toolbar button into a compile action.
+ *
+ * Matches against textContent, the `title` attribute AND `aria-label` — the
+ * add-to-chart button is icon-only (empty textContent) on non-English UIs and
+ * carries the label only in its localized `title`. Returns one of
+ * 'save-and-add' | 'add-or-update' | 'save' | null.
+ *
+ * Exported so it can be unit-tested in Node and embedded into the in-page IIFE
+ * via toString() — keep it self-contained (no closures / outer references).
+ *
+ * Localized labels: English via anchored regex; other locales by exact title.
+ * Add a locale by extending ADD_OR_UPDATE_LABELS below.
+ */
+export function classifyPineButton(b) {
+  if (!b) return null;
+  var labels = [b.text || '', b.title || '', b.aria || ''].map(function (s) { return String(s).trim(); });
+  var className = String(b.className || '');
+  // Korean (차트에 넣기 = Add to chart, 차트에서 업데이트 = Update on chart). Extend per locale.
+  var ADD_OR_UPDATE_LABELS = ['차트에 넣기', '차트에서 업데이트'];
+  function anyMatch(re) { for (var i = 0; i < labels.length; i++) { if (re.test(labels[i])) return true; } return false; }
+  function anyEq(arr) { for (var i = 0; i < labels.length; i++) { if (arr.indexOf(labels[i]) !== -1) return true; } return false; }
+  if (anyMatch(/save and add to chart/i)) return 'save-and-add';
+  if (anyMatch(/^(add to chart|update on chart)/i) || anyEq(ADD_OR_UPDATE_LABELS)) return 'add-or-update';
+  if (className.indexOf('saveButton') !== -1) return 'save';
+  return null;
+}
+
 export async function compile() {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
   const clicked = await evaluate(`
     (function() {
+      var classify = ${classifyPineButton.toString()};
       var btns = document.querySelectorAll('button');
-      var fallback = null;
+      var addBtn = null;
       var saveBtn = null;
       for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (/save and add to chart/i.test(text)) {
-          btns[i].click();
-          return 'Save and add to chart';
-        }
-        if (!fallback && /^(Add to chart|Update on chart)/i.test(text)) {
-          fallback = btns[i];
-        }
-        if (!saveBtn && btns[i].className.indexOf('saveButton') !== -1 && btns[i].offsetParent !== null) {
-          saveBtn = btns[i];
-        }
+        var b = btns[i];
+        var kind = classify({ text: b.textContent, title: b.getAttribute('title'), aria: b.getAttribute('aria-label'), className: (b.className || '').toString() });
+        if (kind === 'save-and-add' && b.offsetParent !== null) { b.click(); return 'Save and add to chart'; }
+        if (kind === 'add-or-update' && !addBtn && b.offsetParent !== null) addBtn = b;
+        if (kind === 'save' && !saveBtn && b.offsetParent !== null) saveBtn = b;
       }
-      if (fallback) { fallback.click(); return fallback.textContent.trim(); }
+      if (addBtn) { addBtn.click(); return (addBtn.getAttribute('title') || addBtn.textContent.trim() || 'Add to chart'); }
       if (saveBtn) { saveBtn.click(); return 'Pine Save'; }
       return null;
     })()

--- a/tests/pine_compile_button.test.js
+++ b/tests/pine_compile_button.test.js
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the Pine-editor compile/add-to-chart button classifier.
+ * No TradingView connection needed.
+ *
+ * Regression: the old finder matched ONLY English button textContent
+ * (/^(Add to chart|Update on chart)/), so on a Korean UI — where the button is
+ * icon-only with title="차트에 넣기" and empty textContent — it fell through to
+ * the Save button, and pine_smart_compile never added the script to the chart.
+ *
+ * Run: node --test tests/pine_compile_button.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyPineButton } from '../src/core/pine.js';
+
+describe('classifyPineButton()', () => {
+  it('classifies English "Add to chart" by textContent', () => {
+    assert.equal(classifyPineButton({ text: 'Add to chart' }), 'add-or-update');
+  });
+
+  it('classifies English "Update on chart" by textContent', () => {
+    assert.equal(classifyPineButton({ text: 'Update on chart' }), 'add-or-update');
+  });
+
+  it('classifies Korean "차트에 넣기" by title when textContent is empty (icon button)', () => {
+    assert.equal(classifyPineButton({ text: '', title: '차트에 넣기' }), 'add-or-update');
+  });
+
+  it('classifies Korean "차트에서 업데이트" (update on chart) by title', () => {
+    assert.equal(classifyPineButton({ text: '', title: '차트에서 업데이트' }), 'add-or-update');
+  });
+
+  it('classifies "Save and add to chart" with higher priority than plain add', () => {
+    assert.equal(classifyPineButton({ text: 'Save and add to chart' }), 'save-and-add');
+  });
+
+  it('classifies the save button by its locale-independent className hook', () => {
+    assert.equal(
+      classifyPineButton({ text: '', className: 'saveButton-fF7iXGw2 saved-fF7iXGw2 lightButton-Mym3My5x' }),
+      'save'
+    );
+  });
+
+  it('returns null for unrelated buttons (publish, etc.)', () => {
+    assert.equal(classifyPineButton({ text: '퍼블리쉬', className: 'publishButton-HeHIQL4x' }), null);
+    assert.equal(classifyPineButton({ text: 'Publish', className: 'publishButton-x' }), null);
+  });
+
+  it('returns null for empty / nullish input', () => {
+    assert.equal(classifyPineButton({}), null);
+    assert.equal(classifyPineButton(null), null);
+  });
+
+  it('does not misclassify "Save and add to chart" as plain add (anchor check)', () => {
+    // The add/update regex is anchored, so this must take the save-and-add branch.
+    assert.notEqual(classifyPineButton({ text: 'Save and add to chart' }), 'add-or-update');
+  });
+});

--- a/tests/strategy_results.test.js
+++ b/tests/strategy_results.test.js
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for strategy-results extraction logic (data_get_strategy_results).
+ * No TradingView connection needed — exercises the pure helpers directly.
+ *
+ * Fixture shape captured live from TradingView Desktop 3.2.0 (new strategy tester):
+ *   dataSource.reportData() === { currency, trades, filledOrders, buyHoldPercent,
+ *                                 settings, performance: { <scalars>, all, long, short } }
+ *   dataSource.performance() === null  (NOT the metrics source in the new tester)
+ *
+ * Run: node --test tests/strategy_results.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  findStrategySource,
+  flattenStrategyReport,
+  getStrategyResults,
+} from '../src/core/data.js';
+
+// ── Fixture: real report shape from a live MA-cross strategy on BTCUSDT.P 60m ──
+const REAL_PERFORMANCE = {
+  // top-level scalar metrics
+  maxStrategyDrawDown: 6531.179023799979,
+  openPL: 0,
+  buyHoldReturn: 4250.5576191,
+  sharpeRatio: 0.05490388357994154,
+  sortinoRatio: 0.09152865649589953,
+  maxStrategyDrawDownPercent: 0.385925896387918,
+  maxStrategyRunUp: 7839.5670689,
+  maxMarginUsed: 17288.91382,
+  avgMarginUsed: 6231.811589,
+  // per-side buckets
+  all: {
+    netProfit: 734.0950199000217,
+    netProfitPercent: 0.07340950199000218,
+    grossProfit: 40034.53835990002,
+    grossLoss: 39300.44334,
+    profitFactor: 1.0186790518760602,
+    percentProfitable: 0.327455919395466,
+    totalTrades: 397,
+    numberOfWiningTrades: 130,
+    numberOfLosingTrades: 267,
+    avgTrade: 1.849105844,
+    commissionPaid: 0,
+  },
+  long: {
+    netProfit: 734.0950199000217,
+    totalTrades: 397,
+    profitFactor: 1.0186790518760602,
+    percentProfitable: 0.327455919395466,
+  },
+  short: {
+    netProfit: 0,
+    totalTrades: 0,
+    profitFactor: 0,
+    percentProfitable: 0,
+  },
+};
+
+const RAW = { currency: 'USDT', tradesCount: 397, performance: REAL_PERFORMANCE };
+
+// ── flattenStrategyReport() ────────────────────────────────────────────────
+describe('flattenStrategyReport()', () => {
+  it('extracts headline metrics from the "all" bucket, unprefixed', () => {
+    const m = flattenStrategyReport(RAW);
+    assert.equal(m.netProfit, 734.0950199000217);
+    assert.equal(m.profitFactor, 1.0186790518760602);
+    assert.equal(m.percentProfitable, 0.327455919395466);
+    assert.equal(m.totalTrades, 397);
+  });
+
+  it('includes top-level performance scalars (sharpe, sortino, drawdown)', () => {
+    const m = flattenStrategyReport(RAW);
+    assert.equal(m.sharpeRatio, 0.05490388357994154);
+    assert.equal(m.sortinoRatio, 0.09152865649589953);
+    assert.equal(m.maxStrategyDrawDown, 6531.179023799979);
+  });
+
+  it('prefixes long/short bucket metrics', () => {
+    const m = flattenStrategyReport(RAW);
+    assert.equal(m.long_netProfit, 734.0950199000217);
+    assert.equal(m.short_totalTrades, 0);
+    assert.equal(m.short_netProfit, 0);
+  });
+
+  it('includes currency and tradesCount', () => {
+    const m = flattenStrategyReport(RAW);
+    assert.equal(m.currency, 'USDT');
+    assert.equal(m.tradesCount, 397);
+  });
+
+  it('emits only scalar values — never nested objects or arrays', () => {
+    const m = flattenStrategyReport(RAW);
+    for (const [k, v] of Object.entries(m)) {
+      const t = typeof v;
+      assert.ok(
+        t === 'number' || t === 'string' || t === 'boolean',
+        `metric ${k} must be scalar, got ${t}`
+      );
+    }
+  });
+
+  it('returns an empty object for missing/blank input', () => {
+    assert.deepEqual(flattenStrategyReport(null), {});
+    assert.deepEqual(flattenStrategyReport({}), {});
+    assert.deepEqual(flattenStrategyReport({ performance: null }), {});
+  });
+});
+
+// ── findStrategySource() ─────────────────────────────────────────────────────
+describe('findStrategySource()', () => {
+  // A real strategy: overlay (is_price_study === true) exposing reportData()
+  const overlayStrategy = {
+    metaInfo: () => ({ is_price_study: true, description: 'MCP Test Strategy' }),
+    reportData: () => ({ performance: {} }),
+    performance: () => null,
+  };
+  // A non-strategy study (e.g. Volume): performance() exists on EVERY study,
+  // is_price_study === false, but no reportData/ordersData.
+  const volumeLike = {
+    metaInfo: () => ({ is_price_study: false, description: 'Volume' }),
+    performance: () => null,
+  };
+
+  it('selects an overlay strategy (is_price_study true) — regression for the is_price_study filter bug', () => {
+    assert.equal(findStrategySource([volumeLike, overlayStrategy]), overlayStrategy);
+  });
+
+  it('does NOT select a study that only has performance() — regression for the performance-discriminator bug', () => {
+    assert.equal(findStrategySource([volumeLike]), null);
+  });
+
+  it('matches on ordersData when reportData is absent', () => {
+    const ordersOnly = { metaInfo: () => ({ is_price_study: true }), ordersData: () => [] };
+    assert.equal(findStrategySource([volumeLike, ordersOnly]), ordersOnly);
+  });
+
+  it('returns null when no strategy is present', () => {
+    assert.equal(findStrategySource([volumeLike, { metaInfo: () => ({}) }]), null);
+  });
+});
+
+// ── getStrategyResults() glue (mocked evaluate) ──────────────────────────────
+describe('getStrategyResults() — wiring', () => {
+  function depsReturning(value) {
+    return { _deps: { evaluate: async () => value } };
+  }
+
+  it('flattens the raw payload returned by the browser into metric_count + metrics', async () => {
+    const res = await getStrategyResults(depsReturning(RAW));
+    assert.equal(res.success, true);
+    assert.equal(res.source, 'internal_api');
+    assert.ok(res.metric_count > 10, `expected many metrics, got ${res.metric_count}`);
+    assert.equal(res.metrics.netProfit, 734.0950199000217);
+    assert.equal(res.metrics.currency, 'USDT');
+  });
+
+  it('surfaces the no-strategy error with zero metrics', async () => {
+    const res = await getStrategyResults(depsReturning({ error: 'No strategy found on chart. Add a strategy indicator first.' }));
+    assert.equal(res.success, true);
+    assert.equal(res.metric_count, 0);
+    assert.match(res.error, /No strategy found/);
+  });
+});

--- a/tests/strategy_results.test.js
+++ b/tests/strategy_results.test.js
@@ -15,6 +15,7 @@ import {
   findStrategySource,
   flattenStrategyReport,
   getStrategyResults,
+  normalizeOrder,
 } from '../src/core/data.js';
 
 // ── Fixture: real report shape from a live MA-cross strategy on BTCUSDT.P 60m ──
@@ -160,5 +161,35 @@ describe('getStrategyResults() — wiring', () => {
     assert.equal(res.success, true);
     assert.equal(res.metric_count, 0);
     assert.match(res.error, /No strategy found/);
+  });
+});
+
+// ── normalizeOrder() ─────────────────────────────────────────────────────────
+// Raw order leg shape captured live from ordersData() on TradingView 3.2.0.
+describe('normalizeOrder()', () => {
+  const rawEntry = { b: true, c: 'Long', e: true, id: 'Long', p: 43674, q: 0.228969, tm: 0, tp: 'MARKET' };
+
+  it('maps the single-letter order keys to readable names', () => {
+    const o = normalizeOrder(rawEntry);
+    assert.equal(o.isBuy, true);
+    assert.equal(o.comment, 'Long');
+    assert.equal(o.isEntry, true);
+    assert.equal(o.price, 43674);
+    assert.equal(o.qty, 0.228969);
+    assert.equal(o.type, 'MARKET');
+    assert.equal(o.id, 'Long');
+  });
+
+  it('maps tm -> seq (verified live: tm mirrors order sequence index, not bar/time)', () => {
+    assert.equal(normalizeOrder({ tm: 200 }).seq, 200);
+  });
+
+  it('passes through unmapped scalar keys unchanged', () => {
+    assert.equal(normalizeOrder({ somethingNew: 5 }).somethingNew, 5);
+  });
+
+  it('drops nested objects, functions and null/undefined', () => {
+    const o = normalizeOrder({ p: 1, nested: { x: 1 }, fn: () => {}, nil: null, und: undefined });
+    assert.deepEqual(Object.keys(o), ['price']);
   });
 });


### PR DESCRIPTION
## What

Three fixes to `src/core/data.js` and `src/core/pine.js`, with test coverage:

1. **fix(data): detect strategy by reportData/ordersData, read new-tester metrics** — strategy detection now keys off `reportData`/`ordersData` and reads metrics from TradingView's newer strategy-tester UI (the prior path missed the new tester layout).
2. **feat(data): map getTrades order legs to readable keys** — `getTrades` order legs mapped to human-readable keys instead of raw indices.
3. **fix(pine): match add-to-chart button by title/aria, not English text only** — the "add to chart" button matcher uses `title`/`aria-label`, so it works on non-English TradingView locales (previously matched English button text only).

## Tests
Adds `tests/strategy_results.test.js` and `tests/pine_compile_button.test.js`.

## Notes
Branched from `main`; 3 commits ahead, 0 behind (clean fast-forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)