### PR TITLE
fix(chart): scrollToDate throws ReferenceError — wire it through _resolve(_deps)

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -157,7 +157,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -7,7 +7,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeString, requireFinite } from '../src/connection.js';
-import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
+import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange, scrollToDate } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
@@ -32,6 +32,21 @@ function mockDeps(overrides = {}) {
     evaluate,
   };
 }
+
+// ── scrollToDate() dependency wiring ─────────────────────────────────────
+
+describe('scrollToDate() — dependency injection (regression)', () => {
+  it('uses the injected evaluate instead of an undefined module binding', async () => {
+    // Regression: scrollToDate omitted `_deps`/`_resolve`, so it referenced a
+    // bare `evaluate` (the import is aliased to `_evaluate`) → "evaluate is not
+    // defined" at runtime. It must resolve deps like every other chart fn.
+    const { _deps, evaluate } = mockDeps();
+    const result = await scrollToDate({ date: '2024-01-15', _deps });
+    assert.equal(result.success, true);
+    assert.ok(evaluate.calls.some(c => c.includes('zoomToBarsRange')),
+      'scrollToDate issued its zoom evaluate call through the injected dep');
+  });
+});
 
 // ── safeString() ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`scrollToDate()` in `src/core/chart.js` calls a bare `evaluate(...)` twice, but the module only imports it **aliased** as `_evaluate`:

```js
import { evaluate as _evaluate, ... } from '../connection.js';
```

Every other function in the file obtains `evaluate` via `const { evaluate } = _resolve(_deps);`. `scrollToDate` was the only one that skipped this, so a bare `evaluate` is never in scope. **Every call throws `ReferenceError: evaluate is not defined`** — the `chart_scroll_to_date` MCP tool and `tv chart scroll` CLI path are completely broken on current `main`.

## Fix

Add the `_deps` parameter and the `const { evaluate } = _resolve(_deps);` line, matching the exact pattern used by `getState`, `setVisibleRange`, etc. Two-line change, no behavior change beyond making the function actually run.

## Test

Adds a regression test in `tests/sanitization.test.js` that calls `scrollToDate` with a mocked `_deps` and asserts it issues its `zoomToBarsRange` evaluate call through the injected dependency. Full `sanitization.test.js` suite: **35/35 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)