### PR TITLE
Fix "evaluate is not defined" error in scrollToDate and symbolInfo

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -157,7 +157,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
@@ -196,7 +197,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};


### PR DESCRIPTION
## Summary
- `scrollToDate` and `symbolInfo` in `src/core/chart.js` referenced `evaluate` directly instead of resolving it from `_deps` via `_resolve()`, causing a `ReferenceError: evaluate is not defined` whenever either function ran (e.g. `tv scroll <date>`).
- Updated both functions to destructure `evaluate` from `_resolve(_deps)`, matching the pattern used by every other exported function in the file.

## Test plan
- [x] Ran `tv scroll 2026-06-05T13:00:00` — previously threw `evaluate is not defined`, now succeeds and returns the centered timestamp/window.
- [x] Ran `tv ohlcv` after scrolling to confirm bar retrieval still works end-to-end.