### PR TITLE
Fix TradingView Desktop 3.2.x chart detection + broken draw list/remove/clear

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -67,7 +67,7 @@ export async function connect() {
     try {
       const target = await findChartTarget();
       if (!target) {
-        throw new Error('No TradingView chart target found. Is TradingView open with a chart?');
+        throw new Error('No TradingView chart is open. The desktop app may be showing the "New Tab" launcher (common right after an update) — open or click into a chart tab, then retry.');
       }
       targetInfo = target;
       client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
@@ -90,10 +90,38 @@ export async function connect() {
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
-    || null;
+  const pages = targets.filter(t => t.type === 'page');
+
+  // 1. Strong match: a real TradingView chart URL. Works on the 2.9.x web URL
+  //    (https://www.tradingview.com/chart/...) and the 3.2.x desktop, which still
+  //    loads the chart from that same URL inside its Electron shell.
+  const byUrl = pages.find(t => /tradingview\.com\/chart/i.test(t.url || ''));
+  if (byUrl) return byUrl;
+
+  // 2. Fallback: probe each page for a live chart API. We deliberately do NOT
+  //    match "tradingview" loosely in the URL: the 3.2.x desktop wraps the app in
+  //    file://.../TradingView.Desktop_x.y.z/.../app.asar/app/{new-tab,window,...}
+  //    shell pages whose PATHS contain "TradingView" but expose no chart API.
+  //    Matching those connected us to the New Tab launcher and produced confusing
+  //    "TradingViewApi is undefined" errors. Detect the real chart by the API.
+  for (const t of pages) {
+    if (!t.webSocketDebuggerUrl) continue;
+    let probe;
+    try {
+      probe = await CDP({ host: CDP_HOST, port: CDP_PORT, target: t.id });
+      const { result } = await probe.Runtime.evaluate({
+        expression: "typeof window.TradingViewApi !== 'undefined' && !!(window.TradingViewApi && window.TradingViewApi._activeChartWidgetWV)",
+        returnByValue: true,
+      });
+      if (result && result.value === true) return t;
+    } catch {
+      // unreachable / detached target — skip it
+    } finally {
+      if (probe) { try { await probe.close(); } catch {} }
+    }
+  }
+
+  return null;
 }
 
 export async function getTargetInfo() {

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -7,6 +7,12 @@ function _resolve(deps) {
   return { evaluate: deps?.evaluate || _evaluate, getChartApi: deps?.getChartApi || _getChartApi };
 }
 
+// listDrawings/getProperties/removeOne/clearAll call bare evaluate()/getChartApi(),
+// but the module only imports them under the _-prefixed aliases. Bind the bare
+// names so those functions work (drawShape keeps using _resolve for dep injection).
+const evaluate = _evaluate;
+const getChartApi = _getChartApi;
+
 export async function drawShape({ shape, point, point2, overrides: overridesRaw, text, _deps }) {
   const { evaluate, getChartApi } = _resolve(_deps);
   const overrides = overridesRaw ? (typeof overridesRaw === 'string' ? JSON.parse(overridesRaw) : overridesRaw) : {};


### PR DESCRIPTION
## Summary

Two fixes found while running this against **TradingView Desktop 3.2.0** on Windows.

### 1. `findChartTarget` selects the wrong page on 3.2.x (`src/connection.js`)

On 3.2.x the desktop wraps everything in `file://.../TradingView.Desktop_<ver>/.../app.asar/app/{new-tab,window,tooltip,...}` shell pages. When no chart is open (e.g. the app launches to the **New Tab** launcher after an auto-update), the previous fallback:

```js
targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
```

matched the New Tab page — its `file://` path contains `TradingView.Desktop` — and connected there, where `window.TradingViewApi` is `undefined`. Every subsequent call then failed with a confusing `JS evaluation error: ... reading '_activeChartWidgetWV'` / `TradingViewApi is undefined`, which looks like a total incompatibility rather than "no chart open".

This change makes the fallback **probe page targets for a live `window.TradingViewApi`** instead of loosely matching the URL, and has `connect()` throw a clear *"No TradingView chart is open…"* error when there genuinely is no chart. The strong `tradingview.com/chart` URL match (used by both 2.9.x and 3.2.x when a chart **is** open) is unchanged, so the happy path is unaffected.

### 2. `tv draw list|get|remove|clear` throw `getChartApi is not defined` (`src/core/drawing.js`)

`listDrawings` / `getProperties` / `removeOne` / `clearAll` call bare `evaluate()` / `getChartApi()`, but the module only imports those as `_evaluate` / `_getChartApi`, so each of those commands throws `ReferenceError: getChartApi is not defined`. (`drawShape` is unaffected because it resolves them via `_resolve`.) This binds the bare names; `drawShape` keeps using `_resolve` for dependency injection.

## Testing

- `npm run test:unit` → **27 pass / 2 fail**. The 2 failures are a pre-existing Windows-only crash (`exit 0xC0000409`) in an invalid-Pine CLI test and reproduce identically on a clean checkout of `main` — unrelated to this change.
- Verified live against TradingView Desktop **3.2.0**: `tv status` / `tv state` connect, indicators add, and `tv draw list` works after the fix (previously threw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
