### PR TITLE
Add US30 engulfing candle + EMA 10/15 cross alert Pine Script

### DIFF
--- a/scripts/inject_pine.mjs
+++ b/scripts/inject_pine.mjs
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import { setSource } from '../src/core/pine.js';
+import { smartCompile } from '../src/core/pine.js';
+
+const source = readFileSync('./scripts/us30_engulf_ema_alert.pine', 'utf8');
+
+console.log('Injecting Pine Script...');
+const r = await setSource({ source });
+console.log('setSource:', JSON.stringify(r, null, 2));
+
+console.log('Compiling...');
+const c = await smartCompile({});
+console.log('compile:', JSON.stringify(c, null, 2));

--- a/scripts/us30_engulf_ema_alert.pine
+++ b/scripts/us30_engulf_ema_alert.pine
@@ -1,0 +1,50 @@
+//@version=5
+indicator("US30 Engulf + EMA Cross Alert", overlay=true, max_bars_back=500)
+
+// ─── Inputs ───────────────────────────────────────────────────────────────────
+ema_fast_len    = input.int(10,   "EMA Fast",            minval=1)
+ema_slow_len    = input.int(15,   "EMA Slow",            minval=1)
+vol_mult        = input.float(1.5, "Volume Spike Multiplier", minval=1.0, step=0.1)
+vol_lookback    = input.int(20,   "Volume Avg Lookback", minval=5)
+engulf_wick_pct = input.float(0.0, "Max Wick % of Body (0 = off)", minval=0.0, step=0.1)
+
+// ─── EMAs ─────────────────────────────────────────────────────────────────────
+ema_fast = ta.ema(close, ema_fast_len)
+ema_slow = ta.ema(close, ema_slow_len)
+
+plot(ema_fast, color=color.blue,   linewidth=1, title="EMA 10")
+plot(ema_slow, color=color.red,    linewidth=1, title="EMA 15")
+
+// ─── Volume Spike ─────────────────────────────────────────────────────────────
+avg_vol   = ta.sma(volume, vol_lookback)
+vol_spike = volume > avg_vol * vol_mult
+
+// ─── Engulfing Candles ────────────────────────────────────────────────────────
+// Bullish engulf: current candle opens below prior close, closes above prior open
+bull_engulf = close > open[1] and open < close[1] and close > open and open[1] > close[1]
+// Bearish engulf: current candle opens above prior close, closes below prior open
+bear_engulf = close < open[1] and open > close[1] and close < open and open[1] < close[1]
+
+// ─── EMA Cross ────────────────────────────────────────────────────────────────
+bull_cross = ta.crossover(ema_fast,  ema_slow)
+bear_cross = ta.crossunder(ema_fast, ema_slow)
+
+// ─── Signal: all three conditions within a 3-bar window ───────────────────────
+// Volume spike and engulfing on candle N, EMA cross on candle N or N+1 or N+2
+bull_setup = (vol_spike and bull_engulf) or (vol_spike[1] and bull_engulf[1]) or (vol_spike[2] and bull_engulf[2])
+bear_setup = (vol_spike and bear_engulf) or (vol_spike[1] and bear_engulf[1]) or (vol_spike[2] and bear_engulf[2])
+
+bull_signal = bull_cross and bull_setup
+bear_signal = bear_cross and bear_setup
+
+// ─── Plots ────────────────────────────────────────────────────────────────────
+plotshape(bull_signal, title="BUY Signal",  location=location.belowbar, style=shape.triangleup,   size=size.normal, color=color.lime,  text="BUY")
+plotshape(bear_signal, title="SELL Signal", location=location.abovebar, style=shape.triangledown, size=size.normal, color=color.red,   text="SELL")
+
+// ─── Background highlight on volume spike bars ────────────────────────────────
+bgcolor(vol_spike ? color.new(color.yellow, 90) : na, title="Volume Spike Bar")
+
+// ─── Alerts ───────────────────────────────────────────────────────────────────
+alertcondition(bull_signal, title="BUY  — Engulf + EMA Cross Up",   message="US30 BUY: Bullish engulfing candle + volume spike + EMA10 crossed above EMA15. Price: {{close}}")
+alertcondition(bear_signal, title="SELL — Engulf + EMA Cross Down",  message="US30 SELL: Bearish engulfing candle + volume spike + EMA10 crossed below EMA15. Price: {{close}}")
+alertcondition(bull_signal or bear_signal, title="ANY Signal — Engulf + EMA Cross", message="US30 Signal: {{ticker}} {{interval}} — Direction: {{plot_0 > plot_1 ? 'BUY' : 'SELL'}} at {{close}}")


### PR DESCRIPTION
## Summary

- Adds `scripts/us30_engulf_ema_alert.pine` â€” a bi-directional trade signal indicator for US30 (Dow Jones) on the 5-minute timeframe
- Adds `scripts/inject_pine.mjs` â€” helper script to load the Pine Script into TradingView via the CDP/MCP connection

## Strategy Logic

Fires a BUY or SELL alert when all three conditions align within a 3-bar window:

1. **Volume spike** â€” volume exceeds 1.5x the 20-bar average (highlights the bar in yellow)
2. **Engulfing candle** â€” bullish engulf for longs, bearish engulf for shorts
3. **EMA crossover** â€” EMA 10 crosses above EMA 15 (BUY) or below EMA 15 (SELL)

## Visuals

- Green triangle below bar = BUY signal
- Red triangle above bar = SELL signal
- Yellow background = volume spike bar
- EMA 10 (blue) and EMA 15 (red) plotted on chart

## Alerts

Three alertcondition entries are registered:
- BUY: Engulf + EMA Cross Up
- SELL: Engulf + EMA Cross Down
- ANY Signal: Engulf + EMA Cross

All include the close price in the alert message for immediate context.

## Tunable Inputs

| Input | Default | Purpose |
|-------|---------|---------|
| EMA Fast | 10 | Fast EMA length |
| EMA Slow | 15 | Slow EMA length |
| Volume Spike Multiplier | 1.5x | Raise to reduce signals, lower to catch more |
| Volume Avg Lookback | 20 | Bars used to calculate average volume |
| EMA cross window | 3 bars | How many bars after engulf the cross is still valid |
