### PR TITLE
feat(chart): add chart_set_right_offset for future/projection space

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -157,6 +157,18 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
+// Set the chart's right offset: the number of empty bars shown to the right of
+// the last bar (i.e. how much future / projection space). Useful for extending
+// trendlines and channels past the latest candle.
+export async function setRightOffset({ bars, _deps }) {
+  const { evaluate } = _resolve(_deps);
+  const n = requireFinite(bars, 'bars');
+  await evaluate(`(function() { try { ${CHART_API}._chartWidget.model().timeScale().setRightOffset(${n}); } catch (e) {} })()`);
+  await new Promise(r => setTimeout(r, 300));
+  const actual = await evaluate(`(function() { try { var r = ${CHART_API}.getVisibleRange(); return { from: r.from || 0, to: r.to || 0 }; } catch (e) { return { from: 0, to: 0, error: e.message }; } })()`);
+  return { success: true, right_offset: n, actual: actual || { from: 0, to: 0 } };
+}
+
 export async function scrollToDate({ date }) {
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);

--- a/src/tools/chart.js
+++ b/src/tools/chart.js
@@ -59,6 +59,13 @@ export function registerChartTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
+  server.tool('chart_set_right_offset', 'Set the chart right offset: number of empty bars to the right of the last bar (future/projection space). Use after chart_set_visible_range to reveal room for extended trendlines/channels past the latest candle.', {
+    bars: z.coerce.number().describe('Number of empty bars to show on the right (e.g., 60 ≈ 60 future periods)'),
+  }, async ({ bars }) => {
+    try { return jsonResult(await core.setRightOffset({ bars })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
   server.tool('symbol_info', 'Get detailed metadata about the current symbol (name, exchange, type, description)', {}, async () => {
     try { return jsonResult(await core.symbolInfo()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/tests/chart_right_offset.test.js
+++ b/tests/chart_right_offset.test.js
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for chart_set_right_offset.
+ * Pure unit (mocked CDP eval) — no TradingView Desktop required.
+ *
+ * Run: node --test tests/chart_right_offset.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { setRightOffset } from '../src/core/chart.js';
+
+function mockDeps() {
+  const calls = [];
+  const evaluate = async (expr) => {
+    calls.push(expr);
+    if (expr.includes('getVisibleRange')) return { from: 100, to: 200 };
+    return undefined;
+  };
+  evaluate.calls = calls;
+  return { _deps: { evaluate, evaluateAsync: evaluate, waitForChartReady: async () => true, getChartApi: async () => 'window.__api' }, evaluate };
+}
+
+describe('setRightOffset()', () => {
+  it('calls timeScale().setRightOffset(n) with the requested bar count', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await setRightOffset({ bars: 30, _deps });
+    const call = evaluate.calls.find((c) => c.includes('setRightOffset'));
+    assert.ok(call, 'a setRightOffset expression should be emitted');
+    assert.match(call, /setRightOffset\(30\)/);
+  });
+
+  it('returns success and echoes the offset + actual range', async () => {
+    const { _deps } = mockDeps();
+    const res = await setRightOffset({ bars: 60, _deps });
+    assert.equal(res.success, true);
+    assert.equal(res.right_offset, 60);
+    assert.deepEqual(res.actual, { from: 100, to: 200 });
+  });
+
+  it('coerces numeric strings', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const res = await setRightOffset({ bars: '45', _deps });
+    assert.equal(res.right_offset, 45);
+    assert.match(evaluate.calls.find((c) => c.includes('setRightOffset')), /setRightOffset\(45\)/);
+  });
+
+  it('rejects non-finite bar counts', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(() => setRightOffset({ bars: 'abc', _deps }), /bars must be a finite number/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `chart_set_right_offset` — sets the chart's **right offset** (empty bars to the right of the last bar = future / projection space). After `chart_set_visible_range`, this reveals room so extended trendlines and channels render *past* the latest candle (e.g. reproducing an analyst chart that projects a channel months forward).

## Changes
- `core/chart.js`: new `setRightOffset({ bars })` → `timeScale().setRightOffset(n)`, returns the resulting visible range.
- `tools/chart.js`: new `chart_set_right_offset` tool.

## Testing
- `node --check`; mock-deps smoke.
- **Verified live** (OANDA:XAUUSD 1D): `setRightOffset(60)` moved the right edge to ~2026-08-28 (≈60 periods past the last bar at 2026-06-05); `setRightOffset(5)` → 2026-06-12.

## Note
Right offset shifts the left edge inward proportionally (fixed viewport), so widen `from` in `chart_set_visible_range` if you want to preserve the same left-side history.
