### PR TITLE
Fix 'evaluate is not defined' in 3 chart.js functions missed by the DI refactor

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,7 +115,8 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
-export async function getVisibleRange() {
+export async function getVisibleRange({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -157,7 +158,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
@@ -196,7 +198,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};

--- a/tests/chart.test.js
+++ b/tests/chart.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for chart.js functions missed by the DI refactor (f23eb1b):
+ * getVisibleRange, scrollToDate, symbolInfo. Each previously referenced a
+ * bare `evaluate` identifier that resolves nowhere (module imports it as
+ * `_evaluate`), so EVERY invocation threw `ReferenceError: evaluate is not
+ * defined` — these tests fail on that regression by construction, since
+ * exercising the functions at all requires the `_resolve(_deps)` line.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getVisibleRange, scrollToDate, symbolInfo } from '../src/core/chart.js';
+
+// ── Mock helpers (same shape as replay.test.js) ─────────────────────────
+
+/**
+ * Create a mock evaluate function that returns scripted values.
+ * Calls are tracked in .calls array.
+ * @param {object} responses — map of substring→return value. First matching key wins.
+ */
+function mockEvaluate(responses = {}) {
+  const calls = [];
+  const fn = async (expr) => {
+    calls.push(expr);
+    for (const [key, val] of Object.entries(responses)) {
+      if (expr.includes(key)) return typeof val === 'function' ? val(calls.length) : val;
+    }
+    return undefined;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function mockDeps(responses = {}) {
+  const evaluate = mockEvaluate(responses);
+  return { _deps: { evaluate }, evaluate };
+}
+
+// ── getVisibleRange() ────────────────────────────────────────────────────
+
+describe('getVisibleRange() — DI + pass-through', () => {
+  it('returns visible_range and bars_range from the chart', async () => {
+    const { _deps, evaluate } = mockDeps({
+      'getVisibleRange': {
+        visible_range: { from: 1383264000, to: 1780617600 },
+        bars_range: { firstBar: 10, lastBar: 2400 },
+      },
+    });
+    const result = await getVisibleRange({ _deps });
+    assert.equal(result.success, true);
+    assert.deepEqual(result.visible_range, { from: 1383264000, to: 1780617600 });
+    assert.deepEqual(result.bars_range, { firstBar: 10, lastBar: 2400 });
+    assert.equal(evaluate.calls.length, 1);
+    assert.ok(evaluate.calls[0].includes('getVisibleBarsRange'), 'queries the bars range');
+  });
+
+});
+
+// ── scrollToDate() ───────────────────────────────────────────────────────
+
+describe('scrollToDate() — DI + window math', () => {
+  it('centers a daily chart on an ISO date with a ±25-bar window', async () => {
+    const { _deps, evaluate } = mockDeps({
+      '.resolution()': 'D',
+      'zoomToBarsRange': undefined,
+    });
+    const result = await scrollToDate({ date: '2014-01-02', _deps });
+    const ts = Math.floor(new Date('2014-01-02').getTime() / 1000);
+    assert.equal(result.success, true);
+    assert.equal(result.centered_on, ts);
+    assert.equal(result.resolution, 'D');
+    assert.deepEqual(result.window, { from: ts - 25 * 86400, to: ts + 25 * 86400 });
+    const zoomCall = evaluate.calls.find((c) => c.includes('zoomToBarsRange'));
+    assert.ok(zoomCall, 'issues the zoom expression');
+    assert.ok(zoomCall.includes(String(ts - 25 * 86400)), 'window lower bound in the expression');
+  });
+
+  it('accepts a unix-timestamp string and intraday resolutions', async () => {
+    const { _deps } = mockDeps({ '.resolution()': '15', 'zoomToBarsRange': undefined });
+    const result = await scrollToDate({ date: '1700000000', _deps });
+    assert.equal(result.centered_on, 1700000000);
+    assert.deepEqual(result.window, {
+      from: 1700000000 - 25 * 15 * 60,
+      to: 1700000000 + 25 * 15 * 60,
+    });
+  });
+
+  it('rejects an unparseable date before any CDP call', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await assert.rejects(
+      () => scrollToDate({ date: 'not-a-date', _deps }),
+      /Could not parse date/,
+    );
+    assert.equal(evaluate.calls.length, 0, 'no evaluate call for invalid input');
+  });
+});
+
+// ── symbolInfo() ─────────────────────────────────────────────────────────
+
+describe('symbolInfo() — DI + pass-through', () => {
+  it('spreads the symbolExt fields into the result', async () => {
+    const info = {
+      symbol: 'ORCL', full_name: 'NYSE:ORCL', exchange: 'NYSE',
+      description: 'Oracle Corporation', type: 'stock', pro_name: 'NYSE:ORCL',
+      typespecs: [], resolution: '1D', chart_type: 1,
+    };
+    const { _deps, evaluate } = mockDeps({ 'symbolExt': info });
+    const result = await symbolInfo({ _deps });
+    assert.equal(result.success, true);
+    assert.equal(result.symbol, 'ORCL');
+    assert.equal(result.exchange, 'NYSE');
+    assert.equal(result.resolution, '1D');
+    assert.equal(evaluate.calls.length, 1);
+    assert.ok(evaluate.calls[0].includes('symbolExt'), 'queries symbolExt');
+  });
+
+});


### PR DESCRIPTION
## Problem

The f23eb1b DI refactor ("Add DI and full test coverage for chart.js…") destructured `evaluate` per-function via `const { evaluate } = _resolve(_deps);` in 5 chart.js functions but skipped **3**:

- `getVisibleRange` (src/core/chart.js:118)
- `scrollToDate` (src/core/chart.js:160)
- `symbolInfo` (src/core/chart.js:199)

Each still referenced a bare `evaluate` identifier, which resolves nowhere (the module imports it as `_evaluate`) — so **every invocation of the `chart_scroll_to_date`, `symbol_info`, and `chart_get_visible_range` MCP tools (and the `scroll`/`info`/`range` CLI commands) threw `ReferenceError: evaluate is not defined`**.

## Fix

Add the `_deps` parameter + resolve line to all 3, matching their 5 siblings; `= {}` defaults on `getVisibleRange`/`symbolInfo` since the MCP tool + CLI layers call them with no arguments.

## Tests

New `tests/chart.test.js` — 5 DI tests using the `mockEvaluate`/`mockDeps` pattern from `replay.test.js`: range pass-through, scroll window math (daily + intraday), invalid-date rejection before any CDP call, symbolExt spread. Each fails with the pre-fix `ReferenceError` by construction (exercising the functions requires the resolve line).

- `node --test tests/chart.test.js` → 5/5 pass
- `npm run test:unit` → 29/29 pass
- `node --test tests/replay.test.js tests/sanitization.test.js` → 105/105 pass

## Live verification

Against a running headless container (CDP): `tv info` → full symbolExt readback, `tv range` → real visible range, `tv scroll 2026-01-15` → centered with the correct ±25-bar window. All three previously threw the ReferenceError on this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)