### PR TITLE
fix(chart): pass study inputs as an object so indicator params apply

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -89,12 +89,16 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;
 
   if (action === 'add') {
-    const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
+    // createStudy expects inputs as a plain { inputId: value } object. The
+    // [{ id, value }] form is silently ignored by the charting library, leaving
+    // the study at its default inputs — e.g. a "Moving Average" requested with
+    // { length: 200 } would stay at the default length (9). Pass the object map.
+    const inputObj = inputs && typeof inputs === 'object' ? inputs : {};
     const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
     await evaluate(`
       (function() {
         var chart = ${CHART_API};
-        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputArr)});
+        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputObj)});
       })()
     `);
     await new Promise(r => setTimeout(r, 1500));

--- a/tests/chart_studies.test.js
+++ b/tests/chart_studies.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for chart_manage_indicator study-input formatting.
+ * Pure unit (mocked CDP eval) — no TradingView Desktop required.
+ *
+ * Run: node --test tests/chart_studies.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { manageIndicator } from '../src/core/chart.js';
+
+// Mock evaluate that records expressions and returns scripted study-id lists so
+// the add() path resolves a new entity without a live chart.
+function mockDeps() {
+  const calls = [];
+  let studyListCount = 0;
+  const evaluate = async (expr) => {
+    calls.push(expr);
+    if (expr.includes('getAllStudies')) {
+      // 1st call (before) → none; later (after) → one new study
+      return studyListCount++ === 0 ? [] : ['study_new'];
+    }
+    return undefined;
+  };
+  evaluate.calls = calls;
+  return { _deps: { evaluate, evaluateAsync: evaluate, waitForChartReady: async () => true, getChartApi: async () => 'window.__api' }, evaluate };
+}
+
+const createCall = (evaluate) => evaluate.calls.find((c) => c.includes('createStudy'));
+
+describe('manageIndicator() — study input formatting', () => {
+  it('passes inputs as a { key: value } object, not [{ id, value }]', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await manageIndicator({ action: 'add', indicator: 'Moving Average', inputs: '{"length":50}', _deps });
+    const call = createCall(evaluate);
+    assert.ok(call, 'a createStudy expression should be emitted');
+    assert.match(call, /\{"length":50\}/);          // object form
+    assert.doesNotMatch(call, /"id":"length"/);      // not the ignored [{id,value}] form
+  });
+
+  it('accepts an already-parsed object for inputs', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await manageIndicator({ action: 'add', indicator: 'Moving Average', inputs: { length: 200 }, _deps });
+    assert.match(createCall(evaluate), /\{"length":200\}/);
+  });
+
+  it('emits an empty object when no inputs are given', async () => {
+    const { _deps, evaluate } = mockDeps();
+    await manageIndicator({ action: 'add', indicator: 'Volume', _deps });
+    const call = createCall(evaluate);
+    assert.match(call, /createStudy\([\s\S]*\{\}\)/);
+    assert.doesNotMatch(call, /\[\{/);
+  });
+
+  it('reports the newly created study id', async () => {
+    const { _deps } = mockDeps();
+    const res = await manageIndicator({ action: 'add', indicator: 'Moving Average', inputs: '{"length":50}', _deps });
+    assert.equal(res.success, true);
+    assert.equal(res.entity_id, 'study_new');
+  });
+
+  it('remove requires an entity_id', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(() => manageIndicator({ action: 'remove', _deps }), /entity_id required/);
+  });
+});


### PR DESCRIPTION
## Summary
`chart_manage_indicator` (add) built the `createStudy` inputs as an array of `{ id, value }` objects. The charting library **silently ignores** that shape, so every study fell back to its **default inputs**.

Most visible symptom: adding a `Moving Average` with `{ length: 50 }` and another with `{ length: 200 }` produced **two identical MA(9) lines** (same legend value, one visible curve) instead of a 50 and a 200.

## Fix
Pass `inputs` as the plain `{ inputId: value }` object `createStudy` actually expects. Isolated to the `add` branch of `manageIndicator` in `src/core/chart.js`.

```diff
-    const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
+    const inputObj = inputs && typeof inputs === 'object' ? inputs : {};
...
-        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputArr)});
+        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputObj)});
```

The tool already accepts `inputs` as a JSON string and parses it to an object upstream, so the public tool interface is unchanged.

## Testing
- `node --check src/core/chart.js`.
- **Verified live** on `OANDA:XAUUSD` (1D): before the fix, two "Moving Average" adds with `{length:50}` / `{length:200}` both read `MA 4,467.846` (length 9). After the fix, the legend reads `MA 50 close 4,627.385` and `MA 200 close 4,427.760` with two distinct curves. Confirmed via `getStudyById(id).getInputValues()` returning `length: 50` / `length: 200`.
- Cross-checked the format empirically: object `{length:200}` and positional `[200]` both apply; the prior `[{id,value}]` form does not.