### PR TITLE
Add one-click TradingView MCP launcher for Windows Store app

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "tradingview": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["src/server.js"],
+      "cwd": "C:\\Users\\MLB\\Desktop\\Tradingview-mcp"
+    }
+  }
+}

--- a/_health.mjs
+++ b/_health.mjs
@@ -1,0 +1,7 @@
+import { healthCheck } from './src/core/health.js';
+try {
+  const result = await healthCheck();
+  console.log(JSON.stringify(result, null, 2));
+} catch(e) {
+  console.error('Error:', e.message);
+}

--- a/_open_chart.mjs
+++ b/_open_chart.mjs
@@ -1,0 +1,43 @@
+import CDP from 'chrome-remote-interface';
+
+const targets = await fetch('http://localhost:9222/json').then(r => r.json());
+const newTab = targets.find(t => t.title === 'New tab');
+const client = await CDP({ target: newTab.id });
+await client.Runtime.enable();
+// Click the NIFTY layout item
+const result = await client.Runtime.evaluate({
+  expression: `
+    (function() {
+      // Find the NIFTY layout card and click it
+      const spans = Array.from(document.querySelectorAll('span'));
+      const niftySpan = spans.find(s => s.textContent.includes('NIFTY'));
+      if (!niftySpan) return 'NIFTY span not found';
+
+      // Walk up to find a clickable parent
+      let el = niftySpan;
+      for (let i = 0; i < 6; i++) {
+        el = el.parentElement;
+        if (!el) break;
+        if (el.tagName === 'A' || el.tagName === 'BUTTON' || el.getAttribute('role') === 'button' || el.getAttribute('tabindex') === '0') {
+          el.click();
+          return 'clicked: ' + el.tagName + ' ' + el.className.substring(0, 40);
+        }
+      }
+      // If no clickable parent found, just click the span itself
+      niftySpan.click();
+      return 'clicked span: ' + niftySpan.textContent;
+    })()
+  `,
+  returnByValue: true
+});
+
+console.log('Click result:', result.result.value);
+
+await new Promise(r => setTimeout(r, 4000));
+
+// Check what targets exist now
+const newTargets = await fetch('http://localhost:9222/json').then(r => r.json());
+console.log('Targets after click:');
+newTargets.forEach(t => console.log(' -', t.title, '|', t.url.substring(0, 80)));
+
+await client.close();

--- a/_set_nifty.mjs
+++ b/_set_nifty.mjs
@@ -1,0 +1,14 @@
+import { setSymbol } from './src/core/chart.js';
+
+// Wait for chart API to be ready
+for (let i = 0; i < 10; i++) {
+  try {
+    const result = await setSymbol({ symbol: 'NSE:NIFTY' });
+    console.log('Success:', JSON.stringify(result, null, 2));
+    process.exit(0);
+  } catch (e) {
+    console.log(`Attempt ${i+1} failed: ${e.message} — retrying...`);
+    await new Promise(r => setTimeout(r, 2000));
+  }
+}
+console.error('Failed to set symbol after 10 attempts');

--- a/_set_symbol.mjs
+++ b/_set_symbol.mjs
@@ -1,0 +1,7 @@
+import { setSymbol } from './src/core/chart.js';
+try {
+  const result = await setSymbol({ symbol: 'NSE:NIFTY' });
+  console.log(JSON.stringify(result, null, 2));
+} catch(e) {
+  console.error('Error:', e.message);
+}

--- a/launch-tv.ps1
+++ b/launch-tv.ps1
@@ -1,0 +1,58 @@
+# TradingView MCP Launcher
+# Run this once to start TradingView with CDP enabled for Claude MCP
+
+# 1. Check loopback exemption (needed for UWP app to allow localhost CDP)
+$loopback = CheckNetIsolation.exe LoopbackExempt -s 2>$null
+if ($loopback -notmatch "tradingview") {
+    Write-Host "Adding loopback exemption (needs admin)..." -ForegroundColor Yellow
+    Start-Process "CheckNetIsolation.exe" -ArgumentList "LoopbackExempt -a -n=TradingView.Desktop_n534cwy3pjxzj" -Verb RunAs -Wait
+}
+
+# 2. Kill any existing TradingView
+$existing = Get-Process -Name "TradingView" -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "Closing existing TradingView..." -ForegroundColor Yellow
+    Start-Process "taskkill" -ArgumentList "/F /IM TradingView.exe" -Verb RunAs -Wait
+    Start-Sleep -Seconds 2
+}
+
+# 3. Launch TradingView in user session with CDP on port 9222
+Write-Host "Launching TradingView with CDP..." -ForegroundColor Cyan
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+namespace AppLaunch {
+    [ComImport][Guid("2e941141-7f97-4756-ba1d-9decde894a3d")][InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IApplicationActivationManager {
+        int ActivateApplication([MarshalAs(UnmanagedType.LPWStr)] string appUserModelId, [MarshalAs(UnmanagedType.LPWStr)] string arguments, int options, out uint processId);
+        int ActivateForFile([MarshalAs(UnmanagedType.LPWStr)] string x, IntPtr y, [MarshalAs(UnmanagedType.LPWStr)] string z, out uint pid);
+        int ActivateForProtocol([MarshalAs(UnmanagedType.LPWStr)] string x, IntPtr y, out uint pid);
+    }
+    [ComImport][Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+    public class AppActMgr {}
+    public static class Launcher {
+        public static uint Launch(string aumid, string args) {
+            var mgr = (IApplicationActivationManager)new AppActMgr();
+            uint procId = 0;
+            mgr.ActivateApplication(aumid, args, 0, out procId);
+            return procId;
+        }
+    }
+}
+"@ -ErrorAction Stop
+
+$procId = [AppLaunch.Launcher]::Launch("TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop", "--remote-debugging-port=9222")
+Write-Host "TradingView launched (PID: $procId)" -ForegroundColor Green
+
+# 4. Wait for CDP to be ready
+Write-Host "Waiting for CDP to be ready..." -ForegroundColor Cyan
+for ($i = 0; $i -lt 15; $i++) {
+    Start-Sleep -Seconds 1
+    try {
+        $r = Invoke-WebRequest -Uri "http://localhost:9222/json" -TimeoutSec 2 -ErrorAction Stop
+        Write-Host "CDP ready on port 9222!" -ForegroundColor Green
+        Write-Host "TradingView MCP is ready. Start Claude Code and use the tradingview tools." -ForegroundColor Green
+        break
+    } catch {}
+    Write-Host "  waiting... ($($i+1)s)" -ForegroundColor Gray
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,4 @@
+@echo off
+echo Starting TradingView MCP...
+powershell -ExecutionPolicy Bypass -File "%~dp0launch-tv.ps1"
+pause

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Starting TradingView MCP..."
+powershell.exe -ExecutionPolicy Bypass -File "$(dirname "$0")/launch-tv.ps1"


### PR DESCRIPTION
## Summary
- Adds `launch-tv.ps1` — core PowerShell script that handles loopback exemption, kills existing TradingView, and launches it with `--remote-debugging-port=9222` via COM `IApplicationActivationManager`
- Adds `start.bat` — double-click launcher for Windows Explorer (one-click)
- Adds `start.sh` — Git Bash equivalent for terminal users

## Why this is needed
TradingView on Windows is a Store (UWP/Desktop Bridge) app. Standard `Start-Process` or `spawn()` cannot launch it with CDP flags — the `WindowsApps` folder is access-restricted. This launcher uses the Windows COM activation API (`IApplicationActivationManager`) to correctly pass `--remote-debugging-port=9222` while launching in the user visible desktop session.

Also adds loopback exemption check (`CheckNetIsolation.exe`) which is required for UWP apps to allow localhost CDP connections.

## Test plan
- [ ] Double-click `start.bat` — TradingView opens visibly on screen
- [ ] CDP accessible at `http://localhost:9222/json`
- [ ] MCP `tv_health_check` returns `cdp_connected: true`

Generated with Claude Code