### PR TITLE
Fix quote_get symbol handling + add watchlist files

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -2,6 +2,7 @@
  * Core data access logic.
  */
 import { evaluate, evaluateAsync, KNOWN_PATHS, safeString } from '../connection.js';
+import { setSymbol } from './chart.js';
 
 const MAX_OHLCV_BARS = 500;
 const MAX_TRADES = 20;
@@ -243,6 +244,20 @@ export async function getEquity() {
 }
 
 export async function getQuote({ symbol } = {}) {
+  // The quote is read from the ACTIVE chart's bars. If a specific symbol is
+  // requested we must switch the chart to it first — previously the `symbol`
+  // arg was used only as a label, so passing a symbol returned the currently
+  // loaded chart's data mislabeled as the requested symbol.
+  if (symbol) {
+    let current = '';
+    try {
+      current = await evaluate(`(function(){ try { return ${CHART_API}.symbol(); } catch(e){ return ''; } })()`);
+    } catch (e) { /* fall through and just switch */ }
+    const norm = (s) => String(s == null ? '' : s).split(':').pop().trim().toUpperCase();
+    if (norm(current) !== norm(symbol)) {
+      await setSymbol({ symbol });
+    }
+  }
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};

--- a/watchlists/hq-swing-analysis.md
+++ b/watchlists/hq-swing-analysis.md
@@ -1,0 +1,164 @@
+# HQ Swing — Full Analysis (Steps 2–4) — 2026-06-23
+
+**Scope:** All 95 HQ Swing names. Steps 2–4 of the analysis standard:
+- **Step 2 — Catalysts & calendar:** next earnings date + macro events.
+- **Step 3 — Fundamentals/sentiment:** analyst activity, short interest, valuation (verified outlets only).
+- **Step 4 — Levels:** regime (price vs 200d SMA + ADX-14), 50d MA pullback support, 200d trend pivot. For the 9 cleanest PASS entries, precise breakout/pullback lines are drawn on the charts.
+
+**Sourcing:** Prices/levels = live TradingView feed (snapshot 2026-06-23). Catalysts/fundamentals = verified outlets (Reuters/Bloomberg/CNBC/WSJ/company IR/exchange). Earnings dates are aggregator **estimates** unless flagged CONFIRMED — re-verify vs company IR before trading a print.
+
+> ⭐ **Open position:** Omar is **long CAT** — PASS (extended): px 984.24 vs 200d 676 (+46%), ADX 26, Chandelier long-stop **925.55** (trail stop). Next earnings **~Aug 4**. Trend intact; manage with the 925 Chandelier.
+
+---
+
+## MACRO CALENDAR (Jun 23 – ~Jul 31 2026)
+| Date | Event |
+|------|-------|
+| **Jun 24 (Wed)** | Fed bank **stress-test results** ~4pm (→ BAC, GS, BLK, BX). **MU earnings 4:30pm.** QCOM Investor Day. |
+| **Jun 25 (Thu)** | **PCE** (May) 8:30 — Fed's preferred inflation gauge |
+| Jun 30 (Tue) | JOLTS + Consumer Confidence |
+| **Jul 2 (Thu)** | **Jobs report / NFP** (June) 8:30 (pre-holiday) |
+| Jul 8 (Wed) | FOMC Minutes |
+| **Jul 14 (Tue)** | **CPI** (June) + Q2 earnings season opens (JPM, banks) |
+| Jul 15 (Wed) | PPI (June) |
+| Jul 16 (Thu) | Retail Sales (June) |
+| **Jul 29 (Wed)** | **FOMC decision** 2pm + Powell presser |
+| Jul 30 (Thu) | Q2 GDP advance |
+
+**Earnings clustering for this list:** mid-July banks (BAC ~Jul 14, GS ~mid-Jul, IBKR Jul 21, BLK ~mid-Jul); the **Jul 27–30 megacluster** (NUE Jul 27, CDNS ~Jul 27, MU Jun 24, then GE Jul 16; AAPL/AMZN/META/CMG/FIX/HWM/MCD ~Jul 29–30). Many PASS names report late July — size positions around the prints.
+
+---
+
+## ✅ PASS — regime-aligned longs (23)
+*Price > 200d SMA + ADX≥~20 + uptrend confirmed (Chandelier long / +momentum). Levels: 🟢=breakout, 🔴=pullback support, pivot=200d.*
+
+| Ticker | Px / 200d / ADX | Levels (🟢 breakout / 🔴 pullback) | Earnings | Catalyst + sentiment |
+|--------|-----------------|-----------------------------------|----------|----------------------|
+| **BAC** | 57.91 / 52.27 / 33.6 | 🟢58.10 🔴54.40 *(lines drawn)* | ~Jul 14 | **Fed stress test Jun 24.** Buy, avg ~$61. Fwd P/E ~11–12.5x. |
+| **GS** | 1094 / 880 / 30.2 | 🟢~1104 (20d hi) 🔴 50d≈982 | ~mid-Jul | Stress test Jun 24; $4.50 div Jun 29. JPM PT $900. Fwd P/E ~15x. |
+| **IBKR** | 94.70 / 72.36 / 19.4 | 🟢97.90 🔴87.30 *(lines drawn)* | **Jul 21 CONF** | May metrics: DARTs +47%, client equity +49%. Buy, ~$88. Fwd P/E ~37x. |
+| **CAT** ⭐ | 984 / 676 / 26.4 | 🔴 Chandelier 925.55 (trail) | ~Aug 4 | +46% over 200d. Div +8% (Jun 10). MS upgrade EW $915. ~39x fwd (rich). |
+| **GE** | 356 / 306 / 33.3 | 🔴 Chandelier 327 / 50d≈310 | **Jul 16 CONF** | Paris Air Show order book; RISE open-fan. Strong Buy avg ~$350. ~37x fwd. |
+| **MAR** | 387 / 320 / 26.2 | 🔴 Chandelier 376 / 50d≈372 | ~Aug 4 | Q1 beat, strong summer travel. Mod-Buy ~$383. ~28–30x fwd. SI ~3.2%. |
+| **LLY** | 1107 / 970 / 31.0 | 🔴 Chandelier 1060 / 50d≈1017 | **Aug 5 CONF** | ADA (Jun 5–8): retatrutide ~28% wt loss, oral orforglipron beat. 52wk hi. Buy ~$1,230. ~29x. |
+| **HWM** | 275 / 224 / 23.2 | 🟢290.75 🔴257.30 *(lines drawn)* | ~Jul 30 | Raised FY26 rev guide. JPM PT $310 (Jun 22). ~55x fwd (premium). |
+| **PH** | 948 / 877 / 27.4 | 🟢965 🔴907 *(lines drawn)* | ~Aug 6 | None last 2wk; raised FY26 in Jan. Buy ~$956. ~26x fwd. SI ~1.1%. |
+| **APH** | 159 / 137 / 29.9 | 🔴 Chandelier 147 / 50d≈144 | ~Jul 29 | AI/datacom; $10.5B CommScope conn. acq; defense +44%. Strong Buy. ~29–34x. |
+| **BALL** | 60.49 / 55.46 / 29.8 | 🔴 Chandelier 56 / 50d≈58 | ~early Aug | Q1 beat +16% rev; buybacks. Buy. Fwd P/E ~15.7x. SI low. |
+| **BWXT** | 210 / 197 / 27.8 | 🔴 Chandelier 186 / 50d≈207 | ~Aug 3 | ATI naval-nuclear deal; mPower SMR license. DB/Seaport upgrades. ~43x (rich). |
+| **CDNS** | 379 / 327 / 22.4 | 🟢416.70 🔴372.40 *(lines drawn)* | ~Jul 27 | Intel partnership; AI EDA roadmap. Stifel $432. Strong-Buy. |
+| **NTAP** | 158 / 115 / 43.5 | 🟢165 🔴152 *(lines drawn)* | ~Aug 26 | Record FY26; PT hikes (Cowen $200). SI ~10.9% (elevated). Fwd P/E ~14x. |
+| **WST** | 336 / 272 / 19.5 | 🟢337 🔴311 *(lines drawn)* | ~late Jul | CEO transition (Aug 31); raised 2026 + $1B buyback. Strong Buy ~$359. ~35–43x. |
+| **TLN** | 412 / 372 / 20.1 | 🟢449.85 🔴377.40 *(lines drawn)* | ~early Aug | Closed ECP PJM gas assets (Jun 15); AWS 1.9GW nuclear PPA. Median ~$445. **Overhang:** PJM monitor urged FERC reject. |
+| **URI** | 1063 / 886 / 45 | 🟢1106.90 🔴1002 *(lines drawn)* | ~Jul 22 | RJ PT $1,275, UBS $1,145. SI low ~2.2%. ~21–22x fwd (premium). |
+| **NUE** | 240 / 178 / 35.8 | 🔴 50d≈232 ⚠️ Chandelier **SELL** flip | **Jul 27 CONF** | Strong Q2 guide $4.70–4.80 (Helion gain). BMO PT $250. Fwd P/E ~13.7x. *Near-term pullback signal.* |
+| **STRL** | 892 / 456 / 25.2 | 🔴 50d≈728 (deep) | ~Aug 3–10 | +96% over 200d. Data-center/chip-plant pivot (~90% of $3.8B backlog). KeyBanc $922. ~50–58x (rich). |
+| **AMD** | 520 / 265 / 26.7 | 🔴 Chandelier 463 / 50d≈423 | ~Aug 4 | +96% over 200d. Upgrade cluster (Citi $575, Goldman→Buy $450); MEXT/Rackspace deals. Offset: M Science Q2 GPU warning (-7% Jun 17). ~62x fwd. |
+| **MU** | 1052 / 406 / 26.8 | 🔴 50d≈761 (deep) | **🚨 Jun 24 (TMRW) CONF 4:30pm** | +159% over 200d. PTs slashed UP (Needham $1,550, UBS $1,625); shorts leaning in. Fwd P/E ~11–13x. **Binary tonight.** |
+| **DELL** | 428 / 175 / 46 | 🔴 50d≈292 (deep) | Sep 3 CONF | +144% over 200d. Q1 blowout (AI servers $16.1B, backlog $51.3B). PT wave to $475–550. ~22x fwd. |
+| **STX** | 1039 / 426 / 40 | 🔴 50d≈783 (deep) | ~Jul 16 | +144% over 200d. HAMR/Mozaic ramp. MS Top Pick PT $1,035. ~39–43x (elevated). |
+
+> **Cleanest fresh entries (not extended):** BAC, GS, IBKR, GE, MAR, HWM, PH, APH, BALL, BWXT, CDNS, WST, TLN, URI.
+> **Extended (manage as momentum, don't initiate):** MU (ER tonight!), DELL, STX, AMD, CAT, STRL — all +45% to +159% over their 200d.
+> **Caution:** NUE Chandelier just flipped SELL (pullback); AMD took a GPU-warning hit.
+
+---
+
+## ⚠️ MARGINAL — above 200d but ADX<20 or momentum rolling over (26)
+
+| Ticker | Px / 200d / ADX | Earnings | Note |
+|--------|-----------------|----------|------|
+| **AAPL** | 294 / 269 / 24.4 | ~Jul 30 | Above 200d but Chandelier short, ROC −3.5, lagging SPX. WWDC (Jun 8) Siri delay → ~-$25. PT raises to $350–360 + 1 downgrade. ~30–33x. |
+| **AMZN** | 234 / 233 / 34.7 | ~Jul 30 | Right AT 200d, ADX strong but momentum negative (ROC −12.8, below 50d). Strong Buy ~$313. ~27x fwd. |
+| **NVDA** | 200 / 190 / 13.7 | **Aug 26 CONF** | +5% over 200d, ADX weak, below 50d. Strong Buy targets $250–300. ~21–22x fwd. SI ~1.2%. |
+| **QCOM** | 204 / 167 / 22.6 | ~Aug 5 | Above 200d + ADX ok but Chandelier short, ROC −4. **Investor Day Jun 24** (data-center silicon). WF $230, JPM $265. ~22.7x. |
+| **VRT** | 318 / 225 / 14.5 | ~Jul 29 | +41% over 200d but ADX weak, pulled to 50d. Strong Buy ~$377. ~50–54x (very rich). |
+| **FIX** | 1908 / 1260 / 14.2 | **Jul 29 CONF** | +51% over 200d but ADX weak. Backlog $12.45B. UBS PT $2,125. ~43–47x. |
+| **POWL** | 292 / 170 / 16.5 | ~Aug 4 | +71% over 200d, ADX weak. Record $1.8B backlog (>$400M AI DC order). SI ~9.5% on ~12M float — squeeze setup. ~30x. |
+| **DE** | 592 / 529 / 17.2 | ~Aug 13–14 | +12%, ADX weak. Soft ag demand; PT cuts (DA Davidson $685). ~30–34x. |
+| **MPC** | 249 / 208 / 17.7 | **Aug 4 CONF** | +19.5%, ADX weak. Refining-margin rally +51–60% YTD. June PT raises (WF $344). ~7–15x. |
+| **FTAI** | 262 / 222 / 15.5 | ~Jul 28 | +18%, ADX weak. Div hike; Aero +70% EBITDA. Jefferies $400. SI ~5.4%. ~37x. |
+| **MLI** | 136 / 117 / 18.2 | ~Jul 21 | +16%, ADX weak. Record Q1; Northcoast cut to Neutral. ~16x fwd. |
+| **TT** | 474 / 431 / 12.0 | ~Jul 29 | +10%, ADX weak. AI DC cooling (LiquidStack/Stellar); backlog $10.7B. Buy ~$517. ~29–31x. |
+| **TPR** | 151 / 130 / 14.3 | Aug 13 | +15%, ADX weak. Coach strength; ~$1.6B return. UBS Buy $187, JPM $200. ~20.6x. SI ~5.9%. |
+| **ABBV** | 235 / 221 / 17.5 | ~Jul 24–30 | +6%, ADX weak (but ROC +9, above 50d). Apogee $10.9B acq. Buy ~$252. ~15x fwd. |
+| **EME** | 839 / 728 / 18.6 | ~Jul 23–30 | +15%, ADX weak, below 50d. Data-center cooling; FY26 raised $18.5–19.25B. UBS $945, Oppy $1,100. ~26–28x. |
+| **NET** | 225 / 208 / 14.6 | ~Jul 30 | +8%, ADX weak, Chandelier short. VoidZero acq; raised guide. MS $305. No P/E (P/S name). |
+| **BKR** | 58.68 / 55.22 / 22.8 | **Jul 21** | +6% but Chandelier short, rolling over. LNG/IET momentum; Chart acq mid-26. Citi PT $74. ~28.7x. |
+| **DHI** | 156 / 152 / 22.6 | **Jul 21 CONF** | +2.4% (fresh, just above 200d). WF/Citizens downgrades. ~13.5x fwd. |
+| **ALGN** | 168 / 160 / 13.0 | ~Jul 29 | +5%, ADX weak. **Elliott activist stake** (Mar). SI ~5.2%. ~14.4x fwd. |
+| **GRMN** | 236 / 229 / 11.9 | **Aug 5 CONF** | +3%, ADX weak, Chandelier short. Record Q1. Hold ~$256. ~25x. SI low. |
+| **TDY** | 613 / 589 / 8.6 | **Jul 22** | +4%, ADX dead. Defense-imaging/space launches. Jefferies $775. ~25–32x. |
+| **PGR** | 216 / 214 / 22.6 | **Jul 15** | +0.6% (fresh reclaim). May NPW +6%, NI +36%, CR 82.1. PTs trimmed. ~12–13x fwd. |
+| **COKE** | 183 / 164 / 12.7 | ~Jul 29 | +11.5%, ADX dead. Aluminum cost + leverage. Thin Hold coverage. ~20–26x trailing. |
+| **COST** | 958 / 958 / 15.5 | Sep 24 CONF | Right AT 200d, Chandelier short, ROC −8.8. Citi Neutral, Bernstein/Evercore Buy. ~45–47x (premium). |
+| **ACGL** | 93.71 / 93.39 / 16.0 | ~Jul 28 | AT 200d, fresh Chandelier BUY but ADX weak. $2B notes (Jun 2). Hold-to-Mod-Buy ~$109. |
+| **RKLB** | 95 / 74 / 25.9 | ~Aug 6 | +28% but ROC −24, Chandelier short (space selloff). Nasdaq-100 add. Unprofitable. SI ~4.4%. *Also in Sector Themes.* |
+
+---
+
+## ❌ FAIL — below 200d SMA (no long setup; watch for 200d reclaim) (46)
+
+**With live levels (2026-06-23):**
+| Ticker | Px vs 200d | Earnings | Note |
+|--------|-----------|----------|------|
+| **META** | 562 < 654 | ~Jul 29 | Capex raised $125–145B. Buy ~$825. ~17x fwd. |
+| **TSLA** | 382 < 417 | **Jul 22 CONF** | Robotaxi narrative; NHTSA door-handle probe. Hold ~$395. ~186x (extreme). |
+| **AMT** | 179 < 182 | ~Jul 28 | Just below 200d. Bernstein Outperform $207. ~17x fwd. |
+| **AXON** | 433 < 543 | ~Aug 3 | -20% under 200d. Echodyne radar partnership. Strong Buy ~$671. ~51x. |
+| **BLK** | 1015 < 1069 | ~mid-Jul | Capped redemptions on 2 private-credit funds (Jun 12). Bought ~$5B SpaceX. ~19.3x. |
+| **CEG** | 270 < 319 | ~Aug 6 | Jun 1 secondary $281. Buy. ~23x. *Also in Sector Themes.* |
+| **EFX** | 153 < 203 | **Jul 21 CONF** | Credit Lock launch. WF cut $220, UBS $215. ~17.5–19.5x. |
+| **LDOS** | 106 < 171 | ~Aug 4 | -38% under 200d. **Losing MHS EHR lead-integrator role** (-12%); 2 downgrades. ~8.6x. |
+| **LEN** | 87 < 109 | ~Sep 17 | Q2 (Jun 11) margin compression; soft guide. Consensus **Sell**. ~14.5x. |
+| **MCD** | 272 < 305 | ~Jul 29 | "NEXT" strategy; insider sales. Buy ~$345. ~21.5x. |
+| **MSI** | 389 < 423 | ~Aug 6 | D-Fend $1.5B counter-drone acq. -11% post-Q1 (tariff/memory). Strong Buy ~$500. ~24–27x. |
+| **RACE** | 345 < 377 | **Jul 30 CONF** | New CMCO Jul 1; €250M buyback. MS Overweight $438. ~31–32x. |
+| **ROP** | 330 < 405 | ~late Jul | Q1 beat, raised guide. Buy ~$454. Premium compounder. SI ~3.9%. |
+| **RSG** | 209 < 216 | **Jul 28** | Just below 200d. Goldman/Stifel Buy ~$248. ~28x. SI very low. |
+| **SE** | 92 < 123 | ~Aug 18 | Q1 rev +47%, Shopee GMV +30%. SI ~6%. ~21.7x fwd. |
+| **SHW** | 323 < 335 | ~Jul 21–28 | "Softer-for-longer" demand. UBS downgrade→Neutral $330. ~29x. |
+| **TPL** | 370 < 372 | ~Aug 5 | Just below 200d. Chevron data-center water/land deal. SI ~6%. ~42–44x (rich). |
+| **TYL** | 279 < 407 | ~Jul 29 | -31% under 200d. Investor Day Jun 9 (AI). Buy ~$540. SI 6.3%. ~28x. |
+| **VRSK** | 175 < 208 | ~Jul 29 | **Removed from Nasdaq-100 (Jun 22).** Hurricane model. SI 6.4%. ~24x. |
+| **VRSN** | 247 < 259 | ~late Jul | .com fee hike Nov 1. -20% past month. JPM $308. ~27.8x. |
+| **VST** | 162 < 170 | ~Aug 6 | KKR $10B "Helix" AI-power venture (Jun 11). Strong Buy ~$225. ~17.5x. *Also Sector Themes.* |
+| **WCN** | 159 < 167 | **Jul 22 CONF** | Div +11%. Buy ~$204. ~20x. SI low. |
+| **WMS** | 140 < 147 | ~early Nov | Investor Day Jun 18 (FY30 >$4B rev). Div +11%. Buy ~$171. ~20.5x. |
+| **ZTS** | 77 < 120 | ~Aug 4–11 | -36% under 200d. Argus downgrade→Hold. ~18–19x fwd. |
+| **SFM** | 84.5 < 86 | ~Aug 5 | Just below 200d. Expansion push; insider selling. SI ~11–12% (elevated). ~14.4x. |
+| **RMD** | 191 < 242 | ~Jul 30 | -21% under 200d. Noctrix $340M acq. MS downgrade→EW $230. SI ~8%. ~19.3x. |
+| **SPGI** | 400 < 468 | **Jul 30 CONF** | **Mobility spinoff (MBGL) lists ~Jul 1** — event-driven. ADX 9.5 (dead). ~93% Buy ~$543. ~21.4x. |
+
+**Below 200d per prior scan (research only, no live level this snapshot):**
+| Ticker | Earnings | Note |
+|--------|----------|------|
+| **MSFT** | ~Jul 28–29 | Azure +40%; FY26 capex ~$190B. Buy ~$562. ~20.5x. |
+| **HD** | ~Aug 18 | **Wolfe downgrade Jun 23**; housing softness. Mod-Buy ~$379. ~21–23x. |
+| **LOW** | ~Aug 19 | Insider selling + RBC cut (Jun 22). Mixed; Citi upgrade. ~17.1x. |
+| **MCO** | ~late Jul | AWS/GenAI push. Buy ~$544. ~25–27x. |
+| **MDT** | ~Aug 18 | MiniMed (diabetes) spun off. PT cuts post-Q4. ~12–14x. |
+| **CHTR** | **Jul 24 CONF** | $34.5B Cox merger (approved, closing mid-26). SI ~12.8% (squeeze). ~4.2x (deep value). |
+| **FICO** | **Aug 5 CONF** | $2B buyback; Score 10T adoption. Buy ~$1,580. ~24–33x. |
+| **DASH** | **Jul 30 CONF** | Dollar Tree delivery partnership. Buy ~$246–260. ~28x fwd. |
+| **CMG** | **Jul 29 CONF** | Flat comps guide; HEAP rollout. Buy. ~25.5x. SI ~3.5%. |
+| **CPRT** | ~Sep | -24.6% YTD; JPM/Baird PT cuts. ~25–30x. SI ~3.8%. |
+| **DPZ** | **Jul 20 CONF** | -33% YTD; lowered SSS guide. Buy ~$418. ~16x. |
+| **ANF** | ~late Aug | SoHo flagship; footwear launch. **SI ~19.7% (squeeze-relevant).** Barclays UW $78. |
+| **AON** | ~Jul 26 | Data-center premium volume. Buy ~$413. ~16.7x. |
+| **ERIE** | ~early Aug | -25% YTD; insider buying. Thin Mod-Buy ~$232. ~35x (high for insurer). |
+| **BSX** | **Jul 29 CONF** | -12% on Watchman concerns; Penumbra $14.5B acq pending. Heavy June PT cuts (kept Buy). ~14x. |
+| **BX** | ~Jul 16 | Digital Infra Trust NYSE listing; Broadcom AI financing. BCRED redemptions. ~20.8x. |
+| **DUOL** | ~Aug 5–12 | +26% off April low; AI content engine. DA Davidson $120. ~35x (rich). |
+
+---
+
+## Takeaways for trade selection
+1. **Defensive tape:** only ~24% (23/95) in a clean uptrend regime. Lots below the 200d.
+2. **Best fresh longs (non-extended PASS):** BAC, GS, IBKR, GE, MAR, HWM, PH, APH, BALL, BWXT, CDNS, WST, TLN, URI. Lines are drawn on the last 9 of these for alert conversion.
+3. **Time-sensitive:** **MU reports tonight (Jun 24 4:30pm)** — extended +159%, huge binary. **Fed stress test Jun 24 4pm** → BAC/GS/BLK/BX. **QCOM Investor Day Jun 24.**
+4. **Extended — don't chase:** MU, DELL, STX, AMD, CAT, STRL (all >+45% over 200d). Manage existing, not fresh entries.
+5. **Watch for 200d reclaims:** AMT, TPL, NCLH-adjacent, RSG, SFM, AMZN, COST, PGR all sit within ~3% of their 200d — small moves flip the regime.
+6. **Squeeze-relevant short interest:** ANF ~19.7%, CHTR ~12.8%, SFM ~11–12%, NTAP ~10.9%, POWL ~9.5% (tiny float).
+7. **Power/electrification split** (same as Sector Themes): TLN/CAT-adjacent strong; VRT/FIX/POWL marginal (ADX weak); CEG/VST below 200d.
+</content>

--- a/watchlists/hq-swing.md
+++ b/watchlists/hq-swing.md
@@ -1,0 +1,19 @@
+# HQ Swing Watchlist (95 names) — pulled 2026-06-23 (full, via DOM harvest)
+
+> Source: live TradingView active watchlist, harvested by scrolling the virtualized list (watchlist_get caps at ~51 rows — do NOT rely on it for full lists).
+
+## Full list
+AAPL, ABBV, ACGL, ALGN, AMD, AMT, AMZN, ANF, AON, APH, AXON, BAC, BALL, BKR, BLK, BSX, BWXT, BX, CAT, CDNS, CEG, CHTR, CMG, COKE, COST, CPRT, DASH, DE, DELL, DHI, DPZ, DUOL, EFX, EME, ERIE, FICO, FIX, FTAI, GE, GRMN, GS, HD, HWM, IBKR, LDOS, LEN, LLY, LOW, MAR, MCD, MCO, MDT, META, MLI, MPC, MSFT, MSI, MTZ, MU, NET, NTAP, NUE, NVDA, PGR, PH, POWL, QCOM, RACE, RKLB, RMD, ROP, RSG, SE, SFM, SHW, SPGI, STRL, STX, TDY, TLN, TPL, TPR, TT, TSLA, TYL, URI, VRSK, VRSN, VRT, VST, WCN(TSX), WMS, WST, ZTS
+
+## Notable clusters (for analysis)
+- **Power/nuclear/electrification:** VRT, VST, CEG, TLN, POWL, MTZ, STRL, EME, FIX, HWM, URI, TT, NUE, PH
+- **Semis/memory/storage (today's selloff epicenter + Micron 6/24):** MU, STX, NTAP, DELL, QCOM, NVDA, AMD, CDNS
+- **Megacap tech:** AAPL, MSFT, META, AMZN, TSLA, NVDA
+- **Financials:** GS, BAC, BLK, BX, IBKR, SPGI, MCO, FICO
+- **Insurance:** PGR, AJG, AON, ERIE, ACGL
+- **Defense/aero:** GE, HWM, LDOS, TDY, AXON, BWXT
+- **Healthcare:** LLY, ABBV, BSX, MDT, RMD, WST, ZTS, ALGN
+
+## Already regime-scanned 2026-06-23 (results in chat)
+PASS: GE, BWXT, BALL, EME, AAPL, MAR, GS(ext), LLY, AMD(ext), APH(ext) | MARGINAL: ABBV, FTAI, DE, DHI, MLI, MPC, COKE, COST | FAIL(below 200d): AJG, AON, ERIE, MSFT, CHTR, ANF, BSX, BX, CMG, CPRT, DASH, DPZ, FICO, HD, LOW, MCO, MDT | Spec(LiftOff, below 200d): DUOL
+NOT yet scanned (~58): ALGN, AMT, AMZN, AXON, BAC, BKR, BLK, CDNS, CEG, DELL, EFX, FIX, GRMN, HWM, IBKR, LDOS, LEN, MCD, META, MSI, MU, NET, NTAP, NUE, NVDA, PGR, PH, POWL, QCOM, RACE, RKLB, ROP, RSG, SE, SHW, STX, TDY, TLN, TPL, TPR, TT, TSLA, TYL, URI, VRSK, VRSN, VRT, VST, WCN, WMS, WST, ZTS, NUE, SFM

--- a/watchlists/main-watchlist-analysis.md
+++ b/watchlists/main-watchlist-analysis.md
@@ -1,0 +1,123 @@
+# Main Watchlist — Full Analysis (Steps 2–4) — 2026-06-23/24
+
+**Scope:** All 183 symbols of the main Watchlist. Equities get full Steps 2–4 (catalysts/earnings + fundamentals/sentiment + regime/levels); non-equity assets (crypto/FX/indices/commodities/ETFs) get an adapted read (regime/levels + macro drivers).
+
+**Sourcing:** Prices/levels = live TradingView feed (snapshot 2026-06-23). Catalysts/fundamentals = verified outlets only (Reuters/Bloomberg/CNBC/WSJ/company IR/exchange). Earnings dates are aggregator **estimates** unless flagged CONFIRMED — re-verify vs IR before trading a print.
+
+**Regime rule:** PASS = price > 200d SMA + ADX≥~20 + uptrend confirmed. MARGINAL = above 200d but ADX<20 or rolling over (Chandelier short / −momentum). FAIL = below 200d.
+
+---
+
+## 🌐 MACRO REGIME READ (live feed) — the most important takeaway
+| Asset | Px vs 200d | Regime | Signal |
+|-------|-----------|--------|--------|
+| **S&P 500 (SPX)** | 7365 vs 6912 (+6.6%) | ✅ PASS (ADX 21) | Broad market uptrend intact |
+| **Nasdaq-100 (NDQ)** | 29347 vs 25895 (+13%) | ✅ PASS | Tech leading |
+| **QQQ** | 713.65 vs 630 (+13%) | ✅ PASS | — |
+| **Semis (SMH)** | 622 vs 415 (+50%) | ✅ PASS | **Leadership group** |
+| **Financials (XLF)** | 53.88 vs 52.55 (+2.5%) | ✅ PASS | Fresh reclaim |
+| **Russell 2000 (IWM)** | 295 vs 259 (+14%) | ⚠️ MARGINAL (ADX 11) | Small caps lagging on trend strength |
+| **US Dollar (DXY)** | 101.75 vs 98.78 (+3%) | ✅ PASS (ADX 39) | **Strong & trending — headwind for crypto/metals/commods** |
+| **VIX** | 18.9 | — | Moderate, not panic |
+| **Bitcoin (BTCUSD)** | 62,908 vs 76,453 | ❌ FAIL (−18%) | **Crypto bear** |
+| **Ethereum (ETHUSD)** | 1,676 vs 2,350 | ❌ FAIL (−29%) | Worse than BTC |
+| **Bitcoin ETF (IBIT)** | 35.31 vs 48.96 | ❌ FAIL | Confirms crypto weakness |
+| **Gold (GLD)** | 377 vs 409 (−9%) | ❌ FAIL | Gold corrected |
+| **Gold miners (GDX)** | 77.66 vs 87.22 | ❌ FAIL | — |
+
+**The tape:** Risk-ON in equities — led by **semis/hardware and financials**. Risk-OFF in **crypto, gold, and rate-sensitive commodities**, consistent with a **strong, trending dollar**. Notably, **high-multiple megacap software has rolled over below its 200d** (NOW, ORCL, PLTR, NFLX, UBER, SPOT all FAIL) — a rotation OUT of expensive software INTO semis/hardware (AMAT, ARM, INTC, AMD, MU, STX, NTAP, DELL, CSCO all strong) and financials (JPM, C, XLF).
+
+## MACRO CALENDAR (Jun 24 – ~Jul 31 2026)
+**Jun 24:** Fed stress-test results 4pm (JPM, C, BAC, GS) · MU earnings 4:30pm · QCOM Investor Day · BB earnings | **Jun 25:** PCE (May) · BB earnings | **Jun 29:** HON "HONA" aero spin lists | **Jun 30:** NKE earnings · JOLTS · Consumer Confidence | **Jul 2:** Jobs/NFP | **Jul 9:** PEP earnings | **Jul 14:** CPI · JPM/C/BAC earnings · season opens | **Jul 15:** PPI · JNJ earnings | **Jul 16:** NFLX earnings · Retail Sales | **Jul 29:** FOMC decision + Powell | **Jul 30:** Q2 GDP · VLO/SPGI earnings
+
+---
+
+## ✅ PASS — regime-aligned longs (equities)
+*Levels: 200d = trend pivot; 50d ≈ pullback support.*
+
+### Cleanest (not over-extended)
+| Ticker | Px / 200d / ADX | Earnings | Catalyst + sentiment |
+|--------|-----------------|----------|----------------------|
+| **JPM** | 334 / 307 / 27 | **Jul 14 CONF** | Fed stress test Jun 24; $50B buyback. Buy ~$342. ~14x fwd. |
+| **C** | 145 / 114 / 42 | **Jul 14 CONF** | Investor Day: $30B buyback, 11-13% ROTCE target. Buy ~$137. ~10.6x (cheap). |
+| **SNOW** | 230 / 206 / 34 | **Aug 26 CONF** | Cortex AI consumption; Q1 beat. Buy ~$290. Premium growth. |
+| **ROKU** | 135 / 105 / 26 | ~Jul 30 | **NFLX reportedly bid for Roku (Jun 16)** — M&A premium. 2 downgrades on valuation. |
+| **VMI** | 569 / 439 / 26 | ~Jul 21 | Investor Day Jun 16 (grid capex). Record Q1. Mod-Buy ~$574. ~18-21x. |
+| **FHB** | 28.6 / 25.8 / 28 | ~Jul 24 | Hawaii bank. Weak EPS revisions but trend OK. SI ~6%. |
+| **TGTX** | 54 / 34 / 46 | ~Aug 3-10 | BRIUMVI ramp (US rev $195M); subQ Ph3 late-26. HCW PT $70. SI ~19.5%. Profitable. |
+| **MCHP** | 93 / 73 / 20 | ~Aug 4 | First 3nm PCIe Gen6 switch; data-center +65%. Buy ~$100-113. Early-cycle recovery. |
+| **ARQT** | 26 / 24 / 31 | ~Aug 5 | ZORYVE derm ramp (+65%). Buy ~$34. SI ~12%. |
+| **BROS** | 67 / 56 / 33 | ~Aug 12 | Dutch Bros — unit expansion, 8 straight beats. SI ~10%. ~52-60x (rich). |
+| **TDOC** | 7.7 / 6.8 / 24 | ~Jul 28 | Walmart Better Care distribution. Unprofitable (GAAP). SI ~15.6%. |
+
+### Extended (manage as momentum, not fresh entries — all +45% to +134% over 200d)
+| Ticker | Px / 200d | Earnings | Note |
+|--------|-----------|----------|------|
+| **INTC** | 132 / 57 (+134%) | ~Jul 23 | AI-infra deals (SambaNova/Foxconn); 18A ahead. ~113x fwd (extreme). PT hikes to $110-128. |
+| **ARM** | 366 / 170 (+115%) | ~Aug (est) | AI/datacenter licensing. ADX 42. |
+| **HUT** | 121 / 61 (+98%) | ~Aug 18 | BTC miner→AI/HPC; $4.25B notes. Strong Buy. Unprofitable. *(note: BTC itself below 200d)* |
+| **FLEX** | 152 / 78 (+94%) | ~Jul 23-29 | Added to S&P 500; Cloud&Power SpinCo ~Q1'27. Barclays $203. |
+| **BB** | 8.8 / 4.8 (+86%) | **🚨 Jun 25 (this wk)** | QNX momentum; buyback. ADX 48. Binary print imminent. |
+| **AMAT** | 586 / 322 (+82%) | ~Aug (est) | Semicap leverage to AI. ADX 31. |
+| **PANW** | 291 / 197 (+48%) | ~Aug 24 | Closed $25B CyberArk; strong revisions. ADX 39. |
+| **CSCO** | 121 / 83 (+46%) | ~Aug 12-19 | Q3 blowout (+25% networking); $9B AI orders. MS $130, BofA $150. |
+| **CRWD** | 681 / 492 (+38%) | ~Sep 2 | **4:1 split Jul 2.** Forrester XDR leader. ~137x fwd (premium). ⚠️ Chandelier flipped short (near-term pullback). |
+
+---
+
+## ⚠️ MARGINAL — above 200d but ADX<20 or rolling over (equities)
+
+**Financials/insurance:** CB (332/309, ADX13), NTRS (176/144 — **BNY merger-talk pop**, ADX18.8), MSCI (582/570, short stop — ER Jul 21 CONF)
+**Energy/commodities:** COP (110/105, short stop), CVX (176/172 — **MSFT 20yr power deal Jun 22**, short stop), OXY (52/49, short stop), DVN (43/41 — **Toms Capital/Citadel activist**, short stop), ET (19.2/18.0, short stop), PBR (17/15.6, ROC−15), PSX (170/152, short stop), TALO (14/12.4, short stop), VLO (244/202 — **ER Jul 30 CONF**, ADX12), AROC (39/30, ADX16), FCX (64/54.5, ADX16), MP (skip — see FAIL)
+**Industrials/materials:** GD (350/344, ADX16), HON (222/214 — **HONA spin Jun 29**, ADX16.5), UNP (259/242 — **NS merger pending**, short stop), VMI(PASS), ALB (150/147 — lithium rebound, short stop)
+**Staples/healthcare:** KO (80/74 — ER Jul 28, ADX16.6), JNJ (239/216 — **ER Jul 15 CONF**, ADX15), AMGN (347/333 — MariTide obesity, ADX12), NSRGY (99/98, ADX10), SBUX (101/92 — turnaround, ADX17), NVAX (9/8.5, short stop)
+**Tech/AI/growth:** GOOG (346/312 — ROC−9.8, short stop), CRWV (106/101 — Nasdaq-100 add, ADX12), INOD (87/63 — AI data, ROC−12), NVTS (21/12 — NVIDIA 800VDC, ROC−12, SI 21%), ZETA (19.5/18.7 — short-report overhang, short stop), HIMX (16.8/10.4, ROC−16)
+**Utilities/other:** DTE (149/140, ADX11), NEE (86.4/86.0 — **$67B Dominion merger**, short stop, ROC−3.6), DGX (197/190 — ER Jul 23 CONF, ADX18), BHP (82/68, Chandelier sell), DOW (30.3/29.7 — **div cut 50%**, ROC−15), F (14/13, short stop), CAR (190/158 — **~54-62% short squeeze**, ADX15)
+**Megacap overlaps (from HQ file):** AAPL, AMZN, NVDA, NET, COST, DE — all MARGINAL (above 200d, momentum mixed)
+**Index:** IWM (small caps, ADX11)
+
+---
+
+## ❌ FAIL — below 200d SMA (no long setup; watch for reclaim)
+
+**Megacap software rolled over (the notable rotation):** NOW (96/136, −29%), ORCL (165/204, −19% despite blowout Q4), PLTR (117/160, −27%), NFLX (73/98, −26% — **ER Jul 16 CONF**; bid for Roku; BofA downgrade), UBER (70/82, −15%, ADX dead), SPOT (456/554, −18%), MELI (1584/1966, −19%)
+**Consumer/retail weak:** HD (324/358 — Wolfe downgrade), MCD/PEP/KO(marg), NKE (42/58 — **ER Jun 30 CONF**), SBUX(marg), DIS (104/107), SHAK (54/87, −38%), TOST (24.5/31.6), CVNA (65/73), HAS (83/86), GME (21/23 — eBay bid), PFE (24.7/25.9), CLX (93/108), AMCR (40.4/41.6)
+**Crypto/fintech proxies (all FAIL — tracks BTC/ETH below 200d):** MSTR (104/190, −45%), COIN, CRCL, SOFI (17.3/22.6), SBET (5/9.7), BMNR (15/30), BTBT (2.1/2.3), BTCS (1.1/2.7), CHYM (16.7/21.3), IBIT, HOOD(in ST)
+**Semis/AI laggards:** SMCI (33/35 — GF upgrade Jun 22), MBLY (7.9/10.6), RGTI (21/24 — quantum), SOUN (6.4/10.9, SI 38%), AI (9.7/12.6, SI 33%), BBAI (3.8/5.2, SI 27%)
+**EV/auto:** RIVN (14.9/15.7), LCID (5.2/12 — SI 53%), NIO (5.1/5.8), F(marg)
+**Materials/gold/energy:** NEM (98/103), MP (58.9/62.1 — **Pentagon stake vs China export ban Jun 22**), GLD, GDX
+**Other:** IBM (265/274), BABA (103/149, −31%), FUTU (98/156 — **China probe −28%, Goldman downgrade**), AXON, TSLA, META, MDT, OPEN (4.2/6.1), HTZ (5.1/5.4), SMMT (14.3/17.9 — clinical miss), NVAX(marg)
+
+> **Earnings-confirmed in FAIL bucket (event risk):** NFLX Jul 16, NKE Jun 30, JNJ Jul 15(marg), VLO Jul 30(marg), CHTR/others.
+
+---
+
+## 🪙 Crypto, FX, Commodities, Indices, ETFs
+- **Crypto coins** (BTCUSD, ETHUSD below 200d; SOLUSD, AVAXUSDT, DOGEUSD, DOTUSD, SUIUSD, HYPEHUSD, PURR): **broad crypto bear** — BTC −18% / ETH −29% under 200d. Avoid crypto-proxy longs (COIN, MSTR, IBIT, BMNR, BTBT, SBET, DFDV, ORBS, HYPD all FAIL).
+- **FX:** DXY **strong uptrend** (PASS, ADX 39) → EURUSD/GBPUSD weak, USDJPY likely up. Dollar strength is the macro headwind for risk-tail assets.
+- **Commodities:** Gold (GLD/GDX) below 200d; oil names mixed (CVX/COP/OXY marginal, refiners VLO/PSX/PBF marginal). WTI/USOIL/USO/OILU/OILD track crude; OVX = oil vol.
+- **Equity ETFs:** Bullish — QQQ/SMH/XLF PASS; IWM marginal. Leveraged: SOXL/SPXL (bull) track the PASS semis/index trend; SOXS/inverse track opposite. Sector: XLK (tech, ~PASS w/ QQQ), IGV (software — likely weak given software rollover), KWEB (China — weak, BABA/FUTU below 200d), KRE (regional banks), SKYY (cloud), URA-style not here.
+
+## 🔬 Exotic / micro-cap / structured (identity + caveat)
+- **CBRS** = Cerebras Systems — AI wafer-scale chips, **IPO'd May 2026, reported Q1 today**; watch 60M+ share lockup unlock. Newly public, high-vol.
+- **ORBS** = Eightco Holdings — crypto treasury (WLD/ETH NAV proxy), speculative.
+- **DFDV** = DeFi Dev Corp — Solana treasury proxy (SI ~21.5%), FAIL.
+- **HYPD** = Hyperion DeFi — HYPE-token treasury micro-cap.
+- **LAES** = SEALSQ — post-quantum semis; large cash, dilution history.
+- **CTM** = Castellum — sub-$1 defense micro-cap.
+- **SKK** = SKK Holdings — Singapore civil-works micro-cap + odd drone-asset deal.
+- **NMAX** = Newsmax (NYSE) — media, persistent losses.
+- **UAVS** = AgEagle Aerial — micro-cap drones (regime not pulled; treat as spec).
+- **BIPZ2030 / ETPZ2030** = **Coinbase nano BTC/ETH futures (Dec-2030 expiry), NOT equities** — far-dated, illiquid; pure BTC/ETH derivative exposure. (Both track crypto, which is below 200d.)
+
+---
+
+## Takeaways & trade calls
+1. **Tape is "semis + financials up, crypto + gold + software down, dollar strong."** Lean longs toward the leadership; avoid fighting the crypto/metals downtrend.
+2. **Best regime-aligned fresh longs:** **JPM, C** (banks into Jul 14 earnings + stress test), **SNOW, ROKU** (ROKU has NFLX-bid optionality), **VMI, FHB, MCHP, TGTX**. Cleaner than the extended semis.
+3. **Extended — don't chase, manage:** INTC, ARM, AMAT, FLEX, PANW, CSCO, CRWD (+ HUT). All >+45% over 200d.
+4. **Time-sensitive (Jun 24-25):** 🚨 **MU earnings tonight** (also in HQ list), **Fed stress test** (JPM/C/BAC/GS), **QCOM Investor Day**, **BB earnings Jun 25**, **NKE Jun 30**.
+5. **Avoid / watch-for-reclaim:** the entire megacap-software complex (NOW/ORCL/PLTR/NFLX/UBER/SPOT) is below its 200d — a regime change worth respecting; don't bottom-fish until they reclaim.
+6. **Squeeze-relevant shorts (event-driven only):** CAR ~54-62%, LCID ~53%, SOUN ~38%, AI ~33%, BBAI ~27%, NVTS ~21%, DFDV ~21%, TGTX ~19.5%, ASTS ~18%.
+7. **Crypto exposure:** BTC/ETH below 200d — IBIT and all equity proxies are FAIL. No long edge until BTC reclaims ~$76k (200d).
+</content>

--- a/watchlists/main-watchlist.md
+++ b/watchlists/main-watchlist.md
@@ -1,0 +1,19 @@
+# Main Watchlist (183 symbols) — harvested 2026-06-23 (full, via DOM scroll)
+
+> Source: live TradingView active watchlist. `watchlist_get` truncated at ~58 (alphabetical, cut at L) — full list harvested by scrolling the virtualized `listContainer` and collecting `data-symbol-full`. Total **183**.
+
+## Full list (alphabetical)
+AAPL, ABNB, AI, ALB, AMAT, AMCR, AMD, AMGN, AMZN, APP, ARM, AROC, ARQT, AVAXUSDT, AXON, BABA, BAC, BB, BBAI, BCBP, BHP, BIPZ2030, BMNR, BROS, BTBT, BTCS, BTCUSD, C, CAR, CB, CBRS, CENX, CHYM, CLX, COIN, COP, COST, CRCL, CRWD, CRWV, CSCO, CTM, CVNA, CVX, DAL, DE, DFDV, DGX, DIS, DJI, DOGEUSD, DOTUSD, DOW, DTE, DVN, DXY, ET, ETHUSD, ETPZ2030, EURUSD, EVGO, F, FCX, FHB, FLEX, FSLR, FUTU, GBPUSD, GD, GDX, GLD, GME, GOLD, GOOG, GS, HAS, HD, HIMX, HON, HOOD, HTZ, HUT, HYPD, HYPEHUSD, IBIT, IBM, IGV, INOD, INTC, IWM, JNJ, JPM, KO, KRE, KWEB, LAES, LCID, LUNR, MBLY, MCD, MCHP, MDT, MELI, META, MP, MSCI, MSFT, MSTR, MU, NDQ, NEE, NEM, NET, NFLX, NIO, NKE, NMAX, NOW, NSRGY, NTRS, NVAX, NVDA, NVTS, OILD, OILU, OPEN, ORBS, ORCL, OVX, OXY, PANW, PBF, PBR, PEP, PFE, PLTR, PM, PSX, PURR, QQQ, RGTI, RIVN, ROKU, RSPU, SBET, SBUX, SHAK, SILVER, SKK, SKYY, SMCI, SMH, SMMT, SNOW, SOFI, SOLUSD, SOUN, SOXL, SOXS, SPCX, SPOT, SPX, SPXL, SUIUSD, TALO, TDOC, TGTX, TOST, TSLA, UAVS, UBER, UNP, USDJPY, USO, USOIL, VIX, VLO, VMI, WTI, XLF, XLK, XOM, ZETA
+
+## Asset-class buckets (for analysis treatment)
+- **Crypto coins (9):** BTCUSD, ETHUSD, SOLUSD, AVAXUSDT, DOGEUSD, DOTUSD, SUIUSD, HYPEHUSD, PURR
+- **Crypto equities/proxies:** COIN, MSTR, IBIT(ETF), BMNR, BTBT, BTCS, HUT, SBET, DFDV, CRCL, HYPD
+- **FX (4):** EURUSD, GBPUSD, USDJPY, DXY
+- **Indices/vol (5):** SPX, DJI, NDQ, VIX, OVX
+- **Commodities/oil (incl. proxies):** GOLD(Barrick?), SILVER, WTI, USOIL, USO(ETF), OILU, OILD, GLD(ETF), GDX(ETF), NEM, OVX
+- **ETFs:** QQQ, IWM, GLD, GDX, SMH, SOXL, SOXS, XLF, XLK, IGV, SKYY, KRE, KWEB, USO, SPXL, RSPU, IBIT
+- **Ambiguous/structured (verify):** BIPZ2030, ETPZ2030, CBRS, SKK, NMAX, HYPD, ORBS, CTM, AROC
+- **Overlaps already analyzed (HQ Swing / Sector Themes):** AAPL, AMD, AMZN, AXON, BAC, COIN, CRCL, DAL, DE, GS, HD, HOOD, LUNR, MCD, MDT, META, MSFT, MU, NET, NVDA, SPCX, TSLA, COST
+
+> Equities → full Steps 2–4 (earnings/catalysts + fundamentals/sentiment + regime/levels). Non-equity assets (crypto/FX/indices/commodities/ETFs) → adapted: regime/key levels + macro drivers + relevant sentiment (no earnings/short-interest/P-E).
+</content>

--- a/watchlists/sector-themes-analysis.md
+++ b/watchlists/sector-themes-analysis.md
@@ -1,0 +1,173 @@
+# Sector Themes — Full Analysis (Steps 2–4) — 2026-06-23
+
+**Scope:** All 37 Sector Themes names. Steps 2–4 of the analysis standard:
+- **Step 2 — Catalysts & calendar:** next earnings date + macro events.
+- **Step 3 — Fundamentals/sentiment:** analyst activity, short interest, valuation (verified outlets only).
+- **Step 4 — Levels:** regime (price vs 200d SMA + ADX-14), 50d MA pullback support, 200d trend pivot.
+
+**Sourcing:** Prices/levels = live TradingView feed (snapshot 2026-06-23). Catalysts/fundamentals = verified outlets (Reuters/Bloomberg/CNBC/company IR/exchange). Earnings dates mostly aggregator **estimates** unless flagged CONFIRMED — re-verify vs company IR before trading a print.
+
+---
+
+## MACRO CALENDAR (Jun 23 – ~Jul 31 2026)
+| Date | Event |
+|------|-------|
+| **Jun 24 (Wed)** | Fed bank **stress-test results** ~4pm (32 banks) |
+| **Jun 25 (Thu)** | **PCE** (May) 8:30 — Fed's preferred inflation gauge |
+| Jun 30 (Tue) | JOLTS (May) + Consumer Confidence |
+| **Jul 1 (Wed)** | ISM Manufacturing PMI (June) |
+| **Jul 2 (Thu)** | **Jobs report / NFP** (June) 8:30 (pre-holiday) |
+| Jul 8 (Wed) | FOMC Minutes (June mtg) |
+| **Jul 14 (Tue)** | **CPI** (June) + Q2 earnings season opens (JPM) |
+| Jul 15 (Wed) | PPI (June) |
+| Jul 16 (Thu) | Retail Sales (June) |
+| **Jul 29 (Wed)** | **FOMC decision** 2pm + Powell presser (mtg Jul 28–29) |
+| Jul 30 (Thu) | Q2 GDP advance |
+
+---
+
+## ✅ PASS — regime-aligned longs (9)
+*Price > 200d SMA + ADX≥~20 + uptrend confirmed.*
+
+### DAL — Delta Air Lines  ★ strongest
+- **Regime:** PASS. Px 86.72 vs 200d 66.94 (+29.5%), ADX 31.3, above 50d (~74.96). Levels: pivot 200d=66.94, pullback 50d≈75.
+- **Earnings:** **Jul 10, 2026 BMO — CONFIRMED** (company webcast).
+- **Catalyst:** Berkshire disclosed ~6.1% passive stake (~$2.65B) — first airline buy since COVID exit. Citi 30-day upside catalyst-watch.
+- **Analysts:** Bernstein Outperform $93 (Jun 17), UBS $98. FY26 EPS guide $6.50–7.50.
+- **Valuation:** low-to-high-single-digit fwd P/E — cheap cyclical. SI low.
+
+### GEV — GE Vernova
+- **Regime:** PASS. Px 1034.98 vs 200d 777.57 (+33%), ADX 20.2, Chandelier long (~989). Pullback 50d≈1026 (tight).
+- **Earnings:** ~Jul 29, 2026 BMO (one source Jul 21; est).
+- **Catalyst:** "Orchestrate 2026" (Jun 9–12, grid/AI infra). Q1 orders +71%, backlog $163B; raised FY26 guide on AI data-center power.
+- **Analysts:** Bernstein SocGen init Outperform; Buy consensus avg ~$1,211.
+- **Valuation:** premium (high-double-digit fwd P/E) — momentum/power-demand name.
+
+### HOOD — Robinhood  ★ fresh breakout
+- **Regime:** PASS (fresh). Px 103.25 just reclaimed 200d 102.82 (+0.4%), ADX 27.7, ROC +36, far above 50d (~84). Pivot 200d=102.82 (hold above = thesis).
+- **Earnings:** ~Aug 5, 2026 (est).
+- **Catalyst:** +12% Jun 17 on 10% workforce cut + record volumes; Jun 4 PDT $25K rule eliminated (unlocks ~25% of accounts); World-Cup prediction-market volumes. +~50% off April lows.
+- **Analysts:** target-hike wave (Cantor/Mizuho/Goldman/DB/KeyBanc to $95–115), median ~$97.50.
+- **Valuation:** fwd P/E ~41.5x. SI ~4.2%. Crypto/volume-cyclical.
+
+### HUBB — Hubbell
+- **Regime:** PASS. Px 509.96 vs 200d 472.73 (+7.9%), ADX 24.2, Chandelier long. Pullback 50d≈502, pivot 200d=472.73.
+- **Earnings:** ~Jul 28, 2026 (est).
+- **Catalyst:** Closed $3B NSI Industries acq (Jun 9), funded $1.9B notes (Jun 2). Raised FY26 guide (EPS $19.30–19.85) on grid/data-center demand.
+- **Analysts:** Buy, avg ~$551; Stephens $600.
+- **Valuation:** ~mid-20s fwd P/E.
+
+### JBHT — J.B. Hunt
+- **Regime:** PASS. Px 269.24 vs 200d 204.79 (+31%), ADX 23.6, Chandelier long. Pullback 50d≈260, pivot 200d=204.79.
+- **Earnings:** ~Jul 14, 2026 (some Jul 21; est). NOTE: reports into a soft freight tape.
+- **Catalyst:** none notable; soft-rate freight environment.
+- **Analysts:** Moderate Buy, median ~$215. SI ~3.3%.
+- **Valuation:** fwd P/E ~23x (premium for freight).
+
+### JETS — U.S. Global Jets ETF
+- **Regime:** PASS. Px 31.18 vs 200d 26.82 (+16%), ADX 26.7, Chandelier long. Pivot 200d=26.82.
+- **Type:** ETF — top holds DAL ~12%, AAL ~11%, UAL ~10.5%, LUV ~9.4%; top-10 ≈64%. ER 0.60%, AUM ~$936M.
+- **Note:** clean way to play the airlines-strength theme (DAL/UAL/LUV all PASS). Modest inflows.
+
+### LUV — Southwest Airlines
+- **Regime:** PASS. Px 49.41 vs 200d 39.56 (+25%), ADX 30.3, Chandelier long. Pullback 50d≈41.5.
+- **Earnings:** ~Jul 22, 2026 (est).
+- **Catalyst:** Singapore Air single-ticket partnership; Mideast de-escalation = sector tailwind.
+- **Analysts:** Jefferies $44 (Jun 16), WF Hold; consensus Hold/Mod-Buy avg ~$45.
+- **Valuation:** fwd P/E ~13.5–15x. Mid-cycle margin-recovery story.
+
+### MTZ — MasTec
+- **Regime:** PASS (extended). Px 390.44 vs 200d 275.71 (+41.6%), ADX 22.9, Chandelier long. Pullback 50d≈385.
+- **Earnings:** ~Jul 30, 2026 (est).
+- **Catalyst:** Record Q1 (rev +34%), record ~$20.3B backlog, raised FY26 guide; data-center/power-delivery demand.
+- **Analysts:** broad PT raises into $330–362 (Jefferies/Goldman/Truist/Stifel/Citi).
+- **Valuation:** fwd P/E ~40x (growth premium). SI ~4.2%. *Overlaps HQ Swing.*
+
+### UAL — United Airlines
+- **Regime:** PASS. Px 121.55 vs 200d 102.40 (+18.7%), ADX 30.6, Chandelier long. Pullback 50d≈101.8 (≈200d — strong support shelf).
+- **Earnings:** ~Jul 15, 2026 (est).
+- **Catalyst:** record summer guide >53M pax Jun–Aug; +~10% on the news. Oil tailwind.
+- **Analysts:** UBS Buy $148; consensus Strong Buy avg ~$132. SI ~4.5%.
+- **Valuation:** low fwd P/E (airline). Profitable.
+
+---
+
+## ⚠️ MARGINAL — above 200d but no trend / rolling over, or speculative pullback (14)
+
+### CCJ — Cameco
+- **Regime:** MARGINAL. Px 108.89 vs 200d 103.28 (+5.4%), ADX 15.9 (weak). Pivot 200d=103.28.
+- **Earnings:** ~Jul 30–31, 2026 (est). **Catalyst:** uranium capital-flow momentum; Cameco+Orano buying Tepco's 5% Cigar Lake stake. **Analysts:** Buy, median ~$140. **Val:** fwd P/E ~98x (uranium-cycle optionality). SI low ~1.3%.
+
+### CCL — Carnival
+- **Regime:** MARGINAL (just reclaimed). Px 28.72 vs 200d 28.35 (+1.3%), ADX 20.4. **Reported Q2 TODAY Jun 23** — record rev $6.7B, EPS $0.41 beat, BUT fell ~6% on soft Q3 guide ($1.35 vs $1.42). Next: Q3 ~Sep 28. **Val:** FY26 EPS ~$2.22. Softer European demand flagged.
+
+### ETN — Eaton
+- **Regime:** MARGINAL. Px 405.28 vs 200d 369.56 (+9.7%), ADX 11.4 (dead). At 50d. **Earnings:** ~Aug 4 (est). **Catalyst:** Mobility-biz merger w/Dana ~$5.1B; data-center orders +~240% in Q1. **Analysts:** Buy, RBC $484, median ~$471. **Val:** ~39x trailing.
+
+### LUNR — Intuitive Machines  *(speculative)*
+- **Regime:** MARGINAL/spec. Px 20.95 vs 200d 18.38 (+14%) BUT ROC −38.8, Chandelier short, far below 50d. Sharp pullback (-46% in June after +88% YTD). **Earnings:** ~Aug 18 (est). **Catalyst:** $500M ATM shelf (dilution overhang); NASA gave rover to competitors but expanded LUNR into comms/nav. Pre-profit story name.
+
+### NVDA — Nvidia
+- **Regime:** MARGINAL. Px 200.04 vs 200d 190.09 (+5%), ADX 13.7 (weak), below 50d, ROC −8.9. Pivot 200d=190. **Earnings:** **Aug 26, 2026 AMC — confirmed.** **Catalyst:** June supercomputer/Halos robotics launches; Europe 35 AI supercomputers. **Analysts:** Strong Buy ~38; targets $250–300. **Val:** fwd P/E ~21–22x. SI ~1.2%. *Overlaps HQ Swing.*
+
+### ODFL — Old Dominion Freight
+- **Regime:** MARGINAL. Px 217.58 vs 200d 177.16 (+22.8%), ADX 21.8 BUT Chandelier short (~232), at 50d. **Earnings:** ~Jul 29 (est). **Catalyst:** Citi downgrade; soft LTL volumes. **Analysts:** Hold ~65%, avg ~$209. **Val:** fwd P/E ~38–39x (rich in soft freight cycle). SI ~6.1%.
+
+### PL — Planet Labs  *(speculative)*
+- **Regime:** MARGINAL/spec. Px 28.53 vs 200d 24.07 (+18.5%) BUT ROC −32.8, Chandelier short, far below 50d. **Earnings:** ~Sep 14 (FQ2'27, est). **Catalyst:** 2yr 7-fig contract w/Greece via ESA. **Analysts:** Buy, Needham $53, avg ~$34. Near-breakeven; SI ~9%. Valued on growth.
+
+### PWR — Quanta Services
+- **Regime:** MARGINAL. Px 702.29 vs 200d 526.96 (+33%), ADX 15.3 (weak), at 50d, Chandelier long. **Earnings:** ~Jul 30 (est). **Catalyst:** grid/data-center capex backlog (late-May upgrade wave). **Analysts:** Buy ~20; UBS $900. **Val:** fwd P/E ~48–54x (rich). SI low ~3.1%.
+
+### RCL — Royal Caribbean
+- **Regime:** MARGINAL. Px 309.53 vs 200d 289.86 (+6.8%), ADX 15.6 (weak), above 50d. **Earnings:** **Jul 23, 2026 BMO (TipRanks "confirmed").** **Catalyst:** Mexico minister said "Perfect Day" Quintana Roo "not going to be approved" (overhang); fuel ~$0.62 EPS headwind. FY26 EPS guide $17.10–17.50. **Analysts:** Buy; WF $361, Citi $362. **Val:** fwd P/E ~16–17x.
+
+### RKLB — Rocket Lab  *(speculative)*
+- **Regime:** MARGINAL/spec. Px 95.12 vs 200d 74.08 (+28%) BUT ROC −24, Chandelier short. **Earnings:** ~Aug 6 (est). **Catalyst:** joined Nasdaq-100 (Jun 22); 5-launch Neutron deal; Neutron first flight NET Q4'26. **Analysts:** Buy ~16; KeyBanc $135, avg ~$120. Unprofitable; SI ~4.4%. *Overlaps HQ Swing.*
+
+### ROBO — Robotics & Automation ETF
+- **Regime:** MARGINAL. Px 82.80 vs 200d 73.55 (+12.6%), ADX 20.2 BUT Chandelier **SELL flip** (~86). **Type:** ETF, ~91 holdings, AUM ~$1.9B, diffuse (top-10 ~19%). Portfolio P/E ~32. Near-term pullback signal.
+
+### VRT — Vertiv
+- **Regime:** MARGINAL. Px 318.32 vs 200d 225.10 (+41%), ADX 14.5 (weak), pulled to 50d. **Earnings:** ~Jul 29 (est). **Catalyst:** ThermoKey cooling acq; AGM Jun 17. **Analysts:** Strong Buy avg ~$377; GLJ upgrade Hold (Jun 18). **Val:** fwd P/E ~50–54x (very rich). Mild bullish call flow early June. *Overlaps HQ Swing.*
+
+### XPO — XPO Inc.
+- **Regime:** MARGINAL. Px 199.22 vs 200d 170.58 (+16.8%), ADX 20.5 BUT Chandelier short (~227). **Earnings:** ~Jul 30 (est). **Catalyst:** none last 2wks; 8 analysts cut estimates on freight softness. **Val:** profitable, LTL-cycle geared. SI ~8% (elevated).
+
+### XYZ — Block
+- **Regime:** MARGINAL. Px 72.37 vs 200d 67.27 (+7.6%), ADX 12.8 (weak), above 50d. **Earnings:** ~Jul 30–Aug 6 (est). **Catalyst:** strong Q1 (adj EBITDA ~$1B, GP +27%), raised FY26 guide; Cash App 59M MTAs, Uber partnership. **Analysts:** Buy avg ~$82–86. **Val:** fwd P/E ~16.4x. SI ~3.5%.
+
+---
+
+## ❌ FAIL — below 200d SMA (no long setup; watch for reclaim) (13)
+
+| Ticker | Px vs 200d | Earnings (est) | Note |
+|--------|-----------|----------------|------|
+| **ASTS** | 72.87 < 80.75 | ~Aug 17 | Spec. BlueBirds 8/9/10 launched Jun 17; 11/12/13 in Aug. SI ~18% (high). Pre-revenue. |
+| **BOTZ** (ETF) | 36.64 < 36.87 | — | Robotics/AI ETF, AUM ~$3.5B. Top: ABB/Keyence/Fanuc/NVDA. Just under 200d. |
+| **CEG** | 270.26 < 319.11 | ~Aug 6 | Jun 1 secondary at $281. Buy consensus. Fwd P/E ~23. *Overlaps HQ.* |
+| **COIN** | 158.18 < 236.69 | ~early Aug | -26% YTD. CFTC perp-futures approval; AI tools. SI ~6–10%. Fwd P/E ~71–162x. Spec. |
+| **CRCL** | 75.68 < 98.94 | ~Aug 11 | Newer issue, rate-sensitive. Board transition Jun 12. SI ~12%. Fwd P/E ~98x. Spec. |
+| **LHX** | 293.77 < 315.89 | **Jul 23 (conf)** | -5.9% Jun 20 on US–Iran MOU (defense premium compressed). $495M contract mod. Strong Buy. |
+| **NCLH** | 20.39 < 20.96 | ~Jul 30 | Just below 200d, reclaiming (ROC +24, long stop). SI ~8.8% (high). Fwd P/E ~11.9x (cheapest cruise). |
+| **OKLO** | 57.19 < 84.91 | ~Aug 10–18 | Spec/pre-rev. DOE PDSA approval Jun 11; Centrus HALEU deal. SI ~18% (squeeze-prone). |
+| **SMR** | 10.86 < 20.45 | ~Aug 6–12 | Spec/pre-rev SMR. HIPS milestone Jun 18; TVA up to 6GW. SI ~16.6%. BofA Neutral $12. |
+| **SYM** | 38.57 < 58.00 | **Aug 3 (conf)** | Q2 beat (rev +23%, turned GAAP-positive). EV/EBITDA ~951x (rich). Below 200d. |
+| **URA** (ETF) | 45.58 < 50.08 | — | Uranium ETF, AUM ~$7B, Cameco 23%. YTD +12.5% but below 200d now. |
+| **VST** | 162.39 < 170.17 | ~Aug 6 | KKR $10B "Helix" AI-power venture (Jun 11). Strong Buy avg ~$225. Fwd P/E ~17.5x. *Overlaps HQ.* |
+| **XLY** (ETF) | 113.76 < 117.63 | — | Cons. discretionary SPDR — effectively AMZN (26%)+TSLA (20%). Both below 200d → ETF weak. |
+
+---
+
+## SPCX — SpaceX  *(newly public — no regime yet)*
+- **N/A:** IPO'd Jun 12, 2026 at $135 (raised ~$75B, ~$1.75–1.8T valuation — largest IPO ever). Px 156.11, no 200d history. +19%/+20% first two sessions. Musk >82% voting control, small float. Extreme valuation, hyper-volatile. No earnings scheduled yet.
+
+---
+
+## Theme read (for trade selection)
+- **Airlines are the standout strong theme:** DAL, UAL, LUV all PASS + JETS (ETF) PASS. Mideast de-escalation + lower oil + Berkshire's DAL stake. Cleanest cluster on the list.
+- **Power/electrification is SPLIT:** GEV, HUBB, MTZ PASS; ETN, PWR, VRT MARGINAL (ADX weak/extended); CEG, VST below 200d. Not the uniform leader it was.
+- **Nuclear/uranium = broken:** OKLO, SMR, URA, CCJ(marginal) — all below or barely above 200d. Avoid for longs.
+- **Crypto/fintech weak:** COIN, CRCL below 200d; HOOD (fresh reclaim) and XYZ (marginal) the only ones holding.
+- **Space speculative & selling off:** ASTS below 200d; RKLB/LUNR/PL above 200d but crashing (short stops) — SpaceX IPO sentiment drag persists.
+</content>

--- a/watchlists/sector-themes.md
+++ b/watchlists/sector-themes.md
@@ -1,0 +1,19 @@
+# Sector Themes Watchlist (37 names) — pulled 2026-06-23 (full, via DOM harvest)
+
+> Source: live TradingView active watchlist (full harvest). Mix of thematic stocks + thematic ETFs.
+
+## Full list
+ASTS, BOTZ, CCJ, CCL, CEG, COIN, CRCL, DAL, ETN, GEV, HOOD, HUBB, JBHT, JETS, LHX, LUNR, LUV, MTZ, NCLH, NVDA, ODFL, OKLO, PL, PWR, RCL, RKLB, ROBO, SMR, SPCX, SYM, UAL, URA, VRT, VST, XLY, XPO, XYZ
+
+## Themes
+- **Electrification/power:** GEV, ETN, PWR, VRT, MTZ, HUBB, CEG, VST
+- **Nuclear/SMR/uranium:** OKLO, SMR, CCJ, CEG, VST, URA(ETF)
+- **Space:** ASTS, RKLB, LUNR, SPCX, PL  (note: SpaceX shed ~$600B over 3 sessions — sentiment drag on space names)
+- **Crypto/fintech:** COIN, HOOD, CRCL, XYZ
+- **Airlines/cruise/travel:** JETS(ETF), UAL, DAL, LUV, CCL, RCL, NCLH
+- **Robotics/automation:** SYM, BOTZ(ETF), ROBO(ETF)
+- **Logistics:** JBHT, ODFL, XPO
+- **Defense:** LHX | **Megacap AI:** NVDA
+- **ETFs in this list:** JETS, ROBO, URA, XLY, BOTZ
+
+> Mostly high-beta / speculative thematic names — vulnerable on risk-off days. Overlap with HQ Swing: CEG, ETN(no, HQ has no ETN), VRT, MTZ, NVDA, RKLB.


### PR DESCRIPTION
﻿## Summary
Two commits ahead of `main`:

1. **Fix `quote_get`** (`6d235b4`) — `quote_get(symbol)` was returning the active chart's data regardless of the `symbol` argument. It now switches the chart to the requested symbol first, so the returned quote matches the requested ticker. Verified live: quoting `NASDAQ:AAPL` while the chart was on `BATS:SOXX` correctly returned AAPL data.

2. **Add watchlist files + analyses** (`9f88cea`) — watchlist source lists plus full Steps 2–4 analysis docs (`watchlists/hq-swing-analysis.md`, `sector-themes-analysis.md`, `main-watchlist-analysis.md`).

## Test plan
- `quote_get` with a symbol not on the chart returns that symbol's OHLC/last (regression check for the chart-symbol bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
