### PR TITLE
fix(alerts): create/delete via pricealerts REST API instead of DOM

### DIFF
--- a/src/cli/commands/alerts.js
+++ b/src/cli/commands/alerts.js
@@ -12,21 +12,31 @@ register('alert', {
       description: 'Create a price alert',
       options: {
         price: { type: 'string', short: 'p', description: 'Price level' },
-        condition: { type: 'string', short: 'c', description: 'Condition: crossing, greater_than, less_than' },
+        condition: { type: 'string', short: 'c', description: 'Condition: crossing, crossing_up, crossing_down, greater_than, less_than' },
         message: { type: 'string', short: 'm', description: 'Alert message' },
+        symbol: { type: 'string', short: 's', description: 'Symbol (defaults to active chart)' },
+        resolution: { type: 'string', short: 'r', description: 'Resolution (defaults to 1)' },
       },
       handler: (opts) => core.create({
         price: Number(opts.price),
         condition: opts.condition || 'crossing',
         message: opts.message,
+        symbol: opts.symbol,
+        resolution: opts.resolution,
       }),
     }],
     ['delete', {
-      description: 'Delete alerts',
+      description: 'Delete alerts (by id, price, or all)',
       options: {
         all: { type: 'boolean', description: 'Delete all alerts' },
+        id: { type: 'string', description: 'Delete a single alert by alert_id' },
+        price: { type: 'string', short: 'p', description: 'Delete every alert at this price level' },
       },
-      handler: (opts) => core.deleteAlerts({ delete_all: opts.all }),
+      handler: (opts) => core.deleteAlerts({
+        delete_all: opts.all,
+        alert_id: opts.id != null ? Number(opts.id) : undefined,
+        price: opts.price != null ? Number(opts.price) : undefined,
+      }),
     }],
   ]),
 });

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,75 +1,115 @@
 /**
  * Core alert logic.
+ *
+ * Alerts are managed through TradingView's pricealerts REST API
+ * (https://pricealerts.tradingview.com), reusing the desktop app's logged-in
+ * session via `credentials: 'include'`. This is far more reliable than driving
+ * the alert dialog through the DOM: the dialog's price field is a React
+ * controlled input that ignores synthetic value assignments (so DOM-set prices
+ * silently revert to the prefilled current price), and the "Create alert"
+ * button's aria-label casing varies between TradingView Desktop builds.
+ *
+ * REST notes:
+ * - Use Content-Type 'text/plain' to avoid a CORS preflight the endpoint rejects.
+ * - create_alert  body: {"payload": { ...alert spec... }}
+ * - delete_alerts body: {"payload": {"alert_ids": [id, ...]}}
  */
-import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
+import { evaluate, evaluateAsync } from '../connection.js';
 
-export async function create({ condition, price, message }) {
-  const opened = await evaluate(`
+const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
+
+// Map friendly condition names to TradingView alert condition types.
+const CONDITION_TYPES = {
+  cross: 'cross', crossing: 'cross',
+  cross_up: 'cross_up', crossing_up: 'cross_up',
+  cross_down: 'cross_down', crossing_down: 'cross_down',
+  greater: 'greater', greater_than: 'greater', above: 'greater',
+  less: 'less', less_than: 'less', below: 'less',
+};
+
+async function getChartContext() {
+  const r = await evaluate(`
     (function() {
-      var btn = document.querySelector('[aria-label="Create Alert"]')
-        || document.querySelector('[data-name="alerts"]');
-      if (btn) { btn.click(); return true; }
-      return false;
+      try { var c = ${CHART_API}; return { symbol: c.symbol(), resolution: String(c.resolution()) }; }
+      catch (e) { return { symbol: null, resolution: null, error: e.message }; }
     })()
   `);
+  return r || {};
+}
 
-  if (!opened) {
-    const client = await getClient();
-    await client.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 1, key: 'a', code: 'KeyA', windowsVirtualKeyCode: 65 });
-    await client.Input.dispatchKeyEvent({ type: 'keyUp', key: 'a', code: 'KeyA' });
+// POST a text/plain JSON body to a pricealerts endpoint and return the parsed response.
+async function postAlertApi(endpoint, bodyObj) {
+  const bodyStr = JSON.stringify(bodyObj);
+  return await evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/${endpoint}', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      body: ${JSON.stringify(bodyStr)}
+    })
+      .then(function(r) { return r.json(); })
+      .catch(function(e) { return { s: 'error', errmsg: e.message }; })
+  `);
+}
+
+export async function create({ condition, price, message, symbol, resolution }) {
+  const value = Number(price);
+  if (!Number.isFinite(value)) throw new Error('price must be a finite number');
+
+  const type = CONDITION_TYPES[String(condition || 'cross').toLowerCase()] || 'cross';
+
+  const ctx = await getChartContext();
+  const sym = symbol || ctx.symbol;
+  if (!sym) throw new Error(`Could not determine chart symbol (${ctx.error || 'no active chart'}); pass symbol explicitly.`);
+  const res = String(resolution || ctx.resolution || '1');
+
+  const msg = message || `${sym} ${condition || 'crossing'} ${value}`;
+  const expiration = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const payload = {
+    payload: {
+      conditions: [{
+        type,
+        frequency: 'on_first_fire',
+        series: [{ type: 'barset' }, { type: 'value', value }],
+        resolution: res,
+      }],
+      symbol: `=${JSON.stringify({ symbol: sym })}`,
+      resolution: res,
+      message: msg,
+      sound_file: null,
+      sound_duration: 0,
+      popup: true,
+      auto_deactivate: true,
+      email: false,
+      sms_over_email: false,
+      mobile_push: true,
+      web_hook: null,
+      name: null,
+      expiration,
+      active: true,
+      ignore_warnings: true,
+    },
+  };
+
+  const result = await postAlertApi('create_alert', payload);
+  if (!result || result.s !== 'ok') {
+    const err = (result && (result.errmsg || (result.err && JSON.stringify(result.err)))) || 'create failed';
+    return { success: false, price: value, condition: type, symbol: sym, message: msg, error: err, source: 'rest_api' };
   }
-
-  await new Promise(r => setTimeout(r, 1000));
-
-  const priceSet = await evaluate(`
-    (function() {
-      var inputs = document.querySelectorAll('[class*="alert"] input[type="text"], [class*="alert"] input[type="number"]');
-      for (var i = 0; i < inputs.length; i++) {
-        var label = inputs[i].closest('[class*="row"]')?.querySelector('[class*="label"]');
-        if (label && /value|price/i.test(label.textContent)) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-          nativeSet.call(inputs[i], ${safeString(String(price))});
-          inputs[i].dispatchEvent(new Event('input', { bubbles: true }));
-          inputs[i].dispatchEvent(new Event('change', { bubbles: true }));
-          return true;
-        }
-      }
-      if (inputs.length > 0) {
-        var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-        nativeSet.call(inputs[0], ${safeString(String(price))});
-        inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
-        return true;
-      }
-      return false;
-    })()
-  `);
-
-  if (message) {
-    await evaluate(`
-      (function() {
-        var textarea = document.querySelector('[class*="alert"] textarea')
-          || document.querySelector('textarea[placeholder*="message"]');
-        if (textarea) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
-          nativeSet.call(textarea, ${JSON.stringify(message)});
-          textarea.dispatchEvent(new Event('input', { bubbles: true }));
-        }
-      })()
-    `);
-  }
-
-  await new Promise(r => setTimeout(r, 500));
-  const created = await evaluate(`
-    (function() {
-      var btns = document.querySelectorAll('button[data-name="submit"], button');
-      for (var i = 0; i < btns.length; i++) {
-        if (/^create$/i.test(btns[i].textContent.trim())) { btns[i].click(); return true; }
-      }
-      return false;
-    })()
-  `);
-
-  return { success: !!created, price, condition, message: message || '(none)', price_set: !!priceSet, source: 'dom_fallback' };
+  const a = result.r || {};
+  return {
+    success: true,
+    alert_id: a.alert_id,
+    symbol: sym,
+    price: value,
+    condition: type,
+    resolution: res,
+    message: msg,
+    active: a.active,
+    expiration: a.expiration,
+    source: 'rest_api',
+  };
 }
 
 export async function list() {
@@ -83,9 +123,12 @@ export async function list() {
           alerts: data.r.map(function(a) {
             var sym = '';
             try { sym = JSON.parse(a.symbol.replace(/^=/, '')).symbol || a.symbol; } catch(e) { sym = a.symbol; }
+            var price = null;
+            try { (a.condition.series || []).forEach(function(s) { if (s && s.value != null) price = s.value; }); } catch(e) {}
             return {
               alert_id: a.alert_id,
               symbol: sym,
+              price: price,
               type: a.type,
               message: a.message,
               active: a.active,
@@ -100,24 +143,44 @@ export async function list() {
       })
       .catch(function(e) { return { alerts: [], error: e.message }; })
   `);
-  return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
+  return { success: true, alert_count: result?.alerts?.length || 0, source: 'rest_api', alerts: result?.alerts || [], error: result?.error };
 }
 
-export async function deleteAlerts({ delete_all }) {
-  if (delete_all) {
-    const result = await evaluate(`
-      (function() {
-        var alertBtn = document.querySelector('[data-name="alerts"]');
-        if (alertBtn) alertBtn.click();
-        var header = document.querySelector('[data-name="alerts"]');
-        if (header) {
-          header.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 100 }));
-          return { context_menu_opened: true };
-        }
-        return { context_menu_opened: false };
-      })()
-    `);
-    return { success: true, note: 'Alert deletion requires manual confirmation in the context menu.', context_menu_opened: result?.context_menu_opened || false, source: 'dom_fallback' };
+/**
+ * Delete alerts via the REST API.
+ * Pass one of: delete_all (bool), alert_id (number), alert_ids (number[]),
+ * or price (number — deletes every alert whose level matches).
+ */
+export async function deleteAlerts({ delete_all, alert_id, alert_ids, price }) {
+  let ids = [];
+  if (Array.isArray(alert_ids)) ids = ids.concat(alert_ids);
+  if (alert_id != null) ids.push(alert_id);
+
+  if (delete_all || price != null) {
+    const listed = await list();
+    const alerts = listed.alerts || [];
+    if (delete_all) {
+      ids = ids.concat(alerts.map(a => a.alert_id));
+    } else {
+      const target = Number(price);
+      ids = ids.concat(
+        alerts.filter(a => Number(a.price) === target).map(a => a.alert_id)
+      );
+    }
   }
-  throw new Error('Individual alert deletion not yet supported. Use delete_all: true.');
+
+  ids = [...new Set(ids.map(Number).filter(n => Number.isFinite(n)))];
+  if (!ids.length) {
+    return { success: true, deleted: 0, alert_ids: [], note: 'no matching alerts to delete', source: 'rest_api' };
+  }
+
+  const result = await postAlertApi('delete_alerts', { payload: { alert_ids: ids } });
+  const ok = !!result && result.s === 'ok';
+  return {
+    success: ok,
+    deleted: ok ? ids.length : 0,
+    alert_ids: ids,
+    error: ok ? undefined : ((result && (result.errmsg || (result.err && JSON.stringify(result.err)))) || 'delete failed'),
+    source: 'rest_api',
+  };
 }

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -3,12 +3,14 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/alerts.js';
 
 export function registerAlertTools(server) {
-  server.tool('alert_create', 'Create a price alert via the TradingView alert dialog', {
-    condition: z.string().describe('Alert condition (e.g., "crossing", "greater_than", "less_than")'),
+  server.tool('alert_create', 'Create a price alert via the TradingView pricealerts REST API', {
+    condition: z.string().optional().describe('Alert condition: "crossing" (default), "crossing_up", "crossing_down", "greater_than", "less_than"'),
     price: z.coerce.number().describe('Price level for the alert'),
-    message: z.string().optional().describe('Alert message'),
-  }, async ({ condition, price, message }) => {
-    try { return jsonResult(await core.create({ condition, price, message })); }
+    message: z.string().optional().describe('Alert message (defaults to "SYMBOL condition PRICE")'),
+    symbol: z.string().optional().describe('Symbol to alert on (e.g. "BITSTAMP:BTCUSD"); defaults to the active chart symbol'),
+    resolution: z.string().optional().describe('Resolution the condition is evaluated on (e.g. "1", "60", "D"); defaults to "1"'),
+  }, async ({ condition, price, message, symbol, resolution }) => {
+    try { return jsonResult(await core.create({ condition, price, message, symbol, resolution })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
@@ -17,10 +19,13 @@ export function registerAlertTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('alert_delete', 'Delete all alerts or open context menu for deletion', {
+  server.tool('alert_delete', 'Delete alerts via the REST API. Provide one of: delete_all, alert_id, alert_ids, or price.', {
     delete_all: z.coerce.boolean().optional().describe('Delete all alerts'),
-  }, async ({ delete_all }) => {
-    try { return jsonResult(await core.deleteAlerts({ delete_all })); }
+    alert_id: z.coerce.number().optional().describe('Delete a single alert by its alert_id (from alert_list)'),
+    alert_ids: z.array(z.coerce.number()).optional().describe('Delete multiple alerts by alert_id'),
+    price: z.coerce.number().optional().describe('Delete every alert whose price level equals this value'),
+  }, async ({ delete_all, alert_id, alert_ids, price }) => {
+    try { return jsonResult(await core.deleteAlerts({ delete_all, alert_id, alert_ids, price })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }


### PR DESCRIPTION
## Problem

Alert **creation** is unreliable on current TradingView Desktop builds:

1. **Wrong price.** The alert dialog's price field is a React controlled input, so the synthetic `value` assignment in the DOM path is ignored — every alert ends up created at the *prefilled current price* instead of the requested level.
2. **Dialog often doesn't open.** The button lookup uses `aria-label="Create Alert"`, but recent builds (Desktop 3.2.0) use lowercase `"Create alert"`. The fallback `data-name="alerts"` opens the alerts *panel*, not the dialog, and the keyboard-shortcut fallback is focus/order-dependent.
3. **No targeted deletion.** Individual deletion was unsupported; delete-all relied on a context menu requiring manual confirmation.

Repro: `tv alert create -p 60000` while price is ~65,700 → an alert is created at ~65,700, not 60,000.

## Fix

Route **create** and **delete** through the same `pricealerts.tradingview.com` REST API that `list()` already uses, executed in the Desktop app's page context via CDP with `credentials: 'include'`.

This stays within the local-bridge scope from `CONTRIBUTING.md`: the request runs **inside the running Desktop app** using its own session — the same mechanism `list()` already relies on — not a new direct connection from the Node process.

- **`create()`** — `POST /create_alert` with the real `{payload:{…}}` schema and a `text/plain` body (avoids a CORS preflight the endpoint rejects). Auto-fills symbol/resolution from the active chart; maps friendly conditions (`crossing`, `crossing_up`/`crossing_down`, `greater_than`, `less_than`).
- **`deleteAlerts()`** — `POST /delete_alerts` with `{payload:{alert_ids:[…]}}`. Now supports `delete_all`, `alert_id`, `alert_ids[]`, or `price` (deletes every alert at a level).
- **`list()`** — adds a flat `price` field; `source` corrected to `rest_api`.

MCP tool (`src/tools/alerts.js`) and CLI (`src/cli/commands/alerts.js`) signatures updated to expose the new options.

## Testing

- Offline tests pass: `node --test tests/cli.test.js` → **13/13**.
- Verified against a live TradingView Desktop instance:
  - `tv alert create -p 60000 -c less_than` → alert created at **exactly 60,000** (previously prefilled to current price).
  - `tv alert delete --id <id>` → removes a single alert.
  - `tv alert list` → reflects correct price levels.

## Notes

- Condition types `cross`/`cross_up`/`cross_down` map directly to TradingView's alert types; `greater`/`less` are mapped for `greater_than`/`less_than`. `cross` is the most heavily exercised path.
- No new dependencies; no bundled TradingView code; no data caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)