### PR TITLE
Fix cross-symbol quote_get, draw_list ReferenceError, and silent pine-graphics failures

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -59,6 +59,48 @@ function buildGraphicsJS(collectionName, mapKey, filter) {
   `;
 }
 
+// Pine drawing objects (box.new/line.new/label.new/table.new) are only materialized
+// while the study is VISIBLE. A hidden study yields empty graphics collections, which
+// otherwise looks identical to "indicator draws nothing" — return an explicit warning
+// instead so the caller knows to toggle visibility rather than assume no data.
+function buildHiddenMatchJS(filter) {
+  return `
+    (function() {
+      try {
+        var chart = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget;
+        var sources = chart.model().model().dataSources();
+        var filter = ${safeString(filter || '')};
+        var hidden = [];
+        for (var si = 0; si < sources.length; si++) {
+          var s = sources[si];
+          if (!s.metaInfo) continue;
+          try {
+            var meta = s.metaInfo();
+            var name = meta.description || meta.shortDescription || '';
+            if (!name) continue;
+            if (filter && name.indexOf(filter) === -1) continue;
+            var vis = true; try { vis = s.isVisible(); } catch(e) {}
+            if (!vis) hidden.push(name);
+          } catch(e) {}
+        }
+        return hidden;
+      } catch(e) { return []; }
+    })()
+  `;
+}
+
+async function withHiddenWarning(result, filter) {
+  if (result.study_count > 0) return result;
+  const hidden = await evaluate(buildHiddenMatchJS(filter));
+  if (hidden && hidden.length) {
+    result.hidden_studies = hidden;
+    result.warning = `Matched ${hidden.length} indicator(s) but they are HIDDEN (visibility toggled off): `
+      + `${hidden.join(', ')}. Their drawings are not materialized while hidden — make them visible `
+      + `(indicator_toggle_visibility) and retry.`;
+  }
+  return result;
+}
+
 export async function getOhlcv({ count, summary } = {}) {
   const limit = Math.min(count || 100, MAX_OHLCV_BARS);
   let data;
@@ -243,6 +285,50 @@ export async function getEquity() {
 }
 
 export async function getQuote({ symbol } = {}) {
+  // The chart holds bars for ONE symbol only. If the caller asks for a DIFFERENT
+  // symbol, reading chart bars would silently return the wrong instrument — so we
+  // detect that case and fetch a real snapshot from TradingView's quote endpoint
+  // instead (same-origin from the chart page; does not disturb the active chart).
+  const activeSym = await evaluate(
+    `(function(){ try { return String(${CHART_API}.symbol()); } catch(e){ return ''; } })()`
+  );
+  const reqSym = symbol ? String(symbol) : '';
+  const norm = (x) => String(x).toUpperCase();
+  const tail = (x) => norm(x).split(':').pop();
+  const sameSymbol = !reqSym
+    || norm(reqSym) === norm(activeSym)
+    || norm(activeSym).endsWith(':' + norm(reqSym))
+    || tail(activeSym) === tail(reqSym);
+
+  if (reqSym && !sameSymbol) {
+    const snap = await evaluateAsync(`
+      (async function(){
+        try {
+          var url = 'https://scanner.tradingview.com/symbol?symbol=' + encodeURIComponent(${safeString(reqSym)})
+            + '&fields=' + encodeURIComponent('close,open,high,low,volume,change,change_abs,description,exchange,type')
+            + '&no_404=true';
+          var r = await fetch(url, { credentials: 'omit' });
+          if (!r.ok) return { __error: 'HTTP ' + r.status };
+          return await r.json();
+        } catch(e) { return { __error: String((e && e.message) || e) }; }
+      })()
+    `);
+    if (!snap || snap.__error != null || snap.close == null) {
+      throw new Error(
+        `Could not retrieve quote for "${reqSym}"` +
+        (snap && snap.__error ? ` (${snap.__error})` : '') +
+        `. Active chart is "${activeSym}". Cross-symbol quotes use TradingView's snapshot API ` +
+        `and need an exchange-qualified symbol (e.g. TVC:DXY, TVC:US10Y, OANDA:XAUUSD).`
+      );
+    }
+    return {
+      success: true, symbol: reqSym, source: 'snapshot',
+      open: snap.open, high: snap.high, low: snap.low, close: snap.close, last: snap.close,
+      change: snap.change, change_abs: snap.change_abs, volume: snap.volume,
+      description: snap.description, exchange: snap.exchange, type: snap.type,
+    };
+  }
+
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
@@ -274,7 +360,7 @@ export async function getQuote({ symbol } = {}) {
     })()
   `);
   if (!data || (!data.last && !data.close)) throw new Error('Could not retrieve quote. The chart may still be loading.');
-  return { success: true, ...data };
+  return { success: true, source: 'chart', ...data };
 }
 
 export async function getDepth() {
@@ -360,7 +446,7 @@ export async function getStudyValues() {
 export async function getPineLines({ study_filter, verbose } = {}) {
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwglines', 'lines', filter));
-  if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
+  if (!raw || raw.length === 0) return withHiddenWarning({ success: true, study_count: 0, studies: [] }, filter);
 
   const studies = raw.map(s => {
     const hLevels = [];
@@ -384,7 +470,7 @@ export async function getPineLines({ study_filter, verbose } = {}) {
 export async function getPineLabels({ study_filter, max_labels, verbose } = {}) {
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwglabels', 'labels', filter));
-  if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
+  if (!raw || raw.length === 0) return withHiddenWarning({ success: true, study_count: 0, studies: [] }, filter);
 
   const limit = max_labels || 50;
   const studies = raw.map(s => {
@@ -404,7 +490,7 @@ export async function getPineLabels({ study_filter, max_labels, verbose } = {}) 
 export async function getPineTables({ study_filter } = {}) {
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwgtablecells', 'tableCells', filter));
-  if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
+  if (!raw || raw.length === 0) return withHiddenWarning({ success: true, study_count: 0, studies: [] }, filter);
 
   const studies = raw.map(s => {
     const tables = {};
@@ -432,7 +518,7 @@ export async function getPineTables({ study_filter } = {}) {
 export async function getPineBoxes({ study_filter, verbose } = {}) {
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwgboxes', 'boxes', filter));
-  if (!raw || raw.length === 0) return { success: true, study_count: 0, studies: [] };
+  if (!raw || raw.length === 0) return withHiddenWarning({ success: true, study_count: 0, studies: [] }, filter);
 
   const studies = raw.map(s => {
     const zones = [];

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {


### PR DESCRIPTION
## Summary

Three independent reliability bugs, all found and verified against a live TradingView chart while running a multi-symbol macro analysis. They share no code but all caused **silent wrong/empty results** rather than errors, which is the dangerous kind for an analysis tool.

## 1. `quote_get` ignored the requested symbol 🔴 (data-integrity)

`getQuote()` set the output `symbol` to whatever you passed, but **always read the active chart's bar series** for the actual prices. So `quote_get(symbol: "TVC:DXY")`, `"TVC:US10Y"`, `"TVC:VIX"`, etc. all returned the **chart symbol's price** with a misleading label — e.g. every macro symbol came back as Gold.

**Fix:** when the requested symbol differs from the active chart, fetch a real snapshot from TradingView's quote endpoint (`scanner.tradingview.com/symbol`) via an in-page `fetch` (same-origin, no chart disruption). Active-symbol quotes keep the existing fast chart-bars path. Added a `source` field (`chart` | `snapshot`) and `change` / `change_abs`.

```
quote_get(symbol:"TVC:DXY")   → 99.806  "U.S. Dollar Currency Index"  (source: snapshot)
quote_get(symbol:"TVC:US10Y") → 4.483   "US 10Y Government Bonds Yield" (source: snapshot)
quote_get()                   → active chart symbol                    (source: chart)
```

## 2. `draw_list` / `draw_get_properties` threw `getChartApi is not defined`

The dependency-injection refactor aliased the imports to `_getChartApi` / `_evaluate` and routed every function through `_resolve(_deps)` — but `listDrawings()` and `getProperties()` were missed and still referenced the bare, now-undefined identifiers, so both threw a `ReferenceError` on every call.

**Fix:** apply the same `_resolve(_deps)` destructuring used by the rest of the module.

## 3. Pine graphics tools failed silently on hidden indicators

`data_get_pine_boxes` / `_lines` / `_labels` / `_tables` returned `study_count: 0` with no explanation when the target indicator was simply **hidden** — TradingView doesn't materialize a hidden study's `box.new` / `line.new` / `label.new` objects, so the collections are empty. That's indistinguishable from "indicator draws nothing," which sent an analysis down the wrong path.

**Fix:** detect a filter-matched-but-hidden study (`isVisible() === false`) and return an explicit `warning` + `hidden_studies` list telling the caller to toggle visibility and retry. Confirmed: once the study is made visible, the zones read back correctly.

## Testing

All three verified end-to-end against a live chart (TradingView Desktop 3.2.0):
- cross-symbol quotes return correct DXY/US10Y values with `source: snapshot`;
- `draw_list` returns without throwing;
- pine tools emit the hidden-indicator warning, then read the zones correctly once the study is visible.

No changes to behavior for the existing passing cases (active-symbol quotes, visible-indicator graphics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
