### PR TITLE
Fix drawing tools throwing "getChartApi is not defined" + Windows tes…

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };

--- a/tests/drawing.test.js
+++ b/tests/drawing.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests for src/core/drawing.js.
+ * Regression guard: listDrawings/getProperties/removeOne/clearAll must pull
+ * `evaluate`/`getChartApi` from injected deps via _resolve(). A previous refactor
+ * only wired drawShape, leaving the other four referencing undefined identifiers
+ * (ReferenceError: getChartApi is not defined) at runtime.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { drawShape, listDrawings, getProperties, removeOne, clearAll } from '../src/core/drawing.js';
+
+// ── Mock helpers ─────────────────────────────────────────────────────────
+
+function mockEvaluate(responses = {}, sequence) {
+  let callIdx = 0;
+  const calls = [];
+  const fn = async (expr) => {
+    calls.push(expr);
+    if (sequence && callIdx < sequence.length) return sequence[callIdx++];
+    for (const [key, val] of Object.entries(responses)) {
+      if (expr.includes(key)) return typeof val === 'function' ? val(callIdx++) : val;
+    }
+    return undefined;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function mockDeps(responses = {}, sequence) {
+  const evaluate = mockEvaluate(responses, sequence);
+  return { _deps: { evaluate, getChartApi: async () => 'window.__chart' }, evaluate };
+}
+
+// ── clearAll() ─────────────────────────────────────────────────────────────
+
+describe('clearAll() — regression: must not throw "getChartApi is not defined"', () => {
+  it('calls removeAllShapes on the chart api and returns success', async () => {
+    const { _deps, evaluate } = mockDeps({});
+    const result = await clearAll({ _deps });
+    assert.equal(result.success, true);
+    assert.equal(result.action, 'all_shapes_removed');
+    assert.ok(evaluate.calls.some(c => c.includes('window.__chart.removeAllShapes()')));
+  });
+});
+
+// ── listDrawings() ───────────────────────────────────────────────────────────
+
+describe('listDrawings()', () => {
+  it('returns count and shapes from the chart api', async () => {
+    const shapes = [{ id: 'a', name: 'horizontal_line' }, { id: 'b', name: 'trend_line' }];
+    const { _deps } = mockDeps({ 'getAllShapes': shapes });
+    const result = await listDrawings({ _deps });
+    assert.equal(result.success, true);
+    assert.equal(result.count, 2);
+    assert.deepEqual(result.shapes, shapes);
+  });
+
+  it('handles an empty chart', async () => {
+    const { _deps } = mockDeps({ 'getAllShapes': [] });
+    const result = await listDrawings({ _deps });
+    assert.equal(result.count, 0);
+  });
+});
+
+// ── removeOne() ──────────────────────────────────────────────────────────────
+
+describe('removeOne()', () => {
+  it('returns removed=true when the shape is gone', async () => {
+    // removeOne calls evaluate once and gets back the whole result object
+    const { _deps } = mockDeps({}, [{ removed: true, entity_id: 'x1', remaining_shapes: 3 }]);
+    const result = await removeOne({ entity_id: 'x1', _deps });
+    assert.equal(result.success, true);
+    assert.equal(result.removed, true);
+    assert.equal(result.entity_id, 'x1');
+  });
+
+  it('throws when the api reports the shape was not found', async () => {
+    const { _deps } = mockDeps({}, [{ error: 'Shape not found: zzz' }]);
+    await assert.rejects(() => removeOne({ entity_id: 'zzz', _deps }), /not found/i);
+  });
+});
+
+// ── getProperties() ──────────────────────────────────────────────────────────
+
+describe('getProperties()', () => {
+  it('returns the resolved props object', async () => {
+    const { _deps } = mockDeps({}, [{ entity_id: 'p1', visible: true, name: 'horizontal_line' }]);
+    const result = await getProperties({ entity_id: 'p1', _deps });
+    assert.equal(result.success, true);
+    assert.equal(result.entity_id, 'p1');
+    assert.equal(result.visible, true);
+  });
+});
+
+// ── drawShape() (already wired, smoke test) ──────────────────────────────────
+
+describe('drawShape()', () => {
+  it('creates a single-point shape and returns the new entity id', async () => {
+    // before -> [], create -> undefined, after -> ['new1']
+    const { _deps } = mockDeps({}, [[], undefined, ['new1']]);
+    const result = await drawShape({
+      shape: 'horizontal_line',
+      point: { time: 1780860900, price: 0.0027 },
+      _deps,
+    });
+    assert.equal(result.success, true);
+    assert.equal(result.entity_id, 'new1');
+  });
+
+  it('rejects a non-finite price', async () => {
+    const { _deps } = mockDeps({}, [[], undefined, []]);
+    await assert.rejects(() => drawShape({
+      shape: 'horizontal_line',
+      point: { time: 1780860900, price: NaN },
+      _deps,
+    }));
+  });
+});

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
…t path

src/core/drawing.js: the _resolve(_deps) refactor only wired drawShape(). listDrawings/getProperties/removeOne/clearAll still referenced bare `getChartApi`/`evaluate`, which are imported under aliased names (_getChartApi/_evaluate) — so every call threw a ReferenceError at runtime (draw_clear, draw_list, draw_remove_one, draw_get_properties were all broken). Bring evaluate/getChartApi into local scope via _resolve(_deps) in all four, matching drawShape.

tests/drawing.test.js: new regression coverage for the five drawing functions using the same DI/mock pattern as replay.test.js.

tests/sanitization.test.js: the source-audit describe used `new URL(...).pathname`, which yields a leading-slash path ("/C:/...") that readdirSync mangles to "C:\C:\..." on Windows. Use fileURLToPath() so the suite runs on Windows.