### PR TITLE
fix(tab): reconnect CDP client when switching tabs

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -87,6 +87,32 @@ export async function connect() {
   throw new Error(`CDP connection failed after ${MAX_RETRIES} attempts: ${lastError?.message}`);
 }
 
+/**
+ * Reconnect the CDP client to a specific page target by id.
+ * Tab switching uses this so data/screenshot tools follow the activated tab
+ * instead of staying glued to the target picked at first connect.
+ */
+export async function connectToTarget(targetId) {
+  await disconnect();
+  client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
+
+  // Enable required domains (same as connect())
+  await client.Runtime.enable();
+  await client.Page.enable();
+  await client.DOM.enable();
+
+  // Refresh cached target info from the live target list
+  try {
+    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+    const targets = await resp.json();
+    targetInfo = targets.find(t => t.id === targetId) || { id: targetId };
+  } catch {
+    targetInfo = { id: targetId };
+  }
+
+  return client;
+}
+
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,7 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
+import { getClient, evaluate, connectToTarget } from '../connection.js';
 
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
@@ -95,12 +95,15 @@ export async function switchTab({ index }) {
 
   const target = tabs.tabs[idx];
 
-  // Use CDP Target.activateTarget to bring the tab to front
+  // Bring the tab to front in the UI, then rebind the CDP client to it.
   try {
     const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
-    const text = await resp.text();
+    await resp.text();
+    // Rebind: without this the cached client stays on the target chosen at first
+    // connect, so data/screenshot tools silently ignore the tab switch.
+    await connectToTarget(target.id);
     return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
   } catch (e) {
-    throw new Error(`Failed to activate tab ${idx}: ${e.message}`);
+    throw new Error(`Failed to switch to tab ${idx}: ${e.message}`);
   }
 }


### PR DESCRIPTION
## Problem
`tab.switchTab()` brings the target to front via `/json/activate/<id>` but never
reconnects the cached CDP client. `connection.js` caches one client for the
process lifetime (re-resolving only if the current target dies), so every data-
and screenshot-reading tool keeps talking to the target chosen at first connect.
The tab switch is therefore silently cosmetic — `tv_health_check`,
`chart_get_state`, `data_get_*`, `capture_screenshot` all keep returning the
original tab. The function's own doc comment claims "Reconnects CDP to the new
target", but that was never implemented.

## Fix
- Add `connectToTarget(targetId)` to `connection.js`: disconnect, reconnect the
  CDP client to a specific target id, refresh `targetInfo`. Binds by target id,
  so it does not depend on `/json/list` ordering.
- Call it from `switchTab()` after activating the tab.

## Verification
Tested live against TradingView Desktop with 7 chart tabs (mixed
symbols/timeframes). Before: a health check after `switchTab` always reported
the first target. After: it follows the switched tab — each tab returns its own
symbol, resolution, and CDP target id. Existing unit tests pass (29/29). No new
deps; CDP injection sanitizers untouched.
