### PR TITLE
fix: wire sanitization and replay tests into test:unit script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,13 @@ If you're unsure whether a feature fits, open an issue to discuss before submitt
 
 ```bash
 npm install
-npm test          # 29 offline tests (no TradingView needed)
-tv status         # verify CDP connection (TradingView must be running)
+npm run test:unit  # 86 offline tests (no TradingView needed)
+tv status          # verify CDP connection (TradingView must be running)
 ```
 
 ## Pull Requests
 
 - Keep changes focused — one feature or fix per PR
 - Add tests for new functionality where possible
-- Ensure `npm test` passes (29/29)
+- Ensure `npm run test:unit` passes (86/86)
 - Test against a live TradingView Desktop instance before submitting

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ The key flag: `--remote-debugging-port=9222`
 npm test
 ```
 
-29 tests covering: Pine Script static analysis, server-side compilation, and CLI routing.
+86 offline tests covering: Pine Script static analysis, server-side compilation, CLI routing, CDP injection sanitization, and replay functions.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "tv": "node src/cli/index.js",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },


### PR DESCRIPTION
## Summary

- `tests/sanitization.test.js` (36 tests) and `tests/replay.test.js` (21 tests) existed in the repo but were never included in any npm script — they would silently not run for contributors
- Added both files to `test:unit` and `test:all` so all offline tests are discoverable and run together
- Updated stale test count in README and CONTRIBUTING (29 → 86)
- Fixed CONTRIBUTING to reference `npm run test:unit` instead of `npm test`, which runs e2e tests that require a live TradingView instance

## Test plan

- [ ] `npm run test:unit` should now run all 86 offline tests (pine_analyze, cli, sanitization, replay)
- [ ] `npm run test:all` covers all offline + e2e tests
- [ ] No logic changes — docs and package.json scripts only

🤖 Generated with [Claude Code](https://claude.com/claude-code)