### PR TITLE
feat(drawing): native parallel_channel support + draw_parallel_channel tool

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -7,41 +7,53 @@ function _resolve(deps) {
   return { evaluate: deps?.evaluate || _evaluate, getChartApi: deps?.getChartApi || _getChartApi };
 }
 
-export async function drawShape({ shape, point, point2, overrides: overridesRaw, text, _deps }) {
+export async function drawShape({ shape, point, point2, point3, overrides: overridesRaw, text, _deps }) {
   const { evaluate, getChartApi } = _resolve(_deps);
   const overrides = overridesRaw ? (typeof overridesRaw === 'string' ? JSON.parse(overridesRaw) : overridesRaw) : {};
   const apiPath = await getChartApi();
   const overridesStr = JSON.stringify(overrides || {});
   const textStr = text ? JSON.stringify(text) : '""';
 
-  const p1time = requireFinite(point.time, 'point.time');
-  const p1price = requireFinite(point.price, 'point.price');
+  // Build the point list; supports 1-point (createShape) and 2-/3-point
+  // (createMultipointShape) tools — e.g. parallel_channel & pitchfork need 3.
+  const pts = [{ time: requireFinite(point.time, 'point.time'), price: requireFinite(point.price, 'point.price') }];
+  if (point2) pts.push({ time: requireFinite(point2.time, 'point2.time'), price: requireFinite(point2.price, 'point2.price') });
+  if (point3) pts.push({ time: requireFinite(point3.time, 'point3.time'), price: requireFinite(point3.price, 'point3.price') });
 
   const before = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
 
-  if (point2) {
-    const p2time = requireFinite(point2.time, 'point2.time');
-    const p2price = requireFinite(point2.price, 'point2.price');
-    await evaluate(`
-      ${apiPath}.createMultipointShape(
-        [{ time: ${p1time}, price: ${p1price} }, { time: ${p2time}, price: ${p2price} }],
-        { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
-      )
-    `);
-  } else {
-    await evaluate(`
-      ${apiPath}.createShape(
-        { time: ${p1time}, price: ${p1price} },
-        { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} }
-      )
-    `);
-  }
+  const createExpr = pts.length > 1
+    ? `${apiPath}.createMultipointShape(${JSON.stringify(pts)}, { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} })`
+    : `${apiPath}.createShape(${JSON.stringify(pts[0])}, { shape: ${safeString(shape)}, overrides: ${overridesStr}, text: ${textStr} })`;
 
-  await new Promise(r => setTimeout(r, 200));
-  const after = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
-  const newId = (after || []).find(id => !(before || []).includes(id)) || null;
-  const result = { entity_id: newId };
-  return { success: true, shape, entity_id: result?.entity_id };
+  // Fire the create. We deliberately do NOT awaitPromise: on this build the
+  // Promise returned by createMultipointShape can reject ("Value is undefined")
+  // even though the shape IS created, so detect the new entity by polling
+  // getAllShapes instead (3-point shapes like parallel_channel register async).
+  await evaluate(createExpr);
+  let newId = null;
+  for (let i = 0; i < 12 && !newId; i++) {
+    await new Promise(r => setTimeout(r, 150));
+    const after = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
+    newId = (after || []).find(id => !(before || []).includes(id)) || null;
+  }
+  return { success: true, shape, entity_id: newId };
+}
+
+// Convenience wrapper around the native TradingView "parallel_channel" linetool.
+// The main rail is point -> point2; the parallel rail is set either by an explicit
+// point3, or by `width` (price units; positive = parallel rail BELOW the main rail).
+// Using the native shape guarantees the two rails stay truly parallel.
+export async function drawParallelChannel({ point, point2, width, point3, overrides, _deps }) {
+  let third = point3;
+  if (!third) {
+    const w = requireFinite(width, 'width');
+    const p2price = requireFinite(point2.price, 'point2.price');
+    third = { time: point2.time, price: p2price - w };
+  }
+  // Note: TradingView's parallel_channel linetool does not accept a `text`
+  // label (passing one makes createMultipointShape fail); style via overrides.
+  return drawShape({ shape: 'parallel_channel', point, point2, point3: third, overrides, _deps });
 }
 
 export async function listDrawings() {

--- a/src/tools/drawing.js
+++ b/src/tools/drawing.js
@@ -4,13 +4,25 @@ import * as core from '../core/drawing.js';
 
 export function registerDrawingTools(server) {
   server.tool('draw_shape', 'Draw a shape/line on the chart', {
-    shape: z.string().describe('Shape type: horizontal_line, vertical_line, trend_line, rectangle, text'),
+    shape: z.string().describe('Shape type: horizontal_line, vertical_line, trend_line, rectangle, parallel_channel, pitchfork, text'),
     point: z.object({ time: z.coerce.number(), price: z.coerce.number() }).describe('{ time: unix_timestamp, price: number }'),
     point2: z.object({ time: z.coerce.number(), price: z.coerce.number() }).optional().describe('Second point for two-point shapes (trend_line, rectangle)'),
+    point3: z.object({ time: z.coerce.number(), price: z.coerce.number() }).optional().describe('Third point for three-point shapes (parallel_channel, pitchfork)'),
     overrides: z.string().optional().describe('JSON string of style overrides (e.g., \'{"linecolor": "#ff0000", "linewidth": 2}\')'),
     text: z.string().optional().describe('Text content for text shapes'),
-  }, async ({ shape, point, point2, overrides, text }) => {
-    try { return jsonResult(await core.drawShape({ shape, point, point2, overrides, text })); }
+  }, async ({ shape, point, point2, point3, overrides, text }) => {
+    try { return jsonResult(await core.drawShape({ shape, point, point2, point3, overrides, text })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('draw_parallel_channel', 'Draw a parallel channel (two parallel rails) using TradingView\'s native parallel_channel tool. Define the main rail with point + point2; set the channel width in price units with `width` (positive = second rail below the main rail), or pass an explicit point3 the parallel rail passes through. Both rails stay truly parallel.', {
+    point: z.object({ time: z.coerce.number(), price: z.coerce.number() }).describe('Main rail start { time: unix_timestamp, price: number }'),
+    point2: z.object({ time: z.coerce.number(), price: z.coerce.number() }).describe('Main rail end { time: unix_timestamp, price: number }'),
+    width: z.coerce.number().optional().describe('Channel width in price units; positive puts the second rail below the main rail. Ignored if point3 is given.'),
+    point3: z.object({ time: z.coerce.number(), price: z.coerce.number() }).optional().describe('Explicit point the parallel rail passes through (overrides width)'),
+    overrides: z.string().optional().describe('JSON string of style overrides (parallel_channel has no text label; style it here)'),
+  }, async ({ point, point2, width, point3, overrides }) => {
+    try { return jsonResult(await core.drawParallelChannel({ point, point2, width, point3, overrides })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 

--- a/tests/draw_parallel_channel.test.js
+++ b/tests/draw_parallel_channel.test.js
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for parallel_channel drawing support.
+ * Covers drawShape() point handling (1 vs 2 vs 3 points) and the
+ * drawParallelChannel() convenience wrapper.
+ * Pure unit (mocked CDP eval) — no TradingView Desktop required.
+ *
+ * Run: node --test tests/draw_parallel_channel.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { drawShape, drawParallelChannel } from '../src/core/drawing.js';
+
+// Mock: getAllShapes returns [] before the create, then one new id after, so
+// drawShape's poll resolves an entity_id on the first iteration.
+function mockDeps() {
+  const calls = [];
+  let created = false;
+  const evaluate = async (expr) => {
+    calls.push(expr);
+    if (expr.includes('createShape(') || expr.includes('createMultipointShape(')) { created = true; return undefined; }
+    if (expr.includes('getAllShapes')) return created ? ['shape_new'] : [];
+    return undefined;
+  };
+  evaluate.calls = calls;
+  const createExpr = () => calls.find((c) => c.includes('createShape(') || c.includes('createMultipointShape('));
+  return { _deps: { evaluate, evaluateAsync: evaluate, waitForChartReady: async () => true, getChartApi: async () => 'window.__api' }, evaluate, createExpr };
+}
+
+describe('drawShape() — point arity', () => {
+  it('uses createShape for a single point', async () => {
+    const { _deps, createExpr } = mockDeps();
+    await drawShape({ shape: 'horizontal_line', point: { time: 1, price: 2 }, _deps });
+    assert.match(createExpr(), /createShape\(/);
+    assert.doesNotMatch(createExpr(), /createMultipointShape/);
+  });
+
+  it('uses createMultipointShape for two points', async () => {
+    const { _deps, createExpr } = mockDeps();
+    await drawShape({ shape: 'trend_line', point: { time: 1, price: 2 }, point2: { time: 3, price: 4 }, _deps });
+    assert.match(createExpr(), /createMultipointShape\(/);
+    assert.match(createExpr(), /\[\{"time":1,"price":2\},\{"time":3,"price":4\}\]/);
+  });
+
+  it('passes three points for parallel_channel / pitchfork', async () => {
+    const { _deps, createExpr } = mockDeps();
+    await drawShape({ shape: 'parallel_channel', point: { time: 1, price: 2 }, point2: { time: 3, price: 4 }, point3: { time: 5, price: 6 }, _deps });
+    assert.match(createExpr(), /createMultipointShape\(/);
+    assert.match(createExpr(), /\{"time":5,"price":6\}/);
+  });
+
+  it('resolves the new entity_id by polling getAllShapes', async () => {
+    const { _deps } = mockDeps();
+    const res = await drawShape({ shape: 'trend_line', point: { time: 1, price: 2 }, point2: { time: 3, price: 4 }, _deps });
+    assert.equal(res.entity_id, 'shape_new');
+  });
+});
+
+describe('drawParallelChannel()', () => {
+  it('derives the 3rd (parallel) anchor from width below the main rail', async () => {
+    const { _deps, createExpr } = mockDeps();
+    await drawParallelChannel({ point: { time: 100, price: 5000 }, point2: { time: 200, price: 4000 }, width: 1000, _deps });
+    assert.match(createExpr(), /shape: "parallel_channel"/);
+    // third point = { time: point2.time, price: point2.price - width } = 200 / 3000
+    assert.match(createExpr(), /\{"time":200,"price":3000\}/);
+  });
+
+  it('uses an explicit point3 when provided (ignores width)', async () => {
+    const { _deps, createExpr } = mockDeps();
+    await drawParallelChannel({ point: { time: 100, price: 5000 }, point2: { time: 200, price: 4000 }, point3: { time: 200, price: 2500 }, _deps });
+    assert.match(createExpr(), /\{"time":200,"price":2500\}/);
+  });
+
+  it('never attaches a text label (breaks the parallel_channel tool)', async () => {
+    const { _deps, createExpr } = mockDeps();
+    await drawParallelChannel({ point: { time: 100, price: 5000 }, point2: { time: 200, price: 4000 }, width: 1000, _deps });
+    assert.match(createExpr(), /text: ""/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds first-class support for TradingView's native **`parallel_channel`** linetool (and 3-point shapes generally), so a channel renders as a single object with two **truly parallel** rails — instead of emulating one with two independent `trend_line`s that drift into a wedge.

## Changes
- **`drawShape` → N points:** new optional `point3`; the point array is built dynamically so 3-point linetools (`parallel_channel`, `pitchfork`) work via `createMultipointShape`. 1-point shapes still use `createShape` (backward compatible).
- **New `draw_parallel_channel` tool + `drawParallelChannel()` core fn:** define the main rail with `point` → `point2` and the channel width via `width` (price units; positive = lower rail below the main rail) or an explicit `point3`. Guarantees the two rails stay parallel.
- **`draw_shape` schema:** adds `point3`; documents `parallel_channel`/`pitchfork`.

## Build-specific quirks found while testing live (and handled)
- `createMultipointShape` returns a Promise that can **reject** (`"Value is undefined"`) on this TradingView Desktop build *even though the shape is created*. So we **don't `awaitPromise`** — we fire the create and **poll `getAllShapes`** for the new entity id.
- `parallel_channel` does **not** accept a `text` label (passing one makes creation fail), so `draw_parallel_channel` styles via `overrides` only.

## Testing
- `node --check` on both files.
- Mock-deps unit smoke: emits a 3-point `createMultipointShape` with `shape:"parallel_channel"`; generic `point3` path; 1-point `createShape` backward-compat.
- **Verified live** against TradingView Desktop over CDP: `draw_parallel_channel` creates a real `parallel_channel`, returns its `entity_id`, applies `overrides`, and removes cleanly.

## Example
```js
draw_parallel_channel({
  point:  { time: 1696000000, price: 5300 },   // main rail start
  point2: { time: 1718000000, price: 4600 },   // main rail end
  width: 1000,                                  // lower rail 1000 below
  overrides: '{"linecolor":"#2962ff","linewidth":2}'
})
```
