### PR TITLE
fix: prevent infinite loop in Windows launch script when CDP fails

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -41,9 +41,16 @@ start "" "%TV_EXE%" --remote-debugging-port=%PORT%
 echo Waiting for CDP to become available...
 timeout /t 5 /nobreak >nul
 
+set RETRIES=0
 :check
 curl -s http://localhost:%PORT%/json/version >nul 2>&1
 if %errorlevel% neq 0 (
+    set /a RETRIES+=1
+    if %RETRIES% geq 15 (
+        echo.
+        echo Warning: CDP not responding after 15 attempts. TradingView may still be loading.
+        exit /b 1
+    )
     echo Still waiting...
     timeout /t 2 /nobreak >nul
     goto check


### PR DESCRIPTION
## Problem
scripts/launch_tv_debug.bat waits in an unbounded loop for TradingView's CDP endpoint to become available. If TradingView fails to start (or starts without remote debugging), the script hangs forever.

The Linux and Mac equivalents (launch_tv_debug_linux.sh, launch_tv_debug_mac.sh) already cap this wait at 15 attempts and print a warning instead of hanging.

## Fix
Add a retry counter to the Windows script that gives up after 15 attempts (~30s), matching the behavior of the other platform scripts, and exits with a clear warning instead of looping forever.

## Testing
Verified the script still launches and detects CDP normally when TradingView starts successfully; the new retry-limit branch is a straightforward port of the existing Linux/Mac logic.