### PR TITLE
Add NSE India trading rules configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,10 @@
+{
+  "market": "India (NSE)",
+  "strategy": "Swing/Positional",
+  "watchlist": ["NSE:NIFTY", "NSE:BANKNIFTY", "NSE:RELIANCE", "NSE:HDFCBANK", "NSE:ICICIBANK", "NSE:INFY", "NSE:TCS", "NSE:SBIN"],
+  "indicators": ["50 EMA", "200 EMA", "RSI", "VWAP"],
+  "rules": {
+    "bullish": "Price > 50 EMA AND RSI > 50",
+    "bearish": "Price < 50 EMA AND RSI < 45"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `rules.json` — a swing/positional trading configuration for Indian equity markets (NSE) covering 8 key instruments: NIFTY, BANKNIFTY, RELIANCE, HDFCBANK, ICICIBANK, INFY, TCS, SBIN
- Defines indicator stack: 50 EMA, 200 EMA, RSI, VWAP
- Defines bullish/bearish signal rules for use with the TradingView MCP tools
- Fixes `package-lock.json` to include the `bin.tv` entry that was present in `package.json` but missing from the lock file

## What a reviewer should know

`rules.json` is intended as a sample/starter configuration for the Indian equity market context. It shows how users can define their own watchlists, indicator stacks, and signal rules for the MCP to act on. The format is extensible — additional market segments or strategies can be added by following the same schema.

## Test plan

- [ ] `rules.json` is valid JSON (`node -e "require('./rules.json')"`)
- [ ] All symbols in the watchlist are valid NSE tickers on TradingView (NSE: prefix)
- [ ] `npm install` completes cleanly with updated lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)