### PR TITLE
fix: createStudy silently ignores indicator inputs (e.g. MA length); make add/set self-verifying

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -89,18 +89,79 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;
 
   if (action === 'add') {
-    const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
+    if (inputs && (typeof inputs !== 'object' || Array.isArray(inputs))) {
+      throw new Error('inputs must be an object keyed by input id, e.g. { "length": 200 }');
+    }
     const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
+    // IMPORTANT: create the study with NO custom inputs. createStudy's 4th arg expects positional
+    // input VALUES (e.g. [200]) or a keyed object — NOT an array of {id,value} objects. Passing the
+    // wrong shape corrupts the study's input registration: getInputValues() comes back empty and the
+    // study silently falls back to its defaults (e.g. MA length 9 instead of 200). We instead create
+    // clean — which initializes inputs correctly — then apply overrides by id via setInputValues,
+    // and finally re-read to return the values that ACTUALLY took. This makes the tool self-verifying
+    // rather than reporting a false "success".
     await evaluate(`
       (function() {
         var chart = ${CHART_API};
-        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputArr)});
+        chart.createStudy(${safeString(indicator)}, false, false, []);
       })()
     `);
     await new Promise(r => setTimeout(r, 1500));
     const after = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
     const newIds = (after || []).filter(id => !(before || []).includes(id));
-    return { success: newIds.length > 0, action: 'add', indicator, entity_id: newIds[0] || null, new_study_count: newIds.length };
+    const entityId = newIds[0] || null;
+
+    let appliedInputs = null;
+    let warning = null;
+    if (entityId && inputs && Object.keys(inputs).length > 0) {
+      const overridesJson = JSON.stringify(inputs);
+      // Inputs may not be queryable for a moment after creation; retry a few times.
+      for (let attempt = 0; attempt < 4; attempt++) {
+        const res = await evaluate(`
+          (function() {
+            var chart = ${CHART_API};
+            var study = chart.getStudyById(${safeString(entityId)});
+            if (!study) return { ready: false };
+            var cur = study.getInputValues();
+            if (!cur || cur.length === 0) return { ready: false };
+            var ov = ${overridesJson};
+            var applied = {}, unknown = [];
+            for (var key in ov) {
+              if (!Object.prototype.hasOwnProperty.call(ov, key)) continue;
+              var found = false;
+              for (var i = 0; i < cur.length; i++) {
+                if (cur[i].id === key) { cur[i].value = ov[key]; applied[key] = ov[key]; found = true; break; }
+              }
+              if (!found) unknown.push(key);
+            }
+            study.setInputValues(cur);
+            return { ready: true, applied: applied, unknown: unknown, inputs: study.getInputValues() };
+          })()
+        `);
+        if (res && res.ready) {
+          appliedInputs = res.inputs;
+          if (res.unknown && res.unknown.length) {
+            warning = 'Unknown input keys ignored (not valid for this indicator): ' + res.unknown.join(', ');
+          }
+          break;
+        }
+        await new Promise(r => setTimeout(r, 800));
+      }
+      if (appliedInputs === null) {
+        warning = 'Study created, but inputs could not be applied — it did not expose inputs in time. Retry indicator_set_inputs on entity_id ' + entityId + '.';
+      }
+    }
+
+    const out = {
+      success: newIds.length > 0,
+      action: 'add',
+      indicator,
+      entity_id: entityId,
+      new_study_count: newIds.length,
+      inputs: appliedInputs,
+    };
+    if (warning) out.warning = warning;
+    return out;
   } else if (action === 'remove') {
     if (!entity_id) throw new Error('entity_id required for remove action. Use chart_get_state to find study IDs.');
     await evaluate(`

--- a/src/core/indicators.js
+++ b/src/core/indicators.js
@@ -8,8 +8,8 @@ const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 export async function setInputs({ entity_id, inputs: inputsRaw }) {
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;
   if (!entity_id) throw new Error('entity_id is required. Use chart_get_state to find study IDs.');
-  if (!inputs || typeof inputs !== 'object' || Object.keys(inputs).length === 0) {
-    throw new Error('inputs must be a non-empty object, e.g. { length: 50 }');
+  if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs) || Object.keys(inputs).length === 0) {
+    throw new Error('inputs must be a non-empty object keyed by input id, e.g. { "length": 50 }');
   }
 
   const inputsJson = JSON.stringify(inputs);
@@ -20,21 +20,34 @@ export async function setInputs({ entity_id, inputs: inputsRaw }) {
       var study = chart.getStudyById(${safeString(entity_id)});
       if (!study) return { error: 'Study not found: ' + ${safeString(entity_id)} };
       var currentInputs = study.getInputValues();
+      // A correctly-added study always exposes its inputs. Empty here means the study was created
+      // in a broken state (see manageIndicator) — fail loudly instead of reporting a false success.
+      if (!currentInputs || currentInputs.length === 0) {
+        return { error: 'Study ' + ${safeString(entity_id)} + ' exposes no inputs (getInputValues empty). It was likely added in a broken state; remove and re-add it.' };
+      }
       var overrides = ${inputsJson};
-      var updatedKeys = {};
-      for (var i = 0; i < currentInputs.length; i++) {
-        if (overrides.hasOwnProperty(currentInputs[i].id)) {
-          currentInputs[i].value = overrides[currentInputs[i].id];
-          updatedKeys[currentInputs[i].id] = overrides[currentInputs[i].id];
+      var updatedKeys = {}, unknown = [];
+      for (var key in overrides) {
+        if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+        var found = false;
+        for (var i = 0; i < currentInputs.length; i++) {
+          if (currentInputs[i].id === key) { currentInputs[i].value = overrides[key]; updatedKeys[key] = overrides[key]; found = true; break; }
         }
+        if (!found) unknown.push(key);
       }
       study.setInputValues(currentInputs);
-      return { updated_inputs: updatedKeys };
+      // Re-read so we return what ACTUALLY took, not just what we intended.
+      return { updated_inputs: updatedKeys, unknown: unknown, inputs: study.getInputValues() };
     })()
   `);
 
   if (result && result.error) throw new Error(result.error);
-  return { success: true, entity_id, updated_inputs: result.updated_inputs };
+  const out = { success: true, entity_id, updated_inputs: result.updated_inputs, inputs: result.inputs };
+  if (result.unknown && result.unknown.length) {
+    const validIds = (result.inputs || []).map(i => i.id).join(', ');
+    out.warning = 'Unknown input keys ignored (not valid for this indicator): ' + result.unknown.join(', ') + '. Valid ids: ' + validIds;
+  }
+  return out;
 }
 
 export async function toggleVisibility({ entity_id, visible }) {


### PR DESCRIPTION
## Problem

`chart_manage_indicator` reports success when adding an indicator with `inputs`, but the inputs are silently ignored and the study uses its defaults. For example, adding a Moving Average with `{"length": 200}` produces a length-9 MA. `indicator_set_inputs` and `data_get_indicator` then return empty, because the study's inputs never registered.

This is easy to miss because indicators added *without* inputs work fine — so the tool looks healthy until you depend on a specific input value.

## Root cause

`manageIndicator` in `src/core/chart.js` builds:

```js
const inputArr = Object.entries(inputs).map(([k, v]) => ({ id: k, value: v }));
chart.createStudy(indicator, false, false, inputArr); // e.g. [{ id: "length", value: 200 }]
```

The charting library's `createStudy(name, forceOverlay, lock, inputs)` expects `inputs` to be **positional values** (`[200]`) or a keyed object — not an array of `{id, value}` objects. The malformed shape corrupts the study's input registration: `getStudyById(id).getInputValues()` returns `[]`, the study falls back to its defaults, and downstream `setInputValues` / reads have nothing to bind to.

## Fix

- **`chart_manage_indicator` (add)**: create the study clean (no inputs — the path that already worked), then apply overrides by matching input ids via `setInputValues`, then re-read and **return the inputs that actually took**. Warns on unknown keys or inability to apply.
- **`indicator_set_inputs`**: errors when a study exposes no inputs (instead of a silent empty success), reports unknown keys, and returns the verified post-set inputs.

Both tools are now self-verifying — they can no longer report a false success while leaving the chart on defaults.

## Verification

Tested live against TradingView Desktop over CDP:

| Action | Result |
| --- | --- |
| `chart_manage_indicator` add `Bollinger Bands` `{length:55}` | response `inputs` shows `length:55` |
| `indicator_set_inputs` `{length:88}` | response `inputs` shows `length:88` |
| `chart_manage_indicator` remove | clean |

No other `createStudy` call sites or `{id,value}`-into-inputs patterns exist in the codebase (audited), so this was a single-point bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
