### PR TITLE
Fix undefined refs in drawing.js and add MSIX detection to tv_launch

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -45,8 +45,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
 }
 
 export async function listDrawings() {
-  const apiPath = await getChartApi();
-  const shapes = await evaluate(`
+  const apiPath = await _getChartApi();
+  const shapes = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var all = api.getAllShapes();
@@ -57,8 +57,8 @@ export async function listDrawings() {
 }
 
 export async function getProperties({ entity_id }) {
-  const apiPath = await getChartApi();
-  const result = await evaluate(`
+  const apiPath = await _getChartApi();
+  const result = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -86,8 +86,8 @@ export async function getProperties({ entity_id }) {
 }
 
 export async function removeOne({ entity_id }) {
-  const apiPath = await getChartApi();
-  const result = await evaluate(`
+  const apiPath = await _getChartApi();
+  const result = await _evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -107,7 +107,7 @@ export async function removeOne({ entity_id }) {
 }
 
 export async function clearAll() {
-  const apiPath = await getChartApi();
-  await evaluate(`${apiPath}.removeAllShapes()`);
+  const apiPath = await _getChartApi();
+  await _evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };
 }

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -4,6 +4,7 @@
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
 import { existsSync } from 'fs';
 import { execSync, spawn } from 'child_process';
+import { join } from 'path';
 
 export async function healthCheck() {
   await getClient();
@@ -187,6 +188,17 @@ export async function launch({ port, kill_existing } = {}) {
   const candidates = pathMap[platform] || pathMap.linux;
   for (const p of candidates) {
     if (p && existsSync(p)) { tvPath = p; break; }
+  }
+
+  if (!tvPath && platform === 'win32') {
+    try {
+      const psCmd = "(Get-AppxPackage -Name '*TradingView*').InstallLocation";
+      const installLocation = execSync(`powershell -NoProfile -Command "${psCmd}"`, { timeout: 5000 }).toString().trim();
+      if (installLocation) {
+        const candidate = join(installLocation, 'TradingView.exe');
+        if (existsSync(candidate)) tvPath = candidate;
+      }
+    } catch { /* ignore - MSIX package not found */ }
   }
 
   if (!tvPath) {


### PR DESCRIPTION
## Summary

- `drawing.js` imported the connection helpers as `_getChartApi`/`_evaluate`, but `listDrawings`, `getProperties`, `removeOne`, and `clearAll` called the bare (undefined) names. This threw `ReferenceError: getChartApi is not defined` at runtime, breaking the `draw_list`, `draw_clear`, `draw_remove_one`, and `get_properties` MCP tools entirely. Only `drawShape` (which used the `_resolve(deps)` helper correctly) worked.
- `tv_launch`'s Windows auto-detection only checked a few hardcoded standalone install paths, so it couldn't find TradingView Desktop installed via the Microsoft Store (MSIX). The MSIX binary lives under a per-package `WindowsApps` folder that isn't directly listable (`readdirSync` throws `EPERM`). Added a fallback that resolves the install location via `Get-AppxPackage -Name '*TradingView*'`.

## Test plan

- [x] Reproduced the `ReferenceError` on `draw_list`/`draw_clear`/`draw_remove_one` before the fix.
- [x] After the fix: confirmed `draw_list` correctly lists existing shapes, `draw_clear` removes them, and new `draw_shape` + `draw_list` round-trips correctly (verified end-to-end on a live TradingView Desktop session via CDP).
- [x] Confirmed `tv_launch` successfully auto-detects and launches the MSIX/Store install on Windows, returning a valid PID and CDP port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)