### PR TITLE
feat: add Windows Store (Electron) desktop app support

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -90,9 +90,14 @@ export async function connect() {
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
+  const pages = targets.filter(t => t.type === 'page');
+  // Web app: prefer chart URL
+  return pages.find(t => /tradingview\.com\/chart/i.test(t.url))
+    || pages.find(t => /tradingview/i.test(t.url))
+    // Desktop Electron app: renderer window has rendererInitialData in URL
+    || pages.find(t => /rendererInitialData/i.test(t.url))
+    // Desktop Electron app fallback: any non-empty index.html page
+    || pages.find(t => /index\.html/i.test(t.url) && t.title)
     || null;
 }
 

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -2,7 +2,7 @@
  * Core health/discovery/launch logic.
  */
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 
 export async function healthCheck() {
@@ -173,6 +173,7 @@ export async function launch({ port, kill_existing } = {}) {
       `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
       `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
       `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      ...(() => { try { const b=`${process.env.PROGRAMFILES}\\WindowsApps`; return readdirSync(b).filter(d=>d.startsWith('TradingView.Desktop_')).map(d=>`${b}\\${d}\\TradingView.exe`); } catch { return []; } })(),
     ],
     linux: [
       '/opt/TradingView/tradingview',


### PR DESCRIPTION
## Summary

- **`connection.js`**: Extended `findChartTarget()` to match TradingView Desktop Electron renderer pages (identified by `rendererInitialData` in the URL, or `index.html` with a non-empty title), in addition to the existing `tradingview.com` web URL match. Filters to `type === 'page'` upfront to avoid redundant checks.
- **`core/health.js`**: Auto-discovers TradingView Desktop installed via the Microsoft Store (`Program Files\WindowsApps\TradingView.Desktop_*`) by scanning that directory at launch time, so `tv_launch` works without any manual path configuration on Windows Store installs.

## Why

The TradingView Desktop app distributed via the Microsoft Store is packaged as an Electron app (v38, Chrome 140) and loads its chart UI from local `index.html` files rather than `tradingview.com` URLs. The previous `findChartTarget()` logic only matched web-based targets, so the MCP server would silently fail to connect when users had the Store version installed. Similarly, `tv_launch` only searched three hardcoded Win32 paths and missed the versioned `WindowsApps` subdirectory entirely.

## Test plan

- [ ] Verified on Windows 11 with TradingView Desktop v3.2.0 (Microsoft Store install, `Electron/38.2.2`)
- [ ] CDP connects to the Electron renderer target via `rendererInitialData` URL match
- [ ] `tv_health_check` returns `cdp_connected: true`
- [ ] `tv_launch` auto-detects the Store install path without manual configuration
- [ ] Existing web app flow (tradingview.com in browser) unaffected — web URL matches still take priority

🤖 Generated with [Claude Code](https://claude.ai/claude-code)