### PR TITLE
Fix e2e test suite + add MGC/ETH multi-strategy    dashboard

### DIFF
--- a/ibkr_mgc_bot.py
+++ b/ibkr_mgc_bot.py
@@ -1,0 +1,1002 @@
+#!/usr/bin/env python3
+# Python 3.10+ removed implicit event loop creation — patch before ib_insync loads
+import asyncio
+try:
+    asyncio.get_event_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+"""
+MGC Turtle Soup V2 — IBKR Live Bot
+Runs the V2 strategy engine against live Interactive Brokers data.
+
+Usage:
+    python3 ibkr_mgc_bot.py              # paper account (default)
+    python3 ibkr_mgc_bot.py --live       # live account  ← CAREFUL
+    python3 ibkr_mgc_bot.py --host 127.0.0.1 --port 7497
+
+TWS ports:
+    7497 = TWS paper trading
+    7496 = TWS live trading
+    4002 = IB Gateway paper
+    4001 = IB Gateway live
+"""
+
+import argparse
+import json
+import logging
+import math
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import pandas as pd
+from ib_insync import (
+    IB, Contract, LimitOrder, MarketOrder, StopOrder,
+    util, Trade, BarData, RealTimeBar,
+)
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler("ibkr_mgc_bot.log"),
+    ],
+)
+log = logging.getLogger("mgc_bot")
+
+MOUNTAIN = ZoneInfo("America/Denver")
+
+# ── Strategy parameters — 10m chart, synced to TradingView inputs 2026-06-10 ──
+MSS_OFFSET      = 6
+BAR_LENGTH      = 5      # warmup buffer only (no HTF aggregation on 10m)
+ATR_LEN         = 2
+TREND_EMA_LEN   = 50
+LONG_RR         = 1.6
+SHORT_RR        = 1.8
+LONG_SL_ATR     = 5.3
+SHORT_SL_ATR    = 7.2
+RISK_PCT        = 0.025
+MAX_CONTRACTS   = 7
+MGC_INIT_MARGIN = 4200  # per contract initial margin (COMEX) — conservative buffer above ~$4,075
+LONG_MAX_HOLD   = 33
+SHORT_MAX_HOLD  = 42
+MIN_DISP_ATR    = 0.65
+MIN_ATR_POINTS  = 4.18
+LONG_HOURS      = {8, 10, 11}
+SHORT_HOURS     = {8, 9, 12}
+
+# Filter mode — set via --filter-mode CLI arg
+# "Baseline"     : session 0800-1330 MT + side-hour filter (default, best PF)
+# "Session Only" : session 0800-1330 MT, any hour within session (+27% trades, lower PF)
+# "24h Full"     : no session, no hour filter, trade 24h (+3.7x trades, highest DD)
+FILTER_MODE     = "Baseline"   # overridden by parse_args()
+
+# Account
+POINT_VALUE     = 10.0
+TICK_SIZE       = 0.10
+COMMISSION      = 1.20
+SLIP_TICKS      = 2
+
+# Daily safety limits
+MAX_DAILY_LOSS_USD  = 500.0   # bot pauses if daily loss exceeds this
+MAX_TRADES_PER_DAY  = 10
+
+
+# ── Contract ──────────────────────────────────────────────────────────────────
+
+DELIVERY_BUFFER_DAYS = 25  # skip contracts expiring within this many days
+
+def get_mgc_contract(ib: IB) -> Contract:
+    """Resolve the nearest MGC contract outside IBKR's delivery restriction window."""
+    from datetime import datetime, timedelta
+    c = Contract(symbol="MGC", secType="FUT", exchange="COMEX", currency="USD")
+    details = ib.reqContractDetails(c)
+    if not details:
+        raise RuntimeError("No MGC contract details returned — is TWS connected?")
+    details.sort(key=lambda d: d.contract.lastTradeDateOrContractMonth)
+    today = datetime.now()
+    cutoff = today + timedelta(days=DELIVERY_BUFFER_DAYS)
+    # Pick the first contract that expires after the delivery buffer
+    tradeable = [d for d in details
+                 if datetime.strptime(d.contract.lastTradeDateOrContractMonth, "%Y%m%d") > cutoff]
+    if not tradeable:
+        log.warning("No contracts outside delivery window — using nearest available")
+        tradeable = details
+    front = tradeable[0].contract
+    log.info(f"MGC contract: {front.localSymbol}  expiry={front.lastTradeDateOrContractMonth}"
+             f"  (skipped {len(details)-len(tradeable)} near-expiry contracts)")
+    return front
+
+
+# ── Indicator helpers ─────────────────────────────────────────────────────────
+
+def _wilder_atr(highs, lows, closes, n=ATR_LEN):
+    if len(closes) < n + 1:
+        return float("nan")
+    trs = []
+    for i in range(1, len(closes)):
+        h, l, pc = highs[i], lows[i], closes[i - 1]
+        trs.append(max(h - l, abs(h - pc), abs(l - pc)))
+    alpha = 1.0 / n
+    atr = trs[0]
+    for tr in trs[1:]:
+        atr = alpha * tr + (1 - alpha) * atr
+    return atr
+
+
+def _ema(values, span):
+    alpha = 2.0 / (span + 1)
+    e = values[0]
+    for v in values[1:]:
+        e = alpha * v + (1 - alpha) * e
+    return e
+
+
+# ── State machine dataclasses ─────────────────────────────────────────────────
+
+@dataclass
+class BarWindow:
+    """Rolling window of OHLCV bars for indicator calculation."""
+    maxlen: int
+    opens:   deque = field(default_factory=deque)
+    highs:   deque = field(default_factory=deque)
+    lows:    deque = field(default_factory=deque)
+    closes:  deque = field(default_factory=deque)
+    times:   deque = field(default_factory=deque)
+
+    def __post_init__(self):
+        for attr in ("opens", "highs", "lows", "closes", "times"):
+            setattr(self, attr, deque(maxlen=self.maxlen))
+
+    def push(self, o, h, l, c, t):
+        self.opens.append(o); self.highs.append(h)
+        self.lows.append(l);  self.closes.append(c)
+        self.times.append(t)
+
+    def full(self):
+        return len(self.closes) == self.maxlen
+
+    @property
+    def last_close(self): return self.closes[-1] if self.closes else float("nan")
+    @property
+    def last_high(self): return self.highs[-1] if self.highs else float("nan")
+    @property
+    def last_low(self): return self.lows[-1] if self.lows else float("nan")
+
+
+@dataclass
+class BotState:
+    # Pending signal state machine
+    pending_state:      str   = "idle"
+    pending_entry_type: str   = ""
+    pending_break_bar:  int   = -1
+    pending_start_bar:  int   = -1
+    pending_high:       float = float("nan")
+    pending_low:        float = float("nan")
+
+    # Active position tracking
+    active_side:        str   = ""
+    active_entry_price: float = float("nan")
+    active_stop:        float = float("nan")
+    active_target:      float = float("nan")
+    active_entry_bar:   int   = -1
+    active_qty:         int   = 0
+    last_exit_bar:      int   = -100_000
+
+    # IBKR order IDs
+    entry_order_id:     int   = -1
+    sl_order_id:        int   = -1
+    tp_order_id:        int   = -1
+
+    # Performance tracking
+    bar_index:          int   = 0
+    daily_pnl:          float = 0.0
+    trades_today:       int   = 0
+    today_date:         str   = ""
+    equity:             float = 0.0   # updated from IBKR account
+
+    def reset_pending(self):
+        self.pending_state      = "idle"
+        self.pending_entry_type = ""
+        self.pending_break_bar  = -1
+        self.pending_start_bar  = -1
+        self.pending_high       = float("nan")
+        self.pending_low        = float("nan")
+
+    needs_protective_orders: bool = False   # set when adopted position has no bracket
+
+    def reset_active(self):
+        self.active_side              = ""
+        self.active_entry_price       = float("nan")
+        self.active_stop              = float("nan")
+        self.active_target            = float("nan")
+        self.active_entry_bar         = -1
+        self.active_qty               = 0
+        self.entry_order_id           = -1
+        self.sl_order_id              = -1
+        self.tp_order_id              = -1
+        self.needs_protective_orders  = False
+
+
+# ── Main bot class ────────────────────────────────────────────────────────────
+
+class MGCBot:
+    def __init__(self, ib: IB, contract: Contract, paper: bool = True):
+        self.ib       = ib
+        self.contract = contract
+        self.paper    = paper
+        self.state    = BotState()
+
+        # Bar windows — need enough history for indicators
+        warmup = max(MSS_OFFSET, BAR_LENGTH, ATR_LEN) + 5
+        self.bars_3m  = BarWindow(maxlen=warmup + 10)
+        self.bars_15m = BarWindow(maxlen=TREND_EMA_LEN + 5)
+
+        # Partial 3m aggregation from 1m IBKR bars (if needed)
+        self._partial_3m: list = []
+
+        self._trade_log: list[dict] = []
+        self._log_path = Path("mgc_live_trades.json")
+        self._seeding = True   # True during historical seed — no real orders
+        self._equity_fetched = False  # accountValues() called at most once per bot instance
+        self._last_processed_ts: datetime = datetime.fromtimestamp(0, tz=timezone.utc)
+        self._last_poll_time: float = 0.0
+
+    # ── IBKR account equity ───────────────────────────────────────────────────
+
+    def _refresh_equity(self):
+        # Use portfolio() — no reqAccountSummary subscription, avoids Error 322 on reconnects
+        try:
+            portfolio = self.ib.portfolio()
+            if portfolio:
+                # Sum market value of all positions as proxy for equity change
+                pass
+            # Preferred: pull from managed accounts summary via wrapper
+            wrapper = self.ib.wrapper
+            if hasattr(wrapper, 'acctValue') and wrapper.acctValue:
+                val = wrapper.acctValue.get("NetLiquidation-USD")
+                if val:
+                    self.state.equity = float(val)
+                    log.debug(f"Equity: ${self.state.equity:,.2f}")
+                    return
+            # Fallback: accountValues — call at most ONCE per bot lifetime to avoid Error 322
+            if self.state.equity == 0.0 and not self._equity_fetched:
+                self._equity_fetched = True
+                acct = [v for v in self.ib.accountValues()
+                        if v.tag == "NetLiquidation" and v.currency == "USD"]
+                if acct:
+                    self.state.equity = float(acct[0].value)
+                    log.info(f"Equity (initial fetch): ${self.state.equity:,.2f}")
+        except Exception as e:
+            log.warning(f"Equity refresh skipped: {e} — using cached ${self.state.equity:,.2f}")
+
+    # ── Indicator computation ─────────────────────────────────────────────────
+
+    def _compute_3m_indicators(self):
+        """Compute all 3m-bar indicators from current bar window."""
+        h = list(self.bars_3m.highs)
+        l = list(self.bars_3m.lows)
+        c = list(self.bars_3m.closes)
+        o = list(self.bars_3m.opens)
+
+        if len(c) < MSS_OFFSET + 2:
+            return None
+
+        atr = _wilder_atr(h, l, c)
+        if math.isnan(atr) or atr < MIN_ATR_POINTS:
+            return None
+
+        high_mss      = max(h[-MSS_OFFSET:])
+        low_mss       = min(l[-MSS_OFFSET:])
+        high_mss_prev = max(h[-MSS_OFFSET - 1:-1])
+        low_mss_prev  = min(l[-MSS_OFFSET - 1:-1])
+
+        prev_high_htf = max(h[-BAR_LENGTH - 1:-1])
+        prev_low_htf  = min(l[-BAR_LENGTH - 1:-1])
+
+        body_atr = abs(c[-1] - o[-1]) / atr if atr > 0 else 0.0
+
+        return dict(
+            atr=atr,
+            high_mss=high_mss,
+            low_mss=low_mss,
+            high_mss_prev=high_mss_prev,
+            low_mss_prev=low_mss_prev,
+            prev_high_htf=prev_high_htf,
+            prev_low_htf=prev_low_htf,
+            body_atr=body_atr,
+            h=h[-1], l=l[-1], c=c[-1], o=o[-1],
+        )
+
+    def _htf_trend_ok(self):
+        """Short trend filter: 15m close[1] < 15m EMA(50)[1]."""
+        closes = list(self.bars_15m.closes)
+        if len(closes) < TREND_EMA_LEN + 1:
+            return False   # not enough data → block shorts until warm
+        # Use closes shifted by 1 (previous completed 15m bar)
+        htf_close_prev = closes[-2]
+        ema_prev       = _ema(closes[:-1], TREND_EMA_LEN)
+        return htf_close_prev < ema_prev
+
+    def _session_ok(self, ts: datetime) -> bool:
+        if FILTER_MODE == "24h Full":
+            return True
+        mt = ts.astimezone(MOUNTAIN)
+        h, m = mt.hour, mt.minute
+        after_open   = (h > 8) or (h == 8 and m >= 0)
+        before_close = (h < 13) or (h == 13 and m <= 30)
+        return after_open and before_close
+
+    def _hour_ok(self, mt_hour: int, side: str) -> bool:
+        if FILTER_MODE in ("Session Only", "24h Full"):
+            return True
+        if side == "Long":
+            return mt_hour in LONG_HOURS
+        return mt_hour in SHORT_HOURS
+
+    def _entry_quality_ok(self, ind: dict) -> bool:
+        return ind["body_atr"] >= MIN_DISP_ATR and ind["atr"] >= MIN_ATR_POINTS
+
+    def _calc_qty(self, entry: float, stop: float) -> int:
+        sl_dist  = abs(entry - stop)
+        rpu      = sl_dist * POINT_VALUE
+        if rpu <= 0:
+            return 1
+        cash_risk    = self.state.equity * RISK_PCT
+        raw_qty      = cash_risk / rpu
+        # Cap by available margin so we never exceed account capacity
+        max_by_margin = max(1, int(self.state.equity / MGC_INIT_MARGIN))
+        return int(min(MAX_CONTRACTS, max_by_margin, max(1, math.floor(raw_qty))))
+
+    # ── Daily reset ───────────────────────────────────────────────────────────
+
+    def _check_daily_reset(self, ts: datetime):
+        today = ts.astimezone(MOUNTAIN).strftime("%Y-%m-%d")
+        if today != self.state.today_date:
+            if self.state.today_date:
+                log.info(f"Day change → {today}  |  yesterday P&L: ${self.state.daily_pnl:+,.2f}  trades: {self.state.trades_today}")
+            self.state.today_date   = today
+            self.state.daily_pnl    = 0.0
+            self.state.trades_today = 0
+
+    def _daily_limits_ok(self) -> bool:
+        if self.state.daily_pnl <= -MAX_DAILY_LOSS_USD:
+            log.warning(f"Daily loss limit hit (${self.state.daily_pnl:,.2f}) — pausing bot today")
+            return False
+        if self.state.trades_today >= MAX_TRADES_PER_DAY:
+            log.warning(f"Max trades/day ({MAX_TRADES_PER_DAY}) reached — pausing")
+            return False
+        return True
+
+    # ── Order execution ───────────────────────────────────────────────────────
+
+    def _place_bracket(self, side: str, qty: int,
+                       entry_price: float, sl_price: float, tp_price: float) -> bool:
+        """Place entry limit + OCA stop + OCA limit (bracket). Returns False if rejected."""
+        action     = "BUY"  if side == "Long" else "SELL"
+        sl_action  = "SELL" if side == "Long" else "BUY"
+        tp_action  = "SELL" if side == "Long" else "BUY"
+
+        oca_group = f"MGC_{side}_{int(time.time())}"
+
+        # Entry as limit at the MSS level
+        entry_order = LimitOrder(action, qty, round(entry_price, 1))
+        entry_order.tif = "GTC"
+        entry_order.transmit = False
+
+        # Stop loss
+        sl_order = StopOrder(sl_action, qty, round(sl_price, 1))
+        sl_order.tif        = "GTC"
+        sl_order.ocaGroup   = oca_group
+        sl_order.ocaType    = 1   # cancel with block
+        sl_order.transmit   = False
+
+        # Take profit
+        tp_order = LimitOrder(tp_action, qty, round(tp_price, 1))
+        tp_order.tif        = "GTC"
+        tp_order.ocaGroup   = oca_group
+        tp_order.ocaType    = 1
+        tp_order.transmit   = True   # transmits the whole group
+
+        entry_trade = self.ib.placeOrder(self.contract, entry_order)
+        sl_trade    = self.ib.placeOrder(self.contract, sl_order)
+        tp_trade    = self.ib.placeOrder(self.contract, tp_order)
+
+        self.state.entry_order_id = entry_trade.order.orderId
+        self.state.sl_order_id    = sl_trade.order.orderId
+        self.state.tp_order_id    = tp_trade.order.orderId
+
+        log.info(
+            f"BRACKET {side} {qty}x MGC | "
+            f"Entry={entry_price:.1f}  SL={sl_price:.1f}  TP={tp_price:.1f} | "
+            f"Orders: entry={self.state.entry_order_id} "
+            f"sl={self.state.sl_order_id} tp={self.state.tp_order_id}"
+        )
+
+        # Rollback: if any order is rejected within 2s, cancel the whole bracket
+        self.ib.sleep(2)
+        rejected = [t for t in [entry_trade, sl_trade, tp_trade]
+                    if t.orderStatus.status in ("Inactive", "Cancelled", "ApiCancelled")]
+        if rejected:
+            log.error(f"Bracket rejected — cancelling all {len(rejected)} orders")
+            self._cancel_open_orders()
+            self.state.reset_pending()
+            self.state.active_side = ""
+            return False
+        return True
+
+    def _cancel_open_orders(self):
+        """Cancel any open entry/sl/tp orders for this bot."""
+        for oid in [self.state.entry_order_id,
+                    self.state.sl_order_id,
+                    self.state.tp_order_id]:
+            if oid > 0:
+                try:
+                    order = next((t.order for t in self.ib.openTrades()
+                                  if t.order.orderId == oid), None)
+                    if order:
+                        self.ib.cancelOrder(order)
+                        log.info(f"Cancelled order {oid}")
+                except Exception as e:
+                    log.warning(f"Cancel order {oid} failed: {e}")
+
+    def _close_position_market(self, side: str, qty: int, reason: str):
+        """Market-close an open position (time stop)."""
+        action = "SELL" if side == "Long" else "BUY"
+        mo     = MarketOrder(action, qty)
+        mo.tif = "GTC"
+        self._cancel_open_orders()
+        trade = self.ib.placeOrder(self.contract, mo)
+        log.info(f"MARKET CLOSE {side} {qty}x — {reason}  orderId={trade.order.orderId}")
+
+    # ── Core strategy logic — called on each confirmed 3m bar ─────────────────
+
+    def on_bar(self, bar_time: datetime, o: float, h: float, l: float, c: float):
+        """Process one confirmed 10-minute bar through the V2 state machine."""
+        s = self.state
+        s.bar_index += 1
+
+        self._check_daily_reset(bar_time)
+        self._refresh_equity()
+
+        # Push bar into both windows (same 10m bars — no HTF aggregation)
+        self.bars_3m.push(o, h, l, c, bar_time)
+        self.bars_15m.push(o, h, l, c, bar_time)
+
+        mt = bar_time.astimezone(MOUNTAIN)
+
+        if not self.bars_3m.full():
+            return
+
+        ind = self._compute_3m_indicators()
+
+        # Place protective bracket for adopted position — do this even if strategy
+        # ATR filter rejects the bar (ind may be None here; method handles that case)
+        if not self._seeding and s.needs_protective_orders:
+            self._place_protective_orders(ind)
+
+        if ind is None:
+            return
+
+        mt_hour  = mt.hour
+        sess_ok  = self._session_ok(bar_time)
+        can_re   = (s.bar_index - s.last_exit_bar) > 0
+        eq_ok    = self._entry_quality_ok(ind)
+        short_trend = self._htf_trend_ok()
+        long_trend  = True   # requireLongTrendFilter = false
+
+        # ── Check if position was closed externally (IBKR filled SL/TP) ──────
+        if s.active_side != "":
+            # Skip close-check if entry order is still pending (unfilled limit)
+            entry_pending = any(
+                t.order.orderId == s.entry_order_id
+                and t.orderStatus.status not in ("Inactive", "Cancelled", "ApiCancelled", "Filled")
+                for t in self.ib.openTrades()
+            )
+            if not entry_pending:
+                pos = self._get_ibkr_position()
+                if pos == 0 and s.active_side != "":
+                    pnl = self._estimate_pnl(ind["c"])
+                    s.daily_pnl    += pnl
+                    s.trades_today += 1
+                    log.info(
+                        f"Position closed by IBKR  side={s.active_side}  "
+                        f"estimated_pnl=${pnl:+,.2f}  daily_pnl=${s.daily_pnl:+,.2f}"
+                    )
+                    self._log_trade("IBKR_CLOSE", bar_time, ind["c"], pnl)
+                    s.last_exit_bar = s.bar_index
+                    s.reset_active()
+                    s.reset_pending()
+
+        # ── Time stop check ───────────────────────────────────────────────────
+        if s.active_side != "":
+            hold = s.bar_index - s.active_entry_bar
+            max_hold = LONG_MAX_HOLD if s.active_side == "Long" else SHORT_MAX_HOLD
+            if hold >= max_hold:
+                if self._seeding:
+                    # During historical seed, just roll the entry bar forward so
+                    # the hold counter never fires a real close.
+                    s.active_entry_bar = s.bar_index
+                else:
+                    pnl = self._estimate_pnl(ind["c"])
+                    s.daily_pnl    += pnl
+                    s.trades_today += 1
+                    log.info(
+                        f"TIME STOP  side={s.active_side}  hold={hold}bars  "
+                        f"close={ind['c']:.1f}  estimated_pnl=${pnl:+,.2f}"
+                    )
+                    self._cancel_open_orders()   # cancel bracket before market close
+                    self._close_position_market(s.active_side, s.active_qty, "Time Exit")
+                    self._log_trade("TIME_EXIT", bar_time, ind["c"], pnl)
+                    s.last_exit_bar = s.bar_index
+                    s.reset_active()
+                    s.reset_pending()
+                    return
+
+        # ── Daily limits ──────────────────────────────────────────────────────
+        if s.active_side == "" and not self._daily_limits_ok():
+            return
+
+        # ── State machine ─────────────────────────────────────────────────────
+        # Guard: never enter a new bracket if an IBKR position is already open
+        if s.active_side == "" and self._get_ibkr_position() != 0:
+            log.warning("Skipping new signal — IBKR position already open (stale state)")
+            return
+
+        if s.active_side == "" and can_re:
+
+            # Idle → waiting_break
+            if s.pending_state == "idle":
+                s.pending_state     = "waiting_break"
+                s.pending_start_bar = s.bar_index
+                s.pending_high      = ind["prev_high_htf"]
+                s.pending_low       = ind["prev_low_htf"]
+                log.debug(f"New cycle  ref_high={s.pending_high:.1f}  ref_low={s.pending_low:.1f}")
+
+            # Waiting for sweep
+            elif s.pending_state == "waiting_break" and s.bar_index > s.pending_start_bar:
+                if ind["l"] < s.pending_low:
+                    s.pending_state      = "waiting_execution"
+                    s.pending_entry_type = "Long"
+                    s.pending_break_bar  = s.bar_index
+                    log.info(f"SWEEP Long  low={ind['l']:.1f} < ref={s.pending_low:.1f}  bar={s.bar_index}")
+                elif ind["h"] > s.pending_high:
+                    s.pending_state      = "waiting_execution"
+                    s.pending_entry_type = "Short"
+                    s.pending_break_bar  = s.bar_index
+                    log.info(f"SWEEP Short  high={ind['h']:.1f} > ref={s.pending_high:.1f}  bar={s.bar_index}")
+
+            # Waiting for MSS entry trigger
+            elif (s.pending_state == "waiting_execution"
+                  and s.bar_index > s.pending_break_bar
+                  and sess_ok and eq_ok):
+
+                if s.pending_entry_type == "Long" and long_trend and self._hour_ok(mt_hour, "Long"):
+                    ll = ind["high_mss_prev"]
+                    if ind["h"] > ll and ind["c"] > ind["o"]:
+                        sl    = ind["low_mss_prev"] - ind["atr"] * LONG_SL_ATR
+                        sd    = abs(ll - sl)
+                        tp    = ll + sd * LONG_RR
+                        qty   = self._calc_qty(ll, sl)
+                        ep    = ll + SLIP_TICKS * TICK_SIZE
+
+                        log.info(
+                            f"SIGNAL Long  entry={ep:.1f}  SL={sl:.1f}  TP={tp:.1f}  "
+                            f"qty={qty}  bar={s.bar_index}  {bar_time.strftime('%H:%M')} MT"
+                        )
+                        if not self._seeding:
+                            if self._place_bracket("Long", qty, ep, sl, tp):
+                                s.active_side        = "Long"
+                                s.active_entry_price = ep
+                                s.active_stop        = sl
+                                s.active_target      = tp
+                                s.active_entry_bar   = s.bar_index
+                                s.active_qty         = qty
+                                self._log_trade("ENTRY", bar_time, ep, 0.0,
+                                                side="Long", sl=sl, tp=tp, qty=qty)
+                        else:
+                            log.info(f"SEED Long (no order): entry={ep:.1f} SL={sl:.1f} TP={tp:.1f} qty={qty}")
+
+                    s.reset_pending()
+
+                elif s.pending_entry_type == "Short" and short_trend and self._hour_ok(mt_hour, "Short"):
+                    sl2 = ind["low_mss_prev"]
+                    if ind["l"] < sl2 and ind["c"] < ind["o"]:
+                        ss  = ind["high_mss_prev"] + ind["atr"] * SHORT_SL_ATR
+                        sd  = abs(sl2 - ss)
+                        st  = sl2 - sd * SHORT_RR
+                        qty = self._calc_qty(sl2, ss)
+                        ep  = sl2 - SLIP_TICKS * TICK_SIZE
+
+                        log.info(
+                            f"SIGNAL Short  entry={ep:.1f}  SL={ss:.1f}  TP={st:.1f}  "
+                            f"qty={qty}  bar={s.bar_index}  {bar_time.strftime('%H:%M')} MT"
+                        )
+                        if not self._seeding:
+                            if self._place_bracket("Short", qty, ep, ss, st):
+                                s.active_side        = "Short"
+                                s.active_entry_price = ep
+                                s.active_stop        = ss
+                                s.active_target      = st
+                                s.active_entry_bar   = s.bar_index
+                                s.active_qty         = qty
+                                self._log_trade("ENTRY", bar_time, ep, 0.0,
+                                                side="Short", sl=ss, tp=st, qty=qty)
+                        else:
+                            log.info(f"SEED Short (no order): entry={ep:.1f} SL={ss:.1f} TP={st:.1f} qty={qty}")
+
+                    s.reset_pending()
+
+    def _get_ibkr_position(self) -> int:
+        """Return current net position in MGC (positive=long, negative=short, 0=flat)."""
+        for pos in self.ib.positions():
+            if (pos.contract.symbol == "MGC"
+                    and pos.contract.secType == "FUT"):
+                return int(pos.position)
+        return 0
+
+    def _adopt_orphaned_position(self):
+        """Adopt an IBKR position the bot has no record of (e.g. after a service restart)."""
+        s = self.state
+        if s.active_side != "":
+            return  # already tracking — nothing to do
+
+        ibkr_pos = self._get_ibkr_position()
+        if ibkr_pos == 0:
+            return  # flat, nothing to adopt
+
+        side = "Long" if ibkr_pos > 0 else "Short"
+        qty  = abs(ibkr_pos)
+
+        # Entry price from portfolio average cost.
+        # IBKR reports averageCost as price * multiplier for futures — divide back to price.
+        entry_price = float("nan")
+        for item in self.ib.portfolio():
+            if item.contract.symbol == "MGC" and item.contract.secType == "FUT":
+                mult = float(item.contract.multiplier) if item.contract.multiplier else 10.0
+                entry_price = item.averageCost / mult
+                break
+
+        # Reconstruct SL/TP from any open bracket orders on this contract
+        sl_id, tp_id = -1, -1
+        sl_price, tp_price = float("nan"), float("nan")
+        for trade in self.ib.openTrades():
+            if trade.contract.symbol != "MGC":
+                continue
+            ot = trade.order.orderType
+            if ot == "STP":
+                sl_id    = trade.order.orderId
+                sl_price = trade.order.auxPrice
+            elif ot == "LMT":
+                tp_id    = trade.order.orderId
+                tp_price = trade.order.lmtPrice
+
+        s.active_side        = side
+        s.active_qty         = qty
+        s.active_entry_price = entry_price
+        s.active_stop        = sl_price
+        s.active_target      = tp_price
+        s.active_entry_bar   = s.bar_index
+        s.sl_order_id        = sl_id
+        s.tp_order_id        = tp_id
+
+        if sl_id == -1:
+            s.needs_protective_orders = True
+
+        log.info(
+            f"Adopted orphaned {side} x{qty} @ {entry_price:.1f}  "
+            f"SL={sl_price:.1f}  TP={tp_price:.1f}  "
+            f"(sl_id={sl_id}  tp_id={tp_id})"
+            + ("  → will place protective bracket on first live bar" if sl_id == -1 else "")
+        )
+
+    def _place_protective_orders(self, ind):
+        """Place SL + TP OCA bracket for an adopted position that had no open orders."""
+        s = self.state
+        if not s.active_side or not s.needs_protective_orders:
+            return
+
+        # Use strategy-computed ATR when available; otherwise compute raw ATR from bars
+        if ind is not None:
+            atr = ind["atr"]
+        else:
+            h = list(self.bars_3m.highs)
+            l = list(self.bars_3m.lows)
+            c = list(self.bars_3m.closes)
+            if len(c) < 5:
+                log.warning("Protective bracket deferred — not enough bars yet")
+                return
+            atr = max(_wilder_atr(h, l, c), 3.0)   # floor at 3 points
+
+        ep  = s.active_entry_price
+
+        if s.active_side == "Short":
+            sl_price  = round(ep + atr * SHORT_SL_ATR, 1)
+            tp_price  = round(ep - abs(ep - sl_price) * SHORT_RR, 1)
+            sl_action = "BUY"
+            tp_action = "BUY"
+        else:
+            sl_price  = round(ep - atr * LONG_SL_ATR, 1)
+            tp_price  = round(ep + abs(ep - sl_price) * LONG_RR, 1)
+            sl_action = "SELL"
+            tp_action = "SELL"
+
+        qty       = s.active_qty
+        oca_group = f"MGC_Adopted_{int(time.time())}"
+
+        sl_order          = StopOrder(sl_action, qty, sl_price)
+        sl_order.tif      = "GTC"
+        sl_order.ocaGroup = oca_group
+        sl_order.ocaType  = 1
+        sl_order.transmit = False
+
+        tp_order          = LimitOrder(tp_action, qty, tp_price)
+        tp_order.tif      = "GTC"
+        tp_order.ocaGroup = oca_group
+        tp_order.ocaType  = 1
+        tp_order.transmit = True
+
+        sl_trade = self.ib.placeOrder(self.contract, sl_order)
+        tp_trade = self.ib.placeOrder(self.contract, tp_order)
+
+        self.ib.sleep(2)
+        rejected = [t for t in [sl_trade, tp_trade]
+                    if t.orderStatus.status in ("Inactive", "Cancelled", "ApiCancelled")]
+        if rejected:
+            log.error(f"Protective bracket rejected — will retry next bar")
+            return
+
+        s.sl_order_id            = sl_trade.order.orderId
+        s.tp_order_id            = tp_trade.order.orderId
+        s.active_stop            = sl_price
+        s.active_target          = tp_price
+        s.needs_protective_orders = False
+
+        log.info(
+            f"Protective bracket placed for adopted {s.active_side} x{qty} @ {ep:.1f}  "
+            f"SL={sl_price:.1f}  TP={tp_price:.1f}  atr={atr:.2f}  "
+            f"(sl_id={s.sl_order_id}  tp_id={s.tp_order_id})"
+        )
+
+    def _estimate_pnl(self, exit_price: float) -> float:
+        s = self.state
+        if s.active_side == "Long":
+            gross = (exit_price - s.active_entry_price) * POINT_VALUE * s.active_qty
+        else:
+            gross = (s.active_entry_price - exit_price) * POINT_VALUE * s.active_qty
+        return gross - COMMISSION * s.active_qty * 2
+
+    def _log_trade(self, event: str, ts: datetime, price: float, pnl: float, **kwargs):
+        record = dict(event=event, time=ts.isoformat(), price=price,
+                      pnl=pnl, equity=self.state.equity, **kwargs)
+        self._trade_log.append(record)
+        self._log_path.write_text(json.dumps(self._trade_log, indent=2))
+
+    def _write_runtime(self):
+        """Write live state for the dashboard to read."""
+        s = self.state
+        runtime = dict(
+            equity=round(s.equity, 2),
+            active_side=s.active_side,
+            active_entry_price=round(s.active_entry_price, 2) if s.active_side else None,
+            active_stop=round(s.active_stop, 2) if s.active_side else None,
+            active_target=round(s.active_target, 2) if s.active_side else None,
+            daily_pnl=round(s.daily_pnl, 2),
+            trades_today=s.trades_today,
+            bar_index=s.bar_index,
+            filter_mode=FILTER_MODE,
+            ts=datetime.now(timezone.utc).isoformat(),
+        )
+        try:
+            Path("mgc_runtime.json").write_text(json.dumps(runtime))
+        except Exception:
+            pass
+
+    # ── Bar polling fallback (when updateEvent stream isn't delivering) ────────
+
+    def _poll_latest_bars(self):
+        """Fetch the last 30 minutes of bars and process any not yet seen."""
+        try:
+            bars = self.ib.reqHistoricalData(
+                self.contract,
+                endDateTime="",
+                durationStr="3600 S",
+                barSizeSetting="10 mins",
+                whatToShow="TRADES",
+                useRTH=False,
+                keepUpToDate=False,
+            )
+            # Process all completed bars (skip last — may still be in progress)
+            for bar in bars[:-1]:
+                ts = pd.Timestamp(bar.date).to_pydatetime()
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts > self._last_processed_ts:
+                    log.info(f"POLL Bar {ts}  O={bar.open} H={bar.high} L={bar.low} C={bar.close}")
+                    self._last_processed_ts = ts
+                    self._last_bar_time = time.time()
+                    self.on_bar(ts, bar.open, bar.high, bar.low, bar.close)
+                    self._write_runtime()
+        except Exception as e:
+            log.warning(f"Bar poll failed: {e}")
+
+    # ── Bar feed wiring ───────────────────────────────────────────────────────
+
+    def _subscribe_bars(self):
+        """Request historical + live 10m bars. Returns the bar list object."""
+        bars = self.ib.reqHistoricalData(
+            self.contract,
+            endDateTime="",
+            durationStr="2 D",
+            barSizeSetting="10 mins",
+            whatToShow="TRADES",
+            useRTH=False,
+            keepUpToDate=True,
+        )
+        if self._seeding:
+            log.info(f"Seeding {len(bars)} historical 10m bars …")
+            for bar in bars[:-1]:
+                ts = pd.Timestamp(bar.date).to_pydatetime()
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                self._last_processed_ts = ts
+                self.on_bar(ts, bar.open, bar.high, bar.low, bar.close)
+            self._seeding = False
+            log.info("Historical seed done — live mode active")
+        else:
+            log.info(f"Bar feed resubscribed ({len(bars)} bars, no re-seed)")
+
+        def on_bar_update(bars, has_new_bar):
+            if has_new_bar and len(bars) >= 2:
+                bar = bars[-2]
+                ts  = pd.Timestamp(bar.date).to_pydatetime()
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts <= self._last_processed_ts:
+                    return  # already processed by poll
+                log.info(f"Bar {ts}  O={bar.open} H={bar.high} L={bar.low} C={bar.close}")
+                self._last_processed_ts = ts
+                self._last_bar_time = time.time()
+                self.on_bar(ts, bar.open, bar.high, bar.low, bar.close)
+                self._write_runtime()
+
+        bars.updateEvent += on_bar_update
+        return bars
+
+    def run(self):
+        self._refresh_equity()
+        log.info(f"Starting MGC bot  paper={self.paper}  contract={self.contract.localSymbol}  equity=${self.state.equity:,.2f}")
+        self._adopt_orphaned_position()
+        self._active_bars = self._subscribe_bars()
+        self._feed_dead = False
+        self._last_bar_time = time.time()
+        BAR_TIMEOUT = 1200  # resubscribe if no bar in 20 min (2× the 10m bar interval)
+
+        def on_error(reqId, errorCode, errorString, contract):
+            if errorCode == 10182:
+                log.warning("Bar feed lost (10182) — will resubscribe …")
+                self._feed_dead = True
+            elif errorCode not in (2104, 2106, 2158, 2103, 2105, 2157, 1100, 1102):
+                log.warning(f"IBKR error {errorCode} (req {reqId}): {errorString}")
+
+        self.ib.errorEvent += on_error
+
+        POLL_INTERVAL = 600  # poll every 10 minutes when stream is silent
+        log.info("Bot running — Ctrl+C to stop")
+        try:
+            while True:
+                self.ib.sleep(10)
+
+                # Polling fallback: fetch bars manually when updateEvent isn't delivering
+                if (time.time() - self._last_poll_time) > POLL_INTERVAL and self.ib.isConnected():
+                    self._last_poll_time = time.time()
+                    self._poll_latest_bars()
+
+                # Heartbeat: resubscribe if no bar received in BAR_TIMEOUT seconds
+                feed_stale = (time.time() - self._last_bar_time) > BAR_TIMEOUT
+                if (self._feed_dead or feed_stale) and self.ib.isConnected():
+                    reason = "10182 error" if self._feed_dead else f"no bar for {BAR_TIMEOUT//60}min"
+                    log.warning(f"Bar feed stale ({reason}) — resubscribing in 15s …")
+                    time.sleep(15)
+                    try:
+                        self._seeding = False
+                        self._active_bars = self._subscribe_bars()
+                        self._feed_dead = False
+                        self._last_bar_time = time.time()
+                        log.info("Bar feed restored ✓")
+                    except Exception as e:
+                        log.error(f"Resubscribe failed: {e} — will retry next cycle")
+        except KeyboardInterrupt:
+            log.info("Shutting down …")
+            self._cancel_open_orders()
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+RECONNECT_DELAY = 60   # seconds to wait before reconnect attempt
+
+def parse_args():
+    p = argparse.ArgumentParser(description="MGC Turtle Soup V2 — IBKR Bot")
+    p.add_argument("--host",   default="127.0.0.1")
+    p.add_argument("--port",   type=int, default=7497,
+                   help="7497=TWS paper, 7496=TWS live, 4002=Gateway paper, 4001=Gateway live")
+    p.add_argument("--client", type=int, default=1)
+    p.add_argument("--live",   action="store_true",
+                   help="Connect to LIVE account (default: paper)")
+    p.add_argument("--filter-mode", default="Baseline",
+                   choices=["Baseline", "Session Only", "24h Full"],
+                   help=(
+                       "Baseline    = session 0800-1330 MT + hour filter  [PF 1.53, DD 16%%]\n"
+                       "Session Only= session 0800-1330 MT, any hour      [PF 1.30, DD 23%%]\n"
+                       "24h Full    = no session/hour filters, trade 24h  [PF 1.20, DD 52%%]"
+                   ))
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    paper = not args.live
+
+    if not paper:
+        confirm = input("⚠  LIVE account mode. Type YES to continue: ")
+        if confirm.strip() != "YES":
+            print("Aborted.")
+            return
+
+    global FILTER_MODE
+    FILTER_MODE = args.filter_mode
+    log.info(f"Filter mode: {FILTER_MODE}")
+
+    # Preserve strategy state across reconnects
+    saved_state: BotState | None = None
+
+    while True:
+        ib = IB()
+        try:
+            log.info(f"Connecting to IBKR  {args.host}:{args.port}  clientId={args.client}")
+            ib.connect(args.host, args.port, clientId=args.client)
+
+            contract = get_mgc_contract(ib)
+            bot = MGCBot(ib, contract, paper=paper)
+
+            # Restore state after reconnect so bar_index / daily P&L persist
+            if saved_state is not None:
+                log.info("Restoring strategy state after reconnect …")
+                bot.state = saved_state
+
+            bot.run()
+
+        except KeyboardInterrupt:
+            log.info("Keyboard interrupt — shutting down permanently")
+            break
+
+        except Exception as e:
+            saved_state = bot.state if 'bot' in dir() else None
+            log.error(f"Bot error: {e} — reconnecting in {RECONNECT_DELAY}s")
+            try:
+                ib.disconnect()
+            except Exception:
+                pass
+            time.sleep(RECONNECT_DELAY)
+            log.info("Attempting reconnect …")
+            continue
+
+        finally:
+            try:
+                ib.disconnect()
+            except Exception:
+                pass
+            log.info("Disconnected from IBKR")
+        break   # clean exit (KeyboardInterrupt path)
+
+
+if __name__ == "__main__":
+    main()

--- a/ibkr_mgc_bot.py
+++ b/ibkr_mgc_bot.py
@@ -249,6 +249,11 @@ class MGCBot:
         self._equity_fetched = False  # accountValues() called at most once per bot instance
         self._last_processed_ts: datetime = datetime.fromtimestamp(0, tz=timezone.utc)
         self._last_poll_time: float = 0.0
+        # Cached IBKR account snapshot (updated via updatePortfolio events)
+        self._acct_id: str = ""
+        self._acct_realized: float = 0.0
+        self._acct_unrealized: float = 0.0
+        self._acct_mkt_price: float = 0.0
 
     # ── IBKR account equity ───────────────────────────────────────────────────
 
@@ -783,21 +788,11 @@ class MGCBot:
     def _write_runtime(self):
         """Write live state for the dashboard to read."""
         s = self.state
-        # Pull account data from IBKR portfolio
-        realized_pnl = 0.0
-        unrealized_pnl = 0.0
-        account_id = ""
-        mkt_price = None
-        try:
-            items = self.ib.portfolio()
-            for item in items:
-                realized_pnl   += item.realizedPNL or 0.0
-                unrealized_pnl += item.unrealizedPNL or 0.0
-                account_id      = item.account or account_id
-                if item.contract.symbol == "MGC":
-                    mkt_price = round(item.marketPrice, 2) if item.marketPrice else None
-        except Exception:
-            pass
+        # Use cached account data from updatePortfolio events
+        realized_pnl   = self._acct_realized
+        unrealized_pnl = self._acct_unrealized
+        account_id     = self._acct_id
+        mkt_price      = self._acct_mkt_price or None
         runtime = dict(
             equity=round(s.equity, 2),
             realized_pnl=round(realized_pnl, 2),
@@ -894,6 +889,17 @@ class MGCBot:
         self._refresh_equity()
         log.info(f"Starting MGC bot  paper={self.paper}  contract={self.contract.localSymbol}  equity=${self.state.equity:,.2f}")
         self._adopt_orphaned_position()
+
+        def on_portfolio_update(item):
+            self._acct_realized   = item.realizedPNL or 0.0
+            self._acct_unrealized = item.unrealizedPNL or 0.0
+            if item.account:
+                self._acct_id = item.account
+            if item.contract and item.contract.symbol == "MGC" and item.marketPrice:
+                self._acct_mkt_price = round(item.marketPrice, 2)
+
+        self.ib.updatePortfolioEvent += on_portfolio_update
+
         self._active_bars = self._subscribe_bars()
         self._feed_dead = False
         self._last_bar_time = time.time()

--- a/ibkr_mgc_bot.py
+++ b/ibkr_mgc_bot.py
@@ -783,8 +783,27 @@ class MGCBot:
     def _write_runtime(self):
         """Write live state for the dashboard to read."""
         s = self.state
+        # Pull account data from IBKR portfolio
+        realized_pnl = 0.0
+        unrealized_pnl = 0.0
+        account_id = ""
+        mkt_price = None
+        try:
+            items = self.ib.portfolio()
+            for item in items:
+                realized_pnl   += item.realizedPNL or 0.0
+                unrealized_pnl += item.unrealizedPNL or 0.0
+                account_id      = item.account or account_id
+                if item.contract.symbol == "MGC":
+                    mkt_price = round(item.marketPrice, 2) if item.marketPrice else None
+        except Exception:
+            pass
         runtime = dict(
             equity=round(s.equity, 2),
+            realized_pnl=round(realized_pnl, 2),
+            unrealized_pnl=round(unrealized_pnl, 2),
+            account=account_id,
+            mkt_price=mkt_price,
             active_side=s.active_side,
             active_entry_price=round(s.active_entry_price, 2) if s.active_side else None,
             active_stop=round(s.active_stop, 2) if s.active_side else None,

--- a/ibkr_mgc_dashboard.py
+++ b/ibkr_mgc_dashboard.py
@@ -1,0 +1,757 @@
+#!/usr/bin/env python3
+"""
+Multi-Strategy Bot Dashboard — MGC (IBKR) + ETH (Hyperliquid)
+Run: python3 ibkr_mgc_dashboard.py
+Open: http://localhost:8080
+"""
+
+import asyncio, json, subprocess, sys, time
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import aiofiles
+import httpx
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+import uvicorn
+
+# ── Config ────────────────────────────────────────────────────────────────────
+BOT_DIR      = Path(__file__).parent
+BOT_SCRIPT   = BOT_DIR / "ibkr_mgc_bot.py"
+TRADE_LOG    = BOT_DIR / "mgc_live_trades.json"
+BOT_LOG      = BOT_DIR / "ibkr_mgc_bot.log"
+RUNTIME_FILE = BOT_DIR / "mgc_runtime.json"
+MOUNTAIN     = ZoneInfo("America/Denver")
+
+ETH_BOT_URL  = "https://hl-webhook-bot.fly.dev"
+
+app = FastAPI(title="Bot Dashboard")
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def bot_pid():
+    try:
+        r = subprocess.run(["pgrep","-f","ibkr_mgc_bot.py"], capture_output=True, text=True)
+        pids = r.stdout.strip().split()
+        return int(pids[0]) if pids else None
+    except: return None
+
+def load_runtime():
+    try: return json.loads(RUNTIME_FILE.read_text()) if RUNTIME_FILE.exists() else {}
+    except: return {}
+
+def load_trades():
+    try: return json.loads(TRADE_LOG.read_text()) if TRADE_LOG.exists() else []
+    except: return []
+
+def load_log_tail(n=80):
+    try: return BOT_LOG.read_text().splitlines()[-n:] if BOT_LOG.exists() else []
+    except: return []
+
+def completed_trades(raw):
+    """Pair ENTRY events with their EXIT events into completed trade records."""
+    result = []
+    pending = None
+    for t in raw:
+        ev = t.get("event", "")
+        if ev == "ENTRY":
+            pending = t
+        elif ev and ev != "ENTRY":
+            result.append({
+                "time": t.get("time"),
+                "side": pending.get("side", "") if pending else "",
+                "entry_price": pending.get("price", 0) if pending else 0,
+                "exit_price": t.get("price", 0),
+                "pnl": t.get("pnl", 0),
+                "equity": t.get("equity"),
+                "event": ev,
+                "qty": pending.get("qty", 1) if pending else 1,
+            })
+            pending = None
+    return result
+
+def calc_metrics(trades, cur_equity):
+    if not trades:
+        return dict(total=0, wins=0, losses=0, wr=0, pf=0, net=0,
+                    equity=cur_equity, avg_win=0, avg_loss=0, max_dd=0, equity_curve=[cur_equity])
+    pnls = [t["pnl"] for t in trades]
+    W = [p for p in pnls if p > 0]; L = [p for p in pnls if p < 0]
+    gp = sum(W); gl = abs(sum(L))
+    start_eq = cur_equity - sum(pnls)
+    eq = [round(start_eq, 2)]
+    for p in pnls: eq.append(round(eq[-1] + p, 2))
+    pk = eq[0]; dd = 0.0
+    for e in eq:
+        if e > pk: pk = e
+        d = (pk - e) / pk * 100 if pk > 0 else 0
+        if d > dd: dd = d
+    return dict(total=len(pnls), wins=len(W), losses=len(L),
+                wr=round(len(W)/len(pnls)*100, 1),
+                pf=round(gp/gl, 3) if gl else 0,
+                net=round(sum(pnls), 2), equity=round(eq[-1], 2),
+                avg_win=round(sum(W)/len(W), 2) if W else 0,
+                avg_loss=round(sum(L)/len(L), 2) if L else 0,
+                max_dd=round(dd, 1), equity_curve=eq)
+
+def metrics(raw_trades):
+    rt = load_runtime() or {}
+    trades = completed_trades(raw_trades)
+    cur_eq = rt.get("equity", 5000.0)
+    return calc_metrics(trades, cur_eq)
+
+# ── MGC API ───────────────────────────────────────────────────────────────────
+
+@app.get("/api/mgc/status")
+def mgc_status():
+    now = datetime.now(timezone.utc).astimezone(MOUNTAIN)
+    h,m = now.hour, now.minute
+    sess = (h>8 or h==8) and (h<13 or (h==13 and m<=30))
+    fm = contract = "—"
+    if BOT_LOG.exists():
+        for ln in reversed(BOT_LOG.read_text().splitlines()):
+            if "Filter mode:" in ln and fm=="—": fm=ln.split("Filter mode:")[-1].strip()
+            if "MGC contract:" in ln and contract=="—": contract=ln.split("MGC contract:")[-1].split()[0]
+            if fm!="—" and contract!="—": break
+    rt = {}
+    if RUNTIME_FILE.exists():
+        try: rt=json.loads(RUNTIME_FILE.read_text())
+        except: pass
+    pid = bot_pid()
+    return dict(running=pid is not None, pid=pid, filter_mode=fm, contract=contract,
+                denver=now.strftime("%H:%M MT"), session=sess,
+                equity=rt.get("equity",3500), daily_pnl=rt.get("daily_pnl",0),
+                trades_today=rt.get("trades_today",0),
+                active_side=rt.get("active_side",""),
+                active_entry=rt.get("active_entry_price"),
+                active_sl=rt.get("active_stop"), active_tp=rt.get("active_target"))
+
+@app.get("/api/mgc/trades")
+def mgc_trades():
+    raw = load_trades()
+    paired = completed_trades(raw)
+    m = metrics(raw)
+    return {"trades": list(reversed(paired[-50:])), "metrics": m}
+
+@app.get("/api/mgc/log")
+def mgc_log():
+    return {"lines": load_log_tail(80)}
+
+@app.post("/api/mgc/start")
+def mgc_start(filter_mode: str = "24h Full"):
+    if bot_pid(): return {"ok":False,"msg":"Already running"}
+    subprocess.Popen([sys.executable, str(BOT_SCRIPT), "--filter-mode", filter_mode], cwd=str(BOT_DIR))
+    time.sleep(1); return {"ok":True,"msg":f"Started [{filter_mode}]"}
+
+@app.post("/api/mgc/stop")
+def mgc_stop():
+    pid=bot_pid()
+    if not pid: return {"ok":False,"msg":"Not running"}
+    subprocess.run(["kill", str(pid)]); time.sleep(1)
+    return {"ok":True,"msg":f"Stopped PID {pid}"}
+
+@app.post("/api/mgc/restart")
+def mgc_restart(filter_mode: str = "24h Full"):
+    mgc_stop(); time.sleep(2); return mgc_start(filter_mode)
+
+@app.post("/api/mgc/close-position")
+def mgc_close():
+    (BOT_DIR/"mgc_control.json").write_text(json.dumps({"command":"close_position","ts":time.time()}))
+    return {"ok":True,"msg":"Close command sent"}
+
+# ── ETH API (proxy to Fly.io) ─────────────────────────────────────────────────
+
+@app.get("/api/eth/status")
+async def eth_status():
+    try:
+        async with httpx.AsyncClient(timeout=8) as c:
+            r = await c.get(f"{ETH_BOT_URL}/health")
+            return r.json()
+    except Exception as e:
+        return {"ok":False,"error":str(e),"equity_usd":0,"bot_enabled":False,"bot_blocked":False,"testnet":True}
+
+@app.post("/api/eth/enable")
+async def eth_enable():
+    try:
+        async with httpx.AsyncClient(timeout=8) as c:
+            r = await c.post(f"{ETH_BOT_URL}/admin/enable", json={"secret":"ayush_supertrend_secure_9284"})
+            return r.json()
+    except Exception as e: return {"ok":False,"msg":str(e)}
+
+@app.post("/api/eth/disable")
+async def eth_disable():
+    try:
+        async with httpx.AsyncClient(timeout=8) as c:
+            r = await c.post(f"{ETH_BOT_URL}/admin/disable", json={"secret":"ayush_supertrend_secure_9284"})
+            return r.json()
+    except Exception as e: return {"ok":False,"msg":str(e)}
+
+@app.post("/api/eth/unblock")
+async def eth_unblock():
+    try:
+        async with httpx.AsyncClient(timeout=8) as c:
+            r = await c.post(f"{ETH_BOT_URL}/unblock", json={"secret":"ayush_supertrend_secure_9284"})
+            return r.json()
+    except Exception as e: return {"ok":False,"msg":str(e)}
+
+@app.get("/api/eth/fills")
+async def eth_fills(wallet: str = ""):
+    if not wallet:
+        return {"ok": False, "error": "no_wallet", "trades": [], "metrics": {}}
+    try:
+        async with httpx.AsyncClient(timeout=12) as c:
+            health = (await c.get(f"{ETH_BOT_URL}/health")).json()
+            hl_url = health.get("api_url", "https://api.hyperliquid-testnet.xyz")
+            cur_eq = float(health.get("equity_usd", 0))
+            raw = (await c.post(f"{hl_url}/info", json={"type": "userFills", "user": wallet})).json()
+        if not isinstance(raw, list):
+            return {"ok": False, "error": str(raw), "trades": [], "metrics": {}}
+        trades, open_t = [], None
+        for f in sorted(raw, key=lambda x: x["time"]):
+            if f.get("coin") != "ETH":
+                continue
+            d = f.get("dir", ""); px = float(f.get("px", 0))
+            ts = datetime.fromtimestamp(f["time"]/1000, tz=timezone.utc).isoformat()
+            if "Open" in d:
+                open_t = {"time": ts, "entry_price": px,
+                          "side": "Long" if "Long" in d else "Short",
+                          "fee": float(f.get("fee", 0))}
+            elif "Close" in d and open_t:
+                net = round(float(f.get("closedPnl", 0)) - float(f.get("fee", 0)) - open_t["fee"], 4)
+                trades.append({"time": ts, "side": open_t["side"],
+                               "entry_price": open_t["entry_price"], "exit_price": px,
+                               "pnl": net, "event": d})
+                open_t = None
+        m = calc_metrics(trades, cur_eq)
+        return {"ok": True, "trades": list(reversed(trades[-50:])), "metrics": m}
+    except Exception as e:
+        return {"ok": False, "error": str(e), "trades": [], "metrics": {}}
+
+# ── WebSocket — MGC live log ───────────────────────────────────────────────────
+
+@app.websocket("/ws/mgc-log")
+async def ws_mgc_log(ws: WebSocket):
+    await ws.accept()
+    last = BOT_LOG.stat().st_size if BOT_LOG.exists() else 0
+    try:
+        while True:
+            await asyncio.sleep(2)
+            if not BOT_LOG.exists(): continue
+            sz = BOT_LOG.stat().st_size
+            if sz > last:
+                async with aiofiles.open(BOT_LOG) as f: txt = await f.read()
+                lines = txt.splitlines(); new = []; chars = 0
+                for ln in reversed(lines):
+                    chars += len(ln)
+                    if chars > sz - last + 200: break
+                    new.insert(0, ln)
+                last = sz
+                if new: await ws.send_text(json.dumps(new))
+    except WebSocketDisconnect: pass
+
+# ── Dashboard HTML ────────────────────────────────────────────────────────────
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard(): return HTML
+
+HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Bot Dashboard</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'SF Mono',monospace;background:#0d0d0d;color:#e0e0e0;font-size:12px}
+.topbar{background:#111;border-bottom:1px solid #1e1e1e;padding:10px 16px;display:flex;align-items:center;gap:12px}
+.topbar h1{font-size:14px;color:#fff;letter-spacing:1px}
+.tabs{display:flex;gap:4px;margin-left:auto}
+.tab{padding:5px 14px;border-radius:4px;cursor:pointer;font-size:11px;border:1px solid #2a2a2a;background:#1a1a1a;color:#888}
+.tab.active{background:#3b82f6;color:#fff;border-color:#3b82f6}
+.tab:hover:not(.active){background:#222;color:#ccc}
+.dot{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:4px}
+.dot.g{background:#22c55e;box-shadow:0 0 5px #22c55e}
+.dot.r{background:#ef4444;box-shadow:0 0 5px #ef4444}
+.dot.y{background:#eab308}
+.page{display:none;padding:10px;gap:10px}
+.page.active{display:grid}
+/* MGC layout */
+#page-mgc{grid-template-columns:240px 1fr 320px;grid-template-rows:auto 1fr}
+/* ETH layout */
+#page-eth{grid-template-columns:260px 1fr 320px}
+/* Both layout */
+#page-both{grid-template-columns:1fr 1fr}
+.card{background:#111;border:1px solid #1e1e1e;border-radius:7px;padding:12px}
+.card h2{font-size:10px;color:#555;text-transform:uppercase;letter-spacing:1px;margin-bottom:10px}
+.row{display:flex;justify-content:space-between;padding:4px 0;border-bottom:1px solid #181818}
+.row:last-child{border:none}
+.lbl{color:#666;font-size:10px}.val{font-size:12px;font-weight:600}
+.g{color:#22c55e}.r{color:#ef4444}.dim{color:#555}
+.badge{display:inline-block;padding:1px 7px;border-radius:10px;font-size:10px;font-weight:600}
+.bg{background:#052e16;color:#22c55e;border:1px solid #16a34a}
+.br{background:#2d0707;color:#ef4444;border:1px solid #dc2626}
+.by{background:#1c1400;color:#eab308;border:1px solid #ca8a04}
+.btn{padding:5px 10px;border:none;border-radius:4px;font-size:10px;cursor:pointer;font-family:inherit;font-weight:600}
+.btn:hover{opacity:.8}
+.bg2{background:#22c55e;color:#000}.br2{background:#ef4444;color:#fff}
+.bb{background:#3b82f6;color:#fff}.bo{background:#f97316;color:#fff}
+.bgr{background:#333;color:#ccc}.bpu{background:#a855f7;color:#fff}
+.btns{display:flex;flex-wrap:wrap;gap:5px;margin-top:8px}
+select,input{background:#1a1a1a;color:#e0e0e0;border:1px solid #2a2a2a;border-radius:4px;padding:4px 7px;font-size:10px;font-family:inherit}
+.mg{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:4px}
+.mb{background:#0a0a0a;border-radius:4px;padding:7px;text-align:center}
+.mv{font-size:16px;font-weight:700;margin-top:2px}
+.ml{font-size:9px;color:#444;text-transform:uppercase;letter-spacing:.5px}
+.log{overflow-y:auto;font-size:10px;line-height:1.7;background:#080808;border-radius:4px;padding:7px;height:100%;min-height:160px}
+.ll{padding:0}.ls{color:#22c55e;font-weight:bold}.lb{color:#3b82f6;font-weight:bold}
+.le{color:#ef4444}.lw{color:#eab308}.lv{color:#a78bfa}.ld{color:#444}.li{color:#666}
+.ct{position:relative;height:160px}
+.ap{background:#0f2518;border:1px solid #1a4731;border-radius:5px;padding:8px;margin-top:8px}
+.msg{font-size:10px;color:#666;margin-top:6px;min-height:14px}
+/* chart symbol bar */
+.cbar{display:flex;gap:5px;align-items:center;margin-bottom:6px}
+</style>
+</head>
+<body>
+<div class="topbar">
+  <span class="dot g" id="dot-mgc"></span>
+  <h1>ALGO TRADING DASHBOARD</h1>
+  <span id="clock" style="color:#444;font-size:11px;margin-left:8px"></span>
+  <div class="tabs">
+    <div class="tab active" onclick="showTab('mgc')">📊 MGC (IBKR)</div>
+    <div class="tab" onclick="showTab('eth')">⚡ ETH (Hyperliquid)</div>
+    <div class="tab" onclick="showTab('both')">🔀 Overview</div>
+  </div>
+</div>
+
+<!-- ═══════════════ MGC PAGE ═══════════════ -->
+<div id="page-mgc" class="page active" style="height:calc(100vh - 42px)">
+
+  <!-- col 1: status + controls -->
+  <div style="display:flex;flex-direction:column;gap:10px;overflow-y:auto">
+    <div class="card">
+      <h2>MGC Bot (IBKR Paper)</h2>
+      <div class="row"><span class="lbl">Status</span><span id="m-status">—</span></div>
+      <div class="row"><span class="lbl">PID</span><span class="val dim" id="m-pid">—</span></div>
+      <div class="row"><span class="lbl">Contract</span><span class="val" id="m-contract">—</span></div>
+      <div class="row"><span class="lbl">Filter Mode</span><span class="val" id="m-filter">—</span></div>
+      <div class="row"><span class="lbl">Session</span><span id="m-session">—</span></div>
+      <div class="row"><span class="lbl">Denver Time</span><span class="val" id="m-time">—</span></div>
+    </div>
+    <div class="card">
+      <h2>Account</h2>
+      <div class="row"><span class="lbl">Equity</span><span class="val g" id="m-eq">—</span></div>
+      <div class="row"><span class="lbl">Daily P&L</span><span class="val" id="m-dpnl">—</span></div>
+      <div class="row"><span class="lbl">Trades Today</span><span class="val" id="m-tt">—</span></div>
+      <div id="m-posbox" style="display:none" class="ap">
+        <div style="font-size:10px;color:#888">OPEN POSITION</div>
+        <div class="val g" id="m-side" style="font-size:14px;margin-top:2px">—</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px;margin-top:6px;font-size:10px">
+          <div><div class="lbl">Entry</div><div id="m-entry">—</div></div>
+          <div><div style="color:#ef4444">SL</div><div id="m-sl" style="color:#ef4444">—</div></div>
+          <div><div style="color:#22c55e">TP</div><div id="m-tp" style="color:#22c55e">—</div></div>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <h2>Controls</h2>
+      <select id="m-fm" style="width:100%;margin-bottom:6px">
+        <option value="Baseline">Baseline (session+hour)</option>
+        <option value="Session Only">Session Only</option>
+        <option value="24h Full" selected>24h Full (no filters)</option>
+      </select>
+      <div class="btns">
+        <button class="btn bg2" onclick="mCtrl('/api/mgc/start')">▶ Start</button>
+        <button class="btn br2" onclick="mCtrl('/api/mgc/stop')">■ Stop</button>
+        <button class="btn bb" onclick="mCtrl('/api/mgc/restart')">↻ Restart</button>
+        <button class="btn bo" onclick="mCtrl('/api/mgc/close-position')">✕ Close</button>
+      </div>
+      <div class="msg" id="m-msg"></div>
+    </div>
+  </div>
+
+  <!-- col 2: metrics + equity + trades + chart -->
+  <div style="display:flex;flex-direction:column;gap:10px;overflow-y:auto">
+    <div class="card">
+      <h2>Performance</h2>
+      <div class="mg">
+        <div class="mb"><div class="ml">Net P&L</div><div class="mv" id="m-net">—</div></div>
+        <div class="mb"><div class="ml">Win Rate</div><div class="mv" id="m-wr">—</div></div>
+        <div class="mb"><div class="ml">Profit Factor</div><div class="mv" id="m-pf">—</div></div>
+        <div class="mb"><div class="ml">Max DD</div><div class="mv r" id="m-dd">—</div></div>
+        <div class="mb"><div class="ml">Avg Win</div><div class="mv g" id="m-aw">—</div></div>
+        <div class="mb"><div class="ml">Avg Loss</div><div class="mv r" id="m-al">—</div></div>
+      </div>
+    </div>
+    <div class="card">
+      <h2>Equity Curve</h2>
+      <div class="ct"><canvas id="m-chart"></canvas></div>
+    </div>
+    <div class="card" style="flex:1;overflow-y:auto">
+      <h2>Recent Trades <span id="m-tc" class="dim"></span></h2>
+      <div style="display:grid;grid-template-columns:75px 38px 58px 58px 64px 50px;gap:3px;padding:3px 0;font-size:9px;color:#444;text-transform:uppercase">
+        <span>Time</span><span>Side</span><span>Entry</span><span>Exit</span><span>P&L</span><span>Result</span>
+      </div>
+      <div id="m-trades"></div>
+    </div>
+    <div class="card">
+      <div class="cbar">
+        <h2 style="margin:0">Chart</h2>
+        <input id="m-sym" value="COMEX_MINI:MGC1!" style="flex:1">
+        <select id="m-tf"><option value="1">1m</option><option value="3" selected>3m</option><option value="5">5m</option><option value="15">15m</option><option value="60">1H</option><option value="D">D</option></select>
+        <button class="btn bgr" onclick="loadChart('m')">Load</button>
+      </div>
+      <div id="m-tv" style="height:220px;border-radius:4px;overflow:hidden;background:#0a0a0a"></div>
+    </div>
+  </div>
+
+  <!-- col 3: live log -->
+  <div class="card" style="display:flex;flex-direction:column;overflow:hidden">
+    <h2>Live Log <span id="m-ws" class="dim" style="font-size:9px"></span></h2>
+    <div class="log" id="m-log"></div>
+  </div>
+</div>
+
+<!-- ═══════════════ ETH PAGE ═══════════════ -->
+<div id="page-eth" class="page" style="height:calc(100vh - 42px)">
+
+  <!-- col 1: status + controls -->
+  <div style="display:flex;flex-direction:column;gap:10px;overflow-y:auto">
+    <div class="card">
+      <h2>ETH Supertrend (Hyperliquid)</h2>
+      <div class="row"><span class="lbl">Bot Status</span><span id="e-status">—</span></div>
+      <div class="row"><span class="lbl">Network</span><span class="val" id="e-net">—</span></div>
+      <div class="row"><span class="lbl">Equity</span><span class="val g" id="e-eq">—</span></div>
+      <div class="row"><span class="lbl">Bot Enabled</span><span id="e-enabled">—</span></div>
+      <div class="row"><span class="lbl">Bot Blocked</span><span id="e-blocked">—</span></div>
+      <div class="row"><span class="lbl">Block Reason</span><span class="val dim" id="e-reason">—</span></div>
+      <div class="row"><span class="lbl">Instrument</span><span class="val">ETH-USD Perp</span></div>
+      <div class="row"><span class="lbl">Timeframe</span><span class="val">4H Supertrend</span></div>
+    </div>
+    <div class="card">
+      <h2>Controls</h2>
+      <div class="btns">
+        <button class="btn bg2" onclick="eCtrl('/api/eth/enable')">✓ Enable</button>
+        <button class="btn br2" onclick="eCtrl('/api/eth/disable')">✗ Disable</button>
+        <button class="btn bpu" onclick="eCtrl('/api/eth/unblock')">⟳ Unblock</button>
+      </div>
+      <div class="msg" id="e-msg"></div>
+    </div>
+    <div class="card">
+      <h2>Trade History Config</h2>
+      <div style="font-size:9px;color:#555;margin-bottom:6px">Hyperliquid wallet address (for fills)</div>
+      <input id="e-wallet" placeholder="0x..." style="width:100%;font-size:9px" oninput="saveWallet()">
+      <div style="font-size:9px;color:#444;margin-top:5px" id="e-wallet-status"></div>
+    </div>
+  </div>
+
+  <!-- col 2: metrics + equity + trades -->
+  <div style="display:flex;flex-direction:column;gap:10px;overflow-y:auto">
+    <div class="card">
+      <h2>Performance</h2>
+      <div class="mg">
+        <div class="mb"><div class="ml">Net P&L</div><div class="mv" id="e-net">—</div></div>
+        <div class="mb"><div class="ml">Win Rate</div><div class="mv" id="e-wr">—</div></div>
+        <div class="mb"><div class="ml">Profit Factor</div><div class="mv" id="e-pf">—</div></div>
+        <div class="mb"><div class="ml">Max DD</div><div class="mv r" id="e-dd">—</div></div>
+        <div class="mb"><div class="ml">Avg Win</div><div class="mv g" id="e-aw">—</div></div>
+        <div class="mb"><div class="ml">Avg Loss</div><div class="mv r" id="e-al">—</div></div>
+      </div>
+    </div>
+    <div class="card">
+      <h2>Equity Curve</h2>
+      <div class="ct"><canvas id="e-chart"></canvas></div>
+    </div>
+    <div class="card" style="flex:1;overflow-y:auto">
+      <h2>Recent Trades <span id="e-tc" class="dim"></span></h2>
+      <div style="display:grid;grid-template-columns:75px 38px 62px 62px 70px 60px;gap:3px;padding:3px 0;font-size:9px;color:#444;text-transform:uppercase">
+        <span>Time</span><span>Side</span><span>Entry</span><span>Exit</span><span>P&L</span><span>Result</span>
+      </div>
+      <div id="e-trades"><div class="dim" style="padding:8px;font-size:10px">Set wallet address to load history</div></div>
+    </div>
+  </div>
+
+  <!-- col 3: chart + info -->
+  <div style="display:flex;flex-direction:column;gap:10px;overflow-y:auto">
+    <div class="card">
+      <div class="cbar">
+        <h2 style="margin:0">Chart</h2>
+        <input id="e-sym" value="COINBASE:ETHUSD" style="flex:1">
+        <select id="e-tf">
+          <option value="60">1H</option>
+          <option value="240" selected>4H</option>
+          <option value="D">1D</option>
+        </select>
+        <button class="btn bgr" onclick="loadChart('e')">Load</button>
+      </div>
+      <div id="e-tv" style="height:280px;border-radius:4px;overflow:hidden;background:#0a0a0a"></div>
+    </div>
+    <div class="card">
+      <h2>Webhook Setup</h2>
+      <div style="background:#0a0a0a;border-radius:4px;padding:8px;font-size:9px;color:#888;font-family:monospace;line-height:1.8">
+        <div style="color:#555">URL:</div>
+        <div style="color:#3b82f6">https://hl-webhook-bot.fly.dev/tradingview</div>
+        <div style="color:#555;margin-top:6px">Payload:</div>
+        <div style="color:#22c55e">{"secret":"ayush_supertrend_secure_9284",</div>
+        <div style="color:#22c55e">&nbsp;"action":"entry","side":"buy",</div>
+        <div style="color:#22c55e">&nbsp;"symbol":"ETH","leverage":5}</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════ BOTH / OVERVIEW ═══════════════ -->
+<div id="page-both" class="page" style="height:calc(100vh - 42px)">
+  <div class="card">
+    <h2>MGC Bot — IBKR Paper</h2>
+    <div class="row"><span class="lbl">Status</span><span id="b-m-status">—</span></div>
+    <div class="row"><span class="lbl">Equity</span><span class="val g" id="b-m-eq">—</span></div>
+    <div class="row"><span class="lbl">Filter Mode</span><span class="val" id="b-m-filter">—</span></div>
+    <div class="row"><span class="lbl">Contract</span><span class="val" id="b-m-contract">—</span></div>
+    <div class="row"><span class="lbl">Daily P&L</span><span class="val" id="b-m-dpnl">—</span></div>
+    <div class="row"><span class="lbl">Session</span><span id="b-m-session">—</span></div>
+    <div class="row"><span class="lbl">Active Position</span><span class="val" id="b-m-side">Flat</span></div>
+    <div style="margin-top:10px">
+      <div class="ct"><canvas id="b-m-chart"></canvas></div>
+    </div>
+    <div class="btns" style="margin-top:8px">
+      <button class="btn bg2" onclick="mCtrl('/api/mgc/start')">▶ Start</button>
+      <button class="btn br2" onclick="mCtrl('/api/mgc/stop')">■ Stop</button>
+      <button class="btn bb" onclick="mCtrl('/api/mgc/restart')">↻ Restart</button>
+    </div>
+    <div class="msg" id="b-m-msg"></div>
+  </div>
+  <div class="card">
+    <h2>ETH Bot — Hyperliquid</h2>
+    <div class="row"><span class="lbl">Status</span><span id="b-e-status">—</span></div>
+    <div class="row"><span class="lbl">Equity</span><span class="val g" id="b-e-eq">—</span></div>
+    <div class="row"><span class="lbl">Network</span><span class="val" id="b-e-net">—</span></div>
+    <div class="row"><span class="lbl">Bot Enabled</span><span id="b-e-enabled">—</span></div>
+    <div class="row"><span class="lbl">Bot Blocked</span><span id="b-e-blocked">—</span></div>
+    <div style="margin-top:10px">
+      <div class="ct"><canvas id="b-e-chart"></canvas></div>
+    </div>
+    <div class="btns" style="margin-top:8px">
+      <button class="btn bg2" onclick="eCtrl('/api/eth/enable')">✓ Enable</button>
+      <button class="btn br2" onclick="eCtrl('/api/eth/disable')">✗ Disable</button>
+      <button class="btn bpu" onclick="eCtrl('/api/eth/unblock')">⟳ Unblock</button>
+    </div>
+    <div class="msg" id="b-e-msg"></div>
+  </div>
+</div>
+
+<script>
+// ── Tab switching ──────────────────────────────────────────────────────────
+function showTab(t){
+  document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
+  document.querySelectorAll('.tab').forEach(tb=>tb.classList.remove('active'));
+  document.getElementById('page-'+t).classList.add('active');
+  event.target.classList.add('active');
+}
+
+// ── Charts ─────────────────────────────────────────────────────────────────
+const charts = {};
+function mkChart(id, data){
+  const ctx = document.getElementById(id);
+  if(!ctx) return;
+  if(charts[id]) charts[id].destroy();
+  const c = data.length>1 && data[data.length-1]>=data[0] ? '#22c55e':'#ef4444';
+  charts[id] = new Chart(ctx,{type:'line',data:{labels:data.map((_,i)=>i),datasets:[{data,borderColor:c,borderWidth:1.5,fill:true,backgroundColor:c+'15',pointRadius:0,tension:0.1}]},options:{responsive:true,maintainAspectRatio:false,animation:false,plugins:{legend:{display:false}},scales:{x:{display:false},y:{grid:{color:'#111'},ticks:{color:'#444',font:{size:9}}}}}});
+}
+
+// ── TradingView chart embed ────────────────────────────────────────────────
+function loadChart(prefix){
+  const sym = document.getElementById(prefix+'-sym').value.trim();
+  const tf = document.getElementById(prefix+'-tf').value;
+  const el = document.getElementById(prefix+'-tv');
+  el.innerHTML='';
+  const s=document.createElement('script');
+  s.src='https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js';
+  s.async=true;
+  s.innerHTML=JSON.stringify({"autosize":true,"symbol":sym,"interval":tf,"timezone":"America/Denver","theme":"dark","style":"1","locale":"en","enable_publishing":false,"hide_top_toolbar":false,"hide_legend":false,"save_image":false,"calendar":false,"support_host":"https://www.tradingview.com"});
+  el.appendChild(s);
+}
+
+// ── MGC polling ─────────────────────────────────────────────────────────────
+async function pollMGC(){
+  try{
+    const [sr,tr]=await Promise.all([fetch('/api/mgc/status'),fetch('/api/mgc/trades')]);
+    const s=await sr.json(), t=await tr.json(), m=t.metrics;
+    const run=s.running;
+    document.getElementById('dot-mgc').className='dot '+(run?'g':'r');
+    const badge=run?'<span class="badge bg">RUNNING</span>':'<span class="badge br">STOPPED</span>';
+    ['m-status','b-m-status'].forEach(id=>{const e=document.getElementById(id);if(e)e.innerHTML=badge;});
+    set('m-pid',s.pid||'—');
+    set('m-contract',s.contract); set('b-m-contract',s.contract);
+    set('m-filter',s.filter_mode); set('b-m-filter',s.filter_mode);
+    set('m-time',s.denver);
+    const sb=s.session?'<span class="badge bg">OPEN</span>':'<span class="badge by">CLOSED</span>';
+    ['m-session','b-m-session'].forEach(id=>{const e=document.getElementById(id);if(e)e.innerHTML=sb;});
+    const eq='$'+s.equity.toLocaleString('en-US',{minimumFractionDigits:2});
+    set('m-eq',eq); set('b-m-eq',eq);
+    const dp=(s.daily_pnl||0); const dpstr=(dp>=0?'+':'')+' $'+dp.toFixed(2);
+    setC('m-dpnl',dpstr,dp>0?'val g':dp<0?'val r':'val dim');
+    setC('b-m-dpnl',dpstr,dp>0?'val g':dp<0?'val r':'val dim');
+    set('m-tt',s.trades_today||0);
+    const hp=s.active_side&&s.active_side!='';
+    const pb=document.getElementById('m-posbox');if(pb)pb.style.display=hp?'block':'none';
+    if(hp){set('m-side',s.active_side.toUpperCase());set('m-entry',(s.active_entry||0).toFixed(1));set('m-sl',(s.active_sl||0).toFixed(1));set('m-tp',(s.active_tp||0).toFixed(1));}
+    set('b-m-side',hp?s.active_side.toUpperCase():'Flat');
+    set('m-net',(m.net>=0?'+':'')+'$'+m.net.toFixed(0),m.net>=0?'mv g':'mv r');
+    set('m-wr',m.wr.toFixed(1)+'%');set('m-pf',m.pf.toFixed(3));
+    set('m-dd',m.max_dd.toFixed(1)+'%');set('m-aw','+$'+m.avg_win.toFixed(2));
+    set('m-al','-$'+Math.abs(m.avg_loss).toFixed(2));
+    set('m-tc','('+m.total+' trades)');
+    mkChart('m-chart',m.equity_curve||[]);mkChart('b-m-chart',m.equity_curve||[]);
+    const th=t.trades.map(tr=>{
+      const dt=new Date(tr.time||tr.exit_time||'');
+      const ts=isNaN(dt)?'—':dt.toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit'});
+      const pnl=tr.pnl||tr.net_pnl_usd||0; const side=(tr.side||tr.direction||'').toUpperCase();
+      const en=(tr.entry_price||0).toFixed(1); const ex=(tr.exit_price||0).toFixed(1);
+      const res=tr.event||tr.exit_reason||tr.result||'';
+      return `<div style="display:grid;grid-template-columns:75px 38px 58px 58px 64px 50px;gap:3px;padding:3px 0;border-bottom:1px solid #141414;font-size:10px">
+        <span class="dim">${ts}</span>
+        <span style="color:${side=='LONG'?'#22c55e':'#ef4444'}">${side}</span>
+        <span>${en}</span><span>${ex}</span>
+        <span class="${pnl>=0?'g':'r'}">${pnl>=0?'+':''}$${pnl.toFixed(2)}</span>
+        <span class="dim">${res}</span></div>`;}).join('');
+    const tl=document.getElementById('m-trades');if(tl)tl.innerHTML=th||'<div class="dim" style="padding:8px">No trades yet</div>';
+  }catch(e){}
+}
+
+// ── ETH wallet ──────────────────────────────────────────────────────────────
+function saveWallet(){
+  const w=document.getElementById('e-wallet')?.value.trim()||'';
+  localStorage.setItem('eth_wallet',w);
+  const s=document.getElementById('e-wallet-status');
+  if(s)s.textContent=w?'Saved ✓':'Cleared';
+}
+function loadWalletInput(){
+  const w=localStorage.getItem('eth_wallet')||'';
+  const el=document.getElementById('e-wallet');
+  if(el)el.value=w;
+}
+
+// ── ETH polling ──────────────────────────────────────────────────────────────
+async function pollETH(){
+  try{
+    const r=await fetch('/api/eth/status'); const s=await r.json();
+    const ok=s.ok;
+    const badge=ok?'<span class="badge bg">ONLINE</span>':'<span class="badge br">OFFLINE</span>';
+    ['e-status','b-e-status'].forEach(id=>{const e=document.getElementById(id);if(e)e.innerHTML=badge;});
+    const net=s.testnet?'<span class="badge by">TESTNET</span>':'<span class="badge bg">MAINNET</span>';
+    set('e-net',net); set('b-e-net',net);
+    const eq='$'+(s.equity_usd||0).toFixed(2);
+    set('e-eq',eq); set('b-e-eq',eq);
+    const en=s.bot_enabled?'<span class="badge bg">YES</span>':'<span class="badge br">NO</span>';
+    set('e-enabled',en); set('b-e-enabled',en);
+    const bl=s.bot_blocked?'<span class="badge br">BLOCKED</span>':'<span class="badge bg">NO</span>';
+    set('e-blocked',bl); set('b-e-blocked',bl);
+    set('e-reason',s.block_reason||'—');
+  }catch(e){}
+  // Fetch fills if wallet configured
+  const wallet=localStorage.getItem('eth_wallet')||'';
+  if(!wallet) return;
+  try{
+    const r=await fetch('/api/eth/fills?wallet='+encodeURIComponent(wallet));
+    const d=await r.json();
+    if(!d.ok) return;
+    const m=d.metrics;
+    set('e-net',(m.net>=0?'+':'')+'$'+m.net.toFixed(2),m.net>=0?'mv g':'mv r');
+    set('e-wr',m.wr.toFixed(1)+'%');
+    set('e-pf',m.pf.toFixed(3));
+    set('e-dd',m.max_dd.toFixed(1)+'%');
+    set('e-aw','+$'+(m.avg_win||0).toFixed(2));
+    set('e-al','-$'+Math.abs(m.avg_loss||0).toFixed(2));
+    set('e-tc','('+m.total+' trades)');
+    mkChart('e-chart',m.equity_curve||[]);
+    const th=d.trades.map(tr=>{
+      const dt=new Date(tr.time||'');
+      const ts=isNaN(dt)?'—':dt.toLocaleString('en-US',{month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',hour12:false});
+      const pnl=tr.pnl||0; const side=(tr.side||'').toUpperCase();
+      const en=(tr.entry_price||0).toFixed(1); const ex=(tr.exit_price||0).toFixed(1);
+      const ev=(tr.event||'').replace('Close ','').replace('Open ','');
+      return `<div style="display:grid;grid-template-columns:75px 38px 62px 62px 70px 60px;gap:3px;padding:3px 0;border-bottom:1px solid #141414;font-size:10px">
+        <span class="dim">${ts}</span>
+        <span style="color:${side==='LONG'?'#22c55e':'#ef4444'}">${side}</span>
+        <span>${en}</span><span>${ex}</span>
+        <span class="${pnl>=0?'g':'r'}">${pnl>=0?'+':''}$${pnl.toFixed(2)}</span>
+        <span class="dim">${ev}</span></div>`;
+    }).join('');
+    const tl=document.getElementById('e-trades');
+    if(tl)tl.innerHTML=th||'<div class="dim" style="padding:8px">No completed trades yet</div>';
+  }catch(e){}
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+async function mCtrl(url){
+  const fm=document.getElementById('m-fm')?.value||'24h Full';
+  try{
+    const r=await fetch(url+'?filter_mode='+encodeURIComponent(fm),{method:'POST'});
+    const d=await r.json();
+    ['m-msg','b-m-msg'].forEach(id=>{const e=document.getElementById(id);if(e)e.textContent=d.msg||'';});
+    setTimeout(()=>['m-msg','b-m-msg'].forEach(id=>{const e=document.getElementById(id);if(e)e.textContent='';}),5000);
+    setTimeout(pollMGC,1500);
+  }catch(e){}
+}
+async function eCtrl(url){
+  try{
+    const r=await fetch(url,{method:'POST'});const d=await r.json();
+    ['e-msg','b-e-msg'].forEach(id=>{const e=document.getElementById(id);if(e)e.textContent=JSON.stringify(d);});
+    setTimeout(()=>['e-msg','b-e-msg'].forEach(id=>{const e=document.getElementById(id);if(e)e.textContent='';}),5000);
+    setTimeout(pollETH,1000);
+  }catch(e){}
+}
+
+// ── Log WebSocket ────────────────────────────────────────────────────────────
+let ws=null;
+function connectWS(){
+  ws=new WebSocket('ws://'+location.host+'/ws/mgc-log');
+  ws.onopen=()=>{const e=document.getElementById('m-ws');if(e)e.textContent='● live';};
+  ws.onclose=()=>{const e=document.getElementById('m-ws');if(e)e.textContent='○ reconnecting';setTimeout(connectWS,3000);};
+  ws.onmessage=e=>{
+    const lines=JSON.parse(e.data); const box=document.getElementById('m-log');
+    if(!box)return;
+    lines.forEach(ln=>{
+      const d=document.createElement('div'); d.className='ll';
+      const cl=ln.includes('SIGNAL')?'ls':ln.includes('BRACKET')?'lb':ln.includes('ERROR')?'le':ln.includes('WARN')?'lw':ln.includes('SWEEP')?'lv':ln.includes('SEED')?'ld':'li';
+      d.className='ll '+cl;
+      d.textContent=ln.replace(/^.*?(INFO|ERROR|WARNING)\s+/,'');
+      box.appendChild(d);
+    });
+    box.scrollTop=box.scrollHeight;
+  };
+}
+async function loadInitLog(){
+  try{const r=await fetch('/api/mgc/log');const d=await r.json();
+    const box=document.getElementById('m-log');if(!box)return;
+    d.lines.forEach(ln=>{const div=document.createElement('div');
+      const cl=ln.includes('SIGNAL')?'ls':ln.includes('BRACKET')?'lb':ln.includes('ERROR')?'le':ln.includes('WARN')?'lw':ln.includes('SWEEP')?'lv':ln.includes('SEED')?'ld':'li';
+      div.className='ll '+cl;div.textContent=ln.replace(/^.*?(INFO|ERROR|WARNING)\s+/,'');box.appendChild(div);});
+    box.scrollTop=box.scrollHeight;}catch(e){}
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+function set(id,val,cls){
+  const e=document.getElementById(id);if(!e)return;
+  if(typeof val==='string'&&val.startsWith('<'))e.innerHTML=val;
+  else e.textContent=val;
+  if(cls)e.className=cls;
+}
+function setC(id,val,cls){set(id,val,cls);}
+function tick(){document.getElementById('clock').textContent=new Date().toLocaleTimeString('en-US',{hour12:false});}
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+loadInitLog(); connectWS();
+loadChart('m'); loadChart('e');
+loadWalletInput();
+pollMGC(); pollETH();
+setInterval(pollMGC,6000); setInterval(pollETH,30000); setInterval(tick,1000);
+tick();
+</script>
+</body>
+</html>"""
+
+if __name__ == "__main__":
+    print("Dashboard → http://localhost:8080")
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="warning")

--- a/ibkr_mgc_dashboard.py
+++ b/ibkr_mgc_dashboard.py
@@ -627,7 +627,7 @@ function saveWallet(){
   if(s)s.textContent=w?'Saved ✓':'Cleared';
 }
 function loadWalletInput(){
-  const w=localStorage.getItem('eth_wallet')||'';
+  const w=localStorage.getItem('eth_wallet')||'0xD8cb475a415cEd00aAd3F794a2451eB096735a38';
   const el=document.getElementById('e-wallet');
   if(el)el.value=w;
 }

--- a/ibkr_mgc_dashboard.py
+++ b/ibkr_mgc_dashboard.py
@@ -120,7 +120,12 @@ def mgc_status():
     pid = bot_pid()
     return dict(running=pid is not None, pid=pid, filter_mode=fm, contract=contract,
                 denver=now.strftime("%H:%M MT"), session=sess,
-                equity=rt.get("equity",3500), daily_pnl=rt.get("daily_pnl",0),
+                equity=rt.get("equity",3500),
+                realized_pnl=rt.get("realized_pnl", 0),
+                unrealized_pnl=rt.get("unrealized_pnl", 0),
+                account=rt.get("account", "—"),
+                mkt_price=rt.get("mkt_price"),
+                daily_pnl=rt.get("daily_pnl",0),
                 trades_today=rt.get("trades_today",0),
                 active_side=rt.get("active_side",""),
                 active_entry=rt.get("active_entry_price"),
@@ -252,6 +257,34 @@ async def eth_fills(wallet: str = ""):
     except Exception as e:
         return {"ok": False, "error": str(e), "trades": [], "metrics": {}}
 
+@app.get("/api/eth/position")
+async def eth_position(wallet: str = ""):
+    if not wallet:
+        return {"ok": False, "position": None}
+    try:
+        async with httpx.AsyncClient(timeout=10) as c:
+            health = (await c.get(f"{ETH_BOT_URL}/health")).json()
+            hl_url = health.get("api_url", "https://api.hyperliquid-testnet.xyz")
+            state = (await c.post(f"{hl_url}/info", json={"type": "clearinghouseState", "user": wallet})).json()
+        positions = [p["position"] for p in state.get("assetPositions", [])
+                     if p.get("position", {}).get("coin") == "ETH"
+                     and abs(float(p["position"].get("szi", 0))) > 0.0001]
+        if not positions:
+            return {"ok": True, "position": None}
+        p = positions[0]
+        szi = float(p["szi"])
+        return {"ok": True, "position": {
+            "side": "Long" if szi > 0 else "Short",
+            "size": abs(szi),
+            "entry_price": float(p.get("entryPx", 0)),
+            "unrealized_pnl": float(p.get("unrealizedPnl", 0)),
+            "roe": float(p.get("returnOnEquity", 0)) * 100,
+            "liq_price": float(p.get("liquidationPx", 0)),
+            "leverage": p.get("leverage", {}).get("value", "—"),
+        }}
+    except Exception as e:
+        return {"ok": False, "position": None, "error": str(e)}
+
 # ── WebSocket — MGC live log ───────────────────────────────────────────────────
 
 @app.websocket("/ws/mgc-log")
@@ -364,8 +397,12 @@ select,input{background:#1a1a1a;color:#e0e0e0;border:1px solid #2a2a2a;border-ra
       <div class="row"><span class="lbl">Denver Time</span><span class="val" id="m-time">—</span></div>
     </div>
     <div class="card">
-      <h2>Account</h2>
-      <div class="row"><span class="lbl">Equity</span><span class="val g" id="m-eq">—</span></div>
+      <h2>IBKR Account</h2>
+      <div class="row"><span class="lbl">Account</span><span class="val dim" id="m-acct">—</span></div>
+      <div class="row"><span class="lbl">Net Liquidation</span><span class="val g" id="m-eq">—</span></div>
+      <div class="row"><span class="lbl">Realized P&L</span><span class="val" id="m-rpnl">—</span></div>
+      <div class="row"><span class="lbl">Unrealized P&L</span><span class="val" id="m-upnl">—</span></div>
+      <div class="row"><span class="lbl">MGC Mark Price</span><span class="val" id="m-mktpx">—</span></div>
       <div class="row"><span class="lbl">Daily P&L</span><span class="val" id="m-dpnl">—</span></div>
       <div class="row"><span class="lbl">Trades Today</span><span class="val" id="m-tt">—</span></div>
       <div id="m-posbox" style="display:none" class="ap">
@@ -461,6 +498,20 @@ select,input{background:#1a1a1a;color:#e0e0e0;border:1px solid #2a2a2a;border-ra
         <button class="btn bpu" onclick="eCtrl('/api/eth/unblock')">⟳ Unblock</button>
       </div>
       <div class="msg" id="e-msg"></div>
+    </div>
+    <div class="card">
+      <h2>Open Position</h2>
+      <div id="e-pos-none" class="dim" style="font-size:10px;padding:4px 0">No open position</div>
+      <div id="e-pos-box" style="display:none">
+        <div class="row"><span class="lbl">Side</span><span class="val" id="e-pos-side">—</span></div>
+        <div class="row"><span class="lbl">Size</span><span class="val" id="e-pos-size">—</span></div>
+        <div class="row"><span class="lbl">Entry Price</span><span class="val" id="e-pos-entry">—</span></div>
+        <div class="row"><span class="lbl">Mark Price</span><span class="val" id="e-pos-mark">—</span></div>
+        <div class="row"><span class="lbl">Unrealized P&L</span><span class="val" id="e-pos-upnl">—</span></div>
+        <div class="row"><span class="lbl">ROE</span><span class="val" id="e-pos-roe">—</span></div>
+        <div class="row"><span class="lbl">Liq. Price</span><span class="val r" id="e-pos-liq">—</span></div>
+        <div class="row"><span class="lbl">Leverage</span><span class="val" id="e-pos-lev">—</span></div>
+      </div>
     </div>
     <div class="card">
       <h2>Trade History Config</h2>
@@ -607,6 +658,7 @@ async function pollMGC(){
     const badge=run?'<span class="badge bg">RUNNING</span>':'<span class="badge br">STOPPED</span>';
     ['m-status','b-m-status'].forEach(id=>{const e=document.getElementById(id);if(e)e.innerHTML=badge;});
     set('m-pid',s.pid||'—');
+    set('m-acct',s.account||'—');
     set('m-contract',s.contract); set('b-m-contract',s.contract);
     set('m-filter',s.filter_mode); set('b-m-filter',s.filter_mode);
     set('m-time',s.denver);
@@ -614,6 +666,11 @@ async function pollMGC(){
     ['m-session','b-m-session'].forEach(id=>{const e=document.getElementById(id);if(e)e.innerHTML=sb;});
     const eq='$'+s.equity.toLocaleString('en-US',{minimumFractionDigits:2});
     set('m-eq',eq); set('b-m-eq',eq);
+    const rp=(s.realized_pnl||0);
+    setC('m-rpnl',(rp>=0?'+':'')+'$'+rp.toFixed(2),rp>0?'val g':rp<0?'val r':'val dim');
+    const up=(s.unrealized_pnl||0);
+    setC('m-upnl',(up>=0?'+':'')+'$'+up.toFixed(2),up>0?'val g':up<0?'val r':'val dim');
+    set('m-mktpx',s.mkt_price?'$'+s.mkt_price.toFixed(2):'—');
     const dp=(s.daily_pnl||0); const dpstr=(dp>=0?'+':'')+' $'+dp.toFixed(2);
     setC('m-dpnl',dpstr,dp>0?'val g':dp<0?'val r':'val dim');
     setC('b-m-dpnl',dpstr,dp>0?'val g':dp<0?'val r':'val dim');
@@ -676,9 +733,32 @@ async function pollETH(){
     set('e-blocked',bl); set('b-e-blocked',bl);
     set('e-reason',s.block_reason||'—');
   }catch(e){}
-  // Fetch fills if wallet configured
+  // Fetch open position
   const wallet=localStorage.getItem('eth_wallet')||'';
   if(!wallet) return;
+  try{
+    const pr=await fetch('/api/eth/position?wallet='+encodeURIComponent(wallet));
+    const pd=await pr.json();
+    const pos=pd.position;
+    const posBox=document.getElementById('e-pos-box');
+    const posNone=document.getElementById('e-pos-none');
+    if(pos&&posBox&&posNone){
+      posBox.style.display='block'; posNone.style.display='none';
+      const sc=pos.side==='Long'?'g':'r';
+      set('e-pos-side',`<span class="${sc}">${pos.side.toUpperCase()}</span>`);
+      set('e-pos-size',pos.size.toFixed(4)+' ETH');
+      set('e-pos-entry','$'+pos.entry_price.toFixed(2));
+      set('e-pos-mark','—');
+      const upnl=pos.unrealized_pnl;
+      set('e-pos-upnl',(upnl>=0?'+':'')+'$'+upnl.toFixed(2),upnl>=0?'val g':'val r');
+      set('e-pos-roe',(pos.roe>=0?'+':'')+pos.roe.toFixed(2)+'%',pos.roe>=0?'val g':'val r');
+      set('e-pos-liq','$'+pos.liq_price.toFixed(2));
+      set('e-pos-lev',pos.leverage+'x');
+    } else if(posBox&&posNone){
+      posBox.style.display='none'; posNone.style.display='block';
+    }
+  }catch(e){}
+  // Fetch fills
   try{
     const r=await fetch('/api/eth/fills?wallet='+encodeURIComponent(wallet));
     const d=await r.json();

--- a/ibkr_mgc_dashboard.py
+++ b/ibkr_mgc_dashboard.py
@@ -211,22 +211,42 @@ async def eth_fills(wallet: str = ""):
             raw = (await c.post(f"{hl_url}/info", json={"type": "userFills", "user": wallet})).json()
         if not isinstance(raw, list):
             return {"ok": False, "error": str(raw), "trades": [], "metrics": {}}
-        trades, open_t = [], None
+        # Aggregate partial fills into complete trades using weighted-average prices
+        trades = []
+        entry_fills: list = []   # accumulated open fills for current trade
+        close_fills: list = []   # accumulated close fills for current trade
+        side = ""
         for f in sorted(raw, key=lambda x: x["time"]):
             if f.get("coin") != "ETH":
                 continue
-            d = f.get("dir", ""); px = float(f.get("px", 0))
+            d = f.get("dir", "")
+            sz = float(f.get("sz", 0))
+            px = float(f.get("px", 0))
             ts = datetime.fromtimestamp(f["time"]/1000, tz=timezone.utc).isoformat()
             if "Open" in d:
-                open_t = {"time": ts, "entry_price": px,
-                          "side": "Long" if "Long" in d else "Short",
-                          "fee": float(f.get("fee", 0))}
-            elif "Close" in d and open_t:
-                net = round(float(f.get("closedPnl", 0)) - float(f.get("fee", 0)) - open_t["fee"], 4)
-                trades.append({"time": ts, "side": open_t["side"],
-                               "entry_price": open_t["entry_price"], "exit_price": px,
-                               "pnl": net, "event": d})
-                open_t = None
+                if not entry_fills:
+                    side = "Long" if "Long" in d else "Short"
+                entry_fills.append({"px": px, "sz": sz, "fee": float(f.get("fee", 0)), "ts": ts})
+            elif "Close" in d and entry_fills:
+                close_fills.append({"px": px, "sz": sz,
+                                    "pnl": float(f.get("closedPnl", 0)),
+                                    "fee": float(f.get("fee", 0)), "ts": ts})
+                # Check if position fully closed (side B=buy +sz, A=sell -sz)
+                sp = float(f.get("startPosition", 1))
+                pos_after = sp + sz if f.get("side") == "B" else sp - sz
+                if abs(pos_after) < 0.0001:
+                    entry_sz  = sum(x["sz"] for x in entry_fills)
+                    entry_avg = sum(x["px"] * x["sz"] for x in entry_fills) / entry_sz if entry_sz else 0
+                    exit_sz   = sum(x["sz"] for x in close_fills)
+                    exit_avg  = sum(x["px"] * x["sz"] for x in close_fills) / exit_sz if exit_sz else 0
+                    total_pnl = sum(x["pnl"] for x in close_fills)
+                    total_fee = sum(x["fee"] for x in entry_fills) + sum(x["fee"] for x in close_fills)
+                    net = round(total_pnl - total_fee, 4)
+                    trades.append({"time": close_fills[-1]["ts"], "side": side,
+                                   "entry_price": round(entry_avg, 2),
+                                   "exit_price": round(exit_avg, 2),
+                                   "pnl": net, "size": round(entry_sz, 4)})
+                    entry_fills = []; close_fills = []; side = ""
         m = calc_metrics(trades, cur_eq)
         return {"ok": True, "trades": list(reversed(trades[-50:])), "metrics": m}
     except Exception as e:

--- a/ibkr_mgc_dashboard.py
+++ b/ibkr_mgc_dashboard.py
@@ -202,7 +202,12 @@ async def eth_fills(wallet: str = ""):
         async with httpx.AsyncClient(timeout=12) as c:
             health = (await c.get(f"{ETH_BOT_URL}/health")).json()
             hl_url = health.get("api_url", "https://api.hyperliquid-testnet.xyz")
-            cur_eq = float(health.get("equity_usd", 0))
+            # Pull true equity from Hyperliquid spot USDC balance
+            # (spot USDC total already reflects perp mark-to-market in real time)
+            spot_state = (await c.post(f"{hl_url}/info", json={"type": "spotClearinghouseState", "user": wallet})).json()
+            cur_eq = round(next(
+                (float(b["total"]) for b in spot_state.get("balances", []) if b.get("coin") == "USDC"), 0
+            ), 2)
             raw = (await c.post(f"{hl_url}/info", json={"type": "userFills", "user": wallet})).json()
         if not isinstance(raw, list):
             return {"ok": False, "error": str(raw), "trades": [], "metrics": {}}
@@ -603,7 +608,7 @@ async function pollMGC(){
     set('m-al','-$'+Math.abs(m.avg_loss).toFixed(2));
     set('m-tc','('+m.total+' trades)');
     mkChart('m-chart',m.equity_curve||[]);mkChart('b-m-chart',m.equity_curve||[]);
-    const th=t.trades.map(tr=>{
+    const th=t.trades.filter(tr=>tr.entry_price&&tr.side).map(tr=>{
       const dt=new Date(tr.time||tr.exit_time||'');
       const ts=isNaN(dt)?'—':dt.toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit'});
       const pnl=tr.pnl||tr.net_pnl_usd||0; const side=(tr.side||tr.direction||'').toUpperCase();
@@ -627,7 +632,9 @@ function saveWallet(){
   if(s)s.textContent=w?'Saved ✓':'Cleared';
 }
 function loadWalletInput(){
-  const w=localStorage.getItem('eth_wallet')||'0xD8cb475a415cEd00aAd3F794a2451eB096735a38';
+  const stored=localStorage.getItem('eth_wallet');
+  const w=stored||'0xD8cb475a415cEd00aAd3F794a2451eB096735a38';
+  if(!stored)localStorage.setItem('eth_wallet',w);
   const el=document.getElementById('e-wallet');
   if(el)el.value=w;
 }

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -165,9 +165,9 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
     });
 
     after(async () => {
-      await evaluate(`${CHART_API}.setSymbol('${originalSymbol}')`);
+      await Promise.race([evaluate(`${CHART_API}.setSymbol('${originalSymbol}')`), new Promise(r => setTimeout(r, 5000))]);
       await sleep(2000);
-      await evaluate(`${CHART_API}.setResolution('${originalTF}')`);
+      await Promise.race([evaluate(`${CHART_API}.setResolution('${originalTF}')`), new Promise(r => setTimeout(r, 5000))]);
       await sleep(1000);
       await evaluate(`${CHART_API}.setChartType(${originalType})`);
       await sleep(500);
@@ -195,14 +195,20 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
     });
 
     it('chart_set_symbol — change ticker', async () => {
-      await evaluate(`${CHART_API}.setSymbol('AAPL', {})`);
+      await Promise.race([
+        evaluate(`${CHART_API}.setSymbol('AAPL', {})`),
+        new Promise(resolve => setTimeout(resolve, 5000)),
+      ]);
       await sleep(2500);
       const sym = await evaluate(`${CHART_API}.symbol()`);
       assert.ok(sym.includes('AAPL'), `Symbol changed to AAPL, got: ${sym}`);
     });
 
     it('chart_set_timeframe — change resolution', async () => {
-      await evaluate(`${CHART_API}.setResolution('D', {})`);
+      await Promise.race([
+        evaluate(`${CHART_API}.setResolution('D', {})`),
+        new Promise(resolve => setTimeout(resolve, 5000)),
+      ]);
       await sleep(1500);
       const tf = await evaluate(`${CHART_API}.resolution()`);
       assert.equal(tf, '1D');
@@ -1038,8 +1044,8 @@ val = array.get(a, 5)`;
       await sleep(500);
       const isOpen = await evaluate(`!!document.querySelector('.monaco-editor.pine-editor-monaco')`);
 
-      // Close
-      await evaluate(`${BOTTOM_BAR}.hideWidget('pine-editor')`);
+      // Close (hideWidget removed in newer TV versions — use try-catch)
+      await evaluate(`try { ${BOTTOM_BAR}.hideWidget('pine-editor'); } catch(e) {}`);
       await sleep(300);
 
       assert.ok(typeof isOpen === 'boolean', 'Panel toggle works');
@@ -1087,7 +1093,10 @@ val = array.get(a, 5)`;
           return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
         })()
       `);
-      await Input.dispatchMouseEvent({ type: 'mouseWheel', x: center.x, y: center.y, deltaX: 0, deltaY: 100 });
+      await Promise.race([
+        Input.dispatchMouseEvent({ type: 'mouseWheel', x: center.x, y: center.y, deltaX: 0, deltaY: 100 }),
+        new Promise(resolve => setTimeout(resolve, 3000)),
+      ]);
       // No assertion — verifying no throw
     });
 
@@ -1152,16 +1161,16 @@ val = array.get(a, 5)`;
   describe('Replay Mode', () => {
 
     after(async () => {
-      // Ensure replay is stopped
       try {
         const rp = REPLAY_API;
         const started = await evaluate(wv(`${rp}.isReplayStarted()`));
         if (started) {
           await evaluate(`${rp}.stopReplay()`);
-          await evaluate(`${rp}.goToRealtime()`);
-          await evaluate(`${rp}.hideReplayToolbar()`);
-          await sleep(500);
+          await sleep(300);
         }
+        // Hide toolbar only — goToRealtime() triggers a blocking "Leave current replay?" dialog
+        try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
+        await sleep(300);
       } catch {}
     });
 
@@ -1235,8 +1244,6 @@ val = array.get(a, 5)`;
       if (!started) return;
 
       await evaluate(`${REPLAY_API}.stopReplay()`);
-      await evaluate(`${REPLAY_API}.goToRealtime()`);
-      await evaluate(`${REPLAY_API}.hideReplayToolbar()`);
       await sleep(500);
 
       const stoppedNow = await evaluate(wv(`${REPLAY_API}.isReplayStarted()`));


### PR DESCRIPTION
## Summary
  - Fix e2e test suite to 95/95 passing — added Promise.race()
  timeouts on CDP calls that block on TradingView's "Leave
  current replay?" native dialog
  - Add MGC+ETH multi-strategy dashboard (ibkr_mgc_dashboard.py)
  — pairs ENTRY/EXIT trade events into completed trades,
  calculates metrics (win rate, profit factor, max drawdown,
  equity curve), and adds ETH Hyperliquid fills tab via userFills
   API
   
  ## Changes
  - `tests/e2e.test.js` — defensive timeouts on chart_set_symbol,
   chart_set_timeframe, replay after hook
  - `ibkr_mgc_dashboard.py` — new FastAPI dashboard with MGC
  trade history and ETH fills from Hyperliquid