### PR TITLE
fix(windows): detect MSIX/Store TradingView install for launcher

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -17,9 +17,13 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
+REM Check MSIX / Windows Store installs (dir works only if WindowsApps ACL allows it)
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+)
+REM MSIX fallback via Appx — works without admin, unlike a raw dir of WindowsApps
+if "%TV_EXE%"=="" (
+    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "$p=Get-AppxPackage -Name '*TradingView*' | Select-Object -First 1; if ($p) { Join-Path $p.InstallLocation 'TradingView.exe' }"`) do set "TV_EXE=%%i"
 )
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"


### PR DESCRIPTION
## Problem

On Windows 11, TradingView Desktop is distributed primarily as an MSIX/Store
package, installing under `C:\Program Files\WindowsApps\TradingView.Desktop_*`.

`scripts/launch_tv_debug.bat` has an MSIX fallback, but it uses:

```bat
dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe"
```

`%PROGRAMFILES%\WindowsApps` is ACL-restricted — a non-admin `dir` returns
access-denied, so the fallback silently produces nothing and the script exits
with **"Error: TradingView not found"** even though the app is installed.

Reproduced on Windows 11 Pro 26200 with TradingView Desktop 3.2.0 installed
from the Microsoft Store. `Get-AppxPackage` finds it instantly; `dir` does not.

## Fix

Add a `Get-AppxPackage`-based fallback before the final `where` lookup. Appx
queries don't require admin and return the canonical `InstallLocation`, which
we join with `TradingView.exe`.

```bat
for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "$p=Get-AppxPackage -Name '*TradingView*' | Select-Object -First 1; if ($p) { Join-Path $p.InstallLocation 'TradingView.exe' }"`) do set "TV_EXE=%%i"
```

The existing `dir` check is left in place so the script still works on
systems where `WindowsApps` happens to be readable, or on non-MSIX installs.

## Verification

- Windows 11 Pro 26200, TradingView Desktop 3.2.0 (MSIX from Store)
- Before patch: `Error: TradingView not found.`
- After patch: detects `C:\Program Files\WindowsApps\TradingView.Desktop_3.2.0.7916_x64__n534cwy3pjxzj\TradingView.exe`, launches with `--remote-debugging-port=9222`, CDP responds at `http://localhost:9222/json/version` within ~1s.

No changes to Mac/Linux launchers, no new dependencies (PowerShell ships with Windows).