### PR TITLE
Sync package-lock.json with tv bin entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {


### PR DESCRIPTION
## What changed

`package-lock.json` was missing the `bin` field for the `tv` CLI. This adds it so the lockfile matches `package.json`:

```json
"bin": {
  "tv": "src/cli/index.js"
}
```

## Why

`package.json` already declares the `tv` bin (committed in `9274ff3`), pointing at `src/cli/index.js` (which exists and is executable). The lockfile had drifted out of sync, so `npm install`/`npm ci` would keep regenerating this diff. Committing the regenerated lockfile keeps installs deterministic and clean.

## Notes for reviewer

- Lockfile-only change, 3 added lines — no source/dependency changes.
- Verified `package.json` bin entry and `src/cli/index.js` are both present.