### PR TITLE
Sync package-lock.json with tv bin entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {


### PR DESCRIPTION
## What

Adds the missing `bin` entry to the root package metadata in `package-lock.json`:

```json
"bin": { "tv": "src/cli/index.js" }
```

## Why

`package.json` already declares this `bin` field (exposing the `tv` CLI), but the lockfile's root `packages."".` block was out of sync and did not list it. Regenerating the lock entry keeps `npm install` / `npm ci` deterministic and ensures the `tv` binary is linked on install.

## Notes for reviewer

- Single-file, metadata-only change (3 lines added); no dependency version changes.
- `src/cli/index.js` already exists in the tree.

?? Generated with [Claude Code](https://claude.com/claude-code)