### PR TITLE
Add rules.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/current.pine
 temp_*
 *.log
 discovery-log.json
+rules.json


### PR DESCRIPTION
## Summary

- Added rules.json to .gitignore to prevent personal crypto trading config from being tracked upstream

## Why

Personal trading config files (watchlists, risk rules, bias criteria) are user-specific and should not be committed to the shared repo.

## Reviewer notes

No code changes — .gitignore only. Safe to merge.