### PR TITLE
Fix CDP connection and launcher for Windows Store installs

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -2,7 +2,10 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
-const CDP_HOST = 'localhost';
+// Use the IPv4 loopback explicitly. Chrome/Electron's --remote-debugging-port
+// binds only to 127.0.0.1; on Windows 'localhost' often resolves to IPv6 ::1
+// first, which the debug server does not listen on, causing connection failures.
+const CDP_HOST = '127.0.0.1';
 const CDP_PORT = 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -197,6 +197,20 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  // Windows: TradingView is commonly installed as a Microsoft Store (Appx) package,
+  // which lives under C:\Program Files\WindowsApps\<pkg> (a path the static
+  // candidates above never cover). Resolve it via the package manager.
+  if (!tvPath && platform === 'win32') {
+    try {
+      const ps = `powershell -NoProfile -NonInteractive -Command "(Get-AppxPackage -Name '*TradingView*' | Select-Object -First 1).InstallLocation"`;
+      const loc = execSync(ps, { timeout: 8000 }).toString().trim();
+      if (loc) {
+        const candidate = `${loc}\\TradingView.exe`;
+        if (existsSync(candidate)) tvPath = candidate;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath && platform === 'darwin') {
     try {
       const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();
@@ -227,7 +241,7 @@ export async function launch({ port, kill_existing } = {}) {
     try {
       const http = await import('http');
       const ready = await new Promise((resolve) => {
-        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+        http.get(`http://127.0.0.1:${cdpPort}/json/version`, (res) => {
           let data = '';
           res.on('data', (chunk) => data += chunk);
           res.on('end', () => resolve(data));


### PR DESCRIPTION
## Summary

Two Windows-specific fixes that prevented the MCP server from connecting to TradingView Desktop:

### 1. Use IPv4 loopback instead of `localhost` for CDP
`CDP_HOST` is now `127.0.0.1` (was `localhost`), and the launcher's readiness poll uses `127.0.0.1` too. Chrome/Electron's `--remote-debugging-port` binds **only** to `127.0.0.1`, but on Windows `localhost` frequently resolves to IPv6 `::1` first — which the debug server does not listen on — causing connection failures even when TradingView is running with CDP enabled.

### 2. Detect Microsoft Store (Appx) installs in `launch()`
TradingView is commonly installed under `C:\Program Files\WindowsApps\<pkg>`, a path the static candidate list never covers. `launch()` now falls back to `Get-AppxPackage -Name '*TradingView*'` to resolve the install location, so `tv_launch` works on Store installs.

## Testing
- Verified `tv_health_check` connects to a live chart after these changes (CDP on `127.0.0.1:9222`).
- Both files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)