### PR TITLE
fix(core): bind evaluate/getChartApi via _resolve in 7 drawing/chart fns (ReferenceError)

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,7 +115,8 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
-export async function getVisibleRange() {
+export async function getVisibleRange({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -157,7 +158,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
@@ -196,7 +198,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };


### PR DESCRIPTION
## Summary
Seven MCP tools throw a `ReferenceError` at runtime and return `{ "success": false, "error": "getChartApi is not defined" }` (or `"evaluate is not defined"`):

`draw_list`, `draw_remove_one`, `draw_get_properties`, `draw_clear`, `chart_scroll_to_date`, `chart_get_visible_range`, `symbol_info`.

(`draw_shape`, `chart_set_visible_range`, `chart_set_symbol`, etc. were unaffected.)

## Root cause
`src/core/drawing.js` and `src/core/chart.js` import the helpers under aliases (`_evaluate` / `_getChartApi` / `_evaluateAsync`) and expose them via `_resolve(_deps)`. `drawShape()` and `setVisibleRange()` use that pattern, but the seven functions above still call the **bare** `evaluate` / `getChartApi`, which aren't in scope → `ReferenceError`. It reproduces in both local and `TV_CDP_HOST` networked modes (not CDP-specific).

## Fix
Adopt the same `_deps` / `_resolve` pattern in each affected function:

```js
const { evaluate, getChartApi } = _resolve(_deps);  // drawing.js
const { evaluate } = _resolve(_deps);               // chart.js
```

14 insertions / 7 deletions across the two files. No behavior change beyond making the helpers resolvable; also threads an optional `_deps` for DI/testing parity with the rest of the module.

## Testing
- `node --check` on both files.
- Mock-`_deps` smoke test: all 7 functions run with **0 ReferenceErrors**.
- Verified live against TradingView through the MCP: `draw_shape` → `draw_list` (lists it) → `draw_remove_one` (removes it) → `draw_list` (confirms); `chart_scroll_to_date`, `chart_get_visible_range`, `symbol_info` all return data.

## Suggested follow-up
A unit test passing a mock `_deps` per function would catch this class of regression.
