### PR TITLE
Fix CDP tab-switch targeting and drawing-tool import bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,6 +2,7 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
+let preferredTargetId = null;
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
 const MAX_RETRIES = 5;
@@ -90,10 +91,31 @@ export async function connect() {
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
+  // If a specific tab was selected via switchTab, stay on it across reconnects.
+  if (preferredTargetId) {
+    const pref = targets.find(t => t.id === preferredTargetId && t.type === 'page');
+    if (pref) return pref;
+  }
   // Prefer targets with tradingview.com/chart in the URL
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
     || null;
+}
+
+/**
+ * Repoint the CDP client to a specific page target (e.g. after switching tabs).
+ * Closes the current client and connects fresh to the given target id, so all
+ * subsequent evaluate()/screenshot calls operate on the selected tab. The target
+ * becomes "sticky" — reconnects after a dropped client return to it, not tab 0.
+ */
+export async function connectToTarget(targetId) {
+  preferredTargetId = targetId;
+  if (client) {
+    try { await client.close(); } catch {}
+    client = null;
+    targetInfo = null;
+  }
+  return connect();
 }
 
 export async function getTargetInfo() {
@@ -129,6 +151,7 @@ export async function disconnect() {
     try { await client.close(); } catch {}
     client = null;
     targetInfo = null;
+    preferredTargetId = null;
   }
 }
 

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -324,30 +324,60 @@ export async function getDepth() {
 export async function getStudyValues() {
   const data = await evaluate(`
     (function() {
-      var chart = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget;
+      // NOTE (2026-06-18): the data-window (s.dataWindowView().items()._value) is
+      // populated only at the crosshair position, so it is EMPTY in headless/programmatic
+      // access — which made this tool return 0 studies. Fix: fall back through the legend
+      // values provider and finally s.firstValue() (the only reader that returns a live
+      // number in this TV build). Source enumeration tries double- then single-model.
+      var api = window.TradingViewApi._activeChartWidgetWV.value();
+      var chart = api._chartWidget;
       var model = chart.model();
-      var sources = model.model().dataSources();
+      var sources;
+      try { sources = model.model().dataSources(); } catch(e) { sources = null; }
+      if (!sources || !sources.length) { try { sources = model.dataSources(); } catch(e) { sources = []; } }
+      function ok(v) { return v !== undefined && v !== null && v !== '' && v !== '∅'; }
       var results = [];
       for (var si = 0; si < sources.length; si++) {
         var s = sources[si];
-        if (!s.metaInfo) continue;
+        if (!s || typeof s.metaInfo !== 'function') continue;
         try {
           var meta = s.metaInfo();
           var name = meta.description || meta.shortDescription || '';
           if (!name) continue;
           var values = {};
+          // 1) data window (works when a crosshair/last value is present)
           try {
             var dwv = s.dataWindowView();
-            if (dwv) {
-              var items = dwv.items();
-              if (items) {
-                for (var i = 0; i < items.length; i++) {
-                  var item = items[i];
-                  if (item._value && item._value !== '∅' && item._title) values[item._title] = item._value;
-                }
+            var items = dwv && dwv.items ? dwv.items() : null;
+            if (items) {
+              for (var i = 0; i < items.length; i++) {
+                var item = items[i];
+                if (ok(item._value) && item._title) values[item._title] = item._value;
               }
             }
           } catch(e) {}
+          // 2) legend values provider (formatted per-plot values)
+          if (Object.keys(values).length === 0) {
+            try {
+              var lp = s.legendValuesProvider && s.legendValuesProvider();
+              var lv = lp && lp.getValues ? lp.getValues() : null;
+              if (lv && lv.length) {
+                for (var j = 0; j < lv.length; j++) {
+                  var it = lv[j];
+                  var t = it.title || it._title;
+                  var val = (it.value !== undefined ? it.value : it._value);
+                  if (ok(val) && t) values[t] = val;
+                }
+              }
+            } catch(e) {}
+          }
+          // 3) firstValue() fallback — primary plot's live reference value
+          if (Object.keys(values).length === 0) {
+            try {
+              var fv = (typeof s.firstValue === 'function') ? s.firstValue() : null;
+              if (typeof fv === 'number' && isFinite(fv)) values.value = fv;
+            } catch(e) {}
+          }
           if (Object.keys(values).length > 0) results.push({ name: name, values: values });
         } catch(e) {}
       }

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -324,60 +324,30 @@ export async function getDepth() {
 export async function getStudyValues() {
   const data = await evaluate(`
     (function() {
-      // NOTE (2026-06-18): the data-window (s.dataWindowView().items()._value) is
-      // populated only at the crosshair position, so it is EMPTY in headless/programmatic
-      // access — which made this tool return 0 studies. Fix: fall back through the legend
-      // values provider and finally s.firstValue() (the only reader that returns a live
-      // number in this TV build). Source enumeration tries double- then single-model.
-      var api = window.TradingViewApi._activeChartWidgetWV.value();
-      var chart = api._chartWidget;
+      var chart = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget;
       var model = chart.model();
-      var sources;
-      try { sources = model.model().dataSources(); } catch(e) { sources = null; }
-      if (!sources || !sources.length) { try { sources = model.dataSources(); } catch(e) { sources = []; } }
-      function ok(v) { return v !== undefined && v !== null && v !== '' && v !== '∅'; }
+      var sources = model.model().dataSources();
       var results = [];
       for (var si = 0; si < sources.length; si++) {
         var s = sources[si];
-        if (!s || typeof s.metaInfo !== 'function') continue;
+        if (!s.metaInfo) continue;
         try {
           var meta = s.metaInfo();
           var name = meta.description || meta.shortDescription || '';
           if (!name) continue;
           var values = {};
-          // 1) data window (works when a crosshair/last value is present)
           try {
             var dwv = s.dataWindowView();
-            var items = dwv && dwv.items ? dwv.items() : null;
-            if (items) {
-              for (var i = 0; i < items.length; i++) {
-                var item = items[i];
-                if (ok(item._value) && item._title) values[item._title] = item._value;
+            if (dwv) {
+              var items = dwv.items();
+              if (items) {
+                for (var i = 0; i < items.length; i++) {
+                  var item = items[i];
+                  if (item._value && item._value !== '∅' && item._title) values[item._title] = item._value;
+                }
               }
             }
           } catch(e) {}
-          // 2) legend values provider (formatted per-plot values)
-          if (Object.keys(values).length === 0) {
-            try {
-              var lp = s.legendValuesProvider && s.legendValuesProvider();
-              var lv = lp && lp.getValues ? lp.getValues() : null;
-              if (lv && lv.length) {
-                for (var j = 0; j < lv.length; j++) {
-                  var it = lv[j];
-                  var t = it.title || it._title;
-                  var val = (it.value !== undefined ? it.value : it._value);
-                  if (ok(val) && t) values[t] = val;
-                }
-              }
-            } catch(e) {}
-          }
-          // 3) firstValue() fallback — primary plot's live reference value
-          if (Object.keys(values).length === 0) {
-            try {
-              var fv = (typeof s.firstValue === 'function') ? s.firstValue() : null;
-              if (typeof fv === 'number' && isFinite(fv)) values.value = fv;
-            } catch(e) {}
-          }
           if (Object.keys(values).length > 0) results.push({ name: name, values: values });
         } catch(e) {}
       }

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,7 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
+import { getClient, evaluate, connectToTarget } from '../connection.js';
 
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
@@ -16,6 +16,10 @@ export async function list() {
 
   const tabs = targets
     .filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
+    // Sort by chart_id so a given index always maps to the same tab. The raw
+    // /json/list order is recency-based and reshuffles whenever a tab is
+    // activated, which made indices unstable across switchTab calls.
+    .sort((a, b) => (a.url || '').localeCompare(b.url || ''))
     .map((t, i) => ({
       index: i,
       id: t.id,
@@ -95,10 +99,15 @@ export async function switchTab({ index }) {
 
   const target = tabs.tabs[idx];
 
-  // Use CDP Target.activateTarget to bring the tab to front
+  // Bring the tab to the UI front (so it paints), then repoint the CDP client
+  // to that target. Without the repoint, evaluate()/screenshot keep hitting the
+  // originally-connected tab no matter which one is activated.
   try {
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
-    const text = await resp.text();
+    await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
+    // Give the renderer a moment to bring the activated tab to the foreground
+    // and paint before we capture from it.
+    await new Promise(r => setTimeout(r, 400));
+    await connectToTarget(target.id);
     return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
   } catch (e) {
     throw new Error(`Failed to activate tab ${idx}: ${e.message}`);


### PR DESCRIPTION
tab_switch only activated a tab in the UI but never repointed the cached CDP client, so capture_screenshot/evaluate always hit the first-connected tab. Add connectToTarget() + a sticky preferredTargetId so the client follows the activated target and stays on it across reconnects. tab_list now sorts tabs by chart URL for stable indices (raw /json/list order reshuffles by recency).

drawing.js: listDrawings/getProperties/removeOne/clearAll called bare getChartApi()/evaluate() (imported as _getChartApi/_evaluate) and threw 'getChartApi is not defined'; now resolve via _resolve(_deps) like drawShape.

package-lock.json: sync bin entry already declared in package.json.