### PR TITLE
fix: include replay and sanitization tests in npm test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "tv": "node src/cli/index.js",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Summary

- `replay.test.js` and `sanitization.test.js` existed in `tests/` but were not listed in any `package.json` test script, so they were silently skipped by `npm test` and `npm run test:all`
- Adds both files to `test:unit` and `test:all` scripts (105 additional offline tests now run)
- Fixes a Windows path bug in `sanitization.test.js`: `new URL(...).pathname` produces an invalid path on Windows; replaced with `fileURLToPath()` from `node:url`

## Test plan

- [ ] `npm run test:unit` passes (includes sanitization + replay)
- [ ] `npm run test:all` passes
- [ ] Verified locally: 66/66 sanitization tests pass, 39/39 replay tests pass

Generated with [Claude Code](https://claude.com/claude-code)