### PR TITLE
fix: update tool count from 68 to 78 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+78 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 


### PR DESCRIPTION
## Summary

- CLAUDE.md header stated "68 tools" but the actual count is 78
- Verified by counting `server.tool()` calls across all files in `src/tools/` (78 total)
- README.md already had the correct count of 78

## Test plan

- [ ] Verify tool count: count `server.tool(` calls in `src/tools/` directory — should return 78
