### PR TITLE
fix(launch): add Microsoft Store install path for Windows

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -173,6 +173,8 @@ export async function launch({ port, kill_existing } = {}) {
       `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
       `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
       `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      // Microsoft Store install (WindowsApps) — versioned folder, discovered via Get-Process
+      `${process.env.PROGRAMFILES}\\WindowsApps\\TradingView.Desktop_3.2.0.7916_x64__n534cwy3pjxzj\\TradingView.exe`,
     ],
     linux: [
       '/opt/TradingView/tradingview',


### PR DESCRIPTION
tv_launch was unable to find TradingView on systems where it is installed via the Microsoft Store, which places the executable under C:\Program Files\WindowsApps\TradingView.Desktop_3.2.0.7916_x64__n534cwy3pjxzj\TradingView.exe rather than the standard %LOCALAPPDATA%\TradingView\ location.

Adds the versioned WindowsApps path to the win32 candidate list so tv_launch can find, kill, and relaunch TradingView with CDP enabled on Store installs.