### PR TITLE
Add Microsoft Store (MSIX) detection to TradingView launch on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "tv": "node src/cli/index.js",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/launch.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/launch.test.js tests/replay.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/launch.test.js tests/replay.test.js tests/sanitization.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/launch.test.js tests/replay.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/launch.test.js tests/replay.test.js tests/sanitization.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
+    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/launch.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/launch.test.js tests/replay.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/launch.test.js tests/replay.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -2,8 +2,16 @@
  * Core health/discovery/launch logic.
  */
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
-import { execSync, spawn } from 'child_process';
+import { existsSync as _existsSync, readdirSync as _readdirSync } from 'fs';
+import { execSync as _execSync, spawn } from 'child_process';
+
+function _resolve(deps) {
+  return {
+    existsSync: deps?.existsSync || _existsSync,
+    readdirSync: deps?.readdirSync || _readdirSync,
+    execSync: deps?.execSync || _execSync,
+  };
+}
 
 export async function healthCheck() {
   await getClient();
@@ -159,25 +167,63 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
-export async function launch({ port, kill_existing } = {}) {
-  const cdpPort = port || 9222;
-  const killFirst = kill_existing !== false;
-  const platform = process.platform;
+const WINDOWS_APPS_DIR = 'C:\\Program Files\\WindowsApps';
+
+/**
+ * Find TradingView.exe of a Microsoft Store (MSIX) install.
+ * Get-AppxPackage is the reliable route — the WindowsApps directory is
+ * ACL-restricted on most machines, so the directory glob is only a fallback.
+ * Launching the packaged exe directly with --remote-debugging-port works.
+ */
+function findMsixTradingView({ existsSync, readdirSync, execSync }) {
+  try {
+    const loc = execSync(
+      'powershell -NoProfile -NonInteractive -Command "(Get-AppxPackage -Name TradingView.Desktop).InstallLocation"',
+      { timeout: 10000 }
+    ).toString().trim();
+    if (loc) {
+      const exe = `${loc}\\TradingView.exe`;
+      if (existsSync(exe)) return exe;
+    }
+  } catch { /* PowerShell unavailable or package not installed */ }
+
+  try {
+    const pkgs = readdirSync(WINDOWS_APPS_DIR)
+      .filter((name) => /^TradingView\.Desktop_[\d.]+_x64__/.test(name))
+      .sort((a, b) => {
+        const va = a.split('_')[1].split('.').map(Number);
+        const vb = b.split('_')[1].split('.').map(Number);
+        for (let i = 0; i < Math.max(va.length, vb.length); i++) {
+          if ((va[i] || 0) !== (vb[i] || 0)) return (vb[i] || 0) - (va[i] || 0);
+        }
+        return 0;
+      });
+    for (const pkg of pkgs) {
+      const exe = `${WINDOWS_APPS_DIR}\\${pkg}\\TradingView.exe`;
+      if (existsSync(exe)) return exe;
+    }
+  } catch { /* directory unreadable (ACL) or missing */ }
+
+  return null;
+}
+
+export function findTradingViewPath({ platform = process.platform, env = process.env, _deps } = {}) {
+  const { existsSync, readdirSync, execSync } = _resolve(_deps);
 
   const pathMap = {
     darwin: [
       '/Applications/TradingView.app/Contents/MacOS/TradingView',
-      `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
+      `${env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
     ],
     win32: [
-      `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
-      `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
-      `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      `${env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
+      `${env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
+      `${env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
     ],
     linux: [
       '/opt/TradingView/tradingview',
       '/opt/TradingView/TradingView',
-      `${process.env.HOME}/.local/share/TradingView/TradingView`,
+      `${env.HOME}/.local/share/TradingView/TradingView`,
       '/usr/bin/tradingview',
       '/snap/tradingview/current/tradingview',
     ],
@@ -187,6 +233,11 @@ export async function launch({ port, kill_existing } = {}) {
   const candidates = pathMap[platform] || pathMap.linux;
   for (const p of candidates) {
     if (p && existsSync(p)) { tvPath = p; break; }
+  }
+
+  if (!tvPath && platform === 'win32') {
+    tvPath = findMsixTradingView({ existsSync, readdirSync, execSync });
+    candidates.push(`${WINDOWS_APPS_DIR}\\TradingView.Desktop_*_x64__*\\TradingView.exe (Microsoft Store)`);
   }
 
   if (!tvPath) {
@@ -206,6 +257,17 @@ export async function launch({ port, kill_existing } = {}) {
       }
     } catch { /* ignore */ }
   }
+
+  return { tvPath, candidates };
+}
+
+export async function launch({ port, kill_existing, _deps } = {}) {
+  const cdpPort = port || 9222;
+  const killFirst = kill_existing !== false;
+  const platform = process.platform;
+  const { execSync } = _resolve(_deps);
+
+  const { tvPath, candidates } = findTradingViewPath({ platform, _deps });
 
   if (!tvPath) {
     throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -141,13 +141,11 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
 
     it('tv_launch — auto-detect binary (verify path resolution only)', async () => {
       // tv_launch is destructive (kills TradingView), so we only test path detection
+      const { findTradingViewPath } = await import('../src/core/health.js');
+      const { tvPath } = findTradingViewPath();
+      assert.ok(tvPath, 'TradingView binary found on disk');
       const { existsSync } = await import('fs');
-      const paths = [
-        '/Applications/TradingView.app/Contents/MacOS/TradingView',
-        `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
-      ];
-      const found = paths.some(p => existsSync(p));
-      assert.ok(found, 'TradingView binary found on disk');
+      assert.ok(existsSync(tvPath), `resolved path exists: ${tvPath}`);
     });
   });
 

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -1,0 +1,131 @@
+/**
+ * Tests for TradingView path resolution in src/core/health.js.
+ * Covers: standard install paths, Microsoft Store (MSIX) detection via
+ * Get-AppxPackage and WindowsApps directory glob, and the not-found case.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { findTradingViewPath } from '../src/core/health.js';
+
+const WIN_ENV = {
+  LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local',
+  PROGRAMFILES: 'C:\\Program Files',
+  'PROGRAMFILES(X86)': 'C:\\Program Files (x86)',
+};
+
+const MSIX_PKG = 'TradingView.Desktop_3.2.0.7916_x64__n534cwy3pjxzj';
+const MSIX_EXE = `C:\\Program Files\\WindowsApps\\${MSIX_PKG}\\TradingView.exe`;
+
+/** Build _deps where existsSync is true only for the given paths. */
+function mockDeps({ existing = [], execResults = {}, dirEntries = null } = {}) {
+  const execCalls = [];
+  const deps = {
+    existsSync: (p) => existing.includes(p),
+    execSync: (cmd) => {
+      execCalls.push(cmd);
+      for (const [key, val] of Object.entries(execResults)) {
+        if (cmd.includes(key)) {
+          if (val instanceof Error) throw val;
+          return val;
+        }
+      }
+      throw new Error(`command failed: ${cmd}`);
+    },
+    readdirSync: () => {
+      if (dirEntries === null) throw new Error('EPERM: operation not permitted');
+      return dirEntries;
+    },
+  };
+  return { _deps: deps, execCalls };
+}
+
+describe('findTradingViewPath — win32 standard installs', () => {
+  it('finds the %LOCALAPPDATA% install without invoking PowerShell', () => {
+    const exe = `${WIN_ENV.LOCALAPPDATA}\\TradingView\\TradingView.exe`;
+    const { _deps, execCalls } = mockDeps({ existing: [exe] });
+    const { tvPath } = findTradingViewPath({ platform: 'win32', env: WIN_ENV, _deps });
+    assert.equal(tvPath, exe);
+    assert.equal(execCalls.length, 0, 'no shell commands when a static path matches');
+  });
+
+  it('finds the Program Files install', () => {
+    const exe = `${WIN_ENV.PROGRAMFILES}\\TradingView\\TradingView.exe`;
+    const { _deps } = mockDeps({ existing: [exe] });
+    const { tvPath } = findTradingViewPath({ platform: 'win32', env: WIN_ENV, _deps });
+    assert.equal(tvPath, exe);
+  });
+});
+
+describe('findTradingViewPath — win32 MSIX (Microsoft Store)', () => {
+  it('resolves via Get-AppxPackage InstallLocation', () => {
+    const { _deps, execCalls } = mockDeps({
+      existing: [MSIX_EXE],
+      execResults: { 'Get-AppxPackage': `C:\\Program Files\\WindowsApps\\${MSIX_PKG}\r\n` },
+    });
+    const { tvPath } = findTradingViewPath({ platform: 'win32', env: WIN_ENV, _deps });
+    assert.equal(tvPath, MSIX_EXE);
+    assert.ok(execCalls.some(c => c.includes('Get-AppxPackage -Name TradingView.Desktop')));
+  });
+
+  it('falls back to a WindowsApps directory glob when PowerShell fails', () => {
+    const { _deps } = mockDeps({
+      existing: [MSIX_EXE],
+      execResults: { 'Get-AppxPackage': new Error('powershell not found') },
+      dirEntries: ['Microsoft.WindowsCalculator_11.0_x64__8wekyb3d8bbwe', MSIX_PKG],
+    });
+    const { tvPath } = findTradingViewPath({ platform: 'win32', env: WIN_ENV, _deps });
+    assert.equal(tvPath, MSIX_EXE);
+  });
+
+  it('picks the highest version when multiple MSIX packages exist', () => {
+    const oldPkg = 'TradingView.Desktop_3.1.9.8000_x64__n534cwy3pjxzj';
+    const newExe = MSIX_EXE;
+    const oldExe = `C:\\Program Files\\WindowsApps\\${oldPkg}\\TradingView.exe`;
+    const { _deps } = mockDeps({
+      existing: [oldExe, newExe],
+      execResults: { 'Get-AppxPackage': new Error('no powershell') },
+      dirEntries: [oldPkg, MSIX_PKG],
+    });
+    const { tvPath } = findTradingViewPath({ platform: 'win32', env: WIN_ENV, _deps });
+    assert.equal(tvPath, newExe, '3.2.0.7916 beats 3.1.9.8000 despite lexical order');
+  });
+
+  it('ignores non-x64 and unrelated package directories', () => {
+    const { _deps } = mockDeps({
+      existing: [],
+      execResults: { 'Get-AppxPackage': '' },
+      dirEntries: ['TradingView.Desktop_3.2.0.7916_arm64__n534cwy3pjxzj', 'NotTradingView_1.0_x64__abc'],
+    });
+    const { tvPath } = findTradingViewPath({ platform: 'win32', env: WIN_ENV, _deps });
+    assert.equal(tvPath, null);
+  });
+
+  it('survives an ACL-restricted WindowsApps directory', () => {
+    const { _deps } = mockDeps({
+      existing: [],
+      execResults: { 'Get-AppxPackage': '' },
+      dirEntries: null, // readdirSync throws EPERM
+    });
+    const { tvPath, candidates } = findTradingViewPath({ platform: 'win32', env: WIN_ENV, _deps });
+    assert.equal(tvPath, null);
+    assert.ok(candidates.some(c => c.includes('WindowsApps')), 'error message mentions the MSIX path');
+  });
+});
+
+describe('findTradingViewPath — other platforms', () => {
+  it('finds the macOS app bundle', () => {
+    const exe = '/Applications/TradingView.app/Contents/MacOS/TradingView';
+    const { _deps } = mockDeps({ existing: [exe] });
+    const { tvPath } = findTradingViewPath({ platform: 'darwin', env: { HOME: '/Users/test' }, _deps });
+    assert.equal(tvPath, exe);
+  });
+
+  it('does not attempt MSIX detection on linux', () => {
+    const { _deps, execCalls } = mockDeps({
+      existing: ['/opt/TradingView/tradingview'],
+    });
+    const { tvPath } = findTradingViewPath({ platform: 'linux', env: { HOME: '/home/test' }, _deps });
+    assert.equal(tvPath, '/opt/TradingView/tradingview');
+    assert.ok(!execCalls.some(c => c.includes('Get-AppxPackage')));
+  });
+});

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Problem

`tv_launch` (MCP tool) and `tv launch` (CLI) fail to find TradingView on Windows when it is installed from the Microsoft Store (MSIX package). The search only covered `%LOCALAPPDATA%\TradingView`, `Program Files`, and `Program Files (x86)`, and `where TradingView.exe` does not find Store installs either.

## Changes

- **Extracted path resolution** from `launch()` into an exported `findTradingViewPath({ platform, env, _deps })` in `src/core/health.js`, following the repo's DI pattern so it is unit-testable. Both the CLI and MCP tool route through `core.launch()`, so one fix covers both.
- **MSIX detection on win32** after the static paths miss:
  1. `Get-AppxPackage -Name TradingView.Desktop` via PowerShell (primary — the `WindowsApps` directory is ACL-restricted on most machines)
  2. Directory glob of `C:\Program Files\WindowsApps\TradingView.Desktop_*_x64__*\TradingView.exe` as fallback, picking the highest version numerically when multiple packages exist
- The "TradingView not found" error now lists the MSIX location among searched paths.
- **Tests**: new `tests/launch.test.js` with 9 unit tests (standard installs, both MSIX routes, version ordering, non-x64 filtering, ACL-denied directory, macOS/Linux regressions). Fixed the e2e `tv_launch` path test which was hardcoded to macOS-only paths and failed on every Windows machine. Registered `launch.test.js` and the previously unregistered `replay.test.js` in the npm test scripts.

## Verification

- All 9 new unit tests pass; replay unit tests still pass (48/48 combined).
- Verified live on a machine with the Store install: resolution finds `C:\Program Files\WindowsApps\TradingView.Desktop_3.2.0.7916_x64__n534cwy3pjxzj\TradingView.exe`, and launching that exe with `--remote-debugging-port=9222` works.
- e2e `tv_launch` test passes against the live app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)