### PR TITLE
fix(drawing): resolve evaluate/getChartApi in list/remove/clear/getProperties

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -45,6 +45,7 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
 }
 
 export async function listDrawings() {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -57,6 +58,7 @@ export async function listDrawings() {
 }
 
 export async function getProperties({ entity_id }) {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -86,6 +88,7 @@ export async function getProperties({ entity_id }) {
 }
 
 export async function removeOne({ entity_id }) {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -107,6 +110,7 @@ export async function removeOne({ entity_id }) {
 }
 
 export async function clearAll() {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };


### PR DESCRIPTION
## Problem

`draw_list`, `draw_remove_one`, `draw_clear` and `draw_get_properties` fail at runtime with:

```
getChartApi is not defined
```

`draw_shape` works fine, the other four don't.

## Cause

In `src/core/drawing.js`, the module imports the helpers **aliased**:

```js
import { evaluate as _evaluate, getChartApi as _getChartApi, ... } from '../connection.js';
```

`drawShape()` resolves the unaliased names locally:

```js
const { evaluate, getChartApi } = _resolve(_deps);
```

…but `listDrawings()`, `getProperties()`, `removeOne()` and `clearAll()` call the bare
`getChartApi()` / `evaluate()` — which don't exist in their scope (they're `_getChartApi` /
`_evaluate`). Hence the `ReferenceError`. Only `drawShape` was migrated to the `_resolve` pattern.

## Fix

Add the same `const { evaluate, getChartApi } = _resolve();` line to the four affected
functions. Minimal, no behavior change beyond making them actually run.

## Verification

Against a live TradingView Desktop (CDP):

- `draw_list` → returns shapes (previously errored)
- `draw_shape` → draw 4 objects, `draw_list` shows count 4
- `draw_remove_one` → removes by id, `draw_list` back to count 0
- `draw_clear` → no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)