### PR TITLE
Fix ReferenceError in scrollToDate, getVisibleRange, and symbolInfo

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -116,7 +116,7 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
 }
 
 export async function getVisibleRange() {
-  const result = await evaluate(`
+  const result = await _evaluate(`
     (function() {
       var chart = ${CHART_API};
       return { visible_range: chart.getVisibleRange(), bars_range: chart.getVisibleBarsRange() };
@@ -163,7 +163,7 @@ export async function scrollToDate({ date }) {
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
   if (isNaN(timestamp)) throw new Error(`Could not parse date: ${date}. Use ISO format (2024-01-15) or unix timestamp.`);
 
-  const resolution = await evaluate(`${CHART_API}.resolution()`);
+  const resolution = await _evaluate(`${CHART_API}.resolution()`);
   let secsPerBar = 60;
   const res = String(resolution);
   if (res === 'D' || res === '1D') secsPerBar = 86400;
@@ -175,7 +175,7 @@ export async function scrollToDate({ date }) {
   const from = timestamp - halfWindow;
   const to = timestamp + halfWindow;
 
-  await evaluate(`
+  await _evaluate(`
     (function() {
       var chart = ${CHART_API};
       var m = chart._chartWidget.model();
@@ -197,7 +197,7 @@ export async function scrollToDate({ date }) {
 }
 
 export async function symbolInfo() {
-  const result = await evaluate(`
+  const result = await _evaluate(`
     (function() {
       var chart = ${CHART_API};
       var info = chart.symbolExt();


### PR DESCRIPTION
These three functions called bare `evaluate` which is not in scope -- only `_evaluate` (the named import alias) is defined at module level. Caused a ReferenceError at runtime for any call to these tools.