### PR TITLE
Honor TV_CDP_PORT env var instead of hardcoding the CDP port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/cli/commands/health.js
+++ b/src/cli/commands/health.js
@@ -9,7 +9,7 @@ register('status', {
 register('launch', {
   description: 'Launch TradingView with CDP enabled',
   options: {
-    port: { type: 'string', short: 'p', description: 'CDP port (default 9222)' },
+    port: { type: 'string', short: 'p', description: 'CDP port (default 9222, or TV_CDP_PORT env var)' },
     'no-kill': { type: 'boolean', description: 'Do not kill existing instances' },
   },
   handler: (opts) => core.launch({

--- a/src/connection.js
+++ b/src/connection.js
@@ -3,7 +3,7 @@ import CDP from 'chrome-remote-interface';
 let client = null;
 let targetInfo = null;
 const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_PORT = 9223;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -3,7 +3,7 @@ import CDP from 'chrome-remote-interface';
 let client = null;
 let targetInfo = null;
 const CDP_HOST = 'localhost';
-const CDP_PORT = 9223;
+const CDP_PORT = process.env.TV_CDP_PORT ? Number(process.env.TV_CDP_PORT) : 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -160,7 +160,7 @@ export async function uiState() {
 }
 
 export async function launch({ port, kill_existing } = {}) {
-  const cdpPort = port || 9222;
+  const cdpPort = port || 9223;
   const killFirst = kill_existing !== false;
   const platform = process.platform;
 

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -160,7 +160,7 @@ export async function uiState() {
 }
 
 export async function launch({ port, kill_existing } = {}) {
-  const cdpPort = port || 9223;
+  const cdpPort = port || (process.env.TV_CDP_PORT ? Number(process.env.TV_CDP_PORT) : 9222);
   const killFirst = kill_existing !== false;
   const platform = process.platform;
 

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -24,7 +24,7 @@ async function pollLoop(fetcher, { interval = 500, dedupe = true, label = 'strea
   const start = Date.now();
   process.stderr.write(`\u26A0  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n`);
   process.stderr.write(`   Streams from your locally running TradingView Desktop instance only.\n`);
-  process.stderr.write(`   Does not connect to TradingView servers. Requires --remote-debugging-port=9222.\n`);
+  process.stderr.write(`   Does not connect to TradingView servers. Requires --remote-debugging-port=9222 (override via TV_CDP_PORT).\n`);
   process.stderr.write(`   Ensure your usage complies with TradingView's Terms of Use.\n`);
   process.stderr.write(`[stream:${label}] started, interval=${interval}ms, Ctrl+C to stop\n`);
 

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -5,7 +5,7 @@
 import { getClient, evaluate } from '../connection.js';
 
 const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_PORT = process.env.TV_CDP_PORT ? Number(process.env.TV_CDP_PORT) : 9222;
 
 /**
  * List all open chart tabs (CDP page targets).

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -19,7 +19,7 @@ export function registerHealthTools(server) {
   });
 
   server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux.', {
-    port: z.coerce.number().optional().describe('CDP port (default 9222)'),
+    port: z.coerce.number().optional().describe('CDP port (default 9222, or TV_CDP_PORT env var)'),
     kill_existing: z.coerce.boolean().optional().describe('Kill existing TradingView instances first (default true)'),
   }, async ({ port, kill_existing }) => {
     try { return jsonResult(await core.launch({ port, kill_existing })); }


### PR DESCRIPTION
## What

Read the CDP remote-debugging port from a `TV_CDP_PORT` environment variable across the connection, tab, and health modules, falling back to `9222` when the variable is unset.

## Why

The port was hardcoded to `9222` in several places (`src/connection.js`, `src/core/tab.js`, `src/core/health.js`). On machines where `9222` is already occupied by another Chromium/WebView2-based app, there was no way to point the MCP at a different debug port without editing source — and those edits get clobbered on every `git pull`.

## Changes

- `src/connection.js`, `src/core/tab.js` — `CDP_PORT` now reads `process.env.TV_CDP_PORT ? Number(...) : 9222`.
- `src/core/health.js` — `launch()` fallback uses the same env-var-then-9222 logic.
- `src/cli/commands/health.js`, `src/tools/health.js`, `src/core/stream.js` — help/banner text mentions the `TV_CDP_PORT` override.

## Compatibility

Default behavior is unchanged: with `TV_CDP_PORT` unset, the port is still `9222`. The explicit `port`/`--port` argument still takes precedence over the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)