### PR TITLE
chore: sync package-lock.json with tv bin entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {


### PR DESCRIPTION
## What changed
Adds the missing `bin` entry (`tv` → `src/cli/index.js`) to `package-lock.json`, syncing the lockfile with what `package.json` already declares.

## Why
Running a fresh `npm install` reconciles the lockfile and produces this 3-line diff. Committing it keeps installs reproducible and avoids an unexpected dirty working tree for the next person who installs dependencies.

## Notes for reviewer
- No source changes — lockfile only.
- Diff is 3 insertions; no dependency versions changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)