### PR TITLE
fix(windows): detect TradingView installed via Windows Store (MSIX)

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -2,7 +2,7 @@
  * Core health/discovery/launch logic.
  */
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 
 export async function healthCheck() {
@@ -173,6 +173,8 @@ export async function launch({ port, kill_existing } = {}) {
       `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
       `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
       `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      // Windows Store (MSIX) install — scan versioned WindowsApps directory
+      ...(() => { try { return readdirSync('C:\\Program Files\\WindowsApps').filter(d => d.startsWith('TradingView.Desktop_')).map(d => `C:\\Program Files\\WindowsApps\\${d}\\TradingView.exe`); } catch { return []; } })(),
     ],
     linux: [
       '/opt/TradingView/tradingview',


### PR DESCRIPTION
## Summary

- `tv_launch` failed on Windows when TradingView was installed from the Microsoft Store because the MSIX package installs into a versioned directory under `C:\Program Files\WindowsApps\TradingView.Desktop_<version>_x64__<id>\` — none of the three hardcoded win32 paths matched this location.
- Added a runtime fallback that scans `C:\Program Files\WindowsApps` for any directory starting with `TradingView.Desktop_`, mapping each to its `TradingView.exe`. This handles the current version and future updates automatically.
- Also imported `readdirSync` alongside the existing `existsSync` import.

## Reproduction

Install TradingView from the Microsoft Store on Windows, then call `tv_launch`. Without this fix it throws:
```
TradingView not found on win32. Searched: C:\Users\...\AppData\Local\TradingView\TradingView.exe, ...
```

## Test plan

- [ ] Install TradingView from Microsoft Store on Windows
- [ ] Run `tv_launch` — confirm TradingView starts with CDP on port 9222
- [ ] Run `tv_health_check` — confirm `cdp_connected: true`
- [ ] Confirm existing non-Store installs (direct `.exe`) still work via the existing paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
