### PR TITLE
Fix bottom-panel close on newer TradingView builds (hideWidget removed)

### DIFF
--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -49,7 +49,11 @@ export async function openPanel({ panel, action }) {
           else { if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); }
           performed = 'opened';
         } else if (action === 'close' || (action === 'toggle' && isOpen)) {
+          // hideWidget(name) was removed in newer TradingView builds; fall back to
+          // close() (minimizes the bottom panel) and then hide() (hides the bar).
           if (typeof bwb.hideWidget === 'function') bwb.hideWidget(widgetName);
+          else if (typeof bwb.close === 'function') bwb.close();
+          else if (typeof bwb.hide === 'function') bwb.hide();
           performed = 'closed';
         }
         return { was_open: isOpen, performed: performed };

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -49,6 +49,12 @@ async function apiExists(path) {
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 const BARS_PATH = `${CHART_API}._chartWidget.model().mainSeries().bars()`;
 const BOTTOM_BAR = 'window.TradingView.bottomWidgetBar';
+// Resilient close: hideWidget(name) was removed in newer TradingView builds;
+// fall back to close() (minimize) and then hide().
+const CLOSE_BOTTOM = (name) => `(function(){var b=${BOTTOM_BAR};if(!b)return;` +
+  `if(typeof b.hideWidget==='function')b.hideWidget(${JSON.stringify(name)});` +
+  `else if(typeof b.close==='function')b.close();` +
+  `else if(typeof b.hide==='function')b.hide();})()`;
 const REPLAY_API = 'window.TradingViewApi._replayApi';
 
 /** Unwrap TradingView WatchedValue objects */
@@ -628,7 +634,7 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
       assert.ok(typeof data.panel_found === 'boolean', 'Strategy panel detection works');
 
       // Close it
-      await evaluate(`try { ${BOTTOM_BAR}.hideWidget('backtesting'); } catch(e) {}`);
+      await evaluate(`try { ${CLOSE_BOTTOM('backtesting')} } catch(e) {}`);
     });
 
     it('data_get_trades — trade list (panel-dependent)', async () => {
@@ -639,7 +645,7 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
         !!(document.querySelector('[data-name="backtesting"]') || document.querySelector('[class*="strategyReport"]'))
       `);
       assert.ok(typeof panelExists === 'boolean', 'Panel detection works');
-      await evaluate(`try { ${BOTTOM_BAR}.hideWidget('backtesting'); } catch(e) {}`);
+      await evaluate(`try { ${CLOSE_BOTTOM('backtesting')} } catch(e) {}`);
     });
 
     it('data_get_equity — equity curve (panel-dependent)', async () => {
@@ -650,7 +656,7 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
         !!(document.querySelector('[data-name="backtesting"]') || document.querySelector('[class*="strategyReport"]'))
       `);
       assert.ok(typeof panelExists === 'boolean', 'Panel detection works');
-      await evaluate(`try { ${BOTTOM_BAR}.hideWidget('backtesting'); } catch(e) {}`);
+      await evaluate(`try { ${CLOSE_BOTTOM('backtesting')} } catch(e) {}`);
     });
   });
 
@@ -667,7 +673,7 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
     after(async () => {
       // Restore editor state
       if (!editorWasOpen) {
-        await evaluate(`try { ${BOTTOM_BAR}.hideWidget('pine-editor'); } catch(e) {}`);
+        await evaluate(`try { ${CLOSE_BOTTOM('pine-editor')} } catch(e) {}`);
         await sleep(300);
       }
     });
@@ -1039,7 +1045,7 @@ val = array.get(a, 5)`;
       const isOpen = await evaluate(`!!document.querySelector('.monaco-editor.pine-editor-monaco')`);
 
       // Close
-      await evaluate(`${BOTTOM_BAR}.hideWidget('pine-editor')`);
+      await evaluate(CLOSE_BOTTOM('pine-editor'));
       await sleep(300);
 
       assert.ok(typeof isOpen === 'boolean', 'Panel toggle works');


### PR DESCRIPTION
## Summary

`window.TradingView.bottomWidgetBar.hideWidget(name)` was **removed** in recent TradingView Desktop builds (observed on **3.2.0 / Electron 38**). In `src/core/ui.js`, the close/toggle branch of `openPanel()` guarded the call with `typeof bwb.hideWidget === 'function'`, so on these builds **closing a bottom panel silently does nothing** — yet the tool still returns `performed: 'closed'`. The `ui_open_panel — open/close pine-editor` e2e test also called `hideWidget` directly (unguarded) and threw `hideWidget is not a function`.

## Root cause

The `bottomWidgetBar` API was refactored. `showWidget(name)` still exists (so **open** works), but `hideWidget(name)` is gone. The current equivalents are:

- `close()` → minimizes the bottom panel (`if visible, setMode("minimized")`), and safely no-ops when nothing is open
- `hide()` → hides the bottom widget bar entirely

## Fix

- **`src/core/ui.js`**: when `hideWidget` is unavailable, fall back to `bwb.close()`, then `bwb.hide()`. Keeps backward-compat with older builds that still have `hideWidget`.
- **`tests/e2e.test.js`**: add a shared `CLOSE_BOTTOM(name)` helper that tries `hideWidget` → `close` → `hide`, and use it in place of the direct `hideWidget` calls.

## Verification

Tested live against TradingView Desktop **3.2.0** (Electron 38, CDP on 9222):

- `open()` expands the bottom panel to ~315px; `close()` collapses it to ~38px (tab bar only) — confirmed via DOM measurement.
- `ui_open_panel — open/close pine-editor` e2e test: **now passes** (was failing with `hideWidget is not a function`).

Backward compatible: older builds with `hideWidget` are unaffected (first branch of the fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)