### PR TITLE
Fix outdated tool and test counts in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+78 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ If you're unsure whether a feature fits, open an issue to discuss before submitt
 
 ```bash
 npm install
-npm test          # 29 offline tests (no TradingView needed)
+npm test          # 171 offline tests (no TradingView needed)
 tv status         # verify CDP connection (TradingView must be running)
 ```
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ The key flag: `--remote-debugging-port=9222`
 npm test
 ```
 
-29 tests covering: Pine Script static analysis, server-side compilation, and CLI routing.
+171 tests covering: Pine Script static analysis, server-side compilation, CLI routing, CDP sanitization, and replay controls.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: tool count 68 → 78 (verified via `grep -r "server.tool(" src/ | wc -l`)
- **README.md**: test count 29 → 171 (verified via `grep -r "it(" tests/ | wc -l`), added missing test coverage areas (CDP sanitization, replay controls)
- **CONTRIBUTING.md**: test count 29 → 171

## Test plan
- [x] Verified 78 tool registrations by grepping `server.tool(` across `src/tools/`
- [x] Verified 171 test cases by grepping `it(` across `tests/*.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)