### PR TITLE
Detect Windows MSIX/Store TradingView install + add MCP config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Batch files must use CRLF or cmd.exe mangles them (eats the first char of
+# each line). Force it regardless of the user's core.autocrlf setting.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Shell scripts must stay LF so they run on Mac/Linux.
+*.sh text eol=lf

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "node",
+      "args": ["src/server.js"]
+    }
+  }
+}

--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -7,7 +7,8 @@ if "%PORT%"=="" set PORT=9222
 
 REM Kill existing TradingView instances
 taskkill /F /IM TradingView.exe >nul 2>&1
-timeout /t 2 /nobreak >nul
+REM ping-based delay (timeout fails when stdin is redirected, e.g. under PowerShell)
+ping -n 3 127.0.0.1 >nul
 
 REM Auto-detect TradingView install location
 set "TV_EXE="
@@ -17,9 +18,11 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
+REM Check MSIX / Windows Store installs.
+REM WindowsApps is access-protected, so `dir` listing fails — query the package
+REM directly via Get-AppxPackage instead.
 if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+    for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage *TradingView*).InstallLocation"`) do set "TV_EXE=%%i\TradingView.exe"
 )
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
@@ -27,7 +30,7 @@ if "%TV_EXE%"=="" (
 
 if "%TV_EXE%"=="" (
     echo Error: TradingView not found.
-    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps
+    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps ^(MSIX^)
     echo.
     echo If installed elsewhere, run manually:
     echo   "C:\path\to\TradingView.exe" --remote-debugging-port=%PORT%
@@ -39,13 +42,13 @@ echo Starting with --remote-debugging-port=%PORT%...
 start "" "%TV_EXE%" --remote-debugging-port=%PORT%
 
 echo Waiting for CDP to become available...
-timeout /t 5 /nobreak >nul
+ping -n 6 127.0.0.1 >nul
 
 :check
 curl -s http://localhost:%PORT%/json/version >nul 2>&1
 if %errorlevel% neq 0 (
     echo Still waiting...
-    timeout /t 2 /nobreak >nul
+    ping -n 3 127.0.0.1 >nul
     goto check
 )
 

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -197,6 +197,21 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  // Windows Store (MSIX) install: lives under the access-protected WindowsApps
+  // folder, so existsSync/where can't see it. Query the package directly.
+  if (!tvPath && platform === 'win32') {
+    try {
+      const loc = execSync(
+        'powershell -NoProfile -Command "(Get-AppxPackage *TradingView*).InstallLocation"',
+        { timeout: 8000 }
+      ).toString().trim().split('\n')[0].trim();
+      if (loc) {
+        // Don't existsSync() — WindowsApps blocks attribute reads but allows execute.
+        tvPath = `${loc}\\TradingView.exe`;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath && platform === 'darwin') {
     try {
       const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();


### PR DESCRIPTION
## Summary

On Windows, the Microsoft Store (MSIX) build of TradingView installs into the access-protected `WindowsApps` folder. `existsSync`, `where TradingView.exe`, and `dir /s /b` all fail to find it there, so `tv_launch` and the launch script report "TradingView not found" even when it's installed. This adds MSIX detection via `Get-AppxPackage`.

## Changes

- **`src/core/health.js`** — `launch()` gains a win32 fallback that queries `Get-AppxPackage *TradingView*` for the real `InstallLocation` and appends `TradingView.exe`. It deliberately skips `existsSync()` on the result: `WindowsApps` blocks attribute reads but still permits execute, so the file is launchable even though it appears "missing."
- **`scripts/launch_tv_debug.bat`** — same `Get-AppxPackage` MSIX detection, and replaces every `timeout /t` with `ping -n` delays. `timeout` aborts with *"Input redirection is not supported"* when stdin is redirected (e.g. when the script is invoked from PowerShell), which broke the script outright.
- **`.mcp.json`** — registers the stdio `tradingview` MCP server (`node src/server.js`) so the tools load without manual MCP setup.

## Testing

- Verified `Get-AppxPackage` resolves the install to `C:\Program Files\WindowsApps\TradingView.Desktop_3.2.0.7916_x64__n534cwy3pjxzj\TradingView.exe` on a Store install, and launching that exe with `--remote-debugging-port=9222` brings CDP up.
- Smoke-tested the MCP server stdio `initialize` handshake — boots and advertises 78 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)