### PR TITLE
Fix Windows launch script for MSIX/Store TradingView installs

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -1,55 +1,75 @@
 @echo off
+setlocal enabledelayedexpansion
 REM Launch TradingView Desktop on Windows with Chrome DevTools Protocol enabled
+REM Handles both classic installs and Windows Store / MSIX installs.
 REM Usage: scripts\launch_tv_debug.bat [port]
 
 set PORT=%1
 if "%PORT%"=="" set PORT=9222
 
-REM Kill existing TradingView instances
-taskkill /F /IM TradingView.exe >nul 2>&1
-timeout /t 2 /nobreak >nul
-
 REM Auto-detect TradingView install location
 set "TV_EXE="
 
-REM Check common install locations
+REM 1. Check common classic install locations
 if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
+REM 2. MSIX / Windows Store install -- query AppX (dir on WindowsApps is access-denied)
 if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+    for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$p=Get-AppxPackage -Name '*TradingView*'; if($p){Join-Path $p[0].InstallLocation 'TradingView.exe'}"`) do set "TV_EXE=%%i"
 )
+
+REM 3. Last resort: PATH lookup
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
 )
 
 if "%TV_EXE%"=="" (
     echo Error: TradingView not found.
-    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps
+    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps ^(MSIX^), PATH
     echo.
     echo If installed elsewhere, run manually:
     echo   "C:\path\to\TradingView.exe" --remote-debugging-port=%PORT%
     exit /b 1
 )
 
-echo Found TradingView at: %TV_EXE%
-echo Starting with --remote-debugging-port=%PORT%...
-start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+echo Found TradingView at: !TV_EXE!
 
-echo Waiting for CDP to become available...
-timeout /t 5 /nobreak >nul
+REM MSIX apps can respawn themselves without the debug flag on first launch,
+REM so retry the kill-then-launch cycle until CDP actually binds the port.
+set MAX_ATTEMPTS=3
+for /l %%a in (1,1,%MAX_ATTEMPTS%) do (
+    echo.
+    echo Attempt %%a of %MAX_ATTEMPTS%: killing existing instances...
+    taskkill /F /IM TradingView.exe >nul 2>&1
+    REM ping instead of timeout: timeout fails under redirected stdin
+    ping -n 4 127.0.0.1 >nul
 
-:check
-curl -s http://localhost:%PORT%/json/version >nul 2>&1
-if %errorlevel% neq 0 (
-    echo Still waiting...
-    timeout /t 2 /nobreak >nul
-    goto check
+    echo Starting with --remote-debugging-port=%PORT%...
+    start "" "!TV_EXE!" --remote-debugging-port=%PORT%
+
+    echo Waiting for CDP on port %PORT% ...
+    set "CDP_UP="
+    for /l %%w in (1,1,10) do (
+        ping -n 3 127.0.0.1 >nul
+        curl -s http://localhost:%PORT%/json/version >nul 2>&1
+        if !errorlevel! equ 0 (
+            set "CDP_UP=1"
+            goto :ready
+        )
+    )
+    echo CDP did not come up on attempt %%a, retrying...
 )
 
+echo.
+echo Error: CDP never became available on port %PORT% after %MAX_ATTEMPTS% attempts.
+echo TradingView may have respawned without the debug flag. Try running this script again.
+exit /b 1
+
+:ready
 echo.
 echo CDP ready at http://localhost:%PORT%
 curl -s http://localhost:%PORT%/json/version
 echo.
+endlocal


### PR DESCRIPTION
## What

Fixes `scripts/launch_tv_debug.bat` so it works with TradingView Desktop installed as a **Windows Store / MSIX package** (e.g. `TradingView.Desktop` under `C:\Program Files\WindowsApps\...`).

## Why

On an MSIX install the existing script failed in three ways:

1. **Detection failed.** It located the exe via `dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe"`, but `WindowsApps` is access-denied without elevation, so the lookup returned nothing and the script reported "TradingView not found."
2. **CDP would silently drop.** MSIX apps re-activate themselves on first launch and respawn child processes *without* the original `--remote-debugging-port` flag, leaving TradingView running but with no CDP port — so `tv_health_check` reported `cdp_connected: false` even though TradingView was open.
3. **Waits were skipped under redirected stdin.** `timeout /t` errors out with "Input redirection is not supported" when the script is invoked non-interactively, so the wait/poll loops returned immediately.

## Changes

- **MSIX detection** via `Get-AppxPackage` (resolves the real install path regardless of version), added as a fallback after the classic install-location checks. Written pipe-free because `^|` breaks inside a cmd backtick `for` loop.
- **Kill-then-relaunch retry loop** (up to 3 attempts, each polling the CDP port for ~20s) so the respawn race self-heals instead of leaving a flagless instance.
- **`timeout /t` -> `ping -n`** for waits, which works under redirected stdin.

## Testing

Verified end-to-end on a real `TradingView.Desktop` MSIX install (v3.2.0.7916): detection -> launch -> `curl http://localhost:9222/json/version` returns the CDP version, and the MCP `tv_health_check` tool then reports `cdp_connected: true`.

## Notes for reviewers

- Classic (non-MSIX) install paths are unchanged and still checked first, so existing setups are unaffected.
- Detection is dynamic, so it survives TradingView auto-updates (the versioned WindowsApps path is not hardcoded).
