### PR TITLE
Add watchlist_create/list/delete via internal REST API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,15 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `alert_list` → view active alerts
 - `alert_delete` → remove alerts
 
+### "Manage watchlists"
+Named-watchlist management uses TradingView's internal REST API (`/api/v1/symbols_list/`) — language-independent and reliable. Do NOT drive the watchlist UI to create lists.
+
+- `watchlist_create` with `name` + optional `symbols: ["NASDAQ:NVDA", "NASDAQ:AMD"]` → create a named list, pre-populated, in one call. This is the right tool for building a list from scratch (e.g. pushing tickers from an external source). It does NOT change the active list (new list is created inactive), so it won't disturb the user's current view.
+- `watchlist_list` → all named lists with their `id`, name, symbol count, and which is active. Use it to look up an `id` before deleting, or to check whether a named list already exists.
+- `watchlist_delete` with `id` (numeric, from `watchlist_list`) → delete a named list. Scoped by id only, never by name.
+- `watchlist_add` with `symbol` → append a single symbol to the **active** list (UI-based). Prefer `watchlist_create` with the full `symbols` array when building a new list — don't create-then-add one-by-one.
+- `watchlist_get` → read symbols + prices from the **active** list only (DOM-based). For all lists, use `watchlist_list`.
+
 ### "Navigate the UI"
 - `ui_open_panel` → open/close pine-editor, strategy-tester, watchlist, alerts, trading
 - `ui_click` → click buttons by aria-label, text, or data-name

--- a/src/cli/commands/watchlist.js
+++ b/src/cli/commands/watchlist.js
@@ -2,17 +2,36 @@ import { register } from '../router.js';
 import * as core from '../../core/watchlist.js';
 
 register('watchlist', {
-  description: 'Watchlist tools (get, add)',
+  description: 'Watchlist tools (get, add, create, list, delete)',
   subcommands: new Map([
     ['get', {
-      description: 'Get watchlist symbols',
+      description: 'Get symbols from the active watchlist',
       handler: () => core.get(),
     }],
     ['add', {
-      description: 'Add a symbol to the watchlist',
+      description: 'Add a symbol to the active watchlist',
       handler: (opts, positionals) => {
         if (!positionals[0]) throw new Error('Symbol required. Usage: tv watchlist add AAPL');
         return core.add({ symbol: positionals[0] });
+      },
+    }],
+    ['create', {
+      description: 'Create a named watchlist with optional initial symbols. Usage: tv watchlist create "AI – GPU demand" NASDAQ:NVDA NASDAQ:AMD',
+      handler: (opts, positionals) => {
+        const [name, ...symbols] = positionals;
+        if (!name) throw new Error('Name required. Usage: tv watchlist create "My List" SYM1 SYM2');
+        return core.create({ name, symbols });
+      },
+    }],
+    ['list', {
+      description: 'List all named watchlists with ids and symbol counts',
+      handler: () => core.list(),
+    }],
+    ['delete', {
+      description: 'Delete a named watchlist by id. Usage: tv watchlist delete 335018981',
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Watchlist id required. Usage: tv watchlist delete <id>');
+        return core.remove({ id: Number(positionals[0]) });
       },
     }],
   ]),

--- a/src/core/watchlist.js
+++ b/src/core/watchlist.js
@@ -2,7 +2,7 @@
  * Core watchlist logic.
  * Uses TradingView's internal widget API with DOM fallback.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
 
 export async function get() {
   // Try internal API first — reads from the active watchlist widget
@@ -129,4 +129,132 @@ export async function add({ symbol }) {
   await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape' });
 
   return { success: true, symbol, action: 'added' };
+}
+
+// ─── Named-watchlist management via TradingView's internal REST API ──────────
+//
+// TradingView exposes a same-origin REST endpoint for custom (named) watchlists:
+//   GET    {origin}/api/v1/symbols_list/all/          → all custom lists
+//   POST   {origin}/api/v1/symbols_list/custom/       → create  (body {name, symbols})
+//   DELETE {origin}/api/v1/symbols_list/custom/{id}/  → delete
+//
+// These run in-page via CDP, so the logged-in session cookie authenticates the
+// request and no CSRF token is required (verified against a live desktop client).
+// This is the same approach alerts.list() uses against pricealerts.tradingview.com,
+// and is far more robust than driving the localized watchlist UI:
+//   • language-independent (no German/English selector strings)
+//   • no DOM timing/race conditions
+//   • atomic — create a fully-populated named list in a single call
+//   • does NOT change the user's active list (REST create leaves active=false)
+
+/**
+ * Create a named watchlist, optionally pre-populated with symbols, in one call.
+ * @param {{ name: string, symbols?: string[] }} args
+ *   name    — display name for the new list (required, non-empty)
+ *   symbols — optional initial symbols, e.g. ["NASDAQ:NVDA", "NYSE:ORCL"]
+ */
+export async function create({ name, symbols = [] } = {}) {
+  if (typeof name !== 'string' || !name.trim()) {
+    throw new Error('Watchlist name is required (non-empty string)');
+  }
+  const cleanName = name.trim();
+  const cleanSymbols = (Array.isArray(symbols) ? symbols : [])
+    .map(s => String(s).trim())
+    .filter(Boolean);
+
+  // Inject the request body as a JSON literal parsed in-page — avoids any
+  // string-interpolation/injection risk from the name or symbols.
+  const payloadLiteral = safeString(JSON.stringify({ name: cleanName, symbols: cleanSymbols }));
+
+  const result = await evaluateAsync(`
+    (function() {
+      var payload = JSON.parse(${payloadLiteral});
+      var url = location.origin + '/api/v1/symbols_list/custom/';
+      return fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+        body: JSON.stringify(payload)
+      })
+        .then(function(r) { return r.text().then(function(t) {
+          var data = null; try { data = JSON.parse(t); } catch (e) {}
+          return { ok: r.ok, status: r.status, data: data, raw: data ? null : String(t).slice(0, 300) };
+        }); })
+        .catch(function(e) { return { ok: false, status: 0, error: String((e && e.message) || e) }; });
+    })()
+  `);
+
+  if (!result || !result.ok || !result.data) {
+    const detail = result?.error || result?.raw || ('HTTP ' + (result?.status ?? '??'));
+    throw new Error(`Watchlist create failed: ${detail}`);
+  }
+
+  const created = result.data;
+  return {
+    success: true,
+    id: created.id,
+    name: created.name,
+    symbols: created.symbols || cleanSymbols,
+    count: (created.symbols || cleanSymbols).length,
+    active: !!created.active,
+    source: 'rest_api',
+  };
+}
+
+/**
+ * List all custom (named) watchlists with their ids, names, and symbol counts.
+ * REST-based — reads every list, unlike get() which reads only the active one.
+ */
+export async function list() {
+  const result = await evaluateAsync(`
+    fetch(location.origin + '/api/v1/symbols_list/all/', { credentials: 'include', headers: { 'Accept': 'application/json' } })
+      .then(function(r) { return r.text().then(function(t) {
+        var data = null; try { data = JSON.parse(t); } catch (e) {}
+        return { ok: r.ok, status: r.status, data: data, raw: data ? null : String(t).slice(0, 300) };
+      }); })
+      .catch(function(e) { return { ok: false, status: 0, error: String((e && e.message) || e) }; })
+  `);
+
+  if (!result || !result.ok || !Array.isArray(result.data)) {
+    const detail = result?.error || result?.raw || ('HTTP ' + (result?.status ?? '??'));
+    throw new Error(`Watchlist list failed: ${detail}`);
+  }
+
+  const lists = result.data.map(l => ({
+    id: l.id,
+    name: l.name,
+    type: l.type,
+    count: Array.isArray(l.symbols) ? l.symbols.length : 0,
+    active: !!l.active,
+    symbols: l.symbols || [],
+  }));
+  return { success: true, count: lists.length, source: 'rest_api', lists };
+}
+
+/**
+ * Delete a custom watchlist by its numeric id (obtain ids from list()).
+ * Deletion is scoped strictly by id — never by name — to avoid ambiguous matches.
+ * @param {{ id: number }} args
+ */
+export async function remove({ id } = {}) {
+  const numId = Number(id);
+  if (!Number.isInteger(numId) || numId <= 0) {
+    throw new Error('A positive numeric watchlist id is required (get it from watchlist_list)');
+  }
+
+  const result = await evaluateAsync(`
+    fetch(location.origin + '/api/v1/symbols_list/custom/' + ${numId} + '/', {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
+    })
+      .then(function(r) { return { ok: r.ok, status: r.status }; })
+      .catch(function(e) { return { ok: false, status: 0, error: String((e && e.message) || e) }; })
+  `);
+
+  if (!result || !result.ok) {
+    const detail = result?.error || ('HTTP ' + (result?.status ?? '??'));
+    throw new Error(`Watchlist delete failed: ${detail}`);
+  }
+  return { success: true, id: numId, deleted: true, source: 'rest_api' };
 }

--- a/src/tools/watchlist.js
+++ b/src/tools/watchlist.js
@@ -23,4 +23,33 @@ export function registerWatchlistTools(server) {
       return jsonResult({ success: false, error: err.message }, true);
     }
   });
+
+  server.tool('watchlist_create',
+    'Create a new named watchlist, optionally pre-populated with symbols, in a single call. Uses TradingView\'s internal REST API (not UI automation), so it is language-independent and does not change the currently active list. Returns the new list\'s id, name, and symbols.',
+    {
+      name: z.string().min(1).describe('Name for the new watchlist (e.g., "AI – GPU demand")'),
+      symbols: z.array(z.string()).optional().describe('Optional initial symbols in EXCHANGE:TICKER form, e.g. ["NASDAQ:NVDA", "NYSE:ORCL"]'),
+    },
+    async ({ name, symbols }) => {
+      try { return jsonResult(await core.create({ name, symbols: symbols || [] })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    });
+
+  server.tool('watchlist_list',
+    'List all named (custom) watchlists with their ids, names, symbol counts, and which one is active. Reads every list via the internal REST API, unlike watchlist_get which only reads the active list. Use this to look up a watchlist id before deleting, or to check whether a named list already exists.',
+    {},
+    async () => {
+      try { return jsonResult(await core.list()); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    });
+
+  server.tool('watchlist_delete',
+    'Delete a named watchlist by its numeric id (get the id from watchlist_list). Destructive and scoped strictly by id — never by name.',
+    {
+      id: z.number().int().positive().describe('Numeric watchlist id from watchlist_list (e.g., 335018981)'),
+    },
+    async ({ id }) => {
+      try { return jsonResult(await core.remove({ id })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    });
 }


### PR DESCRIPTION
## Summary

Creating a named TradingView watchlist previously required driving the watchlist **UI** (panel → menu → "create list" → type name), which depends on localized selector strings (e.g. German "Neue Liste erstellen…") and DOM timing — the fragile link when building a list programmatically.

This adds a clean, language-independent path using TradingView's **internal same-origin REST API** for custom watchlists, authenticated by the logged-in session cookie (no CSRF token required):

| Method | Endpoint | Result |
|---|---|---|
| GET | `/api/v1/symbols_list/all/` | all custom lists |
| POST | `/api/v1/symbols_list/custom/` (body `{name, symbols}`) | create, returns `id` |
| DELETE | `/api/v1/symbols_list/custom/{id}/` | delete |

Implemented via the existing `evaluateAsync` in-page `fetch` pattern — the same approach `alerts.list()` already uses against `pricealerts.tradingview.com`.

## New tools

- **`watchlist_create`** — `name` + optional `symbols[]`, creates a fully-populated named list in one atomic call. Leaves the new list **inactive**, so it does not disturb the user's active list/view.
- **`watchlist_list`** — all named lists with `id`, name, symbol count, active flag (reads every list, unlike `watchlist_get` which only reads the active one).
- **`watchlist_delete`** — delete by **numeric `id`** (from `watchlist_list`); scoped by id only, never by name.

Matching CLI subcommands (`tv watchlist create|list|delete`) and a CLAUDE.md **"Manage watchlists"** section steering future sessions away from UI automation are included.

## Safety

- Request bodies are built in Node, `JSON.stringify`'d, and injected via the repo's `safeString()` + in-page `JSON.parse` — no string-interpolation/injection risk from names or symbols.
- `watchlist_delete` validates a positive integer id and is scoped strictly by id.

## Testing

Verified live against a running TradingView Desktop client, exercising the **implemented core code** (not raw fetch):

- `create` → `list` → `delete` round-trip ✓
- initial-symbol population (2 symbols in one call) ✓
- new list created `active: false` (active list untouched) ✓
- empty-name guard rejects blank names ✓
- all pre-existing watchlists intact after the round-trip ✓

## Notes

These are undocumented internal endpoints (same caveat RESEARCH.md already makes about every tool in this project). Error handling surfaces a clear `Watchlist create failed: HTTP <status>` if TradingView ever changes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)