### PR TITLE
fix(drawing): resolve getChartApi/evaluate scope in draw_list/get/remove/clear

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -8,7 +8,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
-import { drawShape } from '../src/core/drawing.js';
+import { drawShape, listDrawings, getProperties, removeOne, clearAll } from '../src/core/drawing.js';
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
 
@@ -281,6 +281,47 @@ describe('drawing.js — sanitized evaluate calls', () => {
     const call = evaluate.calls.find(c => c.includes('createMultipointShape'));
     assert.ok(call, 'createMultipointShape called');
     assert.ok(call.includes('"trend_line"'), 'shape name via safeString');
+  });
+});
+
+// ── drawing.js — chart API resolution via DI (regression: getChartApi/evaluate scope) ──
+
+describe('drawing.js — chart API resolution (DI scope regression)', () => {
+  it('listDrawings resolves chart API via injected deps', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const r = await listDrawings({ _deps });
+    assert.equal(r.success, true);
+    const call = evaluate.calls.find(c => c.includes('getAllShapes'));
+    assert.ok(call, 'getAllShapes evaluate call made');
+    assert.ok(call.includes('window.__api'), 'uses resolved apiPath from _deps');
+  });
+
+  it('getProperties resolves chart API via injected deps', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const r = await getProperties({ entity_id: 'abc123', _deps });
+    assert.equal(r.success, true);
+    const call = evaluate.calls.find(c => c.includes('getShapeById'));
+    assert.ok(call, 'getShapeById evaluate call made');
+    assert.ok(call.includes('window.__api'), 'uses resolved apiPath from _deps');
+    assert.ok(call.includes('"abc123"'), 'entity_id via safeString');
+  });
+
+  it('removeOne resolves chart API via injected deps', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const r = await removeOne({ entity_id: 'abc123', _deps });
+    assert.equal(r.success, true);
+    const call = evaluate.calls.find(c => c.includes('removeEntity'));
+    assert.ok(call, 'removeEntity evaluate call made');
+    assert.ok(call.includes('window.__api'), 'uses resolved apiPath from _deps');
+  });
+
+  it('clearAll resolves chart API via injected deps', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const r = await clearAll({ _deps });
+    assert.equal(r.success, true);
+    const call = evaluate.calls.find(c => c.includes('removeAllShapes'));
+    assert.ok(call, 'removeAllShapes evaluate call made');
+    assert.ok(call.includes('window.__api'), 'uses resolved apiPath');
   });
 });
 


### PR DESCRIPTION
## Summary

`listDrawings`, `getProperties`, `removeOne` and `clearAll` in `src/core/drawing.js` call bare `getChartApi()` / `evaluate()`, but those are imported from `connection.js` under the names `_getChartApi` / `_evaluate`. Only `drawShape` was wired through the `_resolve(_deps)` helper when DI was introduced (`f23eb1b`), so the other four throw **`ReferenceError: getChartApi is not defined`** at runtime — `draw_list`, `draw_get_properties`, `draw_remove_one` and `draw_clear` are all broken.

Fix: route all four through the same `_resolve(_deps)` helper as `drawShape`, so they share the chart-API resolver and become unit-testable via injected deps. Production tool wrappers (which pass no `_deps`) keep working via `_resolve` defaults — no behavior change for callers.

## Test plan

- [x] Added regression tests in `tests/sanitization.test.js` reproducing the `ReferenceError` for each of the four tools (fail before, pass after). `node --test tests/sanitization.test.js` → 70/70.
- [x] Verified live against a TradingView Desktop session over CDP: `tv draw list` now returns `{ "success": true, ... }` instead of `{ "success": false, "error": "getChartApi is not defined" }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
