### PR TITLE
Make CDP port configurable via CDP_PORT env var

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -3,7 +3,7 @@ import CDP from 'chrome-remote-interface';
 let client = null;
 let targetInfo = null;
 const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_PORT = parseInt(process.env.CDP_PORT ?? '9222');
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -65,11 +65,11 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
 
   before(async () => {
     try {
-      const targets = await CDP.List({ host: 'localhost', port: 9222 });
+      const targets = await CDP.List({ host: 'localhost', port: parseInt(process.env.CDP_PORT ?? '9222') });
       const chartTarget = targets.find(t => t.url && t.url.includes('tradingview.com/chart'));
       if (!chartTarget) throw new Error('No TradingView chart target found');
 
-      client = await CDP({ host: 'localhost', port: 9222, target: chartTarget.id });
+      client = await CDP({ host: 'localhost', port: parseInt(process.env.CDP_PORT ?? '9222'), target: chartTarget.id });
       await client.Runtime.enable();
       await client.Page.enable();
       await client.DOM.enable();


### PR DESCRIPTION
## Summary

- `connection.js`: `CDP_PORT` now reads from `process.env.CDP_PORT` (default `9222`) instead of being hardcoded
- `tests/e2e.test.js`: same change so tests respect the env var

## Why

Port 9222 can be occupied by other processes (e.g. Lenovo Vantage's EdgeWebView2 on Windows), causing the server and e2e tests to fail silently with a connection error. Reading from `CDP_PORT` lets users override the port without touching the source code.

## Backwards compatibility

Defaults to `9222` — no change needed for existing setups.

## Test plan

- [x] 92/95 e2e tests pass with `CDP_PORT=9229` and TradingView running on that port
- [x] Remaining 3 failures are pre-existing TradingView API version mismatches unrelated to this change