### PR TITLE
Add crypto swing-trading rules config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,19 @@
+{
+  "watchlist": {
+    "majors": ["BINANCE:BTCUSDT", "BINANCE:ETHUSDT", "BINANCE:SOLUSDT"],
+    "alts": ["BINANCE:LINKUSDT", "BINANCE:AVAXUSDT", "BINANCE:SUIUSDT"],
+    "macro": ["CRYPTOCAP:TOTAL", "CRYPTOCAP:TOTAL3", "CRYPTOCAP:BTC.D"]
+  },
+  "timeframes_to_check": ["1W", "1D", "4H"],
+  "bias_criteria": {
+    "bullish": "Price above 50D EMA, RSI on daily between 45 and 70, higher highs and higher lows on 4H",
+    "bearish": "Price below 50D EMA, RSI on daily below 45, lower highs and lower lows on 4H",
+    "neutral": "Price chopping around 50D EMA, RSI between 40 and 60, no clear structure"
+  },
+  "risk_rules": {
+    "max_risk_per_trade": "1% of portfolio",
+    "min_rr_ratio": 2,
+    "no_trades_during": ["major US CPI", "FOMC", "weekend thin liquidity"]
+  },
+  "indicators_i_care_about": ["RSI (14)", "MACD (12, 26, 9)", "50 EMA", "200 EMA", "Volume"]
+}


### PR DESCRIPTION
## Summary

- Adds ules.json with a structured crypto swing-trading configuration
- Updates package-lock.json to reflect 
pm install output after initial setup

## What changed

**ules.json** - new file defining:
- **Watchlist**: BTC, ETH, SOL (majors); LINK, AVAX, SUI (alts); TOTAL, TOTAL3, BTC.D (macro)
- **Timeframes**: 1W, 1D, 4H
- **Bias criteria**: bullish/bearish/neutral conditions based on 50D EMA position and RSI levels
- **Risk rules**: 1% max risk per trade, minimum 2:1 R:R ratio, no trades during CPI/FOMC/weekend thin liquidity
- **Indicators**: RSI (14), MACD (12,26,9), 50 EMA, 200 EMA, Volume

## Reviewer notes

This file is intended to be consumed by the TradingView MCP server to guide analysis and trade filtering. The ules.json path is co-located with the server for easy reference at runtime.