### PR TITLE
fix: correct tool count in CLAUDE.md (68 -> 78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+78 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 


### PR DESCRIPTION
## Summary

- CLAUDE.md stated 68 tools but the actual count of registered MCP tools in src/tools/ is 78, matching the README.
- This fixes the inconsistency so both files agree on the correct number.

## Test plan

- Grep tool names in src/tools/*.js, count matches 78
- README.md already says 78, now CLAUDE.md agrees

Generated with Claude Code