### PR TITLE
Add real-time trading agent, regime classifier, and live dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ strategies/.regime_state/
 ml/models/
 ml/__pycache__/
 ml/**/__pycache__/
+strategies/__pycache__/
+strategies/**/__pycache__/
+ml/serve/public/data/
+.claude/
+.DS_Store
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 node_modules/
+.env
 screenshots/
 scripts/current.pine
 temp_*
 *.log
 discovery-log.json
+strategies/.regime_state/
+ml/models/
+ml/__pycache__/
+ml/**/__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,13 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+79 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 
-### "What's on my chart right now?"
+### START HERE — any chart read/analysis task
+- `chart_snapshot` → **one call returns everything**: state (symbol/timeframe/studies) + quote + OHLCV summary + all indicator values + all pine graphics (lines/labels/tables/boxes). Replaces 7 sequential tool calls. Always try this first.
+
+### "What's on my chart right now?" (fallback — only if chart_snapshot is insufficient)
 1. `chart_get_state` → symbol, timeframe, chart type, list of all indicators with entity IDs
 2. `data_get_study_values` → current numeric values from all visible indicators (RSI, MACD, BBands, EMAs, etc.)
 3. `quote_get` → real-time price, OHLC, volume for current symbol
@@ -25,13 +28,8 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `quote_get` → single latest price snapshot
 
 ### "Analyze my chart" (full report workflow)
-1. `quote_get` → current price
-2. `data_get_study_values` → all indicator readings
-3. `data_get_pine_lines` → key price levels from custom indicators
-4. `data_get_pine_labels` → labeled levels with context (e.g., "Settlement", "ASN O/U")
-5. `data_get_pine_tables` → session stats, analytics tables
-6. `data_get_ohlcv` with `summary: true` → price action summary
-7. `capture_screenshot` → visual confirmation
+1. `chart_snapshot` → **single call** — returns state + quote + OHLCV + study values + all pine graphics
+2. `capture_screenshot` → visual confirmation (optional)
 
 ### "Change the chart"
 - `chart_set_symbol` → switch ticker (e.g., "AAPL", "ES1!", "NYMEX:CL1!")

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,69 @@
+# ML TP/SL 概率预测子系统
+
+独立于 `dashboard-server.js` 的子系统，预测"未来一段时间内先触及止盈还是先触及止损"的概率。完整背景见 [`.claude/plans/soft-mapping-emerson.md`](../.claude/plans/soft-mapping-emerson.md)（本机路径，未提交进仓库）。
+
+## 已知限制
+
+- **Replay 抓取速度**：1h/4h 一次跑几分钟能覆盖 1-2 年；1m/5m 单品种拉 30-45 天可能要跑数小时（无批量历史 API，只能逐bar走）。
+- **没有真正的宏观日历**：`config/sessions.json` 里的 `fomc_dates` 默认是空的，需要你去 [federalreserve.gov](https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm) 手动填。NFP 用"每月第一个周五 08:30 ET"规则自动算，不需要手填。
+- **这是决策辅助，不自动下单**——环境里没有接入真实券商。
+
+## 安装
+
+```bash
+pip3 install -r ml/requirements.txt
+```
+
+## 使用流程（在仓库根目录，`cd tradingview-mcp` 下执行）
+
+### 1. 确认/修改 TP/SL 参数
+
+编辑 `ml/config/symbols.json`——里面的数值是占位默认值，训练前务必核对成你真正想用的止盈止损点数。
+
+### 2. 抓历史数据（需要 TradingView Desktop 打开、CDP 端口 9222 可连）
+
+```bash
+python3 ml/data_collection/collect_replay.py --symbol MNQ1! --timeframe 60 --days 5   # 冒烟测试：先拉一个小窗口
+python3 ml/data_collection/collect_replay.py --symbol MNQ1! --timeframe 60 --days 730 # 1h 全量历史
+python3 ml/data_collection/collect_replay.py --symbol MNQ1! --timeframe 1 --days 30   # 1m 近30天
+```
+
+原始数据写到 `~/data/ml-raw/{symbol}_{timeframe}.parquet`。断点续跑/加宽窗口不需要单独的checkpoint文件——脚本每次都会读一下磁盘上已有数据的最早/最晚日期，和这次请求的目标窗口对比，只补真正缺的那一段（更早的历史缺口、更新的日期缺口，或两者都缺）。所以中断后重跑同一条命令，或者事后把 `--days` 从 5 改成 730，都会自动补齐缺口，不会重新从头抓，也不会像之前那样因为已经有一点数据就误判"已经抓完"。
+
+### 3. 构建特征+标签数据集
+
+```bash
+python3 -m ml.features.build_dataset --symbol MNQ1! --timeframe 1 --context 5,60
+```
+
+输出到 `~/data/ml-processed/{symbol}_{timeframe}.parquet`。
+
+### 4. 训练模型（多空各训一个）
+
+```bash
+python3 -m ml.train.train_model --symbol MNQ1! --timeframe 1 --direction long
+python3 -m ml.train.train_model --symbol MNQ1! --timeframe 1 --direction short
+python3 -m ml.train.evaluate --symbol MNQ1! --timeframe 1 --direction long
+```
+
+模型存到 `ml/models/`（已加入 `.gitignore`，不提交）。
+
+### 5. 启动实时预测服务
+
+```bash
+node ml/serve/server.js
+```
+
+默认监听 `http://localhost:4600`，`GET /api/predictions` 返回当前所有已配置品种×周期的预测缓存；前端页面在同一端口根路径。轮询目标自动从 `symbols.json` 里的品种×周期组合生成，且严格顺序执行（同一张图表一次只能被一个 predict.py 操作，不能并行）。
+
+## 目录结构
+
+```
+config/       symbols.json (TP/SL/预测窗口), sessions.json (时段+宏观日期)
+data_collection/  collect_replay.py — replay驱动的历史抓取，按磁盘已有数据自动补缺口
+features/     indicators.py / liquidity_sweep.py / session_context.py / build_dataset.py
+labels/       triple_barrier.py — 固定ticks的三重界限标签
+train/        train_model.py (LightGBM, 按时间切分, 不shuffle) / evaluate.py (校准曲线)
+models/       训练好的模型 (gitignored)
+serve/        predict.py (实时推理) / live_agent.js (轮询缓存) / server.js (Express) / public/ (前端)
+```

--- a/ml/config/sessions.json
+++ b/ml/config/sessions.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "All times are US Eastern (ET), matching the conventions already used in strategies/mgc_vwap_asian.py, strategies/asian_vol_by_hour.py, strategies/ny_vol_by_hour.py, and strategies/mnq_1m_liq_sweep.pine.",
+  "timezone": "America/New_York",
+  "sessions": {
+    "asian_futures": { "start": "18:00", "end": "02:00", "note": "CME Globex day rollover / Asian futures session, matches mgc_vwap_asian.py ASIAN_START_H/ASIAN_END_H" },
+    "asian_cash_open": { "start": "20:00", "end": "21:30", "note": "Tokyo/HK/Shanghai cash equity opens land in this ET window depending on DST" },
+    "london_open": { "start": "03:00", "end": "05:00" },
+    "ny_premarket": { "start": "04:00", "end": "09:29", "note": "matches mnq_1m_liq_sweep.pine pre-market range" },
+    "ny_open": { "start": "09:30", "end": "10:30", "note": "sweep/reversal window, matches mnq_1m_liq_sweep.pine" },
+    "ny_session": { "start": "09:30", "end": "16:00" }
+  },
+  "macro_slot_et": "08:30",
+  "_macro_slot_note": "Most US scheduled macro releases (CPI, PPI, retail sales, jobless claims, and NFP) land at 08:30 ET on weekdays. session_context.py flags proximity to this time daily regardless of which specific release it is, since there is no structured economic-calendar source in this repo (see news_aggregator.py limitations noted in the plan).",
+  "recurring_macro_rules": {
+    "nfp": { "rule": "first_friday_of_month", "time_et": "08:30" },
+    "cpi_ppi_typical_window": { "rule": "weekday_08:30_any_day", "note": "CPI/PPI dates vary month to month and are not a fixed weekday rule — leave to fomc_dates-style manual list if precision is needed" }
+  },
+  "fomc_dates": [],
+  "_fomc_note": "Intentionally left empty — FOMC meeting dates are irregular and must be filled in from the official Federal Reserve calendar (federalreserve.gov/monetarypolicy/fomccalendars.htm) rather than guessed. Format: ['YYYY-MM-DD', ...] for the second (decision) day of each two-day meeting. Until populated, the fomc_proximity feature in session_context.py will always be 0."
+}

--- a/ml/config/sessions.json
+++ b/ml/config/sessions.json
@@ -4,9 +4,11 @@
   "sessions": {
     "asian_futures": { "start": "18:00", "end": "02:00", "note": "CME Globex day rollover / Asian futures session, matches mgc_vwap_asian.py ASIAN_START_H/ASIAN_END_H" },
     "asian_cash_open": { "start": "20:00", "end": "21:30", "note": "Tokyo/HK/Shanghai cash equity opens land in this ET window depending on DST" },
-    "london_open": { "start": "03:00", "end": "05:00" },
+    "asian_open_active": { "start": "20:00", "end": "22:00", "note": "user-flagged high-activity Asian open window (8-9PM ET)" },
+    "london_open": { "start": "03:00", "end": "08:00" },
     "ny_premarket": { "start": "04:00", "end": "09:29", "note": "matches mnq_1m_liq_sweep.pine pre-market range" },
     "ny_open": { "start": "09:30", "end": "10:30", "note": "sweep/reversal window, matches mnq_1m_liq_sweep.pine" },
+    "ny_open_am": { "start": "09:30", "end": "11:30", "note": "user-flagged high-volatility NY morning window, wider than ny_open" },
     "ny_session": { "start": "09:30", "end": "16:00" }
   },
   "macro_slot_et": "08:30",

--- a/ml/config/symbols.json
+++ b/ml/config/symbols.json
@@ -1,0 +1,45 @@
+{
+  "_comment": "Strategy parameters \u2014 review before training on real data. tp_ticks/sl_ticks are EXCHANGE TICKS (matching the field name), converted to price points internally via tick_size (points_per_tick) \u2014 see build_dataset.py's load_symbol_config(). point_value is $ per 1.0 price-point move (not per tick). horizon_bars = how many bars forward to look for TP/SL resolution before labeling as timeout (dropped from training).",
+  "MNQ1!": {
+    "point_value": 2.0,
+    "tick_size": 0.25,
+    "timeframes": {
+      "1": {
+        "tp_ticks": 120,
+        "sl_ticks": 80,
+        "horizon_bars": 60
+      },
+      "5": {
+        "tp_ticks": 120,
+        "sl_ticks": 80,
+        "horizon_bars": 48
+      },
+      "60": {
+        "tp_ticks": 120,
+        "sl_ticks": 80,
+        "horizon_bars": 24
+      }
+    }
+  },
+  "MGC1!": {
+    "point_value": 10.0,
+    "tick_size": 0.10,
+    "timeframes": {
+      "1": {
+        "tp_ticks": 100.0,
+        "sl_ticks": 50,
+        "horizon_bars": 60
+      },
+      "5": {
+        "tp_ticks": 100.0,
+        "sl_ticks": 50,
+        "horizon_bars": 48
+      },
+      "60": {
+        "tp_ticks": 100.0,
+        "sl_ticks": 50.0,
+        "horizon_bars": 24
+      }
+    }
+  }
+}

--- a/ml/data_collection/collect_replay.py
+++ b/ml/data_collection/collect_replay.py
@@ -260,11 +260,33 @@ def _collect_locked(symbol: str, timeframe: str, start_date: str, end_date: str,
     # docstring for why the bar-to-bar check alone can miss this.
     last_good_close = float(existing["close"].iloc[-1]) if len(existing) else None
 
+    hit_live_edge = False
     try:
-        while batch_idx < max_batches:
+        while batch_idx < max_batches and not hit_live_edge:
             batch_idx += 1
             for step_no in range(batch_size):
-                step_result = tv(["replay", "step"])
+                try:
+                    step_result = tv(["replay", "step"])
+                except RuntimeError as e:
+                    # Confirmed via MGC1! 60m repeatedly dying at this exact
+                    # point: replay stepping toward a market-closed boundary
+                    # (e.g. Friday close -> weekend) exits the replay session
+                    # out from under us instead of just stopping at the last
+                    # available bar. Previously this propagated as an
+                    # unhandled crash, and since the ohlcv() read (and thus
+                    # flush()) for this batch hadn't run yet, EVERY bar
+                    # stepped through in the batch so far was silently lost —
+                    # explaining why retries kept landing on the same
+                    # timestamp. Treat it like reaching end_ts: stop stepping,
+                    # fall through to the ohlcv/flush below, and end the run
+                    # instead of crashing.
+                    if "Replay is not started" in str(e):
+                        print(f"[{symbol} {timeframe}]   step {step_no + 1}/{batch_size} (batch {batch_idx}): "
+                              f"replay exited (likely hit a market-closed boundary) — stopping here, "
+                              f"saving what was collected so far.", file=sys.stderr)
+                        hit_live_edge = True
+                        break
+                    raise
                 if step_pause:
                     time.sleep(step_pause)
                 current_date = step_result.get("current_date")
@@ -275,6 +297,19 @@ def _collect_locked(symbol: str, timeframe: str, start_date: str, end_date: str,
                           f"(batch {batch_idx}), at {epoch_to_datetime_str(current_date)}", file=sys.stderr)
                 if current_date and current_date >= end_ts:
                     break
+
+            if hit_live_edge:
+                # Replay already exited and the chart reverted to live mode —
+                # an ohlcv read here isn't replay data at all (confirmed: it
+                # trips the contamination check against last_good_close nearly
+                # every time), so don't bother reading or flushing it. Whatever
+                # this batch's steps produced before the exit is gone; that's
+                # a real limitation of this API (no per-step bar fetch, only
+                # a bulk read once per batch), not something worth chasing
+                # further right now.
+                print(f"[{symbol} {timeframe}] batch {batch_idx}: skipping ohlcv read after live-edge exit "
+                      f"(chart is back in live mode, not replay)", file=sys.stderr)
+                break
 
             bars = tv(["ohlcv", "-n", "500"]).get("bars", [])
             if bars_look_contaminated(bars, reference_price=last_good_close):
@@ -335,7 +370,14 @@ def _collect_locked(symbol: str, timeframe: str, start_date: str, end_date: str,
     finally:
         if pending_rows:
             existing = flush(symbol, timeframe, existing, pending_rows)
-        tv(["replay", "stop"])
+        try:
+            tv(["replay", "stop"])
+        except RuntimeError as e:
+            # Already exited on its own (the hit_live_edge case above) —
+            # nothing to stop, and letting this raise here would mask the
+            # clean return with a spurious crash.
+            if "Replay is not started" not in str(e):
+                raise
         print(f"[{symbol} {timeframe}] done. total bars on disk: {len(existing)}", file=sys.stderr)
 
     return existing
@@ -384,7 +426,18 @@ def plan_runs(symbol: str, timeframe: str, target_start: str, target_end: str) -
         print(f"[{symbol} {timeframe}] internal gap: {epoch_to_datetime_str(before)} -> {epoch_to_datetime_str(after)}", file=sys.stderr)
         runs.append((epoch_to_replay_datetime_str(before), epoch_to_date_str(after)))
 
-    if existing_max < target_end:
+    # Comparing bare *dates* here ("2026-08-21" < "2026-08-21" is False) missed
+    # a real case: a run that only reaches the first bar of target_end's day
+    # (e.g. just its 00:00 bar) looks "equal" to target_end and gets skipped,
+    # even though nearly the whole day is still missing — confirmed the hard
+    # way when 5m/60m context data quietly stopped updating for the last
+    # ~17-41 hours of two different symbols while the 1m execution data kept
+    # going, freezing the model's top feature at a stale value for that whole
+    # stretch. Compare actual timestamps instead, with a couple hours of
+    # slack so a genuinely-complete day (last bar shortly before target_end's
+    # boundary) doesn't spuriously trigger a run.
+    target_end_ts = date_str_to_epoch(target_end) + 86400
+    if int(existing["time"].max()) < target_end_ts - 2 * 3600:
         # Resume from the *exact* last bar, minute-precise (see
         # epoch_to_replay_datetime_str) — a bare date here would restart
         # replay hours before the last collected bar and re-walk all of it

--- a/ml/data_collection/collect_replay.py
+++ b/ml/data_collection/collect_replay.py
@@ -1,0 +1,442 @@
+"""
+Historical OHLCV collector, driven by TradingView Replay mode over CDP.
+
+There is no bulk historical-export API in this repo's CDP bridge — `data_get_ohlcv`
+only reads whatever's in the chart's live buffered window (capped at 500 bars), and
+replay only advances one bar at a time (`replay_step`). So this script:
+
+  1. Jumps replay to a start date (`replay start -d ...`).
+  2. Steps forward in batches (`replay step` x N), then reads the buffer once per
+     batch (`ohlcv -n 500`) instead of once per bar — cuts CDP round trips by ~N.
+  3. Merges newly-seen bars into a per-symbol/timeframe parquet file, deduped by
+     bar time, flushing to disk periodically so a killed/interrupted run loses
+     at most one flush interval of progress.
+  4. Resumability comes from the data itself, not a separate "last position"
+     tracker: each run compares the requested [start, end] window against the
+     earliest/latest bar already on disk (plan_runs()) and only walks whatever
+     gap is actually missing — an older gap (widening --days after already
+     having some data), a newer gap (catching up to a later --end-date), both,
+     or neither. This also means re-running the exact same command is always
+     safe and does the right thing, including picking up mid-collection after
+     a crash.
+
+1h/4h timeframes: a few hundred bars covers 1-2 years — a full run takes minutes.
+1m/5m timeframes: tens of thousands of bars for a month — budget for a run that
+takes hours. Start with a short --days window and widen it once the pipeline is
+verified end-to-end; widening --days later automatically triggers a backfill
+walk for the newly-added older history.
+
+Usage:
+    python ml/data_collection/collect_replay.py --symbol MNQ1! --timeframe 60 --days 5
+    python ml/data_collection/collect_replay.py --symbol MNQ1! --timeframe 60 --days 730  # widen later — backfills the gap
+    python ml/data_collection/collect_replay.py --symbol MNQ1! --timeframe 1 --days 30 --batch-size 50
+"""
+import argparse
+import json
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None  # POSIX-only; ml/ targets macOS (matches this repo's CDP/TradingView Desktop setup)
+
+import pandas as pd
+
+# All dates in this script — CLI --start-date/--end-date, "today"/"yesterday"
+# defaults, and progress logging — are Eastern Time, matching TradingView's own
+# session/bar-time convention and the ET anchoring already used throughout
+# ml/features/ (session windows, VWAP resets, etc.), not UTC.
+ET = ZoneInfo("America/New_York")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TV_CLI = REPO_ROOT / "src" / "cli" / "index.js"
+
+DATA_DIR = Path.home() / "data" / "ml-raw"
+CHART_LOCK_PATH = DATA_DIR / ".chart.lock"
+
+
+@contextmanager
+def chart_lock():
+    """Exclusive lock so collect_replay.py and predict.py (or two concurrent
+    invocations of either) never drive the shared TradingView Desktop chart at
+    the same time. Without this, one process's symbol/timeframe switch can land
+    in the middle of another process's read — confirmed the hard way: MGC1! raw
+    data collected while the live prediction server was polling in the
+    background has whole stretches of MNQ1! prices mixed into a gold file.
+    Blocking acquire: a collection run and a live-server poll cycle both want
+    the chart eventually, so whichever asked first should just make the other
+    wait rather than fail outright."""
+    if fcntl is None:
+        yield  # no POSIX file locking available — best-effort, no-op
+        return
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(CHART_LOCK_PATH, "w") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def tv(args: list[str]) -> dict:
+    result = subprocess.run(
+        ["node", str(TV_CLI)] + args,
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"tv CLI error ({' '.join(args)}): {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+CHART_SWITCH_RETRIES = 8
+CHART_SWITCH_RETRY_DELAY_S = 1.0
+
+
+def switch_chart(symbol: str, timeframe: str):
+    """`tv symbol`/`tv timeframe` each wait internally for the chart to look
+    ready (src/wait.js's waitForChartReady) and self-report a chart_ready flag —
+    but that wait can time out and return False, and its own comment says
+    "caller should verify". Nothing here verified: a stale/wrong-symbol chart
+    read doesn't raise an error, it silently returns another instrument's bars.
+    Confirmed the hard way — MGC1! raw data collected before this fix has whole
+    stretches of MNQ1! prices mixed in (~$29,000 bars sitting in a ~$4,000 gold
+    file) from exactly this race. Verify actual chart state via `tv state`
+    before trusting a read, not just the switch call's own self-report."""
+    tv(["symbol", symbol])
+    tv(["timeframe", timeframe])
+    actual_symbol, actual_tf = "", ""
+    for attempt in range(CHART_SWITCH_RETRIES):
+        state = tv(["state"])
+        actual_symbol = state.get("symbol", "")
+        actual_tf = str(state.get("resolution", ""))
+        if symbol.upper() in actual_symbol.upper() and actual_tf == str(timeframe):
+            return
+        time.sleep(CHART_SWITCH_RETRY_DELAY_S)
+    raise RuntimeError(
+        f"Chart never confirmed switch to {symbol}/{timeframe} after {CHART_SWITCH_RETRIES} "
+        f"retries (currently showing {actual_symbol}/{actual_tf}) — refusing to read bars off "
+        f"a chart that might still be on the wrong instrument."
+    )
+
+
+MAX_RELATIVE_JUMP = 0.05  # 5% single-bar move — implausible for real 1m/5m/60m futures data
+INTERNAL_GAP_THRESHOLD_SECONDS = 3 * 86400  # 3 days — safely above any normal weekend/holiday closure
+
+
+def bars_look_contaminated(bars: list[dict], reference_price: float | None = None) -> bool:
+    """switch_chart()'s own verification only checks the chart's *symbol label*
+    (chart.symbol()), which can update the instant you switch — while the
+    underlying bar buffer (mainSeriesBars(), what `ohlcv` actually reads) can
+    still be catching up to the new symbol for a moment after. So a read can
+    pass switch_chart()'s check and still return a batch straddling two
+    instruments. Confirmed the hard way even after that fix was live: an
+    otherwise ~$4,000 gold batch with an isolated stretch of ~$29,000 (MNQ-range)
+    bars in it. A >5% bar-to-bar jump is not something real 1m/5m/60m futures
+    data produces — it's the signature of exactly this straddle.
+
+    `reference_price`, when given, is compared against the *first* bar too —
+    confirmed necessary separately: if the whole 500-bar buffer had already
+    flipped to another instrument before this read (not mid-read), every bar
+    inside it is internally consistent with the others, just wrong, so the
+    bar-to-bar check alone sees nothing. Comparing against the last
+    known-good price from *outside* this batch (the previous accepted batch,
+    or on-disk data) catches that case."""
+    closes = [b["close"] for b in bars if b.get("close")]
+    if reference_price and closes:
+        if abs(closes[0] - reference_price) / abs(reference_price) > MAX_RELATIVE_JUMP:
+            return True
+    for prev, cur in zip(closes, closes[1:]):
+        if prev and abs(cur - prev) / abs(prev) > MAX_RELATIVE_JUMP:
+            return True
+    return False
+
+
+def date_str_to_epoch(date_str: str) -> int:
+    """'YYYY-MM-DD' -> unix seconds at ET midnight. `current_date` from the tv
+    CLI's replay status/step/start is itself unix seconds (bar-time convention,
+    not an ISO string despite the field name), so this is what end-date
+    comparisons need to be done against."""
+    return int(datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=ET).timestamp())
+
+
+def epoch_to_date_str(epoch_seconds: int | None) -> str:
+    if not epoch_seconds:
+        return "?"
+    return datetime.fromtimestamp(epoch_seconds, tz=ET).strftime("%Y-%m-%d")
+
+
+def epoch_to_datetime_str(epoch_seconds: int | None) -> str:
+    """Date-only collapses every intraday step on sub-daily timeframes (1h bars
+    stepping hour to hour all print the same day) — use this for per-step
+    progress lines so movement is actually visible, and epoch_to_date_str for
+    end-date comparisons/checkpoints where only the day matters."""
+    if not epoch_seconds:
+        return "?"
+    return datetime.fromtimestamp(epoch_seconds, tz=ET).strftime("%Y-%m-%d %H:%M ET")
+
+
+def epoch_to_replay_datetime_str(epoch_seconds: int) -> str:
+    """A minute-precise ET datetime string for `replay start -d`, not just a
+    bare date. `new Date(str).getTime()` in JS treats a date-*time* string
+    with no timezone suffix ("YYYY-MM-DDTHH:MM:SS") as the *browser's local
+    time* rather than UTC (unlike a bare "YYYY-MM-DD", which JS treats as UTC
+    midnight) — verified directly: passing a bar's exact ET timestamp this way
+    landed replay within 1 minute of that bar, vs. hours off with a bare date.
+    So when resuming a catchup walk from an exact last-collected-bar
+    timestamp, this is what actually eliminates the re-tread almost entirely,
+    not just narrows it."""
+    return datetime.fromtimestamp(epoch_seconds, tz=ET).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def safe_filename(symbol: str, timeframe: str) -> str:
+    return symbol.replace(":", "_").replace("!", "").replace("/", "_") + f"_{timeframe}"
+
+
+def parquet_path(symbol: str, timeframe: str) -> Path:
+    return DATA_DIR / f"{safe_filename(symbol, timeframe)}.parquet"
+
+
+def load_existing(symbol: str, timeframe: str) -> pd.DataFrame:
+    p = parquet_path(symbol, timeframe)
+    if p.exists():
+        return pd.read_parquet(p)
+    return pd.DataFrame(columns=["time", "open", "high", "low", "close", "volume"])
+
+
+def flush(symbol: str, timeframe: str, existing: pd.DataFrame, new_rows: list[dict]) -> pd.DataFrame:
+    if not new_rows:
+        return existing
+    new_df = pd.DataFrame(new_rows)
+    merged = new_df if existing.empty else pd.concat([existing, new_df], ignore_index=True)
+    merged = merged.drop_duplicates(subset="time", keep="last").sort_values("time").reset_index(drop=True)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    merged.to_parquet(parquet_path(symbol, timeframe), index=False)
+    return merged
+
+
+def collect(symbol: str, timeframe: str, start_date: str, end_date: str,
+            batch_size: int, flush_every: int, max_batches: int, step_pause: float):
+    """Acquires chart_lock() for the whole walk — replay mode owns the chart
+    continuously from the first switch_chart() through the final replay stop,
+    so nothing else (a concurrent collect_replay.py run, or the live server's
+    predict.py polling) may touch the chart until this returns."""
+    with chart_lock():
+        return _collect_locked(symbol, timeframe, start_date, end_date, batch_size, flush_every, max_batches, step_pause)
+
+
+def _collect_locked(symbol: str, timeframe: str, start_date: str, end_date: str,
+                     batch_size: int, flush_every: int, max_batches: int, step_pause: float):
+    switch_chart(symbol, timeframe)
+
+    existing = load_existing(symbol, timeframe)
+    print(f"[{symbol} {timeframe}] existing bars on disk: {len(existing)}", file=sys.stderr)
+
+    # end_date arrives as "YYYY-MM-DD"; current_date from the tv CLI is unix
+    # seconds (see date_str_to_epoch's docstring) — convert once so every
+    # in-loop comparison is numeric, not a str-vs-int TypeError waiting to happen.
+    end_ts = date_str_to_epoch(end_date) + 86400  # include the whole end date
+
+    status = tv(["replay", "status"])
+    if not status.get("is_replay_available"):
+        raise RuntimeError(f"Replay not available for {symbol} on timeframe {timeframe}")
+
+    started = tv(["replay", "start", "-d", start_date])
+    print(f"[{symbol} {timeframe}] replay started at {epoch_to_datetime_str(started.get('current_date'))}", file=sys.stderr)
+
+    pending_rows: list[dict] = []
+    seen_times: set[int] = set(existing["time"].tolist())
+    stalled_batches = 0
+    last_current_date = None
+    batch_idx = 0
+    # Tracks the last accepted close across batches (seeded from on-disk data
+    # if resuming), so bars_look_contaminated can catch a batch that's
+    # internally self-consistent but wrong as a *whole* — see that function's
+    # docstring for why the bar-to-bar check alone can miss this.
+    last_good_close = float(existing["close"].iloc[-1]) if len(existing) else None
+
+    try:
+        while batch_idx < max_batches:
+            batch_idx += 1
+            for step_no in range(batch_size):
+                step_result = tv(["replay", "step"])
+                if step_pause:
+                    time.sleep(step_pause)
+                current_date = step_result.get("current_date")
+                # Each step is its own subprocess + CDP round trip (~1-3s) —
+                # print progress every 10 steps so a slow batch doesn't look hung.
+                if (step_no + 1) % 10 == 0:
+                    print(f"[{symbol} {timeframe}]   step {step_no + 1}/{batch_size} "
+                          f"(batch {batch_idx}), at {epoch_to_datetime_str(current_date)}", file=sys.stderr)
+                if current_date and current_date >= end_ts:
+                    break
+
+            bars = tv(["ohlcv", "-n", "500"]).get("bars", [])
+            if bars_look_contaminated(bars, reference_price=last_good_close):
+                print(f"[{symbol} {timeframe}] batch {batch_idx}: bars look contaminated "
+                      f"(implausible jump) — re-confirming chart and retrying this read", file=sys.stderr)
+                switch_chart(symbol, timeframe)
+                time.sleep(2)
+                bars = tv(["ohlcv", "-n", "500"]).get("bars", [])
+                if bars_look_contaminated(bars, reference_price=last_good_close):
+                    raise RuntimeError(
+                        f"OHLCV data for {symbol}/{timeframe} still looks contaminated after a "
+                        f"retry — refusing to write it. Something is switching the chart to another "
+                        f"instrument faster than this can recover from (another process not going "
+                        f"through chart_lock(), or someone interacting with TradingView Desktop "
+                        f"directly). Stop whatever that is and re-run."
+                    )
+            new_count = 0
+            for bar in bars:
+                if bar["time"] not in seen_times:
+                    seen_times.add(bar["time"])
+                    pending_rows.append(bar)
+                    new_count += 1
+            if bars:
+                last_good_close = bars[-1]["close"]
+
+            status = tv(["replay", "status"])
+            current_date = status.get("current_date")
+            print(f"[{symbol} {timeframe}] batch {batch_idx}: +{new_count} new bars, "
+                  f"replay date={epoch_to_datetime_str(current_date)}, pending flush={len(pending_rows)}", file=sys.stderr)
+
+            # "0 new bars" alone doesn't mean replay is stuck — it also happens
+            # while legitimately re-walking a stretch that's already on disk
+            # (e.g. a resumed catchup walk starting a few hours before the last
+            # collected bar, since `replay start -d` snaps to that date's UTC
+            # midnight, not ET midnight — a bounded, self-correcting offset that
+            # this loop should just walk through, not give up on). The real
+            # signal that replay has hit a wall it can't step past (the live
+            # edge, or a genuine data boundary) is current_date itself staying
+            # frozen across batches — confirmed the hard way: this used to give
+            # up after 150 steps of harmless re-tread, aborting collection runs
+            # that had tens of thousands of genuinely new bars still ahead.
+            if current_date == last_current_date:
+                stalled_batches += 1
+                if stalled_batches >= 3:
+                    print(f"[{symbol} {timeframe}] replay date hasn't advanced for 3 batches, stopping.", file=sys.stderr)
+                    break
+            else:
+                stalled_batches = 0
+            last_current_date = current_date
+
+            if batch_idx % flush_every == 0 and pending_rows:
+                existing = flush(symbol, timeframe, existing, pending_rows)
+                pending_rows = []
+
+            if current_date and current_date >= end_ts:
+                print(f"[{symbol} {timeframe}] reached end date {end_date}, stopping.", file=sys.stderr)
+                break
+    finally:
+        if pending_rows:
+            existing = flush(symbol, timeframe, existing, pending_rows)
+        tv(["replay", "stop"])
+        print(f"[{symbol} {timeframe}] done. total bars on disk: {len(existing)}", file=sys.stderr)
+
+    return existing
+
+
+def plan_runs(symbol: str, timeframe: str, target_start: str, target_end: str) -> list[tuple[str, str]]:
+    """Decides which (start_date, end_date) walks are actually needed by
+    comparing the requested [target_start, target_end] window against what's
+    already on disk — not against a separately-tracked "last position"
+    checkpoint, which has no way to express "also go further back in history"
+    and silently ignored a widened --days once any checkpoint existed (the bug
+    that motivated this).
+
+    Replay can only step forward, so backfilling older history means starting
+    a fresh walk at target_start and stepping forward until it reaches
+    whatever's already the earliest bar on disk (dedup handles the overlap) —
+    a separate walk from catching up to target_end.
+
+    Also scans for gaps *inside* [existing_min, existing_max], not just at the
+    two endpoints — confirmed necessary the hard way: an interrupted run (a
+    crash, the machine sleeping mid-collection, anything that kills the
+    process partway) can leave some data collected before the interruption and
+    more collected after a later resume, with a large hole in between. Only
+    checking the outer boundary is blind to that entirely — it sees *a* bar at
+    the start and *a* bar at the end and calls the range complete.
+    """
+    existing = load_existing(symbol, timeframe)
+    if existing.empty:
+        return [(target_start, target_end)]
+
+    existing = existing.sort_values("time").reset_index(drop=True)
+    existing_min = epoch_to_date_str(int(existing["time"].min()))
+    existing_max = epoch_to_date_str(int(existing["time"].max()))
+    print(f"[{symbol} {timeframe}] on disk: {len(existing)} bars, {existing_min} -> {existing_max}", file=sys.stderr)
+
+    runs = []
+    if target_start < existing_min:
+        runs.append((target_start, existing_min))
+
+    # A gap wider than a few days is well beyond any normal weekend/holiday
+    # closure for a nearly-continuous futures market — safe to treat as
+    # genuinely missing data rather than a scheduled gap.
+    gap_seconds = existing["time"].diff()
+    for pos in gap_seconds[gap_seconds > INTERNAL_GAP_THRESHOLD_SECONDS].index:
+        before, after = int(existing["time"].iloc[pos - 1]), int(existing["time"].iloc[pos])
+        print(f"[{symbol} {timeframe}] internal gap: {epoch_to_datetime_str(before)} -> {epoch_to_datetime_str(after)}", file=sys.stderr)
+        runs.append((epoch_to_replay_datetime_str(before), epoch_to_date_str(after)))
+
+    if existing_max < target_end:
+        # Resume from the *exact* last bar, minute-precise (see
+        # epoch_to_replay_datetime_str) — a bare date here would restart
+        # replay hours before the last collected bar and re-walk all of it
+        # for nothing.
+        catchup_start = epoch_to_replay_datetime_str(int(existing["time"].max()))
+        runs.append((catchup_start, target_end))
+    if not runs:
+        print(f"[{symbol} {timeframe}] already covers {target_start} -> {target_end}, nothing to do.", file=sys.stderr)
+    return runs
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True, help="e.g. MNQ1!, MGC1!")
+    parser.add_argument("--timeframe", required=True, help="tv resolution string, e.g. 1, 5, 60")
+    parser.add_argument("--days", type=int, default=30, help="days of history to target, ending at --end-date")
+    parser.add_argument("--start-date", help="YYYY-MM-DD, overrides --days: force a single walk from exactly this date to --end-date")
+    parser.add_argument("--end-date", help="YYYY-MM-DD, default yesterday (today's still-open session is excluded by default)")
+    parser.add_argument("--batch-size", type=int, default=50, help="replay steps per OHLCV read")
+    parser.add_argument("--flush-every", type=int, default=5, help="batches between parquet writes")
+    parser.add_argument("--max-batches", type=int, default=100000, help="safety cap on total batches")
+    parser.add_argument("--step-pause", type=float, default=0.0, help="seconds to sleep after each replay step")
+    args = parser.parse_args()
+
+    # Default end date is yesterday (in ET, TradingView's own session convention —
+    # not whatever timezone this machine's clock happens to be in), not today —
+    # today's session is still in progress and its bars/labels would be incomplete
+    # (a "timeout" label near the end of the data isn't a real timeout, it's just
+    # "hasn't happened yet").
+    end_date = args.end_date or (datetime.now(ET) - timedelta(days=1)).strftime("%Y-%m-%d")
+    # --days counts back from end_date, not "now", so a custom --end-date still
+    # yields exactly `days` days of window.
+    target_start = args.start_date or (datetime.strptime(end_date, "%Y-%m-%d") - timedelta(days=args.days)).strftime("%Y-%m-%d")
+
+    if args.start_date:
+        runs = [(target_start, end_date)]
+    else:
+        runs = plan_runs(args.symbol, args.timeframe, target_start, end_date)
+
+    for i, (start_date, run_end_date) in enumerate(runs):
+        print(f"[{args.symbol} {args.timeframe}] === run {i + 1}/{len(runs)}: {start_date} -> {run_end_date} ===", file=sys.stderr)
+        collect(
+            symbol=args.symbol,
+            timeframe=args.timeframe,
+            start_date=start_date,
+            end_date=run_end_date,
+            batch_size=args.batch_size,
+            flush_every=args.flush_every,
+            max_batches=args.max_batches,
+            step_pause=args.step_pause,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/features/build_dataset.py
+++ b/ml/features/build_dataset.py
@@ -16,9 +16,11 @@ from pathlib import Path
 
 import pandas as pd
 
+from .ict_smc import add_ict_smc_features
 from .indicators import compute_all
 from .liquidity_sweep import add_liquidity_sweep_features
 from .session_context import add_session_context
+from .session_levels import add_session_levels
 from ..data_collection.collect_replay import parquet_path
 from ..labels.triple_barrier import label_triple_barrier
 
@@ -33,6 +35,8 @@ CONTEXT_FEATURE_COLS = [
     "premarket_swept_high_recently", "premarket_swept_low_recently",
     "prior_day_swept_high_recently", "prior_day_swept_low_recently",
     "structural_swept_high_recently", "structural_swept_low_recently",
+    "in_bull_fvg", "in_bear_fvg", "dist_to_bull_fvg", "dist_to_bear_fvg",
+    "in_bull_ob", "in_bear_ob", "dist_to_bull_ob", "dist_to_bear_ob",
 ]
 
 
@@ -62,8 +66,10 @@ def load_symbol_config(symbol: str, timeframe: str) -> dict:
 
 
 def compute_features(raw: pd.DataFrame) -> pd.DataFrame:
-    df = compute_all(raw)
+    df = compute_all(raw)  # must run first — ict_smc's order blocks need atr_14
     df = add_liquidity_sweep_features(df)
+    df = add_ict_smc_features(df)
+    df = add_session_levels(df)
     df = add_session_context(df)
     return df
 
@@ -87,8 +93,26 @@ def build(symbol: str, timeframe: str, context_timeframes: list[str]) -> pd.Data
         ctx_df = compute_features(ctx_raw)
         cols = ["time"] + [c for c in CONTEXT_FEATURE_COLS if c in ctx_df.columns]
         ctx_slice = ctx_df[cols].add_prefix(f"ctx_{ctx_tf}m_").rename(columns={f"ctx_{ctx_tf}m_time": "time"})
-        df = pd.merge_asof(df.sort_values("time"), ctx_slice.sort_values("time"), on="time", direction="backward")
-        print(f"[{symbol} {timeframe}] joined context tf={ctx_tf} ({len(ctx_df)} bars)", file=sys.stderr)
+        # ctx_slice["time"] is each higher-timeframe bar's OPEN time (standard
+        # OHLCV convention, confirmed against src/core/data.js's raw bar array —
+        # time: v[0]). Its feature columns (vwap, rsi, ...) are computed from
+        # that bar's FULL range, which isn't settled until the bar closes. A
+        # plain merge_asof on open time would let e.g. a 1m row at 10:05 match
+        # the 60m bar opened at 10:00 — whose values reflect the entire
+        # 10:00-11:00 hour, i.e. up to 55 minutes of future information relative
+        # to that 1m row. Shift the merge key to each context bar's CLOSE time
+        # so a 1m row only ever sees higher-timeframe bars that had fully
+        # closed by that point — this was a real lookahead leak, not just an
+        # off-by-one, and it's the reason ctx_60m features (esp.
+        # dist_from_vwap_sigma) previously dominated feature importance.
+        ctx_tf_seconds = int(ctx_tf) * 60
+        ctx_slice = ctx_slice.copy()
+        ctx_slice["close_time"] = ctx_slice["time"] + ctx_tf_seconds
+        ctx_slice = ctx_slice.drop(columns=["time"])
+        df = pd.merge_asof(df.sort_values("time"), ctx_slice.sort_values("close_time"),
+                            left_on="time", right_on="close_time", direction="backward")
+        df = df.drop(columns=["close_time"])
+        print(f"[{symbol} {timeframe}] joined context tf={ctx_tf} (close-time aligned, {len(ctx_df)} bars)", file=sys.stderr)
 
     tf_cfg = load_symbol_config(symbol, timeframe)
     df = label_triple_barrier(df, tp_points=tf_cfg["tp_points"], sl_points=tf_cfg["sl_points"],

--- a/ml/features/build_dataset.py
+++ b/ml/features/build_dataset.py
@@ -1,0 +1,122 @@
+"""
+Builds a labeled training dataset for one symbol + execution timeframe:
+raw bars -> indicators + liquidity-sweep + session-context features on the
+execution timeframe, joined with the same feature set computed on one or more
+higher "context" timeframes (as-of merged, so a 1m row only ever sees a 5m/1h/4h
+bar that had *already closed* at that point in time — no lookahead), then
+triple-barrier labeled using ml/config/symbols.json's fixed TP/SL ticks.
+
+Run as a module from the repo root (relative imports need the package context):
+    python -m ml.features.build_dataset --symbol MNQ1! --timeframe 1 --context 5,60
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from .indicators import compute_all
+from .liquidity_sweep import add_liquidity_sweep_features
+from .session_context import add_session_context
+from ..data_collection.collect_replay import parquet_path
+from ..labels.triple_barrier import label_triple_barrier
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "symbols.json"
+OUT_DIR = Path.home() / "data" / "ml-processed"
+
+# Curated columns pulled from context timeframes — not the full feature set, to
+# keep the joined frame from ballooning with mostly-redundant OHLC columns.
+CONTEXT_FEATURE_COLS = [
+    "rsi_14", "macd_hist", "bb_pctb_20", "bb_width_20",
+    "dist_from_vwap_sigma", "atr_14",
+    "premarket_swept_high_recently", "premarket_swept_low_recently",
+    "prior_day_swept_high_recently", "prior_day_swept_low_recently",
+    "structural_swept_high_recently", "structural_swept_low_recently",
+]
+
+
+def load_symbol_config(symbol: str, timeframe: str) -> dict:
+    """tp_ticks/sl_ticks in symbols.json are exchange ticks (matching the field
+    name) — this is the one place that converts them to price points via the
+    symbol's tick_size, so every caller works in points and never has to guess
+    which unit a raw number is in. (This distinction is exactly what caused a
+    real bug once: MGC1!'s tp_ticks=100 was briefly read as 100 *points* instead
+    of 100 ticks = $10, making the configured TP look unreachable relative to
+    gold's actual volatility.)"""
+    all_config = json.loads(CONFIG_PATH.read_text())
+    sym_cfg = all_config.get(symbol)
+    if not sym_cfg:
+        raise ValueError(f"No config for symbol {symbol} in {CONFIG_PATH}")
+    tf_cfg = sym_cfg["timeframes"].get(timeframe)
+    if not tf_cfg:
+        raise ValueError(f"No timeframe {timeframe} config for {symbol} in {CONFIG_PATH}")
+    tick_size = sym_cfg["tick_size"]
+    return {
+        **tf_cfg,
+        "tick_size": tick_size,
+        "point_value": sym_cfg["point_value"],
+        "tp_points": tf_cfg["tp_ticks"] * tick_size,
+        "sl_points": tf_cfg["sl_ticks"] * tick_size,
+    }
+
+
+def compute_features(raw: pd.DataFrame) -> pd.DataFrame:
+    df = compute_all(raw)
+    df = add_liquidity_sweep_features(df)
+    df = add_session_context(df)
+    return df
+
+
+def load_raw(symbol: str, timeframe: str) -> pd.DataFrame:
+    path = parquet_path(symbol, timeframe)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"No raw data at {path} — run collect_replay.py for {symbol} {timeframe} first."
+        )
+    return pd.read_parquet(path)
+
+
+def build(symbol: str, timeframe: str, context_timeframes: list[str]) -> pd.DataFrame:
+    raw = load_raw(symbol, timeframe)
+    print(f"[{symbol} {timeframe}] {len(raw)} raw bars", file=sys.stderr)
+    df = compute_features(raw)
+
+    for ctx_tf in context_timeframes:
+        ctx_raw = load_raw(symbol, ctx_tf)
+        ctx_df = compute_features(ctx_raw)
+        cols = ["time"] + [c for c in CONTEXT_FEATURE_COLS if c in ctx_df.columns]
+        ctx_slice = ctx_df[cols].add_prefix(f"ctx_{ctx_tf}m_").rename(columns={f"ctx_{ctx_tf}m_time": "time"})
+        df = pd.merge_asof(df.sort_values("time"), ctx_slice.sort_values("time"), on="time", direction="backward")
+        print(f"[{symbol} {timeframe}] joined context tf={ctx_tf} ({len(ctx_df)} bars)", file=sys.stderr)
+
+    tf_cfg = load_symbol_config(symbol, timeframe)
+    df = label_triple_barrier(df, tp_points=tf_cfg["tp_points"], sl_points=tf_cfg["sl_points"],
+                               horizon_bars=tf_cfg["horizon_bars"])
+
+    n_labeled_long = df["label_long"].notna().sum()
+    n_labeled_short = df["label_short"].notna().sum()
+    print(f"[{symbol} {timeframe}] labeled rows: long={n_labeled_long} short={n_labeled_short} "
+          f"(of {len(df)} total, rest are horizon timeouts)", file=sys.stderr)
+    return df
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True, help="execution timeframe, e.g. 1, 5")
+    parser.add_argument("--context", default="", help="comma-separated higher timeframes to join as context, e.g. 5,60")
+    parser.add_argument("--out", help="output parquet path, default data/ml-processed/{symbol}_{tf}.parquet")
+    args = parser.parse_args()
+
+    context_tfs = [c.strip() for c in args.context.split(",") if c.strip()]
+    df = build(args.symbol, args.timeframe, context_tfs)
+
+    out_path = Path(args.out) if args.out else OUT_DIR / f"{args.symbol.replace(':', '_').replace('!', '')}_{args.timeframe}.parquet"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(out_path, index=False)
+    print(f"Wrote {len(df)} rows to {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/features/ict_smc.py
+++ b/ml/features/ict_smc.py
@@ -1,0 +1,188 @@
+"""
+ICT/SMC-style structural features not covered by liquidity_sweep.py: Fair
+Value Gaps (FVG) and Order Blocks (OB). Both are inherently *stateful* — "is
+there still an unfilled gap/zone from a few bars ago, and how far away is
+it" requires tracking one open zone forward through time, not just detecting
+where one formed — so unlike most of this pipeline's features these are
+plain sequential loops rather than vectorized pandas ops. Only the single
+most recent unfilled zone in each direction is tracked (not every historical
+gap simultaneously) — a deliberate scope limit, not an oversight: the
+question a live entry cares about is "what's the nearest one," not the full
+history.
+
+Fair Value Gap (FVG) — a 3-candle imbalance: candle 3 doesn't overlap with
+candle 1 at all, meaning candle 2 displaced price so fast it left a gap in
+traded prices. Bullish FVG: low[i] > high[i-2] (gap sits below current price,
+often acts as support on a pullback). Bearish FVG: high[i] < low[i-2] (gap
+above, often resistance). "Filled"/mitigated once price fully retraces
+through the gap zone.
+
+Order Block (OB) — the last opposite-colored candle immediately before a
+displacement move that breaks recent structure. Bullish OB: the last
+bearish (down-close) candle right before a big bullish bar that closes above
+the recent N-bar high. Bearish OB: mirror. Requires atr_14 to already be
+computed (ml/features/indicators.py) to define "big" (displacement) — run
+this after compute_all(), not before.
+"""
+import numpy as np
+import pandas as pd
+
+FVG_LOOKBACK = 2  # 3-candle pattern: compare bar i against bar i-2
+DISPLACEMENT_ATR_MULT = 1.5
+STRUCTURE_LOOKBACK = 20
+
+
+def add_fvg_features(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_values("time").reset_index(drop=True).copy()
+    high, low = df["high"].to_numpy(), df["low"].to_numpy()
+    close = df["close"].to_numpy()
+    n = len(df)
+
+    bull_formed = np.zeros(n, dtype=bool)
+    bear_formed = np.zeros(n, dtype=bool)
+    bull_top = np.full(n, np.nan)
+    bull_bottom = np.full(n, np.nan)
+    bear_top = np.full(n, np.nan)
+    bear_bottom = np.full(n, np.nan)
+
+    for i in range(FVG_LOOKBACK, n):
+        if low[i] > high[i - FVG_LOOKBACK]:
+            bull_formed[i] = True
+            bull_top[i], bull_bottom[i] = low[i], high[i - FVG_LOOKBACK]
+        if high[i] < low[i - FVG_LOOKBACK]:
+            bear_formed[i] = True
+            bear_top[i], bear_bottom[i] = low[i - FVG_LOOKBACK], high[i]
+
+    df["fvg_bullish_formed"] = bull_formed.astype(int)
+    df["fvg_bearish_formed"] = bear_formed.astype(int)
+
+    dist_bull = np.full(n, np.nan)
+    bars_bull = np.full(n, np.nan)
+    in_bull = np.zeros(n, dtype=int)
+    dist_bear = np.full(n, np.nan)
+    bars_bear = np.full(n, np.nan)
+    in_bear = np.zeros(n, dtype=int)
+
+    active_bull_top = active_bull_bottom = np.nan
+    active_bull_idx = -1
+    active_bear_top = active_bear_bottom = np.nan
+    active_bear_idx = -1
+
+    for i in range(n):
+        if bull_formed[i]:
+            active_bull_top, active_bull_bottom, active_bull_idx = bull_top[i], bull_bottom[i], i
+        if bear_formed[i]:
+            active_bear_top, active_bear_bottom, active_bear_idx = bear_top[i], bear_bottom[i], i
+
+        # Fully mitigated once price trades all the way through the gap.
+        if active_bull_idx >= 0 and i > active_bull_idx and low[i] <= active_bull_bottom:
+            active_bull_idx = -1
+        if active_bear_idx >= 0 and i > active_bear_idx and high[i] >= active_bear_top:
+            active_bear_idx = -1
+
+        if active_bull_idx >= 0:
+            dist_bull[i] = close[i] - active_bull_top  # positive = still above the gap
+            bars_bull[i] = i - active_bull_idx
+            in_bull[i] = int(active_bull_bottom <= close[i] <= active_bull_top)
+        if active_bear_idx >= 0:
+            dist_bear[i] = active_bear_bottom - close[i]  # positive = still below the gap
+            bars_bear[i] = i - active_bear_idx
+            in_bear[i] = int(active_bear_bottom <= close[i] <= active_bear_top)
+
+    df["dist_to_bull_fvg"] = dist_bull
+    df["bars_since_bull_fvg"] = bars_bull
+    df["in_bull_fvg"] = in_bull
+    df["dist_to_bear_fvg"] = dist_bear
+    df["bars_since_bear_fvg"] = bars_bear
+    df["in_bear_fvg"] = in_bear
+    return df
+
+
+def add_order_block_features(df: pd.DataFrame, atr_col: str = "atr_14",
+                              displacement_mult: float = DISPLACEMENT_ATR_MULT,
+                              structure_lookback: int = STRUCTURE_LOOKBACK) -> pd.DataFrame:
+    if atr_col not in df.columns:
+        raise ValueError(f"add_order_block_features needs '{atr_col}' — run indicators.compute_all() first")
+    df = df.sort_values("time").reset_index(drop=True).copy()
+    high, low = df["high"].to_numpy(), df["low"].to_numpy()
+    close, open_ = df["close"].to_numpy(), df["open"].to_numpy()
+    atr = df[atr_col].to_numpy()
+    n = len(df)
+
+    roll_high = df["high"].rolling(structure_lookback).max().shift(1).to_numpy()
+    roll_low = df["low"].rolling(structure_lookback).min().shift(1).to_numpy()
+
+    bull_formed = np.zeros(n, dtype=bool)
+    bear_formed = np.zeros(n, dtype=bool)
+    bull_top = np.full(n, np.nan)
+    bull_bottom = np.full(n, np.nan)
+    bear_top = np.full(n, np.nan)
+    bear_bottom = np.full(n, np.nan)
+
+    for i in range(1, n):
+        if np.isnan(atr[i]) or np.isnan(roll_high[i]):
+            continue
+        bar_range = high[i] - low[i]
+        is_displacement = bar_range >= displacement_mult * atr[i]
+        if not is_displacement:
+            continue
+        prev_bearish = close[i - 1] < open_[i - 1]
+        prev_bullish = close[i - 1] > open_[i - 1]
+
+        if close[i] > open_[i] and close[i] > roll_high[i] and prev_bearish:
+            bull_formed[i] = True
+            bull_top[i], bull_bottom[i] = high[i - 1], low[i - 1]
+        if close[i] < open_[i] and close[i] < roll_low[i] and prev_bullish:
+            bear_formed[i] = True
+            bear_top[i], bear_bottom[i] = high[i - 1], low[i - 1]
+
+    df["bull_ob_formed"] = bull_formed.astype(int)
+    df["bear_ob_formed"] = bear_formed.astype(int)
+
+    dist_bull = np.full(n, np.nan)
+    bars_bull = np.full(n, np.nan)
+    in_bull = np.zeros(n, dtype=int)
+    dist_bear = np.full(n, np.nan)
+    bars_bear = np.full(n, np.nan)
+    in_bear = np.zeros(n, dtype=int)
+
+    active_bull_top = active_bull_bottom = np.nan
+    active_bull_idx = -1
+    active_bear_top = active_bear_bottom = np.nan
+    active_bear_idx = -1
+
+    for i in range(n):
+        if bull_formed[i]:
+            active_bull_top, active_bull_bottom, active_bull_idx = bull_top[i], bull_bottom[i], i
+        if bear_formed[i]:
+            active_bear_top, active_bear_bottom, active_bear_idx = bear_top[i], bear_bottom[i], i
+
+        # Mitigated once price closes back through the zone.
+        if active_bull_idx >= 0 and i > active_bull_idx and low[i] <= active_bull_bottom:
+            active_bull_idx = -1
+        if active_bear_idx >= 0 and i > active_bear_idx and high[i] >= active_bear_top:
+            active_bear_idx = -1
+
+        if active_bull_idx >= 0:
+            dist_bull[i] = close[i] - active_bull_top
+            bars_bull[i] = i - active_bull_idx
+            in_bull[i] = int(active_bull_bottom <= close[i] <= active_bull_top)
+        if active_bear_idx >= 0:
+            dist_bear[i] = active_bear_bottom - close[i]
+            bars_bear[i] = i - active_bear_idx
+            in_bear[i] = int(active_bear_bottom <= close[i] <= active_bear_top)
+
+    df["dist_to_bull_ob"] = dist_bull
+    df["bars_since_bull_ob"] = bars_bull
+    df["in_bull_ob"] = in_bull
+    df["dist_to_bear_ob"] = dist_bear
+    df["bars_since_bear_ob"] = bars_bear
+    df["in_bear_ob"] = in_bear
+    return df
+
+
+def add_ict_smc_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Assumes indicators.compute_all() has already run (needs atr_14)."""
+    df = add_fvg_features(df)
+    df = add_order_block_features(df)
+    return df

--- a/ml/features/indicators.py
+++ b/ml/features/indicators.py
@@ -1,0 +1,115 @@
+"""
+Standard technical indicators computed locally from raw OHLCV, in pandas.
+
+There's no historical indicator-series API over CDP (data_get_study_values only
+exposes the *current* value), so every indicator here is recomputed from the raw
+bars collected by data_collection/collect_replay.py rather than read off the chart.
+
+VWAP follows the session-anchored approach already used in
+strategies/mgc_vwap_reversion.py / strategies/mgc_vwap_asian.py: cumulative
+volume-weighted typical price, reset at each session boundary, with
+volume-weighted standard-deviation bands.
+
+All functions take/return a DataFrame with at least
+['time','open','high','low','close','volume'], time = unix seconds (UTC),
+and add columns in place (also returned for chaining).
+"""
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import pandas as pd
+
+ET = ZoneInfo("America/New_York")
+
+
+def _et_index(df: pd.DataFrame) -> pd.DatetimeIndex:
+    return pd.to_datetime(df["time"], unit="s", utc=True).dt.tz_convert(ET)
+
+
+def add_rsi(df: pd.DataFrame, period: int = 14, col: str = "close") -> pd.DataFrame:
+    delta = df[col].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    df[f"rsi_{period}"] = 100 - (100 / (1 + rs))
+    return df
+
+
+def add_macd(df: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int = 9, col: str = "close") -> pd.DataFrame:
+    ema_fast = df[col].ewm(span=fast, adjust=False).mean()
+    ema_slow = df[col].ewm(span=slow, adjust=False).mean()
+    macd = ema_fast - ema_slow
+    macd_signal = macd.ewm(span=signal, adjust=False).mean()
+    df["macd"] = macd
+    df["macd_signal"] = macd_signal
+    df["macd_hist"] = macd - macd_signal
+    return df
+
+
+def add_bollinger(df: pd.DataFrame, period: int = 20, num_std: float = 2.0, col: str = "close") -> pd.DataFrame:
+    mid = df[col].rolling(period).mean()
+    std = df[col].rolling(period).std()
+    df[f"bb_mid_{period}"] = mid
+    df[f"bb_upper_{period}"] = mid + num_std * std
+    df[f"bb_lower_{period}"] = mid - num_std * std
+    df[f"bb_width_{period}"] = (df[f"bb_upper_{period}"] - df[f"bb_lower_{period}"]) / mid
+    df[f"bb_pctb_{period}"] = (df[col] - df[f"bb_lower_{period}"]) / (df[f"bb_upper_{period}"] - df[f"bb_lower_{period}"])
+    return df
+
+
+def add_atr(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
+    prev_close = df["close"].shift(1)
+    tr = pd.concat([
+        df["high"] - df["low"],
+        (df["high"] - prev_close).abs(),
+        (df["low"] - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    df[f"atr_{period}"] = tr.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    return df
+
+
+def add_session_vwap(df: pd.DataFrame, session_start_hour: int = 18) -> pd.DataFrame:
+    """Session-anchored VWAP + volume-weighted std bands.
+
+    Session id increments at `session_start_hour` ET (default 18:00, matching the
+    CME Globex day rollover used in mgc_vwap_reversion.py's session_date()).
+    """
+    et = _et_index(df)
+    session_id = (et - pd.Timedelta(hours=session_start_hour)).dt.floor("D")
+
+    typical = (df["high"] + df["low"] + df["close"]) / 3
+    tp_vol = typical * df["volume"]
+
+    grp = df.groupby(session_id.values)
+    cum_vol = grp["volume"].cumsum()
+    cum_tp_vol = tp_vol.groupby(session_id.values).cumsum()
+    vwap = cum_tp_vol / cum_vol.replace(0, np.nan)
+
+    sq_dev = ((typical - vwap) ** 2) * df["volume"]
+    cum_sq_dev = sq_dev.groupby(session_id.values).cumsum()
+    variance = cum_sq_dev / cum_vol.replace(0, np.nan)
+    std = np.sqrt(variance)
+
+    df["session_id"] = session_id.values
+    df["vwap"] = vwap
+    df["vwap_std"] = std
+    df["vwap_upper1"] = vwap + std
+    df["vwap_lower1"] = vwap - std
+    df["vwap_upper2"] = vwap + 2 * std
+    df["vwap_lower2"] = vwap - 2 * std
+    df["dist_from_vwap"] = df["close"] - vwap
+    df["dist_from_vwap_sigma"] = df["dist_from_vwap"] / std.replace(0, np.nan)
+    return df
+
+
+def compute_all(df: pd.DataFrame, rsi_period: int = 14, macd=(12, 26, 9), bb_period: int = 20,
+                 atr_period: int = 14, vwap_session_start_hour: int = 18) -> pd.DataFrame:
+    df = df.sort_values("time").reset_index(drop=True).copy()
+    add_rsi(df, period=rsi_period)
+    add_macd(df, *macd)
+    add_bollinger(df, period=bb_period)
+    add_atr(df, period=atr_period)
+    add_session_vwap(df, session_start_hour=vwap_session_start_hour)
+    return df

--- a/ml/features/liquidity_sweep.py
+++ b/ml/features/liquidity_sweep.py
@@ -1,0 +1,111 @@
+"""
+ICT-style liquidity-sweep features: "did price just wick through a prior
+high/low and close back inside it" (a stop-run / liquidity grab, often followed
+by reversal), plus "how long ago did that happen."
+
+Ported from the discretionary logic in strategies/mnq_1m_liq_sweep.pine (which
+watches the 04:00-09:29 ET pre-market range and fades a wick-through-and-close-back
+during the 09:30-10:29 ET window), generalized to run on every bar across any
+timeframe/session rather than only that one narrow strategy window, and extended
+with prior-day and rolling-structural reference levels so the model has more than
+one notion of "prior high/low" to work with.
+
+Reference levels computed:
+  - pm_high / pm_low        — pre-market (04:00-09:29 ET) range, frozen for the
+                               rest of the session once the window closes.
+  - prior_day_high / _low   — full-session high/low of the *previous* completed
+                               session (session boundary = 18:00 ET, matching
+                               indicators.add_session_vwap's session_id).
+  - roll_high_N / roll_low_N — rolling N-bar structural high/low (excludes the
+                               current bar, so it's a genuinely "prior" level).
+
+For each reference level, a sweep is: high wicks above the level and closes back
+below it (swept_high — a liquidity grab of highs, often bearish), or the mirror
+for lows (swept_low — often bullish). "Swept recently" flags + bars-since-sweep
+give the model a sense of how fresh the event is.
+"""
+import numpy as np
+import pandas as pd
+
+from .indicators import ET, _et_index
+
+DEFAULT_SESSION_START_HOUR = 18
+PREMARKET_START = 4 * 60       # 04:00 ET, minutes from midnight
+PREMARKET_END = 9 * 60 + 29    # 09:29 ET
+
+
+def _session_id(df: pd.DataFrame, session_start_hour: int = DEFAULT_SESSION_START_HOUR) -> pd.Series:
+    et = _et_index(df)
+    return (et - pd.Timedelta(hours=session_start_hour)).dt.floor("D")
+
+
+def add_premarket_levels(df: pd.DataFrame, session_id: pd.Series) -> pd.DataFrame:
+    et = _et_index(df)
+    tod = et.dt.hour * 60 + et.dt.minute
+    premarket_mask = (tod >= PREMARKET_START) & (tod <= PREMARKET_END)
+
+    pm_high = df["high"].where(premarket_mask)
+    pm_low = df["low"].where(premarket_mask)
+
+    df["pm_high"] = pm_high.groupby(session_id).cummax()
+    df["pm_low"] = pm_low.groupby(session_id).cummin()
+    df["pm_high"] = df.groupby(session_id)["pm_high"].ffill()
+    df["pm_low"] = df.groupby(session_id)["pm_low"].ffill()
+    return df
+
+
+def add_prior_day_levels(df: pd.DataFrame, session_id: pd.Series) -> pd.DataFrame:
+    tmp = df.assign(_sid=session_id)
+    extremes = tmp.groupby("_sid").agg(day_high=("high", "max"), day_low=("low", "min")).reset_index()
+    extremes = extremes.sort_values("_sid")
+    extremes["prior_day_high"] = extremes["day_high"].shift(1)
+    extremes["prior_day_low"] = extremes["day_low"].shift(1)
+    merged = tmp.merge(extremes[["_sid", "prior_day_high", "prior_day_low"]], on="_sid", how="left")
+    df["prior_day_high"] = merged["prior_day_high"].values
+    df["prior_day_low"] = merged["prior_day_low"].values
+    return df
+
+
+def add_rolling_levels(df: pd.DataFrame, period: int = 20) -> pd.DataFrame:
+    df[f"roll_high_{period}"] = df["high"].rolling(period).max().shift(1)
+    df[f"roll_low_{period}"] = df["low"].rolling(period).min().shift(1)
+    return df
+
+
+def _bars_since_true(event: pd.Series, session_id: pd.Series) -> pd.Series:
+    idx = pd.Series(np.arange(len(event)), index=event.index)
+    last_true_idx = idx.where(event).groupby(session_id).ffill()
+    bars_since = idx - last_true_idx
+    return bars_since  # NaN until first occurrence within the session
+
+
+def detect_sweep(df: pd.DataFrame, level_high_col: str, level_low_col: str,
+                  prefix: str, session_id: pd.Series) -> pd.DataFrame:
+    swept_high = (df["high"] > df[level_high_col]) & (df["close"] < df[level_high_col])
+    swept_low = (df["low"] < df[level_low_col]) & (df["close"] > df[level_low_col])
+
+    df[f"{prefix}_swept_high"] = swept_high.astype(int)
+    df[f"{prefix}_swept_low"] = swept_low.astype(int)
+
+    bars_since_high = _bars_since_true(swept_high, session_id)
+    bars_since_low = _bars_since_true(swept_low, session_id)
+    df[f"{prefix}_bars_since_swept_high"] = bars_since_high
+    df[f"{prefix}_bars_since_swept_low"] = bars_since_low
+    df[f"{prefix}_swept_high_recently"] = (bars_since_high.fillna(9999) <= 5).astype(int)
+    df[f"{prefix}_swept_low_recently"] = (bars_since_low.fillna(9999) <= 5).astype(int)
+    return df
+
+
+def add_liquidity_sweep_features(df: pd.DataFrame, session_start_hour: int = DEFAULT_SESSION_START_HOUR,
+                                  rolling_period: int = 20) -> pd.DataFrame:
+    df = df.sort_values("time").reset_index(drop=True).copy()
+    session_id = _session_id(df, session_start_hour)
+
+    add_premarket_levels(df, session_id)
+    add_prior_day_levels(df, session_id)
+    add_rolling_levels(df, period=rolling_period)
+
+    detect_sweep(df, "pm_high", "pm_low", "premarket", session_id)
+    detect_sweep(df, "prior_day_high", "prior_day_low", "prior_day", session_id)
+    detect_sweep(df, f"roll_high_{rolling_period}", f"roll_low_{rolling_period}", "structural", session_id)
+    return df

--- a/ml/features/session_context.py
+++ b/ml/features/session_context.py
@@ -1,0 +1,88 @@
+"""
+Trading-session and macro-event-timing features, driven by ml/config/sessions.json.
+
+Covers: which named session (Asian futures/cash, London, NY pre-market/open) each
+bar falls in, minutes since that session's open (cyclical + linear), day-of-week,
+and proximity to recurring macro-release timing (08:30 ET most US data releases,
+NFP's first-Friday rule) plus a manually-maintained FOMC date list.
+
+See ml/config/sessions.json's _fomc_note: fomc_dates ships empty since meeting
+dates are irregular and must come from the official Fed calendar, not a guess —
+until it's populated, fomc_proximity features stay at their neutral/no-signal value.
+"""
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .indicators import ET, _et_index
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "sessions.json"
+
+
+def load_sessions_config() -> dict:
+    return json.loads(CONFIG_PATH.read_text())
+
+
+def _parse_hm(s: str) -> int:
+    h, m = s.split(":")
+    return int(h) * 60 + int(m)
+
+
+def _in_window(tod_min: pd.Series, start_min: int, end_min: int) -> pd.Series:
+    if start_min <= end_min:
+        return (tod_min >= start_min) & (tod_min <= end_min)
+    return (tod_min >= start_min) | (tod_min <= end_min)  # wraps past midnight
+
+
+def _minutes_since(tod_min: pd.Series, start_min: int) -> pd.Series:
+    return (tod_min - start_min) % 1440
+
+
+def _cyclical(series: pd.Series, period: int, name: str, df: pd.DataFrame):
+    df[f"{name}_sin"] = np.sin(2 * np.pi * series / period)
+    df[f"{name}_cos"] = np.cos(2 * np.pi * series / period)
+
+
+def add_session_context(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:
+    config = config or load_sessions_config()
+    df = df.sort_values("time").reset_index(drop=True).copy()
+
+    et = _et_index(df)
+    tod_min = (et.dt.hour * 60 + et.dt.minute).astype(int)
+    dow = et.dt.dayofweek  # Monday=0 .. Sunday=6
+
+    df["tod_minutes_et"] = tod_min
+    df["day_of_week"] = dow
+    _cyclical(tod_min, 1440, "tod", df)
+    _cyclical(dow, 7, "dow", df)
+
+    for name, window in config["sessions"].items():
+        start_min = _parse_hm(window["start"])
+        end_min = _parse_hm(window["end"])
+        df[f"in_{name}"] = _in_window(tod_min, start_min, end_min).astype(int)
+        df[f"minutes_since_{name}_open"] = _minutes_since(tod_min, start_min)
+
+    macro_min = _parse_hm(config["macro_slot_et"])
+    dist_to_macro = (tod_min - macro_min).abs()
+    dist_to_macro = np.minimum(dist_to_macro, 1440 - dist_to_macro)  # shortest distance around the clock
+    df["minutes_from_macro_slot"] = dist_to_macro
+    df["near_macro_slot"] = (dist_to_macro <= 15).astype(int)
+
+    et_date = et.dt.date
+    is_friday = dow == 4
+    day_of_month = et.dt.day
+    is_first_friday = is_friday & (day_of_month <= 7)
+    df["is_nfp_day"] = (is_first_friday & (dist_to_macro <= 15)).astype(int)
+
+    fomc_dates = set(pd.to_datetime(d).date() for d in config.get("fomc_dates", []))
+    if fomc_dates:
+        df["is_fomc_day"] = et_date.isin(fomc_dates).astype(int)
+        days_to_next = et_date.map(lambda d: min((f - d).days for f in fomc_dates if f >= d), na_action="ignore")
+        df["days_to_next_fomc"] = days_to_next.fillna(999)
+    else:
+        df["is_fomc_day"] = 0
+        df["days_to_next_fomc"] = 999  # no dates configured — neutral sentinel, see sessions.json _fomc_note
+
+    return df

--- a/ml/features/session_levels.py
+++ b/ml/features/session_levels.py
@@ -1,0 +1,77 @@
+"""
+Session range levels (Asian/London high-low, midnight open) and whether NY
+session bars sweep them — a session-level generalization of the premarket/
+prior-day sweep logic in liquidity_sweep.py, since Asian and London ranges
+are reference levels ICT-style NY session trading watches for specifically.
+
+Asian range: 18:00-00:00 ET (the evening portion of the Globex session
+defined in sessions.json's asian_futures window — the part that's within a
+single calendar day, so no midnight-wraparound handling needed for the range
+itself). London range: 03:00-08:00 ET, matching sessions.json's london_open
+(the London morning session through the NY pre-market handoff, not the full
+London trading day).
+Both frozen once their window closes, same pattern as premarket_high/low.
+
+Midnight open: the open price of the bar at 00:00 ET — a distinct ICT
+reference level from either range, anchored to the calendar day rather than
+the 18:00 Globex session boundary everything else here uses.
+"""
+import pandas as pd
+
+from .indicators import _et_index
+from .liquidity_sweep import _session_id, detect_sweep
+
+ASIAN_RANGE_START_MIN = 18 * 60       # 18:00 ET
+LONDON_RANGE_START_MIN = 3 * 60       # 03:00 ET
+LONDON_RANGE_END_MIN = 8 * 60         # 08:00 ET
+NY_SESSION_START_MIN = 9 * 60 + 30    # 09:30 ET
+NY_SESSION_END_MIN = 16 * 60          # 16:00 ET
+
+
+def _add_range_levels(df: pd.DataFrame, session_id: pd.Series, mask: pd.Series, prefix: str) -> pd.DataFrame:
+    high = df["high"].where(mask)
+    low = df["low"].where(mask)
+    df[f"{prefix}_high"] = high.groupby(session_id).cummax()
+    df[f"{prefix}_low"] = low.groupby(session_id).cummin()
+    df[f"{prefix}_high"] = df.groupby(session_id)[f"{prefix}_high"].ffill()
+    df[f"{prefix}_low"] = df.groupby(session_id)[f"{prefix}_low"].ffill()
+    return df
+
+
+def add_midnight_open(df: pd.DataFrame) -> pd.DataFrame:
+    et = _et_index(df)
+    tod = et.dt.hour * 60 + et.dt.minute
+    calendar_date = et.dt.floor("D")
+    midnight_open = df["open"].where(tod == 0)
+    # Only one bar per date has tod==0 (1m data) — propagate it to every row
+    # in that calendar date, both directions, since ffill alone would leave
+    # the pre-midnight rows of the *first* date in the dataset unset anyway
+    # (nothing wrong with that — NaN there just means "unknown," correctly).
+    df["midnight_open"] = midnight_open.groupby(calendar_date).transform(lambda s: s.ffill().bfill())
+    df["dist_from_midnight_open"] = df["close"] - df["midnight_open"]
+    return df
+
+
+def add_session_levels(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_values("time").reset_index(drop=True).copy()
+    session_id = _session_id(df)  # 18:00 ET boundary, matching indicators/liquidity_sweep
+    et = _et_index(df)
+    tod = et.dt.hour * 60 + et.dt.minute
+
+    asian_mask = tod >= ASIAN_RANGE_START_MIN
+    london_mask = (tod >= LONDON_RANGE_START_MIN) & (tod < LONDON_RANGE_END_MIN)
+
+    _add_range_levels(df, session_id, asian_mask, "asian_range")
+    _add_range_levels(df, session_id, london_mask, "london_range")
+    add_midnight_open(df)
+
+    detect_sweep(df, "asian_range_high", "asian_range_low", "asian_range", session_id)
+    detect_sweep(df, "london_range_high", "london_range_low", "london_range", session_id)
+
+    in_ny_session = (tod >= NY_SESSION_START_MIN) & (tod < NY_SESSION_END_MIN)
+    df["in_ny_session_window"] = in_ny_session.astype(int)
+    for prefix in ("asian_range", "london_range"):
+        for side in ("high", "low"):
+            df[f"{prefix}_{side}_swept_in_ny"] = (df[f"{prefix}_swept_{side}"].astype(bool) & in_ny_session).astype(int)
+
+    return df

--- a/ml/labels/triple_barrier.py
+++ b/ml/labels/triple_barrier.py
@@ -1,0 +1,105 @@
+"""
+Triple-barrier labeling: for each bar, look forward up to `horizon_bars` and
+label whether price hits the take-profit level before the stop-loss level
+(1 = TP first, 0 = SL first, NaN = neither hit within the horizon — a timeout,
+dropped from training rather than force-labeled).
+
+TP/SL distances are fixed price points (not exchange ticks — ml/config/symbols.json
+stores ticks; ml/features/build_dataset.py's load_symbol_config() converts via each
+symbol's tick_size before calling this) rather than ATR-scaled, so the same
+tp_points/sl_points apply to every row.
+
+Two labels are produced per bar — label_long (would a long entered at this bar's
+close hit its TP before its SL) and label_short (mirror, for a short entry) —
+since direction comes from the strategy context (e.g. a bullish low-sweep implies
+checking the long label, a bearish high-sweep implies the short label), not from
+the labeling function itself.
+
+If both TP and SL are touched within the same forward bar, intrabar ordering is
+unknown from OHLC alone — this labels it as SL-first (label=0), the conservative
+assumption, rather than guessing optimistically.
+
+`horizon_bars` counts *array positions*, not elapsed time — a raw data file with
+gaps (a symbol whose collection was interrupted partway, or hasn't backfilled a
+stretch yet) can have two adjacent rows that are actually days apart. Scanning
+"the next 60 rows" across a gap like that would compare prices across a real
+30-day jump as if it were 60 consecutive minutes, which isn't what the label is
+supposed to mean. So the forward scan stops the moment it crosses a gap wider
+than `max_gap_bars` x the data's typical spacing, and that row is left as a
+timeout (NaN) rather than mislabeled — we genuinely don't know what happened
+during a stretch with no data. Symptom of this before the fix existed: a small
+number of labels near a coverage gap that didn't actually reflect 60 real
+minutes of price action.
+
+This is a plain nested loop (not vectorized) — O(n * horizon_bars). For a few
+tens of thousands of rows with horizon_bars ~50-60 that's seconds, fine for an
+offline batch step; revisit with numba/vectorization only if it becomes a
+bottleneck on larger pulls.
+"""
+import numpy as np
+import pandas as pd
+
+
+def _first_touch_labels(entry: np.ndarray, highs: np.ndarray, lows: np.ndarray,
+                         tp_dist: np.ndarray, sl_dist: np.ndarray, horizon: int, direction: int,
+                         times: np.ndarray, max_gap_seconds: float):
+    n = len(entry)
+    labels = np.full(n, np.nan)
+    bars_to_resolve = np.full(n, np.nan)
+
+    for i in range(n):
+        end = min(i + 1 + horizon, n)
+        if end <= i + 1:
+            continue
+        e = entry[i]
+        if direction == 1:
+            tp_level = e + tp_dist[i]
+            sl_level = e - sl_dist[i]
+        else:
+            tp_level = e - tp_dist[i]
+            sl_level = e + sl_dist[i]
+
+        for j in range(i + 1, end):
+            if times[j] - times[j - 1] > max_gap_seconds:
+                break  # crossed a data gap — unknown what happened, leave as timeout
+            hit_tp = highs[j] >= tp_level if direction == 1 else lows[j] <= tp_level
+            hit_sl = lows[j] <= sl_level if direction == 1 else highs[j] >= sl_level
+            if hit_tp and hit_sl:
+                labels[i] = 0  # ambiguous same-bar touch — conservative: SL first
+                bars_to_resolve[i] = j - i
+                break
+            elif hit_tp:
+                labels[i] = 1
+                bars_to_resolve[i] = j - i
+                break
+            elif hit_sl:
+                labels[i] = 0
+                bars_to_resolve[i] = j - i
+                break
+
+    return labels, bars_to_resolve
+
+
+def label_triple_barrier(df: pd.DataFrame, tp_points: float, sl_points: float, horizon_bars: int,
+                          max_gap_bars: float = 3.0) -> pd.DataFrame:
+    df = df.sort_values("time").reset_index(drop=True).copy()
+    entry = df["close"].to_numpy(dtype=float)
+    highs = df["high"].to_numpy(dtype=float)
+    lows = df["low"].to_numpy(dtype=float)
+    times = df["time"].to_numpy(dtype=float)
+    tp_arr = np.full(len(df), float(tp_points))
+    sl_arr = np.full(len(df), float(sl_points))
+
+    typical_interval = np.median(np.diff(times)) if len(times) > 1 else 1.0
+    max_gap_seconds = max_gap_bars * typical_interval
+
+    label_long, bars_long = _first_touch_labels(entry, highs, lows, tp_arr, sl_arr, horizon_bars,
+                                                  direction=1, times=times, max_gap_seconds=max_gap_seconds)
+    label_short, bars_short = _first_touch_labels(entry, highs, lows, tp_arr, sl_arr, horizon_bars,
+                                                    direction=-1, times=times, max_gap_seconds=max_gap_seconds)
+
+    df["label_long"] = label_long
+    df["label_short"] = label_short
+    df["bars_to_resolve_long"] = bars_long
+    df["bars_to_resolve_short"] = bars_short
+    return df

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+numpy
+lightgbm
+pyarrow
+scikit-learn
+python-dateutil

--- a/ml/serve/export_strategy_viz.py
+++ b/ml/serve/export_strategy_viz.py
@@ -1,0 +1,154 @@
+"""
+Exports 1m OHLCV bars + a chosen strategy's trade/level events to JSON, for
+the strategy-visualization page served by ml/serve/server.js
+(ml/serve/public/strategy.html).
+
+Data source right now is the already-collected REPLAY data
+(~/data/ml-raw/{symbol}_1.parquet, from ml/data_collection/collect_replay.py)
+— per the explicit instruction this was built under, this is a stand-in
+until the market is open and a live polling source replaces it. That swap
+point is isolated to _load_bars() below; nothing else needs to change when
+it happens (the frontend just consumes whatever bars.json currently holds).
+
+Run as a module from the repo root:
+    python -m ml.serve.export_strategy_viz --symbol MGC1! --strategy trend_breakout
+    python -m ml.serve.export_strategy_viz --symbol MGC1! --strategy liquidity_sweep_asian
+    python -m ml.serve.export_strategy_viz --symbol MNQ1! --strategy liquidity_sweep_ny
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+PUBLIC_DATA_DIR = Path(__file__).resolve().parent / "public" / "data"
+RAW_DIR = Path.home() / "data" / "ml-raw"
+
+
+def _load_bars(symbol: str, days: int | None) -> pd.DataFrame:
+    """Swap point for a live data source later: replace this function's body
+    with a poll of `tv ohlcv` (see ml/serve/predict.py's fetch_bars_df for
+    the existing pattern) once the market is open — the rest of this script
+    and the frontend don't need to know the difference."""
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_1.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No raw 1m data at {path} — run ml/data_collection/collect_replay.py first.")
+    df = pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+    if days is not None:
+        cutoff = int(df["time"].max()) - days * 86400
+        df = df[df["time"] >= cutoff].reset_index(drop=True)
+    return df
+
+
+def _bars_to_json(df: pd.DataFrame) -> list[dict]:
+    return [
+        {"time": int(t), "open": float(o), "high": float(h), "low": float(l), "close": float(c)}
+        for t, o, h, l, c in zip(df["time"], df["open"], df["high"], df["low"], df["close"])
+    ]
+
+
+def _trend_breakout_events(symbol: str, days: int | None) -> dict:
+    # Absolute import: strategies/ is a sibling top-level (namespace) package
+    # to ml/, not a subpackage of it — relative imports can't reach across
+    # that boundary, and this script is always run as `python -m
+    # ml.serve.export_strategy_viz` from the repo root, so the repo root is
+    # already on sys.path and the absolute form just works.
+    from strategies.trend_breakout import backtest as tb
+    cfg = tb.TrendBreakoutConfig()
+    cfg.session_toggles.premarket_handoff_enabled = (symbol != "MGC1!")  # the one window that doesn't work for MGC
+    df = tb.run_backtest(symbol, cfg, days=days)
+    filled = df[df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])].copy()
+
+    trades = []
+    levels = []
+    for _, t in filled.iterrows():
+        trades.append({
+            "direction": t["direction"],
+            "entry_time": int(t["entry_timestamp"]) if pd.notna(t["entry_timestamp"]) else None,
+            "entry_price": float(t["entry_price"]) if pd.notna(t["entry_price"]) else None,
+            "exit_time": int(t["exit_timestamp"]) if pd.notna(t["exit_timestamp"]) else None,
+            "exit_price": float(t["exit_price"]) if pd.notna(t["exit_price"]) else None,
+            "pnl_points": float(t["pnl_points"]) if pd.notna(t["pnl_points"]) else None,
+            "r_multiple": float(t["r_multiple"]) if pd.notna(t["r_multiple"]) else None,
+            "status": t["setup_status"],
+        })
+        if pd.notna(t.get("level_price")) and pd.notna(t.get("timestamp")) and pd.notna(t.get("entry_timestamp")):
+            levels.append({
+                "type": t["level_type"], "price": float(t["level_price"]),
+                "start_time": int(t["timestamp"]), "end_time": int(t["entry_timestamp"]),
+            })
+    return {"strategy": "trend_breakout", "trades": trades, "levels": levels}
+
+
+def _liquidity_sweep_events(symbol: str, days: int | None, session: str) -> dict:
+    from strategies.asian_failed_breakout import backtest as afb
+    from strategies.asian_failed_breakout import config as asian_config
+    from strategies.ny_open_strategies import liquidity_sweep_reversal as ny
+
+    cfg = asian_config.StrategyConfig()
+    if session == "asian":
+        df = afb.run_backtest(symbol, cfg, days=days)
+    else:
+        df = ny.run_backtest(symbol, cfg, days=days)
+    filled = df[df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])].copy()
+
+    trades = []
+    levels = []
+    for _, t in filled.iterrows():
+        trades.append({
+            "direction": t["direction"],
+            "entry_time": int(t["ema9_trigger_timestamp"]) if pd.notna(t["ema9_trigger_timestamp"]) else None,
+            "entry_price": float(t["entry_price"]) if pd.notna(t["entry_price"]) else None,
+            "exit_time": int(t["exit_timestamp"]) if pd.notna(t["exit_timestamp"]) else None,
+            "exit_price": float(t["exit_price"]) if pd.notna(t["exit_price"]) else None,
+            "pnl_points": float(t["pnl_points"]) if pd.notna(t["pnl_points"]) else None,
+            "r_multiple": float(t["r_multiple"]) if pd.notna(t["r_multiple"]) else None,
+            "status": t["setup_status"],
+        })
+        if pd.notna(t.get("important_level_price")) and pd.notna(t.get("timestamp")) and pd.notna(t.get("ema9_trigger_timestamp")):
+            levels.append({
+                "type": t["important_level_type"], "price": float(t["important_level_price"]),
+                "start_time": int(t["timestamp"]), "end_time": int(t["ema9_trigger_timestamp"]),
+            })
+    return {"strategy": f"liquidity_sweep_{session}", "trades": trades, "levels": levels}
+
+
+STRATEGIES = {
+    "trend_breakout": lambda symbol, days: _trend_breakout_events(symbol, days),
+    "liquidity_sweep_asian": lambda symbol, days: _liquidity_sweep_events(symbol, days, "asian"),
+    "liquidity_sweep_ny": lambda symbol, days: _liquidity_sweep_events(symbol, days, "ny"),
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--strategy", choices=list(STRATEGIES), default="trend_breakout")
+    parser.add_argument("--days", type=int, default=None)
+    args = parser.parse_args()
+
+    PUBLIC_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+
+    bars_df = _load_bars(args.symbol, args.days)
+    bars_path = PUBLIC_DATA_DIR / f"{stem}_bars.json"
+    bars_path.write_text(json.dumps(_bars_to_json(bars_df)))
+    print(f"Wrote {len(bars_df)} bars to {bars_path}", file=sys.stderr)
+
+    events = STRATEGIES[args.strategy](args.symbol, args.days)
+    events_path = PUBLIC_DATA_DIR / f"{stem}_{args.strategy}_events.json"
+    events_path.write_text(json.dumps(events))
+    print(f"Wrote {len(events['trades'])} trades / {len(events['levels'])} levels to {events_path}", file=sys.stderr)
+
+    manifest_path = PUBLIC_DATA_DIR / "manifest.json"
+    manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
+    strategies_for_symbol = manifest.setdefault(stem, [])
+    if args.strategy not in strategies_for_symbol:
+        strategies_for_symbol.append(args.strategy)
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/serve/live_agent.js
+++ b/ml/serve/live_agent.js
@@ -1,0 +1,137 @@
+/**
+ * Polls ml/serve/predict.py for each configured symbol/timeframe target and
+ * caches results in memory, mirroring dashboard-server.js's poll-cache-serve
+ * pattern (background interval fills the cache; HTTP handlers only ever read it).
+ *
+ * Targets run strictly sequentially, never in parallel: predict.py drives the
+ * *same* TradingView Desktop chart (switching symbol/timeframe live) via CDP,
+ * so two overlapping predict.py runs would race and corrupt each other's reads.
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SYMBOLS_CONFIG = path.resolve(__dirname, '../config/symbols.json');
+const MODELS_DIR = path.resolve(__dirname, '../models');
+const PREDICTIONS_FILE = path.join(process.env.HOME, 'data', 'ml-predictions.json');
+const PYTHON_BIN = process.env.PYTHON_BIN || 'python3';
+
+let cache = {}; // `${symbol}_${timeframe}` -> prediction result
+let lastError = {};
+let pollInFlight = false;
+let saveTimer = null;
+
+function safeStem(symbol, timeframe) {
+  return symbol.replace(/[:!]/g, '').replace('/', '_') + `_${timeframe}`;
+}
+
+function hasTrainedModel(symbol, timeframe) {
+  const stem = safeStem(symbol, timeframe);
+  return fs.existsSync(path.join(MODELS_DIR, `${stem}_long.txt`)) ||
+    fs.existsSync(path.join(MODELS_DIR, `${stem}_short.txt`));
+}
+
+// Only timeframes with an actual trained model become their own dashboard
+// target/card — everything else in symbols.json (e.g. 5m/60m kept purely as
+// higher-timeframe context, never trained standalone) stays silent instead of
+// showing a permanent "no model yet" placeholder. This also means predict.py
+// never drives the live chart to a timeframe nobody's looking at, which cuts
+// down on unnecessary symbol/timeframe switching on the shared chart. New
+// targets appear automatically the moment a model gets trained — no need to
+// touch this file when that happens.
+function buildTargets() {
+  const config = JSON.parse(fs.readFileSync(SYMBOLS_CONFIG, 'utf8'));
+  const targets = [];
+  for (const [symbol, symCfg] of Object.entries(config)) {
+    if (symbol.startsWith('_')) continue;
+    const tfs = Object.keys(symCfg.timeframes).sort((a, b) => Number(a) - Number(b));
+    for (let i = 0; i < tfs.length; i++) {
+      const timeframe = tfs[i];
+      if (!hasTrainedModel(symbol, timeframe)) continue;
+      targets.push({ symbol, timeframe, context: tfs.slice(i + 1) });
+    }
+  }
+  return targets;
+}
+
+// predict.py now does real work per switch (chart_lock, switch_chart's own
+// verification retries, bars_look_contaminated's retry-then-fail) — a full run
+// with 2 context timeframes measured at ~50s on a cold symbol switch. 30s was
+// killing every single poll before it could finish, which is why the dashboard
+// was showing nothing but "timed out" errors. 120s gives real margin above the
+// measured worst case rather than just barely clearing it.
+const PREDICT_TIMEOUT_MS = 120_000;
+
+// The underlying `tv` CLI hangs indefinitely (no internal timeout) when CDP/
+// TradingView Desktop isn't reachable, so without a hard kill here one dead
+// target would wedge every subsequent target and poll cycle forever.
+function runPredict({ symbol, timeframe, context }) {
+  return new Promise((resolve, reject) => {
+    const args = ['-m', 'ml.serve.predict', '--symbol', symbol, '--timeframe', timeframe];
+    if (context.length) args.push('--context', context.join(','));
+    const proc = spawn(PYTHON_BIN, args, { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill('SIGKILL');
+    }, PREDICT_TIMEOUT_MS);
+    proc.stdout.on('data', d => { stdout += d; });
+    proc.stderr.on('data', d => { stderr += d; });
+    proc.on('close', code => {
+      clearTimeout(timer);
+      if (timedOut) return reject(new Error(`predict.py timed out after ${PREDICT_TIMEOUT_MS}ms (is TradingView Desktop connected?)`));
+      if (code !== 0) return reject(new Error(stderr.trim() || `predict.py exited ${code}`));
+      try {
+        resolve(JSON.parse(stdout.trim().split('\n').pop()));
+      } catch (err) {
+        reject(new Error(`Failed to parse predict.py output: ${err.message}\n${stdout}`));
+      }
+    });
+  });
+}
+
+function scheduleSave() {
+  if (saveTimer) return;
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    fs.mkdirSync(path.dirname(PREDICTIONS_FILE), { recursive: true });
+    fs.writeFileSync(PREDICTIONS_FILE, JSON.stringify({ ts: Date.now(), predictions: cache }, null, 2));
+  }, 2000);
+}
+
+async function pollOnce() {
+  if (pollInFlight) return;
+  pollInFlight = true;
+  try {
+    const targets = buildTargets();
+    for (const target of targets) {
+      const key = `${target.symbol}_${target.timeframe}`;
+      try {
+        const result = await runPredict(target);
+        cache[key] = { ...result, polled_at: Date.now() };
+        delete lastError[key];
+      } catch (err) {
+        lastError[key] = { message: err.message, at: Date.now() };
+        console.error(`[ml-agent] ${key} failed: ${err.message}`);
+      }
+    }
+    scheduleSave();
+  } finally {
+    pollInFlight = false;
+  }
+}
+
+export function startPolling({ intervalMs = 45_000 } = {}) {
+  pollOnce();
+  const timer = setInterval(pollOnce, intervalMs);
+  return () => clearInterval(timer);
+}
+
+export function getCache() {
+  return { predictions: cache, errors: lastError };
+}

--- a/ml/serve/predict.py
+++ b/ml/serve/predict.py
@@ -1,0 +1,165 @@
+"""
+Live inference: pulls the current buffered bars for a symbol (execution
+timeframe + context timeframes) via the `tv` CLI (no replay — this reads
+whatever TradingView Desktop has live), recomputes the exact same feature
+pipeline used in training, and outputs P(TP before SL) for both a long and a
+short entry at the latest close.
+
+This is decision support, not an order router — nothing here places a trade.
+Combine the probabilities with the sweep/session flags in the feature output
+(or the dashboard) to judge which direction the setup actually favors.
+
+Run as a module from the repo root:
+    python -m ml.serve.predict --symbol MNQ1! --timeframe 1 --context 5,60
+"""
+import argparse
+import json
+import sys
+import time
+
+import lightgbm as lgb
+import pandas as pd
+
+from ..data_collection.collect_replay import tv, switch_chart, chart_lock, bars_look_contaminated
+from ..features.build_dataset import compute_features, load_symbol_config, CONTEXT_FEATURE_COLS
+from ..train.train_model import MODELS_DIR
+
+FETCH_RETRIES = 5
+FETCH_RETRY_DELAY_S = 1.0
+
+
+def to_native(v):
+    """pandas/numpy scalars (int64, float64, bool_, ...) aren't JSON-serializable
+    on their own — unwrap to the plain Python type via numpy's .item(), which
+    every numpy scalar exposes."""
+    if v is None:
+        return None
+    if hasattr(v, "item"):
+        v = v.item()
+    if isinstance(v, float) and pd.isna(v):
+        return None
+    return v
+
+
+def fetch_bars_df(count: int = 500) -> pd.DataFrame:
+    # Switching symbol/timeframe just before this doesn't guarantee TradingView
+    # has finished loading the new chart's data yet — "still loading" is a
+    # transient condition that clears within a second or two, not a real failure.
+    # Separately, switch_chart()'s own verification only checks the chart's
+    # symbol *label*, which can update before the underlying bar buffer has
+    # caught up — bars_look_contaminated() catches that straddle at the data
+    # level instead of trusting the label (see collect_replay.py for the full
+    # story on why this check exists).
+    last_err = None
+    for attempt in range(FETCH_RETRIES):
+        try:
+            bars = tv(["ohlcv", "-n", str(count)]).get("bars", [])
+            if bars and not bars_look_contaminated(bars):
+                return pd.DataFrame(bars)
+            last_err = RuntimeError("No bars returned from `tv ohlcv`" if not bars else "bars look contaminated (implausible jump)")
+        except RuntimeError as err:
+            last_err = err
+        time.sleep(FETCH_RETRY_DELAY_S)
+    raise RuntimeError(f"Failed to fetch clean OHLCV after {FETCH_RETRIES} attempts: {last_err}")
+
+
+def build_live_features(symbol: str, timeframe: str, context_tfs: list[str]) -> pd.DataFrame:
+    # Held for the whole sequence of switches+reads, not just each individual
+    # switch_chart() call — otherwise collect_replay.py (or another predict.py
+    # invocation) could still jump in between two of these and read a stale
+    # instrument, same failure mode as before, just narrower.
+    with chart_lock():
+        switch_chart(symbol, timeframe)
+        raw = fetch_bars_df()
+        df = compute_features(raw)
+
+        for ctx_tf in context_tfs:
+            switch_chart(symbol, ctx_tf)
+            ctx_raw = fetch_bars_df()
+            ctx_df = compute_features(ctx_raw)
+            cols = ["time"] + [c for c in CONTEXT_FEATURE_COLS if c in ctx_df.columns]
+            ctx_slice = ctx_df[cols].add_prefix(f"ctx_{ctx_tf}m_").rename(columns={f"ctx_{ctx_tf}m_time": "time"})
+            df = pd.merge_asof(df.sort_values("time"), ctx_slice.sort_values("time"), on="time", direction="backward")
+
+        switch_chart(symbol, timeframe)  # leave the chart on the execution timeframe
+    return df
+
+
+def load_model(symbol: str, timeframe: str, direction: str):
+    stem = f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}"
+    model_path = MODELS_DIR / f"{stem}.txt"
+    meta_path = MODELS_DIR / f"{stem}.meta.json"
+    if not model_path.exists():
+        return None, None
+    return lgb.Booster(model_file=str(model_path)), json.loads(meta_path.read_text())
+
+
+def predict(symbol: str, timeframe: str, context_tfs: list[str]) -> dict:
+    # Check for trained models BEFORE touching the live chart — this call drives
+    # the user's actual TradingView Desktop window (switching symbol/timeframe
+    # live to read each buffer), so a target with no model yet shouldn't cause
+    # any of that chart churn at all, not just skip the inference at the end.
+    models = {d: load_model(symbol, timeframe, d) for d in ("long", "short")}
+    if all(m is None for m, _ in models.values()):
+        return {
+            "type": "ML_PROB_TP", "symbol": symbol, "timeframe": timeframe,
+            "status": "no_model", "prob_long_tp": None, "prob_short_tp": None,
+        }
+
+    df = build_live_features(symbol, timeframe, context_tfs)
+    latest = df.iloc[[-1]]
+
+    tf_cfg = load_symbol_config(symbol, timeframe)
+    result = {
+        "type": "ML_PROB_TP",
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "as_of": int(latest["time"].iloc[0]),
+        "entry": float(latest["close"].iloc[0]),
+        "tp_ticks": tf_cfg["tp_ticks"],
+        "sl_ticks": tf_cfg["sl_ticks"],
+        "tp_points": tf_cfg["tp_points"],
+        "sl_points": tf_cfg["sl_points"],
+        "horizon_bars": tf_cfg["horizon_bars"],
+        "prob_long_tp": None,
+        "prob_short_tp": None,
+        "context_flags": {
+            col: to_native(latest[col].iloc[0]) if col in latest.columns else None
+            for col in [
+                "premarket_swept_high_recently", "premarket_swept_low_recently",
+                "prior_day_swept_high_recently", "prior_day_swept_low_recently",
+                "structural_swept_high_recently", "structural_swept_low_recently",
+                "in_ny_open", "in_asian_futures", "near_macro_slot",
+            ] if col in latest.columns
+        },
+    }
+
+    for direction in ("long", "short"):
+        model, meta = models[direction]
+        if model is None:
+            continue
+        feat_cols = meta["feature_columns"]
+        missing = [c for c in feat_cols if c not in latest.columns]
+        if missing:
+            result[f"prob_{direction}_tp_error"] = f"missing features: {missing}"
+            continue
+        prob = float(model.predict(latest[feat_cols], num_iteration=meta.get("best_iteration"))[0])
+        result[f"prob_{direction}_tp"] = prob
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True)
+    parser.add_argument("--context", default="", help="comma-separated context timeframes, e.g. 5,60")
+    args = parser.parse_args()
+
+    context_tfs = [c.strip() for c in args.context.split(",") if c.strip()]
+    result = predict(args.symbol, args.timeframe, context_tfs)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/serve/public/app.js
+++ b/ml/serve/public/app.js
@@ -1,0 +1,57 @@
+const POLL_MS = 15000;
+
+function probClass(p) {
+  if (p == null) return '';
+  if (p >= 0.6) return 'high';
+  if (p >= 0.45) return 'mid';
+  return 'low';
+}
+
+function fmtProb(p) {
+  return p == null ? '—' : (p * 100).toFixed(1) + '%';
+}
+
+function renderCard(key, pred) {
+  if (pred.status === 'no_model') {
+    return `
+      <div class="card">
+        <h2>${pred.symbol} · ${pred.timeframe}</h2>
+        <div class="flags">no trained model yet</div>
+      </div>
+    `;
+  }
+
+  const flags = Object.entries(pred.context_flags || {})
+    .filter(([, v]) => v)
+    .map(([k]) => k.replace(/_/g, ' '))
+    .join(', ') || 'none';
+
+  return `
+    <div class="card">
+      <h2>${pred.symbol} · ${pred.timeframe}</h2>
+      <div class="row"><span class="label">entry</span><span>${pred.entry?.toFixed(2) ?? '—'}</span></div>
+      <div class="row"><span class="label">long TP first</span><span class="prob ${probClass(pred.prob_long_tp)}">${fmtProb(pred.prob_long_tp)}</span></div>
+      <div class="row"><span class="label">short TP first</span><span class="prob ${probClass(pred.prob_short_tp)}">${fmtProb(pred.prob_short_tp)}</span></div>
+      <div class="row"><span class="label">tp/sl</span><span>${pred.tp_points}/${pred.sl_points}pt (${pred.tp_ticks}/${pred.sl_ticks} ticks, ${pred.horizon_bars} bars)</span></div>
+      <div class="flags">active flags: ${flags}</div>
+    </div>
+  `;
+}
+
+async function poll() {
+  try {
+    const res = await fetch('/api/predictions');
+    const data = await res.json();
+    const cards = document.getElementById('cards');
+    const entries = Object.entries(data.predictions || {});
+    cards.innerHTML = entries.length
+      ? entries.map(([key, pred]) => renderCard(key, pred)).join('')
+      : '<div class="error">No predictions yet — waiting for first poll cycle (or no trained models found).</div>';
+    document.getElementById('updated').textContent = `updated ${new Date().toLocaleTimeString()}`;
+  } catch (err) {
+    document.getElementById('updated').textContent = `poll failed: ${err.message}`;
+  }
+}
+
+poll();
+setInterval(poll, POLL_MS);

--- a/ml/serve/public/index.html
+++ b/ml/serve/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>ML TP/SL Predictions</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>ML Prob(TP before SL)</h1>
+  <div id="updated" class="updated"></div>
+  <div id="cards" class="cards"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/ml/serve/public/strategy.css
+++ b/ml/serve/public/strategy.css
@@ -1,0 +1,102 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0e1117;
+  color: #e6e6e6;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  background: #161b22;
+  border-bottom: 1px solid #2a2f3a;
+  flex-wrap: wrap;
+}
+
+.toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #9aa4b2;
+}
+
+.toolbar select, .toolbar button {
+  background: #21262d;
+  color: #e6e6e6;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+}
+
+.toolbar button {
+  cursor: pointer;
+}
+
+.toolbar button:hover {
+  background: #2d333b;
+}
+
+.grow {
+  flex: 1;
+  min-width: 200px;
+}
+
+.grow input[type="range"] {
+  width: 100%;
+}
+
+.clock {
+  font-variant-numeric: tabular-nums;
+  color: #58a6ff;
+  font-size: 13px;
+  min-width: 170px;
+}
+
+.badge {
+  background: #3a2b0a;
+  color: #e3b341;
+  border: 1px solid #4d3a12;
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+#chart {
+  display: block;
+  width: 100%;
+  height: 62vh;
+  background: #0e1117;
+}
+
+.statbar {
+  display: flex;
+  gap: 24px;
+  padding: 10px 16px;
+  background: #161b22;
+  border-top: 1px solid #2a2f3a;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stat .label {
+  font-size: 11px;
+  color: #9aa4b2;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.stat span:last-child {
+  font-size: 16px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}

--- a/ml/serve/public/strategy.html
+++ b/ml/serve/public/strategy.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Strategy Replay</title>
+<link rel="stylesheet" href="strategy.css">
+</head>
+<body>
+  <div class="toolbar">
+    <label>Symbol
+      <select id="symbol">
+        <option value="MGC1!">MGC1!</option>
+        <option value="MNQ1!">MNQ1!</option>
+      </select>
+    </label>
+    <label>Strategy
+      <select id="strategy">
+        <option value="trend_breakout">trend_breakout</option>
+        <option value="liquidity_sweep_asian">liquidity_sweep_asian</option>
+        <option value="liquidity_sweep_ny">liquidity_sweep_ny</option>
+      </select>
+    </label>
+    <button id="playPause">▶ Play</button>
+    <label>Speed
+      <select id="speed">
+        <option value="1">1x</option>
+        <option value="5" selected>5x</option>
+        <option value="20">20x</option>
+        <option value="100">100x</option>
+      </select>
+    </label>
+    <label class="grow">
+      <input type="range" id="scrub" min="0" max="0" value="0">
+    </label>
+    <span id="clock" class="clock">—</span>
+    <span id="dataMode" class="badge">REPLAY DATA</span>
+  </div>
+
+  <canvas id="chart"></canvas>
+
+  <div class="statbar">
+    <div class="stat"><span class="label">trades so far</span><span id="statN">0</span></div>
+    <div class="stat"><span class="label">win%</span><span id="statWin">—</span></div>
+    <div class="stat"><span class="label">profit factor</span><span id="statPF">—</span></div>
+    <div class="stat"><span class="label">total $</span><span id="statTotal">—</span></div>
+    <div class="stat"><span class="label">position</span><span id="statPos">flat</span></div>
+  </div>
+
+  <script src="strategy.js"></script>
+</body>
+</html>

--- a/ml/serve/public/strategy.js
+++ b/ml/serve/public/strategy.js
@@ -1,0 +1,258 @@
+// Canvas-based candlestick replay + strategy overlay. No external chart
+// library — self-contained, matches this repo's existing vanilla-JS style
+// (public/dashboard.js has no chart dependency either).
+//
+// Data source right now is REPLAY data, pre-exported to JSON by
+// ml/serve/export_strategy_viz.py (see that script's docstring for the
+// planned live-data swap point). This file only ever reads
+// data/{symbol}_bars.json and data/{symbol}_{strategy}_events.json — when
+// the live source replaces the replay export, only those two payload
+// shapes need to keep matching, nothing here changes.
+
+const canvas = document.getElementById('chart');
+const ctx = canvas.getContext('2d');
+
+const state = {
+  symbol: 'MGC1!',
+  strategy: 'trend_breakout',
+  bars: [],
+  timeIndex: new Map(), // time -> bar index
+  events: { trades: [], levels: [] },
+  cursor: 0,
+  windowSize: 180,
+  playing: false,
+  speed: 5,
+  rafId: null,
+  lastTick: 0,
+};
+
+const ET_FMT = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/New_York', month: 'short', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', hour12: false,
+});
+
+function resizeCanvas() {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  render();
+}
+window.addEventListener('resize', resizeCanvas);
+
+function stem(symbol) {
+  return symbol.replace(/[:!]/g, '');
+}
+
+async function loadData() {
+  stopPlayback();
+  const s = stem(state.symbol);
+  const [bars, events] = await Promise.all([
+    fetch(`data/${s}_bars.json`).then(r => { if (!r.ok) throw new Error('no bars'); return r.json(); }),
+    fetch(`data/${s}_${state.strategy}_events.json`).then(r => r.ok ? r.json() : { trades: [], levels: [] }),
+  ]);
+  state.bars = bars;
+  state.events = events;
+  state.timeIndex = new Map(bars.map((b, i) => [b.time, i]));
+  state.cursor = Math.min(state.windowSize, bars.length);
+
+  const scrub = document.getElementById('scrub');
+  scrub.max = String(Math.max(0, bars.length - 1));
+  scrub.value = String(state.cursor);
+
+  render();
+  updateStats();
+}
+
+// nearest bar index at-or-after a given unix-seconds time (bars can have
+// gaps — weekends, session closes — so exact-match lookups aren't safe)
+function indexAtOrAfter(time) {
+  if (state.timeIndex.has(time)) return state.timeIndex.get(time);
+  let lo = 0, hi = state.bars.length - 1, ans = state.bars.length;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (state.bars[mid].time >= time) { ans = mid; hi = mid - 1; } else { lo = mid + 1; }
+  }
+  return ans;
+}
+
+function render() {
+  const rect = canvas.getBoundingClientRect();
+  const w = rect.width, h = rect.height;
+  ctx.clearRect(0, 0, w, h);
+  if (!state.bars.length) return;
+
+  const start = Math.max(0, state.cursor - state.windowSize);
+  const end = Math.max(start + 1, state.cursor);
+  const visible = state.bars.slice(start, end);
+  if (!visible.length) return;
+
+  let lo = Infinity, hi = -Infinity;
+  for (const b of visible) { if (b.low < lo) lo = b.low; if (b.high > hi) hi = b.high; }
+  const pad = (hi - lo) * 0.08 || 1;
+  const yMin = lo - pad, yMax = hi + pad;
+
+  const priceColW = 62;
+  const plotW = w - priceColW;
+  const barW = plotW / visible.length;
+  const xAt = i => i * barW;
+  const yAt = price => h - ((price - yMin) / (yMax - yMin)) * h;
+
+  // gridlines + price axis
+  ctx.strokeStyle = '#1c2128';
+  ctx.fillStyle = '#6e7681';
+  ctx.font = '11px monospace';
+  ctx.textBaseline = 'middle';
+  const gridLines = 6;
+  for (let g = 0; g <= gridLines; g++) {
+    const price = yMin + (yMax - yMin) * (g / gridLines);
+    const y = yAt(price);
+    ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(plotW, y); ctx.stroke();
+    ctx.fillText(price.toFixed(2), plotW + 6, y);
+  }
+
+  // levels (dotted horizontal segments, clipped to their [start_time, end_time])
+  ctx.setLineDash([4, 3]);
+  ctx.strokeStyle = '#58a6ff';
+  ctx.fillStyle = '#58a6ff';
+  ctx.font = '10px monospace';
+  const drawnLabels = new Set();
+  for (const lvl of state.events.levels || []) {
+    const segStartIdx = Math.max(start, indexAtOrAfter(lvl.start_time));
+    const segEndIdx = Math.min(end - 1, indexAtOrAfter(lvl.end_time));
+    if (segEndIdx < start || segStartIdx > end - 1 || segStartIdx > segEndIdx) continue;
+    const y = yAt(lvl.price);
+    const x0 = xAt(segStartIdx - start), x1 = xAt(segEndIdx - start) + barW;
+    ctx.beginPath(); ctx.moveTo(x0, y); ctx.lineTo(x1, y); ctx.stroke();
+    const key = lvl.type + '@' + lvl.price.toFixed(2) + '@' + segEndIdx;
+    if (!drawnLabels.has(key)) {
+      drawnLabels.add(key);
+      ctx.fillText(`${lvl.type} ${lvl.price.toFixed(2)}`, x0 + 2, y - 8);
+    }
+  }
+  ctx.setLineDash([]);
+
+  // candles
+  for (let i = 0; i < visible.length; i++) {
+    const b = visible[i];
+    const cx = xAt(i) + barW / 2;
+    const up = b.close >= b.open;
+    ctx.strokeStyle = ctx.fillStyle = up ? '#3fb950' : '#f85149';
+    ctx.beginPath(); ctx.moveTo(cx, yAt(b.high)); ctx.lineTo(cx, yAt(b.low)); ctx.stroke();
+    const bodyTop = yAt(Math.max(b.open, b.close));
+    const bodyBot = yAt(Math.min(b.open, b.close));
+    ctx.fillRect(xAt(i) + barW * 0.18, bodyTop, Math.max(1, barW * 0.64), Math.max(1, bodyBot - bodyTop));
+  }
+
+  // trades: entry marker, exit marker, connecting line
+  for (const t of state.events.trades || []) {
+    if (t.entry_time == null) continue;
+    const entryIdx = indexAtOrAfter(t.entry_time);
+    if (entryIdx < start || entryIdx > end - 1) continue;
+    const isLong = t.direction === 'long';
+    const win = (t.pnl_points ?? 0) > 0;
+    const color = t.status === 'OPEN_AT_BACKTEST_END' ? '#e3b341' : (win ? '#3fb950' : '#f85149');
+    const ex = xAt(entryIdx - start) + barW / 2;
+    const ey = yAt(t.entry_price);
+
+    ctx.fillStyle = color;
+    ctx.strokeStyle = '#0e1117';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    if (isLong) { ctx.moveTo(ex, ey + 9); ctx.lineTo(ex - 6, ey + 18); ctx.lineTo(ex + 6, ey + 18); }
+    else { ctx.moveTo(ex, ey - 9); ctx.lineTo(ex - 6, ey - 18); ctx.lineTo(ex + 6, ey - 18); }
+    ctx.closePath(); ctx.fill(); ctx.stroke();
+
+    if (t.exit_time != null && t.exit_time <= state.bars[end - 1].time) {
+      const exitIdx = Math.min(end - 1, indexAtOrAfter(t.exit_time));
+      const xx = xAt(exitIdx - start) + barW / 2;
+      const xy = yAt(t.exit_price);
+      ctx.strokeStyle = color;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath(); ctx.moveTo(ex, ey); ctx.lineTo(xx, xy); ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.beginPath();
+      ctx.moveTo(xx - 5, xy - 5); ctx.lineTo(xx + 5, xy + 5);
+      ctx.moveTo(xx + 5, xy - 5); ctx.lineTo(xx - 5, xy + 5);
+      ctx.stroke();
+    }
+  }
+
+  // time axis (a handful of labels across the visible window)
+  ctx.fillStyle = '#6e7681';
+  ctx.textBaseline = 'top';
+  const labelEvery = Math.max(1, Math.floor(visible.length / 6));
+  for (let i = 0; i < visible.length; i += labelEvery) {
+    const label = ET_FMT.format(new Date(visible[i].time * 1000));
+    ctx.fillText(label, xAt(i), h - 14);
+  }
+
+  document.getElementById('clock').textContent = ET_FMT.format(new Date(visible[visible.length - 1].time * 1000)) + ' ET';
+}
+
+function updateStats() {
+  if (!state.bars.length) return;
+  const nowTime = state.bars[Math.min(state.cursor, state.bars.length) - 1].time;
+  const completed = (state.events.trades || []).filter(t => t.exit_time != null && t.exit_time <= nowTime);
+  const open = (state.events.trades || []).find(t => t.entry_time != null && t.entry_time <= nowTime
+    && (t.exit_time == null || t.exit_time > nowTime));
+
+  document.getElementById('statN').textContent = String(completed.length);
+  if (completed.length) {
+    const wins = completed.filter(t => (t.pnl_points ?? 0) > 0);
+    const grossProfit = completed.filter(t => (t.pnl_points ?? 0) > 0).reduce((s, t) => s + t.pnl_points, 0);
+    const grossLoss = -completed.filter(t => (t.pnl_points ?? 0) < 0).reduce((s, t) => s + t.pnl_points, 0);
+    const totalPoints = completed.reduce((s, t) => s + (t.pnl_points ?? 0), 0);
+    document.getElementById('statWin').textContent = (100 * wins.length / completed.length).toFixed(1) + '%';
+    document.getElementById('statPF').textContent = grossLoss > 0 ? (grossProfit / grossLoss).toFixed(2) : '∞';
+    document.getElementById('statTotal').textContent = totalPoints.toFixed(1) + ' pt';
+  } else {
+    document.getElementById('statWin').textContent = '—';
+    document.getElementById('statPF').textContent = '—';
+    document.getElementById('statTotal').textContent = '—';
+  }
+  document.getElementById('statPos').textContent = open ? `${open.direction.toUpperCase()} @ ${open.entry_price.toFixed(2)}` : 'flat';
+}
+
+function stepPlayback(ts) {
+  if (!state.playing) return;
+  if (ts - state.lastTick > 66) { // ~15fps tick
+    state.lastTick = ts;
+    state.cursor = Math.min(state.bars.length, state.cursor + state.speed);
+    document.getElementById('scrub').value = String(state.cursor);
+    render();
+    updateStats();
+    if (state.cursor >= state.bars.length) { stopPlayback(); }
+  }
+  if (state.playing) state.rafId = requestAnimationFrame(stepPlayback);
+}
+
+function startPlayback() {
+  state.playing = true;
+  document.getElementById('playPause').textContent = '⏸ Pause';
+  state.lastTick = 0;
+  state.rafId = requestAnimationFrame(stepPlayback);
+}
+
+function stopPlayback() {
+  state.playing = false;
+  document.getElementById('playPause').textContent = '▶ Play';
+  if (state.rafId) cancelAnimationFrame(state.rafId);
+}
+
+document.getElementById('playPause').addEventListener('click', () => {
+  if (state.playing) stopPlayback(); else startPlayback();
+});
+document.getElementById('speed').addEventListener('change', e => { state.speed = Number(e.target.value); });
+document.getElementById('scrub').addEventListener('input', e => {
+  stopPlayback();
+  state.cursor = Number(e.target.value);
+  render();
+  updateStats();
+});
+document.getElementById('symbol').addEventListener('change', e => { state.symbol = e.target.value; loadData(); });
+document.getElementById('strategy').addEventListener('change', e => { state.strategy = e.target.value; loadData(); });
+
+resizeCanvas();
+loadData();

--- a/ml/serve/public/style.css
+++ b/ml/serve/public/style.css
@@ -1,0 +1,26 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0b0f14;
+  color: #e6edf3;
+  margin: 0;
+  padding: 24px;
+}
+h1 { font-size: 18px; font-weight: 600; margin: 0 0 4px; }
+.updated { font-size: 12px; color: #7d8590; margin-bottom: 20px; }
+.cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
+.card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.card h2 { font-size: 14px; margin: 0 0 10px; color: #e6edf3; }
+.row { display: flex; justify-content: space-between; font-size: 13px; margin: 4px 0; }
+.label { color: #7d8590; }
+.prob { font-weight: 600; }
+.prob.high { color: #3fb950; }
+.prob.mid { color: #d29922; }
+.prob.low { color: #f85149; }
+.flags { margin-top: 8px; font-size: 11px; color: #7d8590; }
+.flag-on { color: #d29922; }
+.error { color: #f85149; font-size: 12px; }

--- a/ml/serve/server.js
+++ b/ml/serve/server.js
@@ -1,0 +1,25 @@
+/**
+ * Standalone Express server for the ML prediction subsystem — deliberately
+ * separate from src/dashboard-server.js (different port, no shared code) per
+ * the "independent subsystem" scope decision.
+ */
+import express from 'express';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startPolling, getCache } from './live_agent.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = process.env.ML_PORT || 4600;
+const POLL_INTERVAL_MS = Number(process.env.ML_POLL_MS) || 45_000;
+
+const app = express();
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/predictions', (req, res) => {
+  res.json(getCache());
+});
+
+app.listen(PORT, () => {
+  console.log(`ML prediction server listening on http://localhost:${PORT}`);
+  startPolling({ intervalMs: POLL_INTERVAL_MS });
+});

--- a/ml/train/backtest.py
+++ b/ml/train/backtest.py
@@ -1,0 +1,184 @@
+"""
+Offline backtest: scores the trained long/short models bar-by-bar over the
+most recent N days and simulates taking a trade whenever a model's
+probability clears a threshold, using the same triple-barrier resolution
+(label_long/label_short, already computed by build_dataset.py) to score each
+simulated trade's outcome — no need to drive TradingView Desktop at all,
+since the raw bars + labels already capture "did TP or SL actually resolve
+first" for every row.
+
+This is *not* a live-execution backtest against a broker or even TradingView's
+own paper-trading replay — it's a direct read of "if the model's signal had
+fired here, would the pre-computed triple-barrier outcome have been a win or
+a loss." Deliberately simple and fast, and immune to all the chart-driving
+fragility (contamination, stalls, pane focus) that historical-data collection
+has been fighting all session.
+
+Position handling: non-overlapping — once a trade is "open" (per
+bars_to_resolve_{long,short}, or the full horizon on a timeout), no new
+signal is taken until it resolves. This is a real strategy constraint, not
+just a simplification: taking a fresh signal every bar while a position is
+still open isn't a coherent trading rule.
+
+Run as a module from the repo root:
+    python -m ml.train.backtest --symbol MNQ1! --timeframe 1 --days 7
+    python -m ml.train.backtest --symbol MGC1! --timeframe 1 --days 7 --threshold 0.6
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import lightgbm as lgb
+import numpy as np
+import pandas as pd
+
+from ..data_collection.collect_replay import epoch_to_date_str
+from ..features.build_dataset import load_symbol_config
+from .train_model import MODELS_DIR, PROCESSED_DIR, load_dataset, time_split
+
+TRADE_LOG_DIR = Path.home() / "data" / "ml-backtests"
+
+
+def load_model(symbol: str, timeframe: str, direction: str):
+    stem = f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}"
+    model_path = MODELS_DIR / f"{stem}.txt"
+    meta_path = MODELS_DIR / f"{stem}.meta.json"
+    if not model_path.exists():
+        raise FileNotFoundError(f"No model at {model_path} — run train_model.py first.")
+    return lgb.Booster(model_file=str(model_path)), json.loads(meta_path.read_text())
+
+
+def held_out_start(df: pd.DataFrame, meta_long: dict, meta_short: dict) -> int:
+    """The earliest timestamp neither model's train/val split ever saw.
+    Confirmed the hard way that skipping this check makes "backtest" numbers
+    meaningless: with only a few days of data on hand, "the last N days"
+    overlapped almost entirely with what the model was *trained* on, so a
+    raised probability threshold just showed better and better fit to data
+    it already memorized (win rate climbing to 88%+) rather than any real
+    out-of-sample edge. Uses each model's own stored test_frac against the
+    same dropna+time_split it was actually trained with, and takes the later
+    (more conservative) of the two directions' boundaries."""
+    boundaries = []
+    for direction, meta in (("long", meta_long), ("short", meta_short)):
+        labeled = df.dropna(subset=[f"label_{direction}"]).reset_index(drop=True)
+        _, test = time_split(labeled, meta["test_frac"])
+        if len(test):
+            boundaries.append(int(test["time"].min()))
+    return max(boundaries) if boundaries else int(df["time"].max())
+
+
+def run_backtest(symbol: str, timeframe: str, days: int, threshold: float, min_edge: float) -> pd.DataFrame:
+    full_df = load_dataset(symbol, timeframe)
+    model_long, meta_long = load_model(symbol, timeframe, "long")
+    model_short, meta_short = load_model(symbol, timeframe, "short")
+    feat_long, feat_short = meta_long["feature_columns"], meta_short["feature_columns"]
+
+    safe_start = held_out_start(full_df, meta_long, meta_short)
+    requested_cutoff = int(full_df["time"].max()) - days * 86400
+    cutoff = max(requested_cutoff, safe_start)
+    if cutoff > requested_cutoff:
+        print(f"[{symbol} {timeframe}] requested {days}-day window starts before the model's held-out "
+              f"test period ({epoch_to_date_str(safe_start)}) — clipping to that boundary so this measures "
+              f"out-of-sample performance, not training-set fit.", file=sys.stderr)
+
+    df = full_df[full_df["time"] >= cutoff].reset_index(drop=True)
+    print(f"[{symbol} {timeframe}] backtest window: {len(df)} bars, {epoch_to_date_str(cutoff)} onward", file=sys.stderr)
+
+    missing_long = [c for c in feat_long if c not in df.columns]
+    missing_short = [c for c in feat_short if c not in df.columns]
+    if missing_long or missing_short:
+        raise ValueError(f"Backtest window missing feature columns (context timeframe data too short for "
+                          f"this window?): long={missing_long} short={missing_short}")
+
+    prob_long = model_long.predict(df[feat_long], num_iteration=meta_long.get("best_iteration"))
+    prob_short = model_short.predict(df[feat_short], num_iteration=meta_short.get("best_iteration"))
+
+    tf_cfg = load_symbol_config(symbol, timeframe)
+    tp_points, sl_points, point_value = tf_cfg["tp_points"], tf_cfg["sl_points"], tf_cfg["point_value"]
+
+    trades = []
+    i = 0
+    n = len(df)
+    while i < n:
+        pl, ps = prob_long[i], prob_short[i]
+        take_long = pl >= threshold and pl - ps >= min_edge
+        take_short = ps >= threshold and ps - pl >= min_edge
+        if not (take_long or take_short):
+            i += 1
+            continue
+
+        direction = "long" if take_long else "short"
+        label_col = f"label_{direction}"
+        bars_col = f"bars_to_resolve_{direction}"
+        label = df[label_col].iloc[i]
+        bars_to_resolve = df[bars_col].iloc[i]
+        prob_used = pl if take_long else ps
+
+        if pd.isna(label):
+            outcome = "timeout"
+            points = 0.0
+            hold_bars = tf_cfg["horizon_bars"]
+        elif label == 1.0:
+            outcome = "win"
+            points = tp_points
+            hold_bars = int(bars_to_resolve)
+        else:
+            outcome = "loss"
+            points = -sl_points
+            hold_bars = int(bars_to_resolve)
+
+        trades.append({
+            "entry_time": int(df["time"].iloc[i]),
+            "direction": direction,
+            "prob": float(prob_used),
+            "entry_price": float(df["close"].iloc[i]),
+            "outcome": outcome,
+            "points": points,
+            "dollars": points * point_value,
+            "hold_bars": hold_bars,
+        })
+        i += max(hold_bars, 1)  # non-overlapping: skip past this trade's resolution
+
+    return pd.DataFrame(trades)
+
+
+def summarize(trades: pd.DataFrame) -> dict:
+    if trades.empty:
+        return {"n_trades": 0}
+    resolved = trades[trades["outcome"] != "timeout"]
+    wins = resolved[resolved["outcome"] == "win"]
+    return {
+        "n_trades": len(trades),
+        "n_resolved": len(resolved),
+        "n_timeout": len(trades) - len(resolved),
+        "win_rate": float(len(wins) / len(resolved)) if len(resolved) else None,
+        "total_points": float(trades["points"].sum()),
+        "total_dollars": float(trades["dollars"].sum()),
+        "avg_points_per_trade": float(trades["points"].mean()),
+        "by_direction": trades.groupby("direction")["points"].agg(["count", "sum", "mean"]).to_dict("index"),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True)
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--threshold", type=float, default=0.55, help="minimum probability to take a trade")
+    parser.add_argument("--min-edge", type=float, default=0.05, help="minimum prob_long - prob_short gap (or vice versa) to pick a direction")
+    args = parser.parse_args()
+
+    trades = run_backtest(args.symbol, args.timeframe, args.days, args.threshold, args.min_edge)
+    summary = summarize(trades)
+    print(json.dumps(summary, indent=2))
+
+    TRADE_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    stem = f"{args.symbol.replace(':', '_').replace('!', '')}_{args.timeframe}"
+    out_path = TRADE_LOG_DIR / f"{stem}_backtest_trades.csv"
+    trades.to_csv(out_path, index=False)
+    print(f"\nTrade log: {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train/backtest.py
+++ b/ml/train/backtest.py
@@ -30,14 +30,20 @@ import sys
 from pathlib import Path
 
 import lightgbm as lgb
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
 from ..data_collection.collect_replay import epoch_to_date_str
 from ..features.build_dataset import load_symbol_config
+from ..features.indicators import ET
 from .train_model import MODELS_DIR, PROCESSED_DIR, load_dataset, time_split
 
 TRADE_LOG_DIR = Path.home() / "data" / "ml-backtests"
+PLOTS_DIR = Path.home() / "data" / "ml-plots"
 
 
 def load_model(symbol: str, timeframe: str, direction: str):
@@ -115,6 +121,7 @@ def run_backtest(symbol: str, timeframe: str, days: int, threshold: float, min_e
         bars_to_resolve = df[bars_col].iloc[i]
         prob_used = pl if take_long else ps
 
+        entry_price = float(df["close"].iloc[i])
         if pd.isna(label):
             outcome = "timeout"
             points = 0.0
@@ -128,11 +135,21 @@ def run_backtest(symbol: str, timeframe: str, days: int, threshold: float, min_e
             points = -sl_points
             hold_bars = int(bars_to_resolve)
 
+        exit_idx = min(i + hold_bars, n - 1)
+        if outcome == "win":
+            exit_price = entry_price + tp_points if direction == "long" else entry_price - tp_points
+        elif outcome == "loss":
+            exit_price = entry_price - sl_points if direction == "long" else entry_price + sl_points
+        else:
+            exit_price = float(df["close"].iloc[exit_idx])
+
         trades.append({
             "entry_time": int(df["time"].iloc[i]),
+            "exit_time": int(df["time"].iloc[exit_idx]),
             "direction": direction,
             "prob": float(prob_used),
-            "entry_price": float(df["close"].iloc[i]),
+            "entry_price": entry_price,
+            "exit_price": exit_price,
             "outcome": outcome,
             "points": points,
             "dollars": points * point_value,
@@ -148,6 +165,8 @@ def summarize(trades: pd.DataFrame) -> dict:
         return {"n_trades": 0}
     resolved = trades[trades["outcome"] != "timeout"]
     wins = resolved[resolved["outcome"] == "win"]
+    gross_profit = trades.loc[trades["dollars"] > 0, "dollars"].sum()
+    gross_loss = -trades.loc[trades["dollars"] < 0, "dollars"].sum()  # positive number
     return {
         "n_trades": len(trades),
         "n_resolved": len(resolved),
@@ -156,8 +175,63 @@ def summarize(trades: pd.DataFrame) -> dict:
         "total_points": float(trades["points"].sum()),
         "total_dollars": float(trades["dollars"].sum()),
         "avg_points_per_trade": float(trades["points"].mean()),
+        # gross profit / gross loss — how many dollars of winners for every dollar
+        # of losers, independent of trade count or win rate. >1 means profitable;
+        # infinite (no losses at all) reported as null rather than a fake number.
+        "profit_factor": float(gross_profit / gross_loss) if gross_loss > 0 else None,
+        "gross_profit": float(gross_profit),
+        "gross_loss": float(gross_loss),
         "by_direction": trades.groupby("direction")["points"].agg(["count", "sum", "mean"]).to_dict("index"),
     }
+
+
+def plot_trade_date(price_df: pd.DataFrame, trades: pd.DataFrame, date: str, symbol: str, timeframe: str, out_path: Path):
+    """Both long and short entries/exits for one calendar day (ET) on a single
+    price chart — green markers for wins, red for losses, triangle-up for long
+    entries, triangle-down for short entries, X for exits."""
+    et = pd.to_datetime(price_df["time"], unit="s", utc=True).dt.tz_convert(ET)
+    day_mask = et.dt.strftime("%Y-%m-%d") == date
+    day = price_df[day_mask]
+    day_times = et[day_mask]
+    if day.empty:
+        raise ValueError(f"No price data for {date}")
+
+    day_trades = trades[trades["entry_time"].apply(lambda t: epoch_to_date_str(int(t))) == date]
+
+    fig, ax = plt.subplots(figsize=(13, 5.5))
+    ax.plot(day_times, day["close"], color="black", linewidth=0.7, label="price", zorder=1)
+
+    for _, t in day_trades.iterrows():
+        entry_dt = pd.to_datetime(t["entry_time"], unit="s", utc=True).tz_convert(ET)
+        exit_dt = pd.to_datetime(t["exit_time"], unit="s", utc=True).tz_convert(ET)
+        win = t["outcome"] == "win"
+        color = "#2CA02C" if win else ("#D62728" if t["outcome"] == "loss" else "#999999")
+        marker_entry = "^" if t["direction"] == "long" else "v"
+        ax.scatter([entry_dt], [t["entry_price"]], marker=marker_entry, color=color, s=90, zorder=5,
+                   edgecolors="black", linewidths=0.5)
+        ax.scatter([exit_dt], [t["exit_price"]], marker="x", color=color, s=80, zorder=5)
+        ax.plot([entry_dt, exit_dt], [t["entry_price"], t["exit_price"]], "--", color=color, linewidth=0.9, zorder=4, alpha=0.8)
+
+    n_long = (day_trades["direction"] == "long").sum()
+    n_short = (day_trades["direction"] == "short").sum()
+    n_win = (day_trades["outcome"] == "win").sum()
+    n_loss = (day_trades["outcome"] == "loss").sum()
+    day_pnl = day_trades["dollars"].sum()
+
+    legend_elems = [
+        plt.Line2D([0], [0], marker="^", color="w", markerfacecolor="gray", markeredgecolor="black", markersize=9, label="long entry"),
+        plt.Line2D([0], [0], marker="v", color="w", markerfacecolor="gray", markeredgecolor="black", markersize=9, label="short entry"),
+        plt.Line2D([0], [0], marker="x", color="gray", markersize=8, label="exit", linestyle="None"),
+        plt.Line2D([0], [0], color="#2CA02C", linewidth=2, label="win"),
+        plt.Line2D([0], [0], color="#D62728", linewidth=2, label="loss"),
+    ]
+    ax.legend(handles=legend_elems, loc="upper left", fontsize=8)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M", tz=ET))
+    ax.set_title(f"{symbol} {timeframe} — {date} — {len(day_trades)} trades ({n_long} long / {n_short} short, "
+                 f"{n_win}W/{n_loss}L, PNL ${day_pnl:+.0f})")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
 
 
 def main():
@@ -167,6 +241,7 @@ def main():
     parser.add_argument("--days", type=int, default=7)
     parser.add_argument("--threshold", type=float, default=0.55, help="minimum probability to take a trade")
     parser.add_argument("--min-edge", type=float, default=0.05, help="minimum prob_long - prob_short gap (or vice versa) to pick a direction")
+    parser.add_argument("--plot-date", help="YYYY-MM-DD (ET) — plot that day's long+short entries/exits on one chart")
     args = parser.parse_args()
 
     trades = run_backtest(args.symbol, args.timeframe, args.days, args.threshold, args.min_edge)
@@ -178,6 +253,13 @@ def main():
     out_path = TRADE_LOG_DIR / f"{stem}_backtest_trades.csv"
     trades.to_csv(out_path, index=False)
     print(f"\nTrade log: {out_path}", file=sys.stderr)
+
+    if args.plot_date and not trades.empty:
+        full_df = load_dataset(args.symbol, args.timeframe)
+        PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+        plot_path = PLOTS_DIR / f"{stem}_backtest_{args.plot_date}.png"
+        plot_trade_date(full_df, trades, args.plot_date, args.symbol, args.timeframe, plot_path)
+        print(f"Plot: {plot_path}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/ml/train/eval_by_session.py
+++ b/ml/train/eval_by_session.py
@@ -1,0 +1,64 @@
+"""
+Scores the unified (all-session) long/short models on their own held-out test
+set, sliced by session (asian/london/ny), to see where the unified model's
+edge actually concentrates — without the confound of session-specific models
+each training on a different (smaller) subset with its own time-based split.
+Complements train_model.py --session, which trains a separate model per
+session instead of just slicing eval.
+
+Run as a module from the repo root:
+    python -m ml.train.eval_by_session --symbol MNQ1! --timeframe 1
+"""
+import argparse
+import json
+import sys
+
+from sklearn.metrics import roc_auc_score, log_loss
+
+from .backtest import held_out_start, load_model
+from .train_model import SESSION_COLUMNS, load_dataset
+
+
+def eval_by_session(symbol: str, timeframe: str) -> dict:
+    df = load_dataset(symbol, timeframe)
+    model_long, meta_long = load_model(symbol, timeframe, "long")
+    model_short, meta_short = load_model(symbol, timeframe, "short")
+
+    cutoff = held_out_start(df, meta_long, meta_short)
+    test = df[df["time"] >= cutoff].reset_index(drop=True)
+    print(f"[{symbol} {timeframe}] held-out test set: {len(test)} rows, from cutoff onward", file=sys.stderr)
+
+    results = {}
+    for label, mask in [("all", test.index == test.index)] + [
+        (name, test[col] == 1) for name, col in SESSION_COLUMNS.items()
+    ]:
+        sub = test[mask]
+        row = {"n_rows": len(sub)}
+        for direction, model, meta in (("long", model_long, meta_long), ("short", model_short, meta_short)):
+            label_col = f"label_{direction}"
+            sub_labeled = sub.dropna(subset=[label_col])
+            if len(sub_labeled) < 10 or sub_labeled[label_col].nunique() < 2:
+                row[direction] = {"n": len(sub_labeled), "auc": None, "note": "too few / single-class rows"}
+                continue
+            feat = meta["feature_columns"]
+            pred = model.predict(sub_labeled[feat], num_iteration=meta.get("best_iteration"))
+            row[direction] = {
+                "n": len(sub_labeled),
+                "auc": round(float(roc_auc_score(sub_labeled[label_col], pred)), 4),
+                "log_loss": round(float(log_loss(sub_labeled[label_col], pred, labels=[0, 1])), 4),
+                "positive_rate": round(float(sub_labeled[label_col].mean()), 4),
+            }
+        results[label] = row
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True)
+    args = parser.parse_args()
+    print(json.dumps(eval_by_session(args.symbol, args.timeframe), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train/eval_session_router.py
+++ b/ml/train/eval_session_router.py
@@ -1,0 +1,85 @@
+"""
+Scores each session-specific model (asian/london/ny x long/short, trained via
+train_model.py --session) on its own held-out test slice, then pools all
+three sessions' held-out predictions into one number: "if every request were
+routed to the specialist model for whatever session it falls in, what's the
+overall out-of-sample performance" — directly comparable to the unified
+model's overall test AUC (eval_by_session.py's "all" row), since asian/
+london/ny sessions don't overlap so every routed row is scored exactly once.
+
+Requires the six session models to already exist (train_model.py --session
+asian/london/ny, --direction long/short).
+
+Run as a module from the repo root:
+    python -m ml.train.eval_session_router --symbol MNQ1! --timeframe 1
+"""
+import argparse
+import json
+import sys
+
+import lightgbm as lgb
+import numpy as np
+from sklearn.metrics import log_loss, roc_auc_score
+
+from .train_model import MODELS_DIR, SESSION_COLUMNS, load_dataset, time_split
+
+
+def load_session_model(symbol: str, timeframe: str, direction: str, session: str):
+    stem = f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}_{session}"
+    model_path = MODELS_DIR / f"{stem}.txt"
+    meta_path = MODELS_DIR / f"{stem}.meta.json"
+    if not model_path.exists():
+        raise FileNotFoundError(f"No model at {model_path} — run train_model.py --session {session} first.")
+    return lgb.Booster(model_file=str(model_path)), json.loads(meta_path.read_text())
+
+
+def eval_session_router(symbol: str, timeframe: str) -> dict:
+    df = load_dataset(symbol, timeframe)
+    per_session = {}
+    pooled = {"long": {"y": [], "p": []}, "short": {"y": [], "p": []}}
+
+    for session, session_col in SESSION_COLUMNS.items():
+        session_df = df[df[session_col] == 1].reset_index(drop=True)
+        row = {}
+        for direction in ("long", "short"):
+            label_col = f"label_{direction}"
+            model, meta = load_session_model(symbol, timeframe, direction, session)
+            labeled = session_df.dropna(subset=[label_col]).reset_index(drop=True)
+            _, test = time_split(labeled, meta["test_frac"])
+            feat = meta["feature_columns"]
+            pred = model.predict(test[feat], num_iteration=meta.get("best_iteration"))
+            y = test[label_col].to_numpy()
+            row[direction] = {
+                "n": len(test),
+                "auc": round(float(roc_auc_score(y, pred)), 4) if len(set(y)) > 1 else None,
+                "log_loss": round(float(log_loss(y, pred, labels=[0, 1])), 4) if len(test) else None,
+                "positive_rate": round(float(y.mean()), 4) if len(test) else None,
+            }
+            pooled[direction]["y"].extend(y.tolist())
+            pooled[direction]["p"].extend(pred.tolist())
+        per_session[session] = row
+
+    overall_routed = {}
+    for direction in ("long", "short"):
+        y = np.array(pooled[direction]["y"])
+        p = np.array(pooled[direction]["p"])
+        overall_routed[direction] = {
+            "n": len(y),
+            "auc": round(float(roc_auc_score(y, p)), 4) if len(set(y)) > 1 else None,
+            "log_loss": round(float(log_loss(y, p, labels=[0, 1])), 4) if len(y) else None,
+            "positive_rate": round(float(y.mean()), 4) if len(y) else None,
+        }
+
+    return {"per_session": per_session, "overall_routed": overall_routed}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True)
+    args = parser.parse_args()
+    print(json.dumps(eval_session_router(args.symbol, args.timeframe), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train/evaluate.py
+++ b/ml/train/evaluate.py
@@ -1,0 +1,71 @@
+"""
+Evaluates a saved model on its held-out time-based test split: reliability
+(calibration) table plus standard classification metrics.
+
+Since the model's whole point is a usable probability (not just a yes/no
+signal), a calibration table matters more than raw accuracy — a model that
+says "65%" should actually resolve TP-first close to 65% of the time.
+
+Run as a module from the repo root:
+    python -m ml.train.evaluate --symbol MNQ1! --timeframe 1 --direction long
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import lightgbm as lgb
+import numpy as np
+import pandas as pd
+from sklearn.calibration import calibration_curve
+from sklearn.metrics import roc_auc_score, log_loss, brier_score_loss
+
+from .train_model import PROCESSED_DIR, MODELS_DIR, load_dataset, time_split
+
+
+def evaluate(symbol: str, timeframe: str, direction: str, n_bins: int = 10):
+    model_path = MODELS_DIR / f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}.txt"
+    meta_path = model_path.with_suffix(".meta.json")
+    if not model_path.exists():
+        raise FileNotFoundError(f"No model at {model_path} — run train_model.py first.")
+
+    meta = json.loads(meta_path.read_text())
+    model = lgb.Booster(model_file=str(model_path))
+
+    label_col = f"label_{direction}"
+    df = load_dataset(symbol, timeframe)
+    df = df.dropna(subset=[label_col]).reset_index(drop=True)
+
+    train_val, test = time_split(df, meta["test_frac"])
+    feat_cols = meta["feature_columns"]
+    pred = model.predict(test[feat_cols], num_iteration=meta.get("best_iteration"))
+    y_true = test[label_col].to_numpy()
+
+    metrics = {
+        "auc": roc_auc_score(y_true, pred) if len(np.unique(y_true)) > 1 else None,
+        "log_loss": log_loss(y_true, pred, labels=[0, 1]),
+        "brier_score": brier_score_loss(y_true, pred),
+        "positive_rate": float(y_true.mean()),
+        "pred_mean": float(pred.mean()),
+    }
+    print(json.dumps(metrics, indent=2))
+
+    frac_pos, mean_pred = calibration_curve(y_true, pred, n_bins=n_bins, strategy="quantile")
+    print("\nCalibration (predicted vs actual TP-first rate, by decile):")
+    print(f"{'predicted':>10}  {'actual':>10}")
+    for p, a in zip(mean_pred, frac_pos):
+        print(f"{p:>10.3f}  {a:>10.3f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True)
+    parser.add_argument("--direction", choices=["long", "short"], required=True)
+    parser.add_argument("--bins", type=int, default=10)
+    args = parser.parse_args()
+    evaluate(args.symbol, args.timeframe, args.direction, n_bins=args.bins)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train/explain.py
+++ b/ml/train/explain.py
@@ -1,0 +1,150 @@
+"""
+Feature-importance and partial-dependence plots for a trained model.
+
+Partial dependence here is the standard definition: hold a sample of real
+rows fixed, sweep *one* feature across its observed range (1st-99th
+percentile, to avoid a couple of outliers stretching the whole axis), re-predict
+at each grid point, and average — the resulting curve shows how the model's
+output moves with that one feature, marginalized over the realistic joint
+distribution of everything else (not "all other features held at their mean,"
+which would put fake feature combinations into the model that never occur
+together in real data).
+
+Run as a module from the repo root:
+    python -m ml.train.explain --symbol MNQ1! --timeframe 1 --direction long
+    python -m ml.train.explain --all   # every model currently in ml/models/
+"""
+import argparse
+import json
+from pathlib import Path
+
+import lightgbm as lgb
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .train_model import MODELS_DIR, load_dataset
+
+PLOTS_DIR = Path.home() / "data" / "ml-plots"
+TOP_N_IMPORTANCE = 15
+TOP_N_PDP = 6
+PDP_GRID_SIZE = 30
+PDP_SAMPLE_SIZE = 500
+
+
+def discover_models() -> list[tuple[str, str, str]]:
+    """(symbol, timeframe, direction) for every *.meta.json directly in
+    MODELS_DIR (not the archive/ subdirectory)."""
+    out = []
+    for meta_path in sorted(MODELS_DIR.glob("*.meta.json")):
+        meta = json.loads(meta_path.read_text())
+        out.append((meta["symbol"], meta["timeframe"], meta["direction"]))
+    return out
+
+
+def load_model(symbol: str, timeframe: str, direction: str):
+    stem = f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}"
+    model = lgb.Booster(model_file=str(MODELS_DIR / f"{stem}.txt"))
+    meta = json.loads((MODELS_DIR / f"{stem}.meta.json").read_text())
+    return model, meta
+
+
+def plot_importance(model, meta, out_path: Path):
+    feat_cols = meta["feature_columns"]
+    gain = model.feature_importance(importance_type="gain")
+    order = np.argsort(gain)[::-1][:TOP_N_IMPORTANCE]
+    names = [feat_cols[i] for i in order][::-1]
+    values = [100 * gain[i] / gain.sum() for i in order][::-1]
+
+    fig, ax = plt.subplots(figsize=(8, 0.4 * len(names) + 1.5))
+    ax.barh(names, values, color="#4C78A8")
+    ax.set_xlabel("% of total gain")
+    ax.set_title(f"{meta['symbol']} {meta['timeframe']} {meta['direction']} — feature importance "
+                 f"(test AUC={meta['metrics']['auc']:.3f})")
+    for i, v in enumerate(values):
+        ax.text(v, i, f" {v:.1f}%", va="center", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def compute_pdp(model, df: pd.DataFrame, feat_cols: list[str], target: str, best_iteration):
+    sample = df[feat_cols].sample(min(PDP_SAMPLE_SIZE, len(df)), random_state=42).copy()
+    values = df[target].dropna()
+    if values.empty or values.min() == values.max():
+        return None, None
+    grid = np.linspace(values.quantile(0.01), values.quantile(0.99), PDP_GRID_SIZE)
+    pdp = []
+    for v in grid:
+        sample[target] = v
+        pdp.append(model.predict(sample, num_iteration=best_iteration).mean())
+    return grid, np.array(pdp)
+
+
+def plot_pdp_grid(model, meta, df: pd.DataFrame, out_path: Path):
+    feat_cols = meta["feature_columns"]
+    gain = model.feature_importance(importance_type="gain")
+    order = np.argsort(gain)[::-1][:TOP_N_PDP]
+    top_feats = [feat_cols[i] for i in order]
+
+    ncols = 3
+    nrows = (len(top_feats) + ncols - 1) // ncols
+    fig, axes = plt.subplots(nrows, ncols, figsize=(5 * ncols, 3.5 * nrows))
+    axes = np.atleast_1d(axes).flatten()
+
+    for ax, feat in zip(axes, top_feats):
+        grid, pdp = compute_pdp(model, df, feat_cols, feat, meta.get("best_iteration"))
+        if grid is None:
+            ax.set_visible(False)
+            continue
+        ax.plot(grid, pdp, color="#4C78A8", linewidth=2)
+        ax.set_title(feat, fontsize=10)
+        ax.set_ylabel("P(TP first)")
+        # rug of the real observed distribution along the bottom, for context
+        obs = df[feat].dropna()
+        obs = obs[(obs >= grid.min()) & (obs <= grid.max())]
+        ax.plot(obs.sample(min(200, len(obs)), random_state=1), [pdp.min()] * min(200, len(obs)),
+                "|", color="gray", alpha=0.3, markersize=8)
+    for ax in axes[len(top_feats):]:
+        ax.set_visible(False)
+
+    fig.suptitle(f"{meta['symbol']} {meta['timeframe']} {meta['direction']} — partial dependence, top {len(top_feats)} features")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def explain_one(symbol: str, timeframe: str, direction: str) -> list[Path]:
+    model, meta = load_model(symbol, timeframe, direction)
+    df = load_dataset(symbol, timeframe)
+    df = df.dropna(subset=[f"label_{direction}"]).reset_index(drop=True)
+
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+    stem = f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}"
+    importance_path = PLOTS_DIR / f"{stem}_importance.png"
+    pdp_path = PLOTS_DIR / f"{stem}_pdp.png"
+
+    plot_importance(model, meta, importance_path)
+    plot_pdp_grid(model, meta, df, pdp_path)
+    return [importance_path, pdp_path]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol")
+    parser.add_argument("--timeframe")
+    parser.add_argument("--direction", choices=["long", "short"])
+    parser.add_argument("--all", action="store_true", help="every model currently in ml/models/")
+    args = parser.parse_args()
+
+    targets = discover_models() if args.all else [(args.symbol, args.timeframe, args.direction)]
+    for symbol, timeframe, direction in targets:
+        paths = explain_one(symbol, timeframe, direction)
+        for p in paths:
+            print(p)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train/train_model.py
+++ b/ml/train/train_model.py
@@ -1,0 +1,131 @@
+"""
+Trains a LightGBM binary classifier predicting P(TP hit before SL) for one
+symbol + execution timeframe + direction (long/short), on the dataset produced
+by ml/features/build_dataset.py.
+
+Split is strictly time-ordered (last `--test-frac` of the data, by time, held
+out) rather than shuffled k-fold — shuffling would leak future bars' feature
+values (via rolling windows / session aggregates) into training folds that
+precede them in time.
+
+Run as a module from the repo root:
+    python -m ml.train.train_model --symbol MNQ1! --timeframe 1 --direction long
+"""
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import lightgbm as lgb
+import pandas as pd
+from sklearn.metrics import roc_auc_score, log_loss, brier_score_loss
+
+PROCESSED_DIR = Path.home() / "data" / "ml-processed"
+MODELS_DIR = Path(__file__).resolve().parent.parent / "models"
+MODELS_ARCHIVE_DIR = MODELS_DIR / "archive"
+
+NON_FEATURE_COLS = {
+    "time", "open", "high", "low", "close", "volume", "session_id",
+    "label_long", "label_short", "bars_to_resolve_long", "bars_to_resolve_short",
+}
+
+
+def load_dataset(symbol: str, timeframe: str) -> pd.DataFrame:
+    path = PROCESSED_DIR / f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No processed dataset at {path} — run build_dataset.py first.")
+    return pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+
+
+def feature_columns(df: pd.DataFrame) -> list[str]:
+    return [c for c in df.columns if c not in NON_FEATURE_COLS and pd.api.types.is_numeric_dtype(df[c])]
+
+
+def time_split(df: pd.DataFrame, test_frac: float):
+    split_idx = int(len(df) * (1 - test_frac))
+    return df.iloc[:split_idx], df.iloc[split_idx:]
+
+
+def train(symbol: str, timeframe: str, direction: str, test_frac: float, val_frac: float):
+    label_col = f"label_{direction}"
+    df = load_dataset(symbol, timeframe)
+    df = df.dropna(subset=[label_col]).reset_index(drop=True)
+    feat_cols = feature_columns(df)
+    print(f"[{symbol} {timeframe} {direction}] {len(df)} labeled rows, {len(feat_cols)} features", file=sys.stderr)
+
+    train_val, test = time_split(df, test_frac)
+    train_df, val_df = time_split(train_val, val_frac)
+
+    train_set = lgb.Dataset(train_df[feat_cols], label=train_df[label_col])
+    val_set = lgb.Dataset(val_df[feat_cols], label=val_df[label_col], reference=train_set)
+
+    params = {
+        "objective": "binary",
+        "metric": ["auc", "binary_logloss"],
+        "learning_rate": 0.05,
+        "num_leaves": 31,
+        "min_data_in_leaf": 50,
+        "feature_fraction": 0.8,
+        "bagging_fraction": 0.8,
+        "bagging_freq": 5,
+        "verbose": -1,
+    }
+    model = lgb.train(
+        params, train_set, num_boost_round=1000, valid_sets=[val_set],
+        callbacks=[lgb.early_stopping(stopping_rounds=50, verbose=False), lgb.log_evaluation(period=0)],
+    )
+
+    test_pred = model.predict(test[feat_cols], num_iteration=model.best_iteration)
+    metrics = {
+        "auc": roc_auc_score(test[label_col], test_pred) if test[label_col].nunique() > 1 else None,
+        "log_loss": log_loss(test[label_col], test_pred, labels=[0, 1]),
+        "brier_score": brier_score_loss(test[label_col], test_pred),
+        "test_rows": len(test),
+        "test_positive_rate": float(test[label_col].mean()),
+        "best_iteration": model.best_iteration,
+    }
+    print(f"[{symbol} {timeframe} {direction}] test metrics: {json.dumps(metrics, indent=2)}", file=sys.stderr)
+
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    model_path = MODELS_DIR / f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}.txt"
+    meta_path = model_path.with_suffix(".meta.json")
+
+    # train_model.py used to overwrite the previous model with no history at
+    # all — confirmed the cost of that directly: every earlier MGC1! model
+    # this session (including the pre-fix, ~0.5-AUC one worth comparing
+    # against) is gone. Archive whatever's about to be replaced, timestamped,
+    # before writing the new one.
+    if model_path.exists():
+        MODELS_ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        shutil.copy2(model_path, MODELS_ARCHIVE_DIR / f"{model_path.stem}_{stamp}.txt")
+        if meta_path.exists():
+            shutil.copy2(meta_path, MODELS_ARCHIVE_DIR / f"{meta_path.stem.replace('.meta', '')}_{stamp}.meta.json")
+
+    model.save_model(str(model_path))
+    meta_path.write_text(json.dumps({
+        "symbol": symbol, "timeframe": timeframe, "direction": direction,
+        "feature_columns": feat_cols, "metrics": metrics,
+        "train_rows": len(train_df), "val_rows": len(val_df), "test_rows": len(test),
+        "time_range": [int(df["time"].min()), int(df["time"].max())],
+        "test_frac": test_frac, "val_frac": val_frac,
+    }, indent=2))
+    print(f"Saved model to {model_path}", file=sys.stderr)
+    return model, metrics
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--timeframe", required=True)
+    parser.add_argument("--direction", choices=["long", "short"], required=True)
+    parser.add_argument("--test-frac", type=float, default=0.2)
+    parser.add_argument("--val-frac", type=float, default=0.15)
+    args = parser.parse_args()
+    train(args.symbol, args.timeframe, args.direction, args.test_frac, args.val_frac)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train/train_model.py
+++ b/ml/train/train_model.py
@@ -26,6 +26,17 @@ PROCESSED_DIR = Path.home() / "data" / "ml-processed"
 MODELS_DIR = Path(__file__).resolve().parent.parent / "models"
 MODELS_ARCHIVE_DIR = MODELS_DIR / "archive"
 
+# Asian/London/NY genuinely trade differently (different volatility, different
+# dominant participants) — session_context.py already tags every row with
+# which session(s) it falls in (in_asian_futures / in_london_open /
+# in_ny_session), so training on a session-filtered subset instead of the
+# whole day is just a row filter, not new feature engineering.
+SESSION_COLUMNS = {
+    "asian": "in_asian_futures",
+    "london": "in_london_open",
+    "ny": "in_ny_session",
+}
+
 NON_FEATURE_COLS = {
     "time", "open", "high", "low", "close", "volume", "session_id",
     "label_long", "label_short", "bars_to_resolve_long", "bars_to_resolve_short",
@@ -48,10 +59,18 @@ def time_split(df: pd.DataFrame, test_frac: float):
     return df.iloc[:split_idx], df.iloc[split_idx:]
 
 
-def train(symbol: str, timeframe: str, direction: str, test_frac: float, val_frac: float):
+def train(symbol: str, timeframe: str, direction: str, test_frac: float, val_frac: float,
+          session: str | None = None):
     label_col = f"label_{direction}"
     df = load_dataset(symbol, timeframe)
     df = df.dropna(subset=[label_col]).reset_index(drop=True)
+
+    if session:
+        session_col = SESSION_COLUMNS[session]
+        before = len(df)
+        df = df[df[session_col] == 1].reset_index(drop=True)
+        print(f"[{symbol} {timeframe} {direction}] session={session}: {before} -> {len(df)} rows", file=sys.stderr)
+
     feat_cols = feature_columns(df)
     print(f"[{symbol} {timeframe} {direction}] {len(df)} labeled rows, {len(feat_cols)} features", file=sys.stderr)
 
@@ -89,7 +108,8 @@ def train(symbol: str, timeframe: str, direction: str, test_frac: float, val_fra
     print(f"[{symbol} {timeframe} {direction}] test metrics: {json.dumps(metrics, indent=2)}", file=sys.stderr)
 
     MODELS_DIR.mkdir(parents=True, exist_ok=True)
-    model_path = MODELS_DIR / f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}.txt"
+    session_suffix = f"_{session}" if session else ""
+    model_path = MODELS_DIR / f"{symbol.replace(':', '_').replace('!', '')}_{timeframe}_{direction}{session_suffix}.txt"
     meta_path = model_path.with_suffix(".meta.json")
 
     # train_model.py used to overwrite the previous model with no history at
@@ -106,7 +126,7 @@ def train(symbol: str, timeframe: str, direction: str, test_frac: float, val_fra
 
     model.save_model(str(model_path))
     meta_path.write_text(json.dumps({
-        "symbol": symbol, "timeframe": timeframe, "direction": direction,
+        "symbol": symbol, "timeframe": timeframe, "direction": direction, "session": session,
         "feature_columns": feat_cols, "metrics": metrics,
         "train_rows": len(train_df), "val_rows": len(val_df), "test_rows": len(test),
         "time_range": [int(df["time"].min()), int(df["time"].max())],
@@ -123,8 +143,9 @@ def main():
     parser.add_argument("--direction", choices=["long", "short"], required=True)
     parser.add_argument("--test-frac", type=float, default=0.2)
     parser.add_argument("--val-frac", type=float, default=0.15)
+    parser.add_argument("--session", choices=list(SESSION_COLUMNS), help="train only on this session's bars (asian/london/ny) instead of all day")
     args = parser.parse_args()
-    train(args.symbol, args.timeframe, args.direction, args.test_frac, args.val_frac)
+    train(args.symbol, args.timeframe, args.direction, args.test_frac, args.val_frac, args.session)
 
 
 if __name__ == "__main__":

--- a/ml/train/vwap_reversion_backtest.py
+++ b/ml/train/vwap_reversion_backtest.py
@@ -1,0 +1,234 @@
+"""
+Rule-based backtest (no ML model involved): Asian-hours VWAP mean-reversion.
+
+Rule as specified: during a fixed ET hour window (default 19:00-22:00 —
+"Asian hours"), if price is >= 2 session-VWAP standard deviations away from
+VWAP, take a reversal trade back toward VWAP. Uses the same session-anchored
+VWAP calculation as the rest of this pipeline (ml/features/indicators.py's
+add_session_vwap), evaluated directly against raw OHLCV — no trained model.
+
+Exit rule (not specified by the request, so documented explicitly rather than
+left implicit): whichever comes first —
+  1. "reverted" — price comes back within `--exit-sigma` of VWAP (the stated target)
+  2. "stopped" — price extends *further* out to `--stop-sigma` (protects against
+     a trend day where 2-sigma keeps extending rather than reverting)
+  3. "window_close" — the 19:00-22:00 window ends before either happens
+
+Non-overlapping: only one position open at a time.
+
+Run as a module from the repo root:
+    python -m ml.train.vwap_reversion_backtest --symbol MGC1! --days 30
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from ..data_collection.collect_replay import parquet_path, epoch_to_date_str
+from ..features.build_dataset import load_symbol_config
+from ..features.indicators import ET, add_session_vwap
+
+TRADE_LOG_DIR = Path.home() / "data" / "ml-backtests"
+PLOTS_DIR = Path.home() / "data" / "ml-plots"
+
+
+def compute_features(symbol: str, days: int) -> pd.DataFrame:
+    raw = pd.read_parquet(parquet_path(symbol, "1")).sort_values("time").reset_index(drop=True)
+    df = add_session_vwap(raw)
+    et = pd.to_datetime(df["time"], unit="s", utc=True).dt.tz_convert(ET)
+    df["hour_et"] = et.dt.hour
+    df["date_et"] = et.dt.strftime("%Y-%m-%d")
+    cutoff = int(df["time"].max()) - days * 86400
+    return df[df["time"] >= cutoff].reset_index(drop=True)
+
+
+def run_backtest(df: pd.DataFrame, start_hour: int, end_hour: int,
+                  sigma_trigger: float, exit_sigma: float, stop_sigma: float, point_value: float,
+                  fixed_tp_sl: tuple[float, float, int] | None = None) -> pd.DataFrame:
+    """fixed_tp_sl, when given, is (tp_points, sl_points, max_hold_bars) — the
+    exact same fixed-distance exit the ML models use (ml/config/symbols.json),
+    checked against each bar's high/low (not just close, same as
+    ml/labels/triple_barrier.py) instead of the sigma-based revert/stop/window
+    rule. Only the *entry* trigger (2-sigma-from-VWAP during the Asian window)
+    stays the hand-specified rule; this isolates whether the entry idea has
+    edge under the same risk/reward the ML models are held to, rather than
+    conflating it with a different, untested exit rule."""
+    df["in_window"] = (df["hour_et"] >= start_hour) & (df["hour_et"] < end_hour)
+
+    trades = []
+    i, n = 0, len(df)
+    in_position = False
+    entry_idx = entry_price = entry_time = entry_sigma = trade_direction = None
+
+    while i < n:
+        row = df.iloc[i]
+        if not in_position:
+            sigma = row["dist_from_vwap_sigma"]
+            if row["in_window"] and pd.notna(sigma):
+                if sigma >= sigma_trigger:
+                    trade_direction = "short"
+                elif sigma <= -sigma_trigger:
+                    trade_direction = "long"
+                else:
+                    trade_direction = None
+                if trade_direction:
+                    entry_idx, entry_price, entry_time, entry_sigma = i, row["close"], row["time"], sigma
+                    in_position = True
+            i += 1
+            continue
+
+        exit_reason = None
+        if fixed_tp_sl:
+            tp_points, sl_points, max_hold_bars = fixed_tp_sl
+            if trade_direction == "long":
+                tp_level, sl_level = entry_price + tp_points, entry_price - sl_points
+                hit_tp, hit_sl = row["high"] >= tp_level, row["low"] <= sl_level
+            else:
+                tp_level, sl_level = entry_price - tp_points, entry_price + sl_points
+                hit_tp, hit_sl = row["low"] <= tp_level, row["high"] >= sl_level
+            if hit_tp and hit_sl:
+                exit_reason = "loss"  # same-bar ambiguity — conservative, matches triple_barrier.py
+            elif hit_tp:
+                exit_reason = "win"
+            elif hit_sl:
+                exit_reason = "loss"
+            elif i - entry_idx >= max_hold_bars:
+                exit_reason = "timeout"
+        else:
+            sigma = row["dist_from_vwap_sigma"]
+            if pd.isna(sigma):
+                exit_reason = "data_gap"
+            elif trade_direction == "short" and sigma <= exit_sigma:
+                exit_reason = "reverted"
+            elif trade_direction == "long" and sigma >= -exit_sigma:
+                exit_reason = "reverted"
+            elif trade_direction == "short" and sigma >= stop_sigma:
+                exit_reason = "stopped"
+            elif trade_direction == "long" and sigma <= -stop_sigma:
+                exit_reason = "stopped"
+            elif not row["in_window"]:
+                exit_reason = "window_close"
+
+        if exit_reason:
+            exit_price = row["close"] if not fixed_tp_sl else (
+                entry_price + tp_points if exit_reason == "win" and trade_direction == "long" else
+                entry_price - tp_points if exit_reason == "win" else
+                entry_price - sl_points if exit_reason == "loss" and trade_direction == "long" else
+                entry_price + sl_points if exit_reason == "loss" else
+                row["close"]
+            )
+            points = (entry_price - exit_price) if trade_direction == "short" else (exit_price - entry_price)
+            trades.append({
+                "entry_time": int(entry_time), "exit_time": int(row["time"]),
+                "entry_date": epoch_to_date_str(int(entry_time)),
+                "direction": trade_direction, "entry_price": float(entry_price), "exit_price": float(exit_price),
+                "entry_sigma": float(entry_sigma), "points": float(points), "dollars": float(points) * point_value,
+                "hold_bars": i - entry_idx, "exit_reason": exit_reason,
+                "entry_idx": entry_idx, "exit_idx": i,
+            })
+            in_position = False
+        i += 1
+
+    return pd.DataFrame(trades)
+
+
+def summarize(trades: pd.DataFrame) -> dict:
+    if trades.empty:
+        return {"n_trades": 0}
+    wins = trades[trades["points"] > 0]
+    return {
+        "n_trades": len(trades),
+        "win_rate": float(len(wins) / len(trades)),
+        "total_points": float(trades["points"].sum()),
+        "total_dollars": float(trades["dollars"].sum()),
+        "avg_points_per_trade": float(trades["points"].mean()),
+        "avg_hold_bars": float(trades["hold_bars"].mean()),
+        "by_exit_reason": trades["exit_reason"].value_counts().to_dict(),
+        "by_direction": trades.groupby("direction")["dollars"].agg(["count", "sum", "mean"]).to_dict("index"),
+    }
+
+
+def plot_trade_date(df: pd.DataFrame, trades: pd.DataFrame, date: str, start_hour: int, end_hour: int,
+                     sigma_trigger: float, out_path: Path):
+    day = df[df["date_et"] == date].reset_index(drop=True)
+    if day.empty:
+        return
+    day_trades = trades[trades["entry_date"] == date]
+    times = pd.to_datetime(day["time"], unit="s", utc=True).dt.tz_convert(ET)
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+    ax.plot(times, day["close"], color="black", linewidth=0.8, label="price")
+    ax.plot(times, day["vwap"], color="#4C78A8", linewidth=1.2, label="session VWAP")
+    ax.fill_between(times, day["vwap"] - sigma_trigger * day["vwap_std"], day["vwap"] + sigma_trigger * day["vwap_std"],
+                     color="#4C78A8", alpha=0.1, label=f"±{sigma_trigger}σ")
+
+    win_start = times.dt.normalize().iloc[0] + pd.Timedelta(hours=start_hour)
+    win_end = times.dt.normalize().iloc[0] + pd.Timedelta(hours=end_hour)
+    ax.axvspan(win_start, win_end, color="orange", alpha=0.08, label=f"{start_hour}:00-{end_hour}:00 ET window")
+
+    for _, t in day_trades.iterrows():
+        entry_dt = pd.to_datetime(t["entry_time"], unit="s", utc=True).tz_convert(ET)
+        exit_dt = pd.to_datetime(t["exit_time"], unit="s", utc=True).tz_convert(ET)
+        win = t["points"] > 0
+        color = "#2CA02C" if win else "#D62728"
+        marker_entry = "v" if t["direction"] == "short" else "^"
+        ax.scatter([entry_dt], [t["entry_price"]], marker=marker_entry, color=color, s=100, zorder=5)
+        ax.scatter([exit_dt], [t["exit_price"]], marker="x", color=color, s=100, zorder=5)
+        ax.plot([entry_dt, exit_dt], [t["entry_price"], t["exit_price"]], "--", color=color, linewidth=1, zorder=4)
+
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M", tz=ET))
+    ax.set_title(f"{date} — VWAP reversion trades ({len(day_trades)} trade(s))")
+    ax.legend(loc="upper left", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--days", type=int, default=30)
+    parser.add_argument("--start-hour", type=int, default=19, help="ET hour, window start (inclusive)")
+    parser.add_argument("--end-hour", type=int, default=22, help="ET hour, window end (exclusive)")
+    parser.add_argument("--sigma-trigger", type=float, default=2.0)
+    parser.add_argument("--exit-sigma", type=float, default=0.2)
+    parser.add_argument("--stop-sigma", type=float, default=3.0)
+    parser.add_argument("--fixed-tp-sl", action="store_true",
+                         help="use the ML model's own tp/sl/horizon from symbols.json instead of the "
+                              "sigma-based revert/stop/window-close exit — isolates the entry idea from the exit rule")
+    parser.add_argument("--plot-dates", type=int, default=4, help="how many trade dates to plot (most recent first)")
+    args = parser.parse_args()
+
+    tf_cfg = load_symbol_config(args.symbol, "1")
+    df = compute_features(args.symbol, args.days)
+    fixed_tp_sl = (tf_cfg["tp_points"], tf_cfg["sl_points"], tf_cfg["horizon_bars"]) if args.fixed_tp_sl else None
+    if fixed_tp_sl:
+        print(f"[{args.symbol}] using ML tp/sl/horizon: {tf_cfg['tp_points']}pt / {tf_cfg['sl_points']}pt / "
+              f"{tf_cfg['horizon_bars']} bars", file=sys.stderr)
+    trades = run_backtest(df, args.start_hour, args.end_hour, args.sigma_trigger,
+                           args.exit_sigma, args.stop_sigma, tf_cfg["point_value"], fixed_tp_sl)
+    summary = summarize(trades)
+    print(json.dumps(summary, indent=2))
+
+    TRADE_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+    suffix = "_fixedtpsl" if args.fixed_tp_sl else ""
+    trades.to_csv(TRADE_LOG_DIR / f"{stem}_vwap_reversion{suffix}_trades.csv", index=False)
+
+    if not trades.empty:
+        dates = trades["entry_date"].drop_duplicates().sort_values(ascending=False).head(args.plot_dates)
+        for date in dates:
+            out_path = PLOTS_DIR / f"{stem}_vwap_reversion{suffix}_{date}.png"
+            plot_trade_date(df, trades, date, args.start_hour, args.end_hour, args.sigma_trigger, out_path)
+            print(out_path, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "chrome-remote-interface": "^0.33.2"
+        "chrome-remote-interface": "^0.33.2",
+        "express": "^5.2.1"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
+    "dashboard": "node src/dashboard-server.js",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
     "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
@@ -24,6 +25,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "chrome-remote-interface": "^0.33.2"
+    "chrome-remote-interface": "^0.33.2",
+    "express": "^5.2.1"
   }
 }

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,187 @@
+const REGIME_POLL_MS = 400;   // matches the server's 300ms CDP tick loop
+const ASIA_POLL_MS   = 15000;
+const NEWS_POLL_MS   = 30000;
+
+function fmt(n, dec = 2) {
+  if (n == null || Number.isNaN(n)) return '--';
+  return Number(n).toLocaleString('en-US', { minimumFractionDigits: dec, maximumFractionDigits: dec });
+}
+
+function el(tag, cls, html) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (html != null) e.innerHTML = html;
+  return e;
+}
+
+function regimeBadge(p) {
+  if (p.regime === 'TRENDING') {
+    const arrow = p.trendDir === 'UP' ? '↑' : p.trendDir === 'DOWN' ? '↓' : '';
+    return `<span class="badge badge-trend">TRENDING ${arrow}</span>`;
+  }
+  if (p.regime === 'RANGING') return `<span class="badge badge-range">RANGING</span>`;
+  if (p.regime === 'TRANSITIONING') return `<span class="badge badge-mixed">MIXED</span>`;
+  return '';
+}
+
+function actionBadge(tb) {
+  if (!tb) return '';
+  if (tb.action === 'CONTINUE') return `<span class="badge badge-continue">CONTINUE ${tb.direction === 'UP' ? '↑' : '↓'} ${tb.strength}</span>`;
+  if (tb.action === 'FADE')     return `<span class="badge badge-fade">FADE ${tb.direction === 'UP' ? '↑' : '↓'} ${tb.strength}</span>`;
+  return `<span class="badge badge-wait">WAIT</span>`;
+}
+
+function reversalBadge(rv) {
+  if (!rv || !rv.probability) return '<span class="row"><span class="label">Reversal</span><span class="value">none</span></span>';
+  const dir = rv.direction === 'UP' ? 'up' : 'down';
+  return `<div class="row"><span class="label">Reversal</span><span class="value ${dir}">${rv.probability} ${rv.direction === 'UP' ? '↑' : '↓'}</span></div>` +
+    (rv.triggers && rv.triggers.length ? `<div class="reason">Triggers: ${rv.triggers.join(', ')}</div>` : '');
+}
+
+function renderRegimeCard(p) {
+  if (!p || p.error) {
+    return `<div class="card"><div class="card-title"><span class="symbol">${p ? p.symbol : '--'}</span></div><div class="empty">${p ? p.error : 'no data'}</div></div>`;
+  }
+  const l = p.layers;
+  return `
+    <div class="card-title">
+      <span class="symbol">${p.symbol}</span>
+      <span class="meta">${p.resolution}m · ${p.session}</span>
+    </div>
+    <div class="row"><span class="label">Regime</span><span>${regimeBadge(p)} <span class="value">${p.confidence}%</span></span></div>
+    <div class="row"><span class="label">Structure</span><span class="value">${l.structure.bos ? 'BOS ' + l.structure.bos.toUpperCase() : (l.structure.choch ? 'CHoCH' : 'no BOS')}</span></div>
+    <div class="row"><span class="label">ATR ratio</span><span class="value">${fmt(l.priceAction.atrRatio)}</span></div>
+    <div class="row"><span class="label">VWAP dev</span><span class="value">${l.priceAction.vwapDev != null ? fmt(l.priceAction.vwapDev) + '%' : 'n/a'}</span></div>
+    <div class="row"><span class="label">Vol ratio (20-bar)</span><span class="value">${fmt(l.volume.ratio)}</span></div>
+    <div class="row"><span class="label">Wk-hr Vol</span><span class="value">${l.volume.weeklyRatio != null ? fmt(l.volume.weeklyRatio) + 'x' : 'n/a'}</span></div>
+    <div class="row"><span class="label">Price</span><span class="value">${fmt(p.close)}</span></div>
+    ${reversalBadge(p.reversal)}
+    <div class="row" style="margin-top:8px"><span class="label">Action</span><span>${actionBadge(p.tradeBias)}</span></div>
+    <div class="reason">${p.tradeBias ? p.tradeBias.reason : ''}</div>
+  `;
+}
+
+let prevRegimeKeys = {};
+
+async function pollRegime() {
+  try {
+    const res = await fetch('/api/regime');
+    const data = await res.json();
+    const container = document.getElementById('regime-cards');
+    container.innerHTML = '';
+
+    if (data.error) {
+      container.appendChild(el('div', 'card', `<div class="empty">connection error: ${data.error}</div>`));
+      return;
+    }
+    if (!data.now || !data.now.panes || data.now.panes.length === 0) {
+      container.appendChild(el('div', 'card', `<div class="empty">waiting for data…</div>`));
+      return;
+    }
+
+    for (const p of data.now.panes) {
+      const card = el('div', 'card', renderRegimeCard(p));
+      const key = p.symbol + ':' + p.regime + ':' + (p.trendDir || '');
+      if (prevRegimeKeys[p.symbol] && prevRegimeKeys[p.symbol] !== key) card.classList.add('flash');
+      prevRegimeKeys[p.symbol] = key;
+      container.appendChild(card);
+    }
+  } catch (err) {
+    document.getElementById('regime-cards').innerHTML = `<div class="card"><div class="empty">fetch failed: ${err.message}</div></div>`;
+  }
+}
+
+function renderAsiaCard(key, idx) {
+  if (!idx || idx.error) {
+    return el('div', 'card idx-card', `<div class="card-title"><span class="symbol">${key}</span></div><div class="empty">${idx ? idx.error : 'no data'}</div>`);
+  }
+  const dir = idx.changePct < 0 ? 'down' : 'up';
+  const card = el('div', 'card idx-card' + (idx.bigDrop ? ' big-drop' : ''),
+    `<div class="card-title"><span class="symbol">${idx.name}</span><span class="meta">${key}</span></div>` +
+    `<div class="change ${dir}">${idx.changePct > 0 ? '+' : ''}${fmt(idx.changePct)}%</div>` +
+    `<div class="row"><span class="label">Price</span><span class="value">${fmt(idx.price)}</span></div>` +
+    `<div class="row"><span class="label">Prev close</span><span class="value">${fmt(idx.prevClose)}</span></div>` +
+    (idx.bigDrop ? `<div class="alert">⚠ Big drop — possible MNQ spillover risk</div>` : '')
+  );
+  return card;
+}
+
+async function pollAsia() {
+  try {
+    const res = await fetch('/api/asia');
+    const data = await res.json();
+    const container = document.getElementById('asia-cards');
+    container.innerHTML = '';
+    for (const key of Object.keys(data)) {
+      if (key.startsWith('_')) continue;
+      container.appendChild(renderAsiaCard(key, data[key]));
+    }
+  } catch (err) {
+    document.getElementById('asia-cards').innerHTML = `<div class="card"><div class="empty">fetch failed: ${err.message}</div></div>`;
+  }
+}
+
+function renderOilCard(label, oil) {
+  if (!oil || oil.error) return el('div', 'card idx-card', `<div class="card-title"><span class="symbol">${label}</span></div><div class="empty">${oil ? oil.error : 'no data'}</div>`);
+  const dir = oil.changePct < 0 ? 'down' : 'up';
+  return el('div', 'card idx-card',
+    `<div class="card-title"><span class="symbol">${label}</span></div>` +
+    `<div class="change ${dir}">${oil.changePct > 0 ? '+' : ''}${fmt(oil.changePct)}%</div>` +
+    `<div class="row"><span class="label">Price</span><span class="value">$${fmt(oil.price)}</span></div>`
+  );
+}
+
+function renderNewsTopic(topic, items) {
+  const col = el('div', 'news-topic');
+  col.appendChild(el('h3', null, topic));
+  if (!items || items.length === 0 || items[0].error) {
+    col.appendChild(el('div', 'empty', items && items[0] && items[0].error ? items[0].error : 'no items'));
+    return col;
+  }
+  for (const item of items) {
+    col.appendChild(el('div', 'news-item',
+      `<a href="${item.link}" target="_blank" rel="noopener">${item.title}</a><br>` +
+      `<span class="src">${item.source || ''} · ${item.published || ''}</span>`
+    ));
+  }
+  return col;
+}
+
+async function pollNews() {
+  try {
+    const res = await fetch('/api/news');
+    const data = await res.json();
+
+    const oilContainer = document.getElementById('oil-cards');
+    oilContainer.innerHTML = '';
+    if (data.oil) {
+      for (const label of Object.keys(data.oil)) {
+        oilContainer.appendChild(renderOilCard(label, data.oil[label]));
+      }
+    }
+
+    const newsContainer = document.getElementById('news-columns');
+    newsContainer.innerHTML = '';
+    if (data.topics) {
+      for (const topic of Object.keys(data.topics)) {
+        newsContainer.appendChild(renderNewsTopic(topic, data.topics[topic]));
+      }
+    }
+  } catch (err) {
+    document.getElementById('news-columns').innerHTML = `<div class="empty">fetch failed: ${err.message}</div>`;
+  }
+}
+
+function tickClock() {
+  document.getElementById('clock').textContent = new Date().toLocaleTimeString('en-US', { hour12: false });
+}
+
+setInterval(tickClock, 1000);
+setInterval(pollRegime, REGIME_POLL_MS);
+setInterval(pollAsia, ASIA_POLL_MS);
+setInterval(pollNews, NEWS_POLL_MS);
+
+tickClock();
+pollRegime();
+pollAsia();
+pollNews();

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,5 +1,5 @@
 const REGIME_POLL_MS = 400;   // matches the server's 300ms CDP tick loop
-const ASIA_POLL_MS   = 15000;
+const ASIA_POLL_MS   = 10000;
 const NEWS_POLL_MS   = 30000;
 
 function fmt(n, dec = 2) {
@@ -95,15 +95,36 @@ function renderAsiaCard(key, idx) {
   if (!idx || idx.error) {
     return el('div', 'card idx-card', `<div class="card-title"><span class="symbol">${key}</span></div><div class="empty">${idx ? idx.error : 'no data'}</div>`);
   }
-  const dir = idx.changePct < 0 ? 'down' : 'up';
+  const dir = idx.changeFromPrevClosePct < 0 ? 'down' : 'up';
+  const dirOpen = idx.changeFromOpenPct < 0 ? 'down' : 'up';
+  const dirDD = idx.dropFromHighPct < 0 ? 'down' : 'up';
+  const statusBadge = idx.marketOpen
+    ? `<span class="badge badge-continue">LIVE</span>`
+    : `<span class="badge badge-wait">CLOSED</span>`;
+  const asOfTime = idx.asOf ? new Date(idx.asOf).toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' }) : '--';
+
   const card = el('div', 'card idx-card' + (idx.bigDrop ? ' big-drop' : ''),
-    `<div class="card-title"><span class="symbol">${idx.name}</span><span class="meta">${key}</span></div>` +
-    `<div class="change ${dir}">${idx.changePct > 0 ? '+' : ''}${fmt(idx.changePct)}%</div>` +
+    `<div class="card-title"><span class="symbol">${idx.name}</span>${statusBadge}</div>` +
+    `<div class="change ${dir}">${idx.changeFromPrevClosePct > 0 ? '+' : ''}${fmt(idx.changeFromPrevClosePct)}%</div>` +
+    `<div class="reason" style="margin-top:-4px">vs prev close · as of ${asOfTime} local</div>` +
     `<div class="row"><span class="label">Price</span><span class="value">${fmt(idx.price)}</span></div>` +
-    `<div class="row"><span class="label">Prev close</span><span class="value">${fmt(idx.prevClose)}</span></div>` +
+    `<div class="row"><span class="label">From open</span><span class="value ${dirOpen}">${idx.changeFromOpenPct > 0 ? '+' : ''}${fmt(idx.changeFromOpenPct)}%</span></div>` +
+    `<div class="row"><span class="label">From session high</span><span class="value ${dirDD}">${idx.dropFromHighPct > 0 ? '+' : ''}${fmt(idx.dropFromHighPct)}%</span></div>` +
+    `<div class="row"><span class="label">Session range</span><span class="value">${fmt(idx.sessionLow)} – ${fmt(idx.sessionHigh)}</span></div>` +
     (idx.bigDrop ? `<div class="alert">⚠ Big drop — possible MNQ spillover risk</div>` : '')
   );
   return card;
+}
+
+function renderImpactCard(impact) {
+  if (!impact) return '';
+  const levelClass = impact.level === 'HIGH' ? 'badge-fade' : impact.level === 'MEDIUM' ? 'badge-mixed' : 'badge-wait';
+  return `
+    <div class="card-title"><span class="symbol">Asia → MNQ spillover risk</span></div>
+    <div class="row"><span class="label">Risk level</span><span class="badge ${levelClass}">${impact.level}</span></div>
+    <div class="row"><span class="label">Indices showing big drop</span><span class="value">${impact.redCount}/3</span></div>
+    <div class="row"><span class="label">Combined drop score</span><span class="value">${fmt(impact.score)}</span></div>
+  `;
 }
 
 async function pollAsia() {
@@ -112,6 +133,11 @@ async function pollAsia() {
     const data = await res.json();
     const container = document.getElementById('asia-cards');
     container.innerHTML = '';
+
+    if (data._impact) {
+      const impactCard = el('div', 'card' + (data._impact.level === 'HIGH' ? ' big-drop' : ''), renderImpactCard(data._impact));
+      container.appendChild(impactCard);
+    }
     for (const key of Object.keys(data)) {
       if (key.startsWith('_')) continue;
       container.appendChild(renderAsiaCard(key, data[key]));

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Trading Agent Dashboard</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Trading Agent Dashboard</h1>
+    <div id="clock"></div>
+  </header>
+
+  <main>
+    <section id="regime-section">
+      <h2>Regime — Trend vs Range</h2>
+      <div id="regime-cards" class="card-row"></div>
+    </section>
+
+    <section id="asia-section">
+      <h2>Asian Indices (Asia-hours spillover risk)</h2>
+      <div id="asia-cards" class="card-row"></div>
+    </section>
+
+    <section id="news-section">
+      <h2>News &amp; Oil</h2>
+      <div id="oil-cards" class="card-row"></div>
+      <div id="news-columns" class="news-columns"></div>
+    </section>
+  </main>
+
+  <footer>
+    <span>Not affiliated with TradingView Inc. or Anthropic. Use subject to TradingView's Terms of Use.</span>
+  </footer>
+
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,117 @@
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  background: #0b0e14;
+  color: #d8dee9;
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background: #11151c;
+  border-bottom: 1px solid #232838;
+}
+header h1 { margin: 0; font-size: 18px; font-weight: 600; color: #f5f7fa; }
+#clock { font-family: monospace; color: #6b7384; font-size: 13px; }
+
+main { padding: 20px 24px 40px; max-width: 1400px; margin: 0 auto; }
+section { margin-bottom: 32px; }
+h2 {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7384;
+  margin: 0 0 12px;
+  font-weight: 600;
+}
+
+.card-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.card {
+  background: #11151c;
+  border: 1px solid #232838;
+  border-radius: 10px;
+  padding: 16px 18px;
+}
+.card.flash { animation: flash 1s ease-out; }
+@keyframes flash { 0% { border-color: #f0a020; } 100% { border-color: #232838; } }
+
+.card-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+.card-title .symbol { font-weight: 700; font-size: 15px; color: #f5f7fa; }
+.card-title .meta { font-size: 12px; color: #6b7384; }
+
+.badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+.badge-trend   { background: #15384a; color: #5fd0ff; }
+.badge-range   { background: #3a1b4a; color: #d291ff; }
+.badge-mixed   { background: #4a3a14; color: #ffcf5f; }
+.badge-continue{ background: #143a1f; color: #5fffa0; }
+.badge-fade    { background: #4a1414; color: #ff7878; }
+.badge-wait    { background: #232838; color: #6b7384; }
+
+.row { display: flex; justify-content: space-between; padding: 4px 0; font-size: 13px; }
+.row .label { color: #6b7384; }
+.row .value { color: #d8dee9; font-family: monospace; }
+.row .value.up { color: #5fffa0; }
+.row .value.down { color: #ff7878; }
+
+.reason { font-size: 12px; color: #8b93a3; margin-top: 8px; line-height: 1.5; }
+
+.idx-card.big-drop { border-color: #5a1f1f; background: #1a0f0f; }
+.idx-card .change { font-size: 22px; font-weight: 700; }
+.idx-card .change.down { color: #ff7878; }
+.idx-card .change.up { color: #5fffa0; }
+.idx-card .alert {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #ff9a6b;
+  font-weight: 600;
+}
+
+.news-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+.news-topic h3 {
+  font-size: 13px;
+  color: #f5f7fa;
+  margin: 0 0 8px;
+  text-transform: capitalize;
+}
+.news-item {
+  font-size: 12.5px;
+  padding: 8px 0;
+  border-bottom: 1px solid #1c212e;
+  line-height: 1.4;
+}
+.news-item a { color: #9fc4ff; text-decoration: none; }
+.news-item a:hover { text-decoration: underline; }
+.news-item .src { color: #6b7384; font-size: 11px; }
+
+footer {
+  text-align: center;
+  font-size: 11px;
+  color: #4a505e;
+  padding: 20px;
+}
+
+.empty { color: #4a505e; font-size: 13px; padding: 12px 0; }

--- a/src/cli/commands/agent.js
+++ b/src/cli/commands/agent.js
@@ -1,0 +1,47 @@
+import { register } from '../router.js';
+import { analyzeChart } from '../../core/agent.js';
+import { analyzeRegime } from '../../core/regime.js';
+
+register('agent', {
+  description: 'Real-time trading agents — regime classifier + signal alerts',
+  subcommands: new Map([
+    ['watch', {
+      description: 'Signal agent: regime + liquidity sweep / VWAP±2SD / EMA9 alerts',
+      options: {
+        interval: { type: 'string', short: 'i', description: 'Poll interval in ms (default 1000)' },
+      },
+      handler: async (opts) => {
+        if (opts.interval) process.argv.push('--interval', opts.interval);
+        await import(new URL('../../../strategies/trading-agent.js', import.meta.url).href);
+      },
+    }],
+    ['regime', {
+      description: 'Regime agent: 4-layer ranging vs trending dashboard for all panes',
+      options: {
+        interval: { type: 'string', short: 'i', description: 'Poll interval in ms (default 1000)' },
+        symbols:  { type: 'string', short: 's', description: 'Comma-separated symbol filter (e.g. MNQ,MGC)' },
+      },
+      handler: async (opts) => {
+        if (opts.interval) process.argv.push('--interval', opts.interval);
+        if (opts.symbols)  process.argv.push('--symbols',  opts.symbols);
+        await import(new URL('../../../strategies/regime-agent.js', import.meta.url).href);
+      },
+    }],
+    ['once', {
+      description: 'Single snapshot — signal analysis (JSON)',
+      options: {},
+      handler: async () => {
+        const result = await analyzeChart();
+        console.log(JSON.stringify(result, null, 2));
+      },
+    }],
+    ['regime-once', {
+      description: 'Single snapshot — regime analysis for all panes (JSON)',
+      options: {},
+      handler: async () => {
+        const result = await analyzeRegime();
+        console.log(JSON.stringify(result, null, 2));
+      },
+    }],
+  ]),
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,6 +25,7 @@ import './commands/ui.js';
 import './commands/pane.js';
 import './commands/tab.js';
 import './commands/stream.js';
+import './commands/agent.js';
 
 // Run
 import { run } from './router.js';

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -128,11 +128,19 @@ export async function run(argv) {
   }
 }
 
+// console.log()/console.error() write asynchronously when stdout/stderr is
+// piped (not a TTY) — a process.exit() issued right after can kill the process
+// before the OS pipe buffer (commonly 64KB) finishes flushing, silently
+// truncating any output past that point. Waiting for the write's own callback
+// guarantees the data is actually handed off before exiting.
+function writeAndExit(stream, str, code) {
+  stream.write(str + '\n', () => process.exit(code));
+}
+
 async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
-    console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    writeAndExit(process.stdout, JSON.stringify(result, null, 2), 0);
   } catch (err) {
     handleError(err);
   }
@@ -140,11 +148,8 @@ async function execute(handler, values, positionals) {
 
 function handleError(err) {
   const message = err.message || String(err);
+  const payload = JSON.stringify({ success: false, error: message }, null, 2);
   // Connection failures get exit code 2
-  if (/CDP|connection|ECONNREFUSED|not running/i.test(message)) {
-    console.error(JSON.stringify({ success: false, error: message }, null, 2));
-    process.exit(2);
-  }
-  console.error(JSON.stringify({ success: false, error: message }, null, 2));
-  process.exit(1);
+  const code = /CDP|connection|ECONNREFUSED|not running/i.test(message) ? 2 : 1;
+  writeAndExit(process.stderr, payload, code);
 }

--- a/src/core/agent.js
+++ b/src/core/agent.js
@@ -1,0 +1,255 @@
+/**
+ * Trading agent analysis engine.
+ * Single CDP evaluate call that computes regime + all signals.
+ *
+ * Regime detection: ADX14 — trending (> 25) vs ranging (≤ 25)
+ * Ranging signals:
+ *   LIQUIDITY_SWEEP_HIGH — wick above 20-bar swing high, last completed bar closed back below
+ *   LIQUIDITY_SWEEP_LOW  — wick below 20-bar swing low,  last completed bar closed back above
+ *   VWAP_UPPER2          — current bar touching VWAP +2SD (intraday only)
+ *   VWAP_LOWER2          — current bar touching VWAP -2SD (intraday only)
+ * Trending signals:
+ *   EMA9_TOUCH           — current bar's range includes EMA9 (pullback entry)
+ */
+import { evaluate } from '../connection.js';
+
+const ANALYSIS_JS = String.raw`
+(function() {
+  // ── Wilder RMA (used by ADX) ──
+  function rma(arr, period) {
+    if (arr.length < period) return null;
+    var val = 0;
+    for (var i = 0; i < period; i++) val += arr[i];
+    val /= period;
+    for (var i = period; i < arr.length; i++) val = (val * (period - 1) + arr[i]) / period;
+    return val;
+  }
+
+  // ── EMA ──
+  function ema(arr, period) {
+    if (arr.length < period) return null;
+    var k = 2 / (period + 1);
+    var val = 0;
+    for (var i = 0; i < period; i++) val += arr[i];
+    val /= period;
+    for (var i = period; i < arr.length; i++) val = arr[i] * k + val * (1 - k);
+    return val;
+  }
+
+  // ── ADX14 ──
+  function adx14(bars) {
+    var period = 14;
+    if (bars.length < period * 2 + 1) return null;
+    var trs = [], pdms = [], ndms = [];
+    for (var i = 1; i < bars.length; i++) {
+      var hi = bars[i].high, lo = bars[i].low;
+      var ph = bars[i-1].high, pl = bars[i-1].low, pc = bars[i-1].close;
+      trs.push(Math.max(hi - lo, Math.abs(hi - pc), Math.abs(lo - pc)));
+      var upMove = hi - ph, downMove = pl - lo;
+      pdms.push(upMove > downMove && upMove > 0 ? upMove : 0);
+      ndms.push(downMove > upMove && downMove > 0 ? downMove : 0);
+    }
+    var sTR = rma(trs, period), sPDM = rma(pdms, period), sNDM = rma(ndms, period);
+    if (!sTR || sTR === 0) return null;
+    // build DX series using progressive RMA
+    var dxArr = [];
+    var trRun = 0, pdRun = 0, ndRun = 0;
+    for (var i = 0; i < trs.length; i++) {
+      if (i < period) {
+        trRun += trs[i]; pdRun += pdms[i]; ndRun += ndms[i];
+        if (i === period - 1) { trRun /= period; pdRun /= period; ndRun /= period; }
+      } else {
+        trRun = (trRun * (period - 1) + trs[i]) / period;
+        pdRun = (pdRun * (period - 1) + pdms[i]) / period;
+        ndRun = (ndRun * (period - 1) + ndms[i]) / period;
+        if (trRun === 0) { dxArr.push(0); continue; }
+        var pdi = 100 * pdRun / trRun, ndi = 100 * ndRun / trRun;
+        var s = pdi + ndi;
+        dxArr.push(s === 0 ? 0 : 100 * Math.abs(pdi - ndi) / s);
+      }
+    }
+    if (dxArr.length < period) return null;
+    return Math.round(rma(dxArr, period) * 100) / 100;
+  }
+
+  // ── VWAP + 2SD (session-aware, intraday only) ──
+  function vwapBands(bars, resolution) {
+    // Skip for daily+ timeframes
+    var res = parseInt(resolution, 10);
+    if (!res || res >= 1440) return null;
+    // Find session start: last bar with a different calendar day
+    var last = bars[bars.length - 1];
+    var lastDay = Math.floor(last.time / 86400);
+    var sessionStart = 0;
+    for (var i = bars.length - 1; i >= 0; i--) {
+      if (Math.floor(bars[i].time / 86400) < lastDay) { sessionStart = i + 1; break; }
+    }
+    var sb = bars.slice(sessionStart);
+    if (sb.length < 2) return null;
+    // cumulative VWAP
+    var cumTPV = 0, cumVol = 0;
+    for (var i = 0; i < sb.length; i++) {
+      var tp = (sb[i].high + sb[i].low + sb[i].close) / 3;
+      cumTPV += tp * sb[i].volume; cumVol += sb[i].volume;
+    }
+    if (cumVol === 0) return null;
+    var vwap = cumTPV / cumVol;
+    // variance weighted by volume
+    var variance = 0, cumV2 = 0, cumTP2 = 0;
+    for (var i = 0; i < sb.length; i++) {
+      var tp = (sb[i].high + sb[i].low + sb[i].close) / 3;
+      cumV2 += sb[i].volume; cumTP2 += tp * sb[i].volume;
+      var vwapHere = cumTP2 / cumV2;
+      variance += sb[i].volume * (tp - vwapHere) * (tp - vwapHere);
+    }
+    var sd = cumVol > 0 ? Math.sqrt(variance / cumVol) : 0;
+    return {
+      vwap:   Math.round(vwap * 100) / 100,
+      upper2: Math.round((vwap + 2 * sd) * 100) / 100,
+      lower2: Math.round((vwap - 2 * sd) * 100) / 100,
+      sd:     Math.round(sd * 100) / 100,
+      session_bars: sb.length,
+    };
+  }
+
+  // ── Pull bars ──
+  var api = window.TradingViewApi._activeChartWidgetWV.value();
+  var chart = api._chartWidget;
+  var model = chart.model();
+  var barsObj = model.mainSeries().bars();
+  if (!barsObj || typeof barsObj.lastIndex !== 'function') return { error: 'No bars available' };
+
+  var end = barsObj.lastIndex();
+  var start = Math.max(barsObj.firstIndex(), end - 150);
+  var bars = [];
+  for (var i = start; i <= end; i++) {
+    var v = barsObj.valueAt(i);
+    if (v) bars.push({ time: v[0], open: v[1], high: v[2], low: v[3], close: v[4], volume: v[5] || 0 });
+  }
+  if (bars.length < 30) return { error: 'Not enough bars (' + bars.length + ')' };
+
+  var resolution = api.resolution();
+  var symbol = api.symbol();
+  var closes = bars.map(function(b){ return b.close; });
+
+  // Current forming bar + last completed bar
+  var cur = bars[bars.length - 1];
+  var prev = bars[bars.length - 2];
+
+  // ── Indicators ──
+  var adxVal = adx14(bars);
+  var regime = adxVal === null ? 'unknown' : (adxVal > 25 ? 'trending' : 'ranging');
+
+  var ema9Val = ema(closes, 9);
+  var vwapData = vwapBands(bars, resolution);
+
+  // Swing high/low over last 20 COMPLETED bars (exclude current forming bar)
+  var lookback = bars.slice(-22, -1);
+  var swingHigh = -Infinity, swingLow = Infinity;
+  for (var i = 0; i < lookback.length; i++) {
+    if (lookback[i].high > swingHigh) swingHigh = lookback[i].high;
+    if (lookback[i].low  < swingLow)  swingLow  = lookback[i].low;
+  }
+  swingHigh = Math.round(swingHigh * 100) / 100;
+  swingLow  = Math.round(swingLow  * 100) / 100;
+
+  // ── Signals ──
+  var signals = [];
+
+  if (regime === 'ranging') {
+    // Liquidity sweeps — check prev COMPLETED bar vs swing levels of bars before it
+    var prevLookback = bars.slice(-23, -2);
+    if (prevLookback.length >= 10) {
+      var ph = -Infinity, pl = Infinity;
+      for (var i = 0; i < prevLookback.length; i++) {
+        if (prevLookback[i].high > ph) ph = prevLookback[i].high;
+        if (prevLookback[i].low  < pl) pl = prevLookback[i].low;
+      }
+      ph = Math.round(ph * 100) / 100;
+      pl = Math.round(pl * 100) / 100;
+      // Buy-side sweep: prev bar wicked above swing high but closed below → short bias
+      if (prev.high > ph && prev.close < ph) {
+        signals.push({
+          type: 'LIQUIDITY_SWEEP_HIGH',
+          bias: 'SHORT',
+          desc: 'Swept buy-side liq above ' + ph + ', closed back below',
+          bar_time: prev.time,
+          entry: prev.close,
+          level: ph,
+        });
+      }
+      // Sell-side sweep: prev bar wicked below swing low but closed above → long bias
+      if (prev.low < pl && prev.close > pl) {
+        signals.push({
+          type: 'LIQUIDITY_SWEEP_LOW',
+          bias: 'LONG',
+          desc: 'Swept sell-side liq below ' + pl + ', closed back above',
+          bar_time: prev.time,
+          entry: prev.close,
+          level: pl,
+        });
+      }
+    }
+    // VWAP bands — live current bar touch
+    if (vwapData) {
+      if (cur.high >= vwapData.upper2 && cur.low <= vwapData.upper2) {
+        signals.push({
+          type: 'VWAP_UPPER2',
+          bias: 'SHORT',
+          desc: 'Price touching VWAP +2SD (' + vwapData.upper2 + ')',
+          bar_time: cur.time,
+          entry: cur.close,
+          level: vwapData.upper2,
+        });
+      }
+      if (cur.high >= vwapData.lower2 && cur.low <= vwapData.lower2) {
+        signals.push({
+          type: 'VWAP_LOWER2',
+          bias: 'LONG',
+          desc: 'Price touching VWAP -2SD (' + vwapData.lower2 + ')',
+          bar_time: cur.time,
+          entry: cur.close,
+          level: vwapData.lower2,
+        });
+      }
+    }
+  }
+
+  if (regime === 'trending') {
+    // EMA9 touch — live current bar
+    if (ema9Val !== null && cur.low <= ema9Val && cur.high >= ema9Val) {
+      var above = prev.close > ema9Val;
+      signals.push({
+        type: 'EMA9_TOUCH',
+        bias: above ? 'LONG' : 'SHORT',
+        desc: 'Price pulling back to EMA9 (' + Math.round(ema9Val * 100) / 100 + ')',
+        bar_time: cur.time,
+        entry: cur.close,
+        level: Math.round(ema9Val * 100) / 100,
+      });
+    }
+  }
+
+  return {
+    symbol:      symbol,
+    resolution:  resolution,
+    ts:          Date.now(),
+    bar_time:    cur.time,
+    close:       cur.close,
+    high:        cur.high,
+    low:         cur.low,
+    adx:         adxVal,
+    regime:      regime,
+    ema9:        ema9Val !== null ? Math.round(ema9Val * 100) / 100 : null,
+    vwap:        vwapData,
+    swing_high:  swingHigh,
+    swing_low:   swingLow,
+    signals:     signals,
+    bar_count:   bars.length,
+  };
+})()
+`;
+
+export async function analyzeChart() {
+  return evaluate(ANALYSIS_JS);
+}

--- a/src/core/asiaIndices.js
+++ b/src/core/asiaIndices.js
@@ -1,0 +1,56 @@
+/**
+ * Asian index cache (Hang Seng, Nikkei 225, KOSPI), sourced from yfinance.
+ * A large overnight drop in any of these during Asia hours can spill over
+ * into MNQ/ES before NY open — refreshed periodically in the background.
+ */
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '../../strategies/asia_indices.py');
+const PYTHON_BIN = process.env.PYTHON_BIN || 'python3';
+
+const REFRESH_INTERVAL_MS = 60 * 1000; // 1 minute — close to real-time without hammering yfinance
+const DROP_THRESHOLD = -1.5;
+
+let cache = {};
+let lastRefresh = 0;
+let refreshPromise = null;
+
+function runPython() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(PYTHON_BIN, [SCRIPT, '--drop-threshold', String(DROP_THRESHOLD)], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', d => { stdout += d; });
+    proc.stderr.on('data', d => { stderr += d; });
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(`asia_indices.py exited ${code}: ${stderr}`));
+      try { resolve(JSON.parse(stdout)); }
+      catch (e) { reject(new Error(`failed to parse asia indices JSON: ${e.message}`)); }
+    });
+    proc.on('error', reject);
+  });
+}
+
+export async function refreshAsiaIndices() {
+  const result = await runPython();
+  cache = result;
+  lastRefresh = Date.now();
+  return cache;
+}
+
+export async function getAsiaIndices() {
+  const stale = Date.now() - lastRefresh > REFRESH_INTERVAL_MS;
+  const coldStart = Object.keys(cache).length === 0;
+
+  if ((stale || coldStart) && !refreshPromise) {
+    refreshPromise = refreshAsiaIndices()
+      .catch(err => { process.stderr.write(`[asiaIndices] refresh failed: ${err.message}\n`); })
+      .finally(() => { refreshPromise = null; });
+  }
+
+  if (coldStart && refreshPromise) await refreshPromise;
+  return { ...cache, _lastRefresh: lastRefresh };
+}

--- a/src/core/asiaIndices.js
+++ b/src/core/asiaIndices.js
@@ -1,7 +1,9 @@
 /**
- * Asian index cache (Hang Seng, Nikkei 225, KOSPI), sourced from yfinance.
- * A large overnight drop in any of these during Asia hours can spill over
- * into MNQ/ES before NY open — refreshed periodically in the background.
+ * Asian index cache (Hang Seng, Nikkei 225, KOSPI), sourced from yfinance
+ * intraday 1-minute bars — not daily candles. A sharp drop or reversal
+ * *during* the Asian session is what can spill over into MNQ/ES before NY
+ * open, so we track change-from-open and drawdown-from-session-high, not
+ * just yesterday's close-to-close move. Refreshed periodically in the background.
  */
 import { spawn } from 'node:child_process';
 import path from 'node:path';
@@ -11,8 +13,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.resolve(__dirname, '../../strategies/asia_indices.py');
 const PYTHON_BIN = process.env.PYTHON_BIN || 'python3';
 
-const REFRESH_INTERVAL_MS = 60 * 1000; // 1 minute — close to real-time without hammering yfinance
-const DROP_THRESHOLD = -1.5;
+const REFRESH_INTERVAL_MS = 30 * 1000; // 30s — yfinance intraday bars themselves lag ~1min on the free tier
+const DROP_THRESHOLD = -1.0;
 
 let cache = {};
 let lastRefresh = 0;

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -429,6 +429,220 @@ export async function getPineTables({ study_filter } = {}) {
   return { success: true, study_count: studies.length, studies };
 }
 
+/**
+ * Single-call snapshot: quote + chart state + study values + pine graphics + ohlcv summary.
+ * Replaces 7 sequential tool calls with one CDP round-trip.
+ */
+export async function getSnapshot({ study_filter, ohlcv_count } = {}) {
+  const filter = study_filter || '';
+  const bars_limit = Math.min(ohlcv_count || 20, MAX_OHLCV_BARS);
+
+  const data = await evaluate(`
+    (function() {
+      var FILTER = ${safeString(filter)};
+      var BARS_LIMIT = ${bars_limit};
+      var api = window.TradingViewApi._activeChartWidgetWV.value();
+      var chart = api._chartWidget;
+      var model = chart.model();
+      var sources = model.model().dataSources();
+      var bars = model.mainSeries().bars();
+
+      // ── 1. State ──
+      var state = { symbol: null, resolution: null, chartType: null, studies: [] };
+      try { state.symbol = api.symbol(); } catch(e) {}
+      try { state.resolution = api.resolution(); } catch(e) {}
+      try { state.chartType = api.chartType(); } catch(e) {}
+      try {
+        var all = api.getAllStudies();
+        state.studies = all.map(function(s) { return { id: s.id, name: s.name || s.title || 'unknown' }; });
+      } catch(e) {}
+
+      // ── 2. Quote ──
+      var quote = { symbol: state.symbol };
+      try {
+        if (bars && typeof bars.lastIndex === 'function') {
+          var last = bars.valueAt(bars.lastIndex());
+          if (last) { quote.time = last[0]; quote.open = last[1]; quote.high = last[2]; quote.low = last[3]; quote.close = last[4]; quote.last = last[4]; quote.volume = last[5] || 0; }
+        }
+      } catch(e) {}
+
+      // ── 3. OHLCV summary ──
+      var ohlcv = null;
+      try {
+        if (bars && typeof bars.lastIndex === 'function') {
+          var end = bars.lastIndex();
+          var start = Math.max(bars.firstIndex(), end - BARS_LIMIT + 1);
+          var barsArr = [];
+          for (var bi = start; bi <= end; bi++) {
+            var bv = bars.valueAt(bi);
+            if (bv) barsArr.push({ time: bv[0], open: bv[1], high: bv[2], low: bv[3], close: bv[4], volume: bv[5] || 0 });
+          }
+          if (barsArr.length > 0) {
+            var maxH = barsArr[0].high, minL = barsArr[0].low, totalVol = 0;
+            for (var oi = 0; oi < barsArr.length; oi++) { if (barsArr[oi].high > maxH) maxH = barsArr[oi].high; if (barsArr[oi].low < minL) minL = barsArr[oi].low; totalVol += barsArr[oi].volume; }
+            var first = barsArr[0], lastBar = barsArr[barsArr.length - 1];
+            ohlcv = {
+              bar_count: barsArr.length,
+              period: { from: first.time, to: lastBar.time },
+              open: first.open, close: lastBar.close,
+              high: Math.round(maxH * 100) / 100, low: Math.round(minL * 100) / 100,
+              range: Math.round((maxH - minL) * 100) / 100,
+              change: Math.round((lastBar.close - first.open) * 100) / 100,
+              change_pct: Math.round(((lastBar.close - first.open) / first.open) * 10000) / 100 + '%',
+              avg_volume: Math.round(totalVol / barsArr.length),
+              last_5_bars: barsArr.slice(-5),
+            };
+          }
+        }
+      } catch(e) {}
+
+      // ── 4. Study values ──
+      var studyValues = [];
+      try {
+        for (var si = 0; si < sources.length; si++) {
+          var s = sources[si];
+          if (!s.metaInfo) continue;
+          try {
+            var meta = s.metaInfo();
+            var name = meta.description || meta.shortDescription || '';
+            if (!name) continue;
+            var values = {};
+            try {
+              var dwv = s.dataWindowView();
+              if (dwv) {
+                var items = dwv.items();
+                if (items) { for (var ii = 0; ii < items.length; ii++) { var item = items[ii]; if (item._value && item._value !== '∅' && item._title) values[item._title] = item._value; } }
+              }
+            } catch(e) {}
+            if (Object.keys(values).length > 0) studyValues.push({ name: name, values: values });
+          } catch(e) {}
+        }
+      } catch(e) {}
+
+      // ── 5. Pine graphics (lines, labels, tables, boxes) helper ──
+      function getGraphics(collName, mapKey) {
+        var results = [];
+        try {
+          for (var si = 0; si < sources.length; si++) {
+            var s = sources[si];
+            if (!s.metaInfo) continue;
+            try {
+              var meta = s.metaInfo();
+              var name = meta.description || meta.shortDescription || '';
+              if (!name) continue;
+              if (FILTER && name.indexOf(FILTER) === -1) continue;
+              var g = s._graphics;
+              if (!g || !g._primitivesCollection) continue;
+              var pc = g._primitivesCollection;
+              var items = [];
+              try {
+                var outer = pc[collName];
+                if (outer) {
+                  var inner = outer.get(mapKey);
+                  if (inner) {
+                    var coll = inner.get(false);
+                    if (coll && coll._primitivesDataById && coll._primitivesDataById.size > 0) {
+                      coll._primitivesDataById.forEach(function(v, id) { items.push({ id: id, raw: v }); });
+                    }
+                  }
+                }
+              } catch(e) {}
+              if (items.length > 0) results.push({ name: name, count: items.length, items: items });
+            } catch(e) {}
+          }
+        } catch(e) {}
+        return results;
+      }
+
+      // Lines
+      var linesRaw = getGraphics('dwglines', 'lines');
+      var pineLines = linesRaw.map(function(s) {
+        var hLevels = [], seen = {};
+        for (var i = 0; i < s.items.length; i++) {
+          var v = s.items[i].raw;
+          var y1 = v.y1 != null ? Math.round(v.y1 * 100) / 100 : null;
+          if (y1 != null && v.y1 === v.y2 && !seen[y1]) { hLevels.push(y1); seen[y1] = true; }
+        }
+        hLevels.sort(function(a, b) { return b - a; });
+        return { name: s.name, total_lines: s.count, horizontal_levels: hLevels };
+      });
+
+      // Labels
+      var labelsRaw = getGraphics('dwglabels', 'labels');
+      var pineLabels = labelsRaw.map(function(s) {
+        var labels = s.items.map(function(item) {
+          var v = item.raw;
+          return { text: v.t || '', price: v.y != null ? Math.round(v.y * 100) / 100 : null };
+        }).filter(function(l) { return l.text || l.price != null; });
+        if (labels.length > 50) labels = labels.slice(-50);
+        return { name: s.name, total_labels: s.count, showing: labels.length, labels: labels };
+      });
+
+      // Tables
+      var tablesRaw = getGraphics('dwgtablecells', 'tableCells');
+      var pineTables = tablesRaw.map(function(s) {
+        var tables = {};
+        for (var i = 0; i < s.items.length; i++) {
+          var v = s.items[i].raw;
+          var tid = v.tid || 0;
+          if (!tables[tid]) tables[tid] = {};
+          if (!tables[tid][v.row]) tables[tid][v.row] = {};
+          tables[tid][v.row][v.col] = v.t || '';
+        }
+        var tableList = Object.keys(tables).map(function(tid) {
+          var rows = tables[tid];
+          var rowNums = Object.keys(rows).map(Number).sort(function(a,b){return a-b;});
+          var formatted = rowNums.map(function(rn) {
+            var cols = rows[rn];
+            var colNums = Object.keys(cols).map(Number).sort(function(a,b){return a-b;});
+            return colNums.map(function(cn){return cols[cn];}).filter(Boolean).join(' | ');
+          }).filter(Boolean);
+          return { rows: formatted };
+        });
+        return { name: s.name, tables: tableList };
+      });
+
+      // Boxes
+      var boxesRaw = getGraphics('dwgboxes', 'boxes');
+      var pineBoxes = boxesRaw.map(function(s) {
+        var zones = [], seen = {};
+        for (var i = 0; i < s.items.length; i++) {
+          var v = s.items[i].raw;
+          var high = v.y1 != null && v.y2 != null ? Math.round(Math.max(v.y1, v.y2) * 100) / 100 : null;
+          var low = v.y1 != null && v.y2 != null ? Math.round(Math.min(v.y1, v.y2) * 100) / 100 : null;
+          if (high != null && low != null) { var key = high + ':' + low; if (!seen[key]) { zones.push({ high: high, low: low }); seen[key] = true; } }
+        }
+        zones.sort(function(a, b) { return b.high - a.high; });
+        return { name: s.name, total_boxes: s.count, zones: zones };
+      });
+
+      return {
+        state: state,
+        quote: quote,
+        ohlcv: ohlcv,
+        study_values: studyValues,
+        pine_lines: pineLines,
+        pine_labels: pineLabels,
+        pine_tables: pineTables,
+        pine_boxes: pineBoxes,
+      };
+    })()
+  `);
+
+  return {
+    success: true,
+    _note: 'Single-call snapshot. Use individual tools only when you need data not included here.',
+    state: data?.state,
+    quote: data?.quote ? { success: true, ...data.quote } : null,
+    ohlcv: data?.ohlcv ? { success: true, ...data.ohlcv } : null,
+    study_values: { success: true, study_count: data?.study_values?.length || 0, studies: data?.study_values || [] },
+    pine_lines: { success: true, study_count: data?.pine_lines?.length || 0, studies: data?.pine_lines || [] },
+    pine_labels: { success: true, study_count: data?.pine_labels?.length || 0, studies: data?.pine_labels || [] },
+    pine_tables: { success: true, study_count: data?.pine_tables?.length || 0, studies: data?.pine_tables || [] },
+    pine_boxes: { success: true, study_count: data?.pine_boxes?.length || 0, studies: data?.pine_boxes || [] },
+  };
+}
+
 export async function getPineBoxes({ study_filter, verbose } = {}) {
   const filter = study_filter || '';
   const raw = await evaluate(buildGraphicsJS('dwgboxes', 'boxes', filter));

--- a/src/core/news.js
+++ b/src/core/news.js
@@ -1,0 +1,55 @@
+/**
+ * News aggregator cache — Trump/Iran/Fed/geopolitical headlines (Google News
+ * RSS, no API key) + WTI/Brent oil price (yfinance). Refreshed periodically
+ * in the background; the dashboard reads from this cache, never blocking.
+ */
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '../../strategies/news_aggregator.py');
+const PYTHON_BIN = process.env.PYTHON_BIN || 'python3';
+
+const REFRESH_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes — RSS sources don't update faster than this anyway
+
+let cache = { topics: {}, oil: {} };
+let lastRefresh = 0;
+let refreshPromise = null;
+
+function runPython() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(PYTHON_BIN, [SCRIPT, '--max-per-topic', '5'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', d => { stdout += d; });
+    proc.stderr.on('data', d => { stderr += d; });
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(`news_aggregator.py exited ${code}: ${stderr}`));
+      try { resolve(JSON.parse(stdout)); }
+      catch (e) { reject(new Error(`failed to parse news JSON: ${e.message}`)); }
+    });
+    proc.on('error', reject);
+  });
+}
+
+export async function refreshNews() {
+  const result = await runPython();
+  cache = result;
+  lastRefresh = Date.now();
+  return cache;
+}
+
+export async function getNews() {
+  const stale = Date.now() - lastRefresh > REFRESH_INTERVAL_MS;
+  const coldStart = Object.keys(cache.topics || {}).length === 0;
+
+  if ((stale || coldStart) && !refreshPromise) {
+    refreshPromise = refreshNews()
+      .catch(err => { process.stderr.write(`[news] refresh failed: ${err.message}\n`); })
+      .finally(() => { refreshPromise = null; });
+  }
+
+  if (coldStart && refreshPromise) await refreshPromise;
+  return { ...cache, _lastRefresh: lastRefresh };
+}

--- a/src/core/regime.js
+++ b/src/core/regime.js
@@ -1,0 +1,538 @@
+/**
+ * Regime Analysis Engine
+ * Four-layer classification: Structure → Price Action → Volume → Session
+ * Returns structured data for all visible chart panes in one CDP call.
+ */
+import { evaluate } from '../connection.js';
+import { ensureFreshBaselines, getWeeklyRatio } from './weeklyVolume.js';
+
+export const REGIME_JS = String.raw`
+(function() {
+
+  // ════════════════════════════════════════════════════════════
+  //  HELPERS
+  // ════════════════════════════════════════════════════════════
+
+  function rma(arr, period) {
+    if (arr.length < period) return null;
+    var v = 0;
+    for (var i = 0; i < period; i++) v += arr[i];
+    v /= period;
+    for (var i = period; i < arr.length; i++) v = (v * (period - 1) + arr[i]) / period;
+    return v;
+  }
+
+  function mean(arr) {
+    if (!arr.length) return 0;
+    return arr.reduce(function(a,b){return a+b;},0) / arr.length;
+  }
+
+  function r2(n) { return Math.round(n * 100) / 100; }
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 1: STRUCTURE  (weight 40)
+  //  Pivot detection → BOS / CHoCH → HH/HL or LH/LL sequence
+  // ════════════════════════════════════════════════════════════
+
+  function findPivots(bars, strength) {
+    strength = strength || 3;
+    var highs = [], lows = [];
+    // exclude the last (strength) bars (unconfirmed)
+    var end = bars.length - strength - 1;
+    for (var i = strength; i <= end; i++) {
+      var isH = true, isL = true;
+      for (var j = 1; j <= strength; j++) {
+        if (bars[i].high <= bars[i-j].high || bars[i].high <= bars[i+j].high) isH = false;
+        if (bars[i].low  >= bars[i-j].low  || bars[i].low  >= bars[i+j].low ) isL = false;
+      }
+      if (isH) highs.push({ idx: i, price: bars[i].high, time: bars[i].time });
+      if (isL) lows.push({  idx: i, price: bars[i].low,  time: bars[i].time });
+    }
+    return { highs: highs, lows: lows };
+  }
+
+  function analyzeStructure(bars, pivots) {
+    var cur   = bars[bars.length - 1];
+    var highs = pivots.highs;
+    var lows  = pivots.lows;
+
+    if (highs.length < 2 || lows.length < 2) {
+      return { score: 0, bos: null, choch: false, priorTrend: 'neutral',
+               lastSwingHigh: null, lastSwingLow: null, sequenceLabel: 'insufficient data' };
+    }
+
+    var lH = highs[highs.length - 1];   // most recent pivot high
+    var pH = highs[highs.length - 2];   // previous pivot high
+    var lL = lows[lows.length - 1];     // most recent pivot low
+    var pL = lows[lows.length - 2];     // previous pivot low
+
+    // Prior trend from last 2 pivot pairs
+    var hhPattern = lH.price > pH.price; // higher high
+    var hlPattern = lL.price > pL.price; // higher low
+    var lhPattern = lH.price < pH.price; // lower high
+    var llPattern = lL.price < pL.price; // lower low
+
+    var priorTrend = 'neutral';
+    if (hhPattern && hlPattern) priorTrend = 'up';
+    else if (lhPattern && llPattern) priorTrend = 'down';
+
+    // BOS: close breaks the last confirmed swing extreme
+    var bosUp   = cur.close > lH.price;
+    var bosDown = cur.close < lL.price;
+    var bos = bosUp ? 'up' : (bosDown ? 'down' : null);
+
+    // CHoCH: break AGAINST prior trend → character change
+    var choch = (priorTrend === 'down' && bosUp) || (priorTrend === 'up' && bosDown);
+
+    // Sequence label for display
+    var seqLabel = priorTrend === 'up'   ? 'HH-HL  ↑' :
+                   priorTrend === 'down' ? 'LH-LL  ↓' : 'Mixed';
+
+    // Score
+    var score = 0;
+    if (bos && !choch)  score = 35;  // confirmed BOS in trend direction
+    else if (choch)     score = 22;  // CHoCH = transition, partial credit
+    else if (priorTrend !== 'neutral') score = 12;  // clear HH/HL or LH/LL without BOS
+    // else score = 0 (no structure)
+
+    return {
+      score: score,
+      bos: bos,
+      choch: choch,
+      priorTrend: priorTrend,
+      lastSwingHigh: r2(lH.price),
+      lastSwingLow:  r2(lL.price),
+      sequenceLabel: seqLabel,
+    };
+  }
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 2: PRICE ACTION  (weight 25 ATR + 15 body + 20 vwap = 60 → split)
+  //  ATR ratio, candle body/wick ratio, VWAP deviation
+  // ════════════════════════════════════════════════════════════
+
+  function calcATR(bars) {
+    var period = 14, baseLen = 20;
+    if (bars.length < period + baseLen + 1) return null;
+    var trs = [];
+    for (var i = 1; i < bars.length; i++) {
+      trs.push(Math.max(
+        bars[i].high - bars[i].low,
+        Math.abs(bars[i].high - bars[i-1].close),
+        Math.abs(bars[i].low  - bars[i-1].close)
+      ));
+    }
+    var curATR  = mean(trs.slice(-period));
+    var baseATR = mean(trs.slice(-(period + baseLen), -period));
+    return { current: r2(curATR), baseline: r2(baseATR), ratio: r2(curATR / baseATR) };
+  }
+
+  function atrScore(ratio) {
+    if (ratio === null) return 0;
+    if (ratio > 1.5)  return 25;
+    if (ratio > 1.3)  return 20;
+    if (ratio > 1.1)  return 12;
+    if (ratio > 0.9)  return 6;
+    return 0;
+  }
+
+  function calcBodyRatio(bars, n) {
+    var recent = bars.slice(-n);
+    var ratios = recent.map(function(b) {
+      var range = b.high - b.low;
+      return range > 0 ? Math.abs(b.close - b.open) / range : 0.5;
+    });
+    return r2(mean(ratios));
+  }
+
+  function bodyScore(ratio) {
+    if (ratio > 0.65) return 15;
+    if (ratio > 0.50) return 10;
+    if (ratio > 0.35) return 5;
+    return 0;
+  }
+
+  function calcVWAP(bars, resolution) {
+    var res = parseInt(resolution, 10);
+    if (!res || res >= 1440) return null;   // daily+ → skip VWAP
+    var lastDay = Math.floor(bars[bars.length-1].time / 86400);
+    var si = 0;
+    for (var i = bars.length - 1; i >= 0; i--) {
+      if (Math.floor(bars[i].time / 86400) < lastDay) { si = i + 1; break; }
+    }
+    var sb = bars.slice(si);
+    if (sb.length < 2) return null;
+    var cumTPV = 0, cumV = 0, cumTPV2 = 0;
+    for (var i = 0; i < sb.length; i++) {
+      var tp = (sb[i].high + sb[i].low + sb[i].close) / 3;
+      cumTPV  += tp * sb[i].volume;
+      cumV    += sb[i].volume;
+      cumTPV2 += tp * tp * sb[i].volume;
+    }
+    if (cumV === 0) return null;
+    var vwap = cumTPV / cumV;
+    var variance = Math.max(cumTPV2 / cumV - vwap * vwap, 0);
+    var sd = Math.sqrt(variance);
+    return { vwap: r2(vwap), upper2: r2(vwap + 2*sd), lower2: r2(vwap - 2*sd), sd: r2(sd) };
+  }
+
+  function vwapScore(devPct) {
+    if (devPct === null) return 0;
+    if (devPct > 0.8)  return 20;
+    if (devPct > 0.5)  return 15;
+    if (devPct > 0.3)  return 8;
+    return 0;
+  }
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 3: VOLUME  (soft filter, weight 0 but shown in display)
+  // ════════════════════════════════════════════════════════════
+
+  function calcVolumeRatio(bars) {
+    var period = 20;
+    if (bars.length < period + 1) return null;
+    var baseline = mean(bars.slice(-(period+1), -1).map(function(b){return b.volume;}));
+    var cur = bars[bars.length-1].volume;
+    return r2(baseline > 0 ? cur / baseline : 1);
+  }
+
+  // Approximate ET hour-of-day (not DST-adjusted; close enough for bucketing)
+  function etHour(unixTs) {
+    return ((unixTs % 86400) / 3600 + 24 - 4) % 24;
+  }
+
+  // NOTE: the weekly seasonal volume baseline is computed Node-side from
+  // yfinance (see src/core/weeklyVolume.js), not here — the browser only
+  // has whatever bars TradingView happens to have buffered in memory, which
+  // isn't reliable enough for a trailing-week baseline. The browser just
+  // reports the current bar's volume + ET hour bucket; Node.js does the lookup.
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 4: SESSION  (prior bias)
+  // ════════════════════════════════════════════════════════════
+
+  function getSession(unixTs) {
+    var h = etHour(unixTs);
+    if (h >= 18 || h < 2)   return 'ASIA';
+    if (h >= 2  && h < 8)   return 'LONDON';
+    if (h >= 8  && h < 9.5) return 'PRE-NY';
+    if (h >= 9.5 && h < 16) return 'NY';
+    return 'OFF';
+  }
+
+  // Session bias applied to raw score (before threshold comparison)
+  var SESSION_BIAS = { ASIA: -8, LONDON: 0, 'PRE-NY': 3, NY: 6, OFF: -5 };
+
+  // ════════════════════════════════════════════════════════════
+  //  CLASSIFICATION  (score 0-100 → regime)
+  // ════════════════════════════════════════════════════════════
+
+  function classify(rawScore, session) {
+    var bias  = SESSION_BIAS[session] || 0;
+    var score = Math.min(100, Math.max(0, rawScore + bias));
+    var regime, confidence;
+    if (score >= 62) {
+      regime = 'TRENDING'; confidence = Math.round(40 + score * 0.6);
+    } else if (score <= 35) {
+      regime = 'RANGING'; confidence = Math.round(40 + (100 - score) * 0.6);
+    } else {
+      regime = 'TRANSITIONING'; confidence = Math.round(50 - Math.abs(score - 48));
+    }
+    return { regime: regime, rawScore: rawScore, adjustedScore: score,
+             confidence: Math.min(97, confidence) };
+  }
+
+  // ════════════════════════════════════════════════════════════
+  //  PER-PANE ANALYSIS
+  // ════════════════════════════════════════════════════════════
+
+  function analyzePane(chartWidget) {
+    try {
+      var model  = chartWidget.model();
+      var ms     = model.mainSeries();
+      var symbol = ms.symbol ? ms.symbol() : '?';
+      var res    = ms.interval ? ms.interval() : '?';
+      var barsObj = ms.bars();
+      if (!barsObj || typeof barsObj.lastIndex !== 'function') return null;
+
+      var end = barsObj.lastIndex();
+      // Pull enough history to cover at least one full session for VWAP on fast
+      // timeframes (200 bars = only 3.3hrs on a 1m chart, not enough for a full day).
+      var resMin = parseInt(res, 10);
+      var fetchLimit = (resMin && resMin < 1440)
+        ? Math.min(1500, Math.ceil((24 * 60) / resMin) + 200)
+        : 200;
+      var start = Math.max(barsObj.firstIndex(), end - fetchLimit + 1);
+      var bars = [];
+      for (var i = start; i <= end; i++) {
+        var v = barsObj.valueAt(i);
+        if (v) bars.push({ time:v[0], open:v[1], high:v[2], low:v[3], close:v[4], volume:v[5]||0 });
+      }
+      if (bars.length < 40) return { symbol:symbol, error:'not enough bars ('+bars.length+')' };
+
+      var cur = bars[bars.length - 1];
+
+      // Layer 1: Structure
+      var pivots = findPivots(bars, 3);
+      var struct = analyzeStructure(bars, pivots);
+
+      // Layer 2: Price action
+      var atr    = calcATR(bars);
+      var body   = calcBodyRatio(bars, 10);
+      var vwapD  = calcVWAP(bars, res);
+      var vwapDev = vwapD ? r2(Math.abs(cur.close - vwapD.vwap) / vwapD.vwap * 100) : null;
+
+      // Layer 3: Volume (local 20-bar baseline; weekly baseline filled in Node-side)
+      var volRatio   = calcVolumeRatio(bars);
+
+      // Session
+      var session = getSession(cur.time);
+
+      // Raw score
+      var rawScore = struct.score
+        + atrScore(atr ? atr.ratio : null)
+        + bodyScore(body)
+        + vwapScore(vwapDev);
+
+      var cls = classify(rawScore, session);
+
+      // Trend direction (for TRENDING regime)
+      var trendDir = null;
+      if (cls.regime === 'TRENDING') {
+        trendDir = struct.bos === 'up'   ? 'UP'   :
+                   struct.bos === 'down' ? 'DOWN' :
+                   struct.priorTrend === 'up' ? 'UP' : 'DOWN';
+      }
+
+      // Range boundaries (for RANGING)
+      var rangeHigh = struct.lastSwingHigh;
+      var rangeLow  = struct.lastSwingLow;
+
+      // ── REVERSAL DETECTION ─────────────────────────────────────────────────
+      var revScore = 0;
+      var revTriggers = [];
+      var revDir = null;
+
+      // 1. CHoCH = structural reversal (strongest single signal)
+      if (struct.choch) {
+        revScore += 35;
+        revTriggers.push('CHoCH');
+        revDir = struct.bos === 'up' ? 'UP' : 'DOWN';
+      }
+
+      // 2. Liquidity sweep on last completed bar
+      //    Wick pierces 20-bar swing level but candle closes back inside
+      var prevBar     = bars[bars.length - 2];
+      var prevLook    = bars.slice(-23, -2);
+      if (prevBar && prevLook.length >= 10) {
+        var ph = prevLook[0].high, pl = prevLook[0].low;
+        for (var pi = 1; pi < prevLook.length; pi++) {
+          if (prevLook[pi].high > ph) ph = prevLook[pi].high;
+          if (prevLook[pi].low  < pl) pl = prevLook[pi].low;
+        }
+        if (prevBar.high > ph && prevBar.close < ph) {
+          revScore += 28; revTriggers.push('Sweep↑→↓'); if (!revDir) revDir = 'DOWN';
+        }
+        if (prevBar.low < pl && prevBar.close > pl) {
+          revScore += 28; revTriggers.push('Sweep↓→↑'); if (!revDir) revDir = 'UP';
+        }
+      }
+
+      // 3. Price at VWAP ±2SD (mean-reversion zone)
+      if (vwapD) {
+        if (cur.high >= vwapD.upper2 && cur.low <= vwapD.upper2) {
+          revScore += 20; revTriggers.push('VWAP+2σ'); if (!revDir) revDir = 'DOWN';
+        }
+        if (cur.high >= vwapD.lower2 && cur.low <= vwapD.lower2) {
+          revScore += 20; revTriggers.push('VWAP-2σ'); if (!revDir) revDir = 'UP';
+        }
+      }
+
+      // 4. Exhaustion candle at swing extreme
+      //    Tiny body (< 30% of range) while price is within 0.2% of swing H/L
+      var curBody = (cur.high - cur.low) > 0
+        ? Math.abs(cur.close - cur.open) / (cur.high - cur.low) : 0.5;
+      var nearSwingH = rangeHigh > 0 && Math.abs(cur.high - rangeHigh) / rangeHigh < 0.002;
+      var nearSwingL = rangeLow  > 0 && Math.abs(cur.low  - rangeLow)  / rangeLow  < 0.002;
+      if (curBody < 0.30 && (nearSwingH || nearSwingL)) {
+        revScore += 18; revTriggers.push('Exhaust');
+        if (nearSwingH && !revDir) revDir = 'DOWN';
+        if (nearSwingL && !revDir) revDir = 'UP';
+      }
+
+      // 5. ATR contraction after a confirmed trend (momentum fading)
+      if (atr && atr.ratio < 0.75 && struct.priorTrend !== 'neutral' && struct.bos) {
+        revScore += 12; revTriggers.push('ATR↓@trend');
+      }
+
+      // 6. Low volume at swing extreme (absorption / lack of follow-through)
+      if (volRatio !== null && volRatio < 0.70) {
+        var atExtreme = cur.high >= rangeHigh || cur.low <= rangeLow;
+        if (atExtreme) { revScore += 12; revTriggers.push('LowVol@lvl'); }
+      }
+
+      var revProb = revScore >= 55 ? 'HIGH'
+                  : revScore >= 30 ? 'MEDIUM'
+                  : revScore >= 15 ? 'LOW'
+                  : null;
+
+      // ── TREND vs LIQUIDITY-RAID DISCRIMINATION (raw flags only) ──────────────
+      // A confirmed BOS (close beyond the level) and a liquidity sweep (wick
+      // beyond the level, close back inside) are structurally mutually exclusive.
+      // The trade action is opposite: BOS → continue with the break;
+      // sweep → fade it (counter-trend, buy the dip / sell the rip).
+      // Final strength/reason is computed Node-side once the yfinance weekly
+      // volume ratio is available — see finalizeTradeBias() below.
+      var atrExp     = atr ? atr.ratio > 1.2 : false;
+      var hasSweep   = revTriggers.indexOf('Sweep↑→↓') !== -1 || revTriggers.indexOf('Sweep↓→↑') !== -1;
+      var sweptHighs = revTriggers.indexOf('Sweep↑→↓') !== -1;
+
+      return {
+        symbol:       symbol,
+        resolution:   res,
+        close:        r2(cur.close),
+        session:      session,
+        regime:       cls.regime,
+        confidence:   cls.confidence,
+        adjustedScore:cls.adjustedScore,
+        trendDir:     trendDir,
+        rangeHigh:    rangeHigh,
+        rangeLow:     rangeLow,
+        layers: {
+          structure: {
+            score:         struct.score,
+            bos:           struct.bos,
+            choch:         struct.choch,
+            priorTrend:    struct.priorTrend,
+            sequence:      struct.sequenceLabel,
+            lastSwingHigh: struct.lastSwingHigh,
+            lastSwingLow:  struct.lastSwingLow,
+          },
+          priceAction: {
+            atrRatio:    atr ? atr.ratio : null,
+            atrScore:    atrScore(atr ? atr.ratio : null),
+            bodyRatio:   body,
+            bodyScore:   bodyScore(body),
+            vwapDev:     vwapDev,
+            vwapScore:   vwapScore(vwapDev),
+            vwap:        vwapD ? vwapD.vwap : null,
+            vwapUpper2:  vwapD ? vwapD.upper2 : null,
+            vwapLower2:  vwapD ? vwapD.lower2 : null,
+          },
+          volume: {
+            ratio:          volRatio,
+            // weeklyRatio/weeklyBaseline/weeklySamples filled in Node-side from yfinance
+            weeklyRatio:    null,
+            weeklyBaseline: null,
+            weeklySamples:  null,
+          },
+        },
+        reversal: {
+          probability: revProb,
+          score:       revScore,
+          direction:   revDir,
+          triggers:    revTriggers,
+        },
+        // Raw structural flags — Node.js finalizes tradeBias once it has the
+        // yfinance weekly volume ratio (see finalizeTradeBias in regime.js)
+        _raw: {
+          bos:          struct.bos,
+          choch:        struct.choch,
+          hasSweep:     hasSweep,
+          sweptHighs:   sweptHighs,
+          atrExpanding: atrExp,
+          etHourBucket: Math.floor(etHour(cur.time)),
+          lastVolume:   cur.volume,
+        },
+        tradeBias: { action: 'WAIT', direction: null, strength: null, reason: 'pending' },
+      };
+    } catch(e) {
+      return { symbol: '?', error: e.message };
+    }
+  }
+
+  // ════════════════════════════════════════════════════════════
+  //  ENTRY: analyze all visible panes
+  // ════════════════════════════════════════════════════════════
+
+  var cwc = window.TradingViewApi._chartWidgetCollection;
+  var all = cwc.getAll();
+  var count = cwc.inlineChartsCount;
+  if (typeof count === 'object' && count && typeof count.value === 'function') count = count.value();
+  count = count || all.length;
+
+  var results = [];
+  for (var i = 0; i < Math.min(all.length, count); i++) {
+    var r = analyzePane(all[i]);
+    if (r) results.push(r);
+  }
+
+  return { ts: Date.now(), panes: results };
+
+})()
+`;
+
+/**
+ * Finalize the CONTINUE/FADE/WAIT trade bias once the real yfinance weekly
+ * volume ratio is known. Mirrors the logic that previously lived entirely
+ * in-browser, just fed by a trustworthy weekly baseline instead of whatever
+ * bars TradingView had buffered.
+ */
+function finalizeTradeBias(raw, wv) {
+  if (!raw) return { action: 'WAIT', direction: null, strength: null, reason: 'no structural trigger' };
+
+  if (raw.bos && !raw.choch) {
+    const dir = raw.bos === 'up' ? 'UP' : 'DOWN';
+    const strength = (wv !== null && wv > 1.4 && raw.atrExpanding) ? 'STRONG'
+                    : (wv !== null && wv < 0.8) ? 'WEAK'
+                    : 'MODERATE';
+    return {
+      action: 'CONTINUE',
+      direction: dir,
+      strength,
+      reason: `BOS ${dir}` + (wv !== null ? `, ${wv}x wk-vol` : ', vol n/a') + (raw.atrExpanding ? ', ATR expanding' : ''),
+    };
+  }
+
+  if (raw.hasSweep) {
+    const dir = raw.sweptHighs ? 'DOWN' : 'UP';
+    const stopHuntSig = wv !== null && wv > 1.3;
+    const strength = stopHuntSig ? 'STRONG' : (wv !== null && wv < 0.8) ? 'WEAK' : 'MODERATE';
+    return {
+      action: 'FADE',
+      direction: dir,
+      strength,
+      reason: 'liquidity sweep' + (wv !== null ? `, ${wv}x wk-vol` : ', vol n/a') + (stopHuntSig ? ' (stop-hunt signature)' : ''),
+    };
+  }
+
+  return { action: 'WAIT', direction: null, strength: null, reason: 'no structural trigger' };
+}
+
+export async function analyzeRegime() {
+  const result = await evaluate(REGIME_JS);
+  if (!result || !result.panes) return result;
+
+  const symbols = result.panes.map(p => p.symbol).filter(Boolean);
+  await ensureFreshBaselines(symbols);
+
+  for (const p of result.panes) {
+    if (p.error || !p._raw) continue;
+    // Baseline is sourced as 1-minute bars from yfinance — only valid to compare
+    // against a chart that's also on 1-minute resolution (otherwise the bar
+    // volumes aren't the same unit and the ratio is meaningless).
+    const wvData = p.resolution === '1'
+      ? getWeeklyRatio(p.symbol, p._raw.etHourBucket, p._raw.lastVolume)
+      : null;
+    const wv = wvData ? wvData.ratio : null;
+
+    p.layers.volume.weeklyRatio    = wv;
+    p.layers.volume.weeklyBaseline = wvData ? wvData.baseline : null;
+    p.layers.volume.weeklySamples  = wvData ? wvData.samples  : null;
+
+    p.tradeBias = finalizeTradeBias(p._raw, wv);
+    delete p._raw;
+  }
+
+  return result;
+}

--- a/src/core/weeklyVolume.js
+++ b/src/core/weeklyVolume.js
@@ -1,0 +1,91 @@
+/**
+ * Weekly volume baseline cache, sourced from yfinance (via weekly_volume_baseline.py)
+ * instead of whatever bars TradingView happens to have buffered in CDP memory.
+ *
+ * Refreshes in the background every REFRESH_INTERVAL_MS. The regime agent's poll
+ * loop never blocks on this except on cold start (no cache yet).
+ */
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, '../../strategies/weekly_volume_baseline.py');
+
+const REFRESH_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+const PYTHON_BIN = process.env.PYTHON_BIN || 'python3';
+
+let cache = {};          // { 'MNQ=F': { '0': avgVol, ..., '23': avgVol, _samples: {...} } }
+let lastRefresh = 0;
+let refreshPromise = null;
+
+/** TradingView symbol ("CME_MINI:MNQU2026", "COMEX_MINI:MGC1!") → Yahoo ticker ("MNQ=F") */
+export function tvSymbolToYahoo(tvSymbol) {
+  if (!tvSymbol) return null;
+  const afterColon = tvSymbol.includes(':') ? tvSymbol.split(':')[1] : tvSymbol;
+  const root = afterColon
+    .replace(/[A-Z]\d{4}$/, '')   // strip month+year code, e.g. "U2026"
+    .replace(/\d+!$/, '')         // strip continuous-contract suffix, e.g. "1!"
+    .replace(/!$/, '');
+  return root ? root + '=F' : null;
+}
+
+function runPython(tickers) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(PYTHON_BIN, [SCRIPT, tickers.join(',')], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', d => { stdout += d; });
+    proc.stderr.on('data', d => { stderr += d; });
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(`weekly_volume_baseline.py exited ${code}: ${stderr}`));
+      try { resolve(JSON.parse(stdout)); }
+      catch (e) { reject(new Error(`failed to parse baseline JSON: ${e.message}`)); }
+    });
+    proc.on('error', reject);
+  });
+}
+
+export async function refreshBaselines(tvSymbols) {
+  const tickers = [...new Set(tvSymbols.map(tvSymbolToYahoo).filter(Boolean))];
+  if (tickers.length === 0) return cache;
+  const result = await runPython(tickers);
+  cache = { ...cache, ...result };
+  lastRefresh = Date.now();
+  return cache;
+}
+
+/** Refresh in the background; only blocks the caller on a cold cache (first call). */
+export async function ensureFreshBaselines(tvSymbols) {
+  const stale = Date.now() - lastRefresh > REFRESH_INTERVAL_MS;
+  const coldStart = Object.keys(cache).length === 0;
+
+  if ((stale || coldStart) && !refreshPromise) {
+    refreshPromise = refreshBaselines(tvSymbols)
+      .catch(err => { process.stderr.write(`[weeklyVolume] refresh failed: ${err.message}\n`); })
+      .finally(() => { refreshPromise = null; });
+  }
+
+  if (coldStart && refreshPromise) await refreshPromise;
+  return cache;
+}
+
+/** Look up the ratio of currentVolume vs the same-hour-of-week baseline for a symbol. */
+export function getWeeklyRatio(tvSymbol, hourBucket, currentVolume) {
+  const yahooTicker = tvSymbolToYahoo(tvSymbol);
+  if (!yahooTicker) return null;
+  const baseline = cache[yahooTicker];
+  if (!baseline || baseline.error) return null;
+  const avg     = baseline[String(hourBucket)];
+  const samples = baseline._samples ? baseline._samples[String(hourBucket)] : 0;
+  if (!avg || avg <= 0 || !samples || samples < 5) return null;
+  return {
+    ratio:    Math.round((currentVolume / avg) * 100) / 100,
+    baseline: avg,
+    samples:  samples,
+  };
+}
+
+export function cacheStatus() {
+  return { lastRefresh, tickers: Object.keys(cache), refreshing: !!refreshPromise };
+}

--- a/src/dashboard-server.js
+++ b/src/dashboard-server.js
@@ -98,7 +98,7 @@ app.get('/api/regime', (req, res) => {
 });
 
 // Proactive background refresh so data is fresh even if the dashboard tab is closed
-setInterval(() => { getAsiaIndices().catch(() => {}); }, 60 * 1000);
+setInterval(() => { getAsiaIndices().catch(() => {}); }, 30 * 1000);
 setInterval(() => { getNews().catch(() => {}); }, 2 * 60 * 1000);
 getAsiaIndices().catch(() => {});
 getNews().catch(() => {});

--- a/src/dashboard-server.js
+++ b/src/dashboard-server.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Dashboard server — serves the live HTML/JS dashboard and the REST API it
+ * polls for regime (trend/range + liquidity-sweep/reversal/trade-bias),
+ * Asian index drops, and news headlines.
+ *
+ * Run: node src/dashboard-server.js [--port 4545]
+ */
+import express from 'express';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+import { analyzeRegime } from './core/regime.js';
+import { getAsiaIndices } from './core/asiaIndices.js';
+import { getNews } from './core/news.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const { values: argv } = parseArgs({
+  options: { port: { type: 'string', short: 'p', default: '4545' } },
+  strict: false,
+});
+const PORT = Number(argv.port) || 4545;
+
+// Only the continuous front-month contracts — ignore the explicit-month
+// duplicates (MNQU2026, MGCQ2026 etc) that also show up as separate panes.
+const SYMBOL_FILTER = ['MGC1!', 'MNQ1!'];
+function keepPane(p) {
+  return SYMBOL_FILTER.some(s => (p.symbol || '').includes(s));
+}
+
+const app = express();
+app.use(express.static(path.resolve(__dirname, '../public')));
+
+// In-memory rolling history, same idea as the CLI agent's history buffer,
+// so the dashboard can show NOW / -1m / -5m / -10m without re-querying CDP.
+const MAX_HISTORY_MS = 12 * 60 * 1000;
+const regimeHistory = [];
+
+function pushHistory(result) {
+  regimeHistory.push({ ts: result.ts || Date.now(), panes: result.panes });
+  const cutoff = Date.now() - MAX_HISTORY_MS;
+  while (regimeHistory.length > 0 && regimeHistory[0].ts < cutoff) regimeHistory.shift();
+}
+
+function snapshotAt(offsetSec) {
+  if (regimeHistory.length === 0) return null;
+  const target = Date.now() - offsetSec * 1000;
+  let best = null, bestDelta = Infinity;
+  for (const h of regimeHistory) {
+    const d = Math.abs(h.ts - target);
+    if (d < bestDelta) { bestDelta = d; best = h; }
+  }
+  return best;
+}
+
+let lastRegimeError = null;
+
+let pollInFlight = false;
+
+async function pollRegime() {
+  if (pollInFlight) return;  // never stack calls if CDP is slow — keeps ticks real-time, not queued
+  pollInFlight = true;
+  try {
+    const result = await analyzeRegime();
+    if (result && result.panes) {
+      result.panes = result.panes.filter(keepPane);
+      pushHistory(result);
+      lastRegimeError = null;
+    }
+  } catch (err) {
+    lastRegimeError = err.message;
+  } finally {
+    pollInFlight = false;
+  }
+}
+
+// Tight poll loop for real-time ticks — CDP round-trip is ~80ms, so 300ms
+// gives a fresh quote/structure read several times a second without
+// hammering the chart. HTTP requests just read the cache, never block on CDP.
+const REGIME_POLL_MS = 300;
+setInterval(pollRegime, REGIME_POLL_MS);
+pollRegime();
+
+app.get('/api/regime', (req, res) => {
+  const now    = snapshotAt(0);
+  const min1   = snapshotAt(60);
+  const min5   = snapshotAt(300);
+  const min10  = snapshotAt(600);
+  res.json({
+    error: lastRegimeError,
+    now:   now  || null,
+    min1:  min1 || null,
+    min5:  min5 || null,
+    min10: min10 || null,
+  });
+});
+
+// Proactive background refresh so data is fresh even if the dashboard tab is closed
+setInterval(() => { getAsiaIndices().catch(() => {}); }, 60 * 1000);
+setInterval(() => { getNews().catch(() => {}); }, 2 * 60 * 1000);
+getAsiaIndices().catch(() => {});
+getNews().catch(() => {});
+
+app.get('/api/asia', async (req, res) => {
+  try {
+    const data = await getAsiaIndices();
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/news', async (req, res) => {
+  try {
+    const data = await getNews();
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(PORT, () => {
+  process.stderr.write(
+    `\x1b[2m⚠  tradingview-mcp  |  Not affiliated with TradingView Inc.\x1b[0m\n` +
+    `Dashboard running at \x1b[1mhttp://localhost:${PORT}\x1b[0m\n`
+  );
+});

--- a/src/server.js
+++ b/src/server.js
@@ -22,12 +22,15 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 78 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — 79 tools for reading and controlling a live TradingView Desktop chart.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 
-Reading your chart:
-- chart_get_state → get symbol, timeframe, all indicator names + entity IDs (call first)
+## START HERE for any chart analysis task:
+- chart_snapshot → SINGLE CALL that returns everything: state + quote + OHLCV + study values + all pine graphics (lines/labels/tables/boxes). Use this FIRST before any other read tools. Only fall back to individual tools if you need something not in the snapshot.
+
+Reading your chart (individual tools — only if chart_snapshot is insufficient):
+- chart_get_state → get symbol, timeframe, all indicator names + entity IDs
 - data_get_study_values → get current numeric values from ALL visible indicators (RSI, MACD, BB, EMA, etc.)
 - quote_get → get real-time price snapshot (last, OHLC, volume)
 - data_get_ohlcv → get price bars. ALWAYS pass summary=true unless you need individual bars

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -83,4 +83,17 @@ export function registerDataTools(server) {
     try { return jsonResult(await core.getStudyValues()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
+
+  server.tool(
+    'chart_snapshot',
+    'FASTEST WAY to analyze a chart. Single CDP call that returns everything at once: chart state (symbol/timeframe/studies), real-time quote, OHLCV summary, all indicator values, and all Pine Script graphics (lines, labels, tables, boxes). Use this INSTEAD of calling chart_get_state + quote_get + data_get_study_values + data_get_pine_* separately. Reduces ~7 sequential tool calls to 1.',
+    {
+      study_filter: z.string().optional().describe('Filter pine graphics to this study name substring. Omit for all studies.'),
+      ohlcv_count: z.coerce.number().optional().describe('Number of recent bars to summarize (default 20, max 500)'),
+    },
+    async ({ study_filter, ohlcv_count }) => {
+      try { return jsonResult(await core.getSnapshot({ study_filter, ohlcv_count })); }
+      catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    }
+  );
 }

--- a/strategies/asia_indices.py
+++ b/strategies/asia_indices.py
@@ -1,22 +1,41 @@
 #!/usr/bin/env python3
 """
-Asian index snapshot — Hang Seng (HK), Nikkei 225 (Japan), KOSPI (Korea).
-A big overnight drop in any of these during Asia hours can spill over into
-MNQ/ES futures before NY open, so we flag moves beyond a threshold.
+Real-time Asian index snapshot — Hang Seng (HK), Nikkei 225 (Japan), KOSPI
+(Korea). Uses intraday 1-minute bars (not daily candles) so a sharp drop or
+reversal *during* the Asian session shows up immediately — this is what can
+spill over into MNQ/ES before NY open, not yesterday's close-to-close move.
 
 Usage:
-    python3 asia_indices.py [--drop-threshold -1.5]
+    python3 asia_indices.py [--drop-threshold -1.0]
 
 Output (stdout, JSON):
     {
-      "HSI":   { "name": "Hang Seng",  "price": 17890.2, "changePct": -2.13, "bigDrop": true,  ... },
-      "N225":  { "name": "Nikkei 225", "price": 38210.5, "changePct": -0.42, "bigDrop": false, ... },
-      "KOSPI": { "name": "KOSPI",      "price": 2580.1,  "changePct": -1.81, "bigDrop": true,  ... }
+      "HSI": {
+        "name": "Hang Seng (HK)",
+        "price": 22671.86,            # most recent intraday price
+        "asOf": "2026-06-26T16:08:00+08:00",
+        "marketOpen": true,           # is the last bar within the last ~10 min?
+        "sessionOpen": 23076.91,      # today's opening print
+        "sessionHigh": 23120.4,
+        "sessionLow": 22650.1,
+        "prevClose": 23076.91,        # prior session's close
+        "changeFromOpenPct": -1.76,   # vs today's open
+        "changeFromPrevClosePct": -2.10,
+        "dropFromHighPct": -1.95,     # drawdown from today's session high (catches reversals)
+        "bigDrop": true
+      },
+      ...
+      "_impact": {
+        "redCount": 2,
+        "score": 3.85,
+        "level": "HIGH"              # LOW / MEDIUM / HIGH spillover risk into MNQ
+      }
     }
 """
 import sys
 import json
 import argparse
+from datetime import datetime, timezone
 
 import yfinance as yf
 
@@ -26,49 +45,87 @@ TICKERS = {
     "KOSPI": {"symbol": "^KS11", "name": "KOSPI (KR)"},
 }
 
+MARKET_STALE_MIN = 10  # if the last bar is older than this, treat the market as closed
+
 
 def fetch_one(key, meta, drop_threshold):
     try:
         t = yf.Ticker(meta["symbol"])
-        hist = t.history(period="5d", interval="1d")
-        if hist is None or hist.empty or len(hist) < 2:
-            return {"name": meta["name"], "error": "no data"}
+        intraday = t.history(period="1d", interval="1m")
+        daily = t.history(period="5d", interval="1d")
 
-        last_close = float(hist["Close"].iloc[-1])
-        prev_close = float(hist["Close"].iloc[-2])
-        change_pct = round((last_close - prev_close) / prev_close * 100, 2)
+        if intraday is None or intraday.empty:
+            return {"name": meta["name"], "error": "no intraday data"}
+        if daily is None or daily.empty or len(daily) < 2:
+            return {"name": meta["name"], "error": "no daily data"}
 
-        # also grab intraday last price if available (more current than daily close)
-        intraday_price = last_close
-        try:
-            fast = t.fast_info
-            if fast and fast.get("lastPrice"):
-                intraday_price = float(fast["lastPrice"])
-        except Exception:
-            pass
+        last_price   = float(intraday["Close"].iloc[-1])
+        session_open = float(intraday["Open"].iloc[0])
+        session_high = float(intraday["High"].max())
+        session_low  = float(intraday["Low"].min())
+        prev_close   = float(daily["Close"].iloc[-2])
+
+        last_ts = intraday.index[-1].to_pydatetime()
+        now = datetime.now(last_ts.tzinfo) if last_ts.tzinfo else datetime.now()
+        age_min = (now - last_ts).total_seconds() / 60.0
+        market_open = age_min <= MARKET_STALE_MIN
+
+        change_from_open       = round((last_price - session_open) / session_open * 100, 2)
+        change_from_prev_close = round((last_price - prev_close) / prev_close * 100, 2)
+        drop_from_high         = round((last_price - session_high) / session_high * 100, 2)
 
         return {
             "name": meta["name"],
-            "price": round(intraday_price, 2),
+            "price": round(last_price, 2),
+            "asOf": last_ts.isoformat(),
+            "marketOpen": market_open,
+            "sessionOpen": round(session_open, 2),
+            "sessionHigh": round(session_high, 2),
+            "sessionLow": round(session_low, 2),
             "prevClose": round(prev_close, 2),
-            "changePct": change_pct,
-            "bigDrop": change_pct <= drop_threshold,
-            "bigRally": change_pct >= abs(drop_threshold),
+            "changeFromOpenPct": change_from_open,
+            "changeFromPrevClosePct": change_from_prev_close,
+            "dropFromHighPct": drop_from_high,
+            "bigDrop": change_from_prev_close <= drop_threshold or drop_from_high <= drop_threshold,
         }
     except Exception as e:
         return {"name": meta["name"], "error": str(e)}
 
 
+def compute_impact(results, drop_threshold):
+    """Aggregate spillover-risk score across all three indices."""
+    red_count = 0
+    score = 0.0
+    for r in results.values():
+        if r.get("error"):
+            continue
+        worst = min(r.get("changeFromPrevClosePct", 0), r.get("dropFromHighPct", 0))
+        if worst < 0:
+            score += abs(worst)
+        if r.get("bigDrop"):
+            red_count += 1
+
+    if red_count >= 2 and score >= 4:
+        level = "HIGH"
+    elif red_count >= 1 and score >= 1.5:
+        level = "MEDIUM"
+    else:
+        level = "LOW"
+
+    return {"redCount": red_count, "score": round(score, 2), "level": level}
+
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--drop-threshold", type=float, default=-1.5,
-                         help="changePct at/below this marks bigDrop=true (default -1.5)")
+    parser.add_argument("--drop-threshold", type=float, default=-1.0,
+                         help="changePct at/below this marks bigDrop=true (default -1.0)")
     args = parser.parse_args()
 
     out = {}
     for key, meta in TICKERS.items():
         out[key] = fetch_one(key, meta, args.drop_threshold)
 
+    out["_impact"] = compute_impact(out, args.drop_threshold)
     print(json.dumps(out))
 
 

--- a/strategies/asia_indices.py
+++ b/strategies/asia_indices.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Asian index snapshot — Hang Seng (HK), Nikkei 225 (Japan), KOSPI (Korea).
+A big overnight drop in any of these during Asia hours can spill over into
+MNQ/ES futures before NY open, so we flag moves beyond a threshold.
+
+Usage:
+    python3 asia_indices.py [--drop-threshold -1.5]
+
+Output (stdout, JSON):
+    {
+      "HSI":   { "name": "Hang Seng",  "price": 17890.2, "changePct": -2.13, "bigDrop": true,  ... },
+      "N225":  { "name": "Nikkei 225", "price": 38210.5, "changePct": -0.42, "bigDrop": false, ... },
+      "KOSPI": { "name": "KOSPI",      "price": 2580.1,  "changePct": -1.81, "bigDrop": true,  ... }
+    }
+"""
+import sys
+import json
+import argparse
+
+import yfinance as yf
+
+TICKERS = {
+    "HSI":   {"symbol": "^HSI",  "name": "Hang Seng (HK)"},
+    "N225":  {"symbol": "^N225", "name": "Nikkei 225 (JP)"},
+    "KOSPI": {"symbol": "^KS11", "name": "KOSPI (KR)"},
+}
+
+
+def fetch_one(key, meta, drop_threshold):
+    try:
+        t = yf.Ticker(meta["symbol"])
+        hist = t.history(period="5d", interval="1d")
+        if hist is None or hist.empty or len(hist) < 2:
+            return {"name": meta["name"], "error": "no data"}
+
+        last_close = float(hist["Close"].iloc[-1])
+        prev_close = float(hist["Close"].iloc[-2])
+        change_pct = round((last_close - prev_close) / prev_close * 100, 2)
+
+        # also grab intraday last price if available (more current than daily close)
+        intraday_price = last_close
+        try:
+            fast = t.fast_info
+            if fast and fast.get("lastPrice"):
+                intraday_price = float(fast["lastPrice"])
+        except Exception:
+            pass
+
+        return {
+            "name": meta["name"],
+            "price": round(intraday_price, 2),
+            "prevClose": round(prev_close, 2),
+            "changePct": change_pct,
+            "bigDrop": change_pct <= drop_threshold,
+            "bigRally": change_pct >= abs(drop_threshold),
+        }
+    except Exception as e:
+        return {"name": meta["name"], "error": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--drop-threshold", type=float, default=-1.5,
+                         help="changePct at/below this marks bigDrop=true (default -1.5)")
+    args = parser.parse_args()
+
+    out = {}
+    for key, meta in TICKERS.items():
+        out[key] = fetch_one(key, meta, args.drop_threshold)
+
+    print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/asian_failed_breakout/__init__.py
+++ b/strategies/asian_failed_breakout/__init__.py
@@ -1,0 +1,7 @@
+"""Asian-session failed-breakout / liquidity-sweep setup: a rule-based state
+machine, not an ML model. See config.py for the full parameter surface and
+engine.py for the state machine itself.
+
+Run a backtest:
+    python -m strategies.asian_failed_breakout.backtest --symbol MGC1! --days 30
+"""

--- a/strategies/asian_failed_breakout/backtest.py
+++ b/strategies/asian_failed_breakout/backtest.py
@@ -1,0 +1,147 @@
+"""
+Backtests the Asian failed-breakout strategy against already-collected 1m/5m
+raw bars (from ml/data_collection/collect_replay.py's output — reused here
+purely as a historical OHLCV source, this module has no other dependency on
+the ml/ subsystem).
+
+Walks 1m bars in time order. Feeds 5m bars into the LevelTracker only once
+they've fully CLOSED relative to the current 1m timestamp (bar `time` is
+open time, matching the convention confirmed in src/core/data.js — a 5m bar
+closes at time+300s) — same causal-join discipline as the fix applied to
+ml/features/build_dataset.py this session, deliberately re-verified here
+rather than assumed.
+
+Run as a module from the repo root:
+    python -m strategies.asian_failed_breakout.backtest --symbol MGC1! --days 30
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from .config import StrategyConfig
+from .engine import StrategyEngine
+from .levels import LevelTracker, _in_window, _parse_hm
+
+RAW_DIR = Path.home() / "data" / "ml-raw"
+OUT_DIR = Path.home() / "data" / "afb-backtests"
+SYMBOLS_CONFIG = Path(__file__).resolve().parent.parent.parent / "ml" / "config" / "symbols.json"
+ET = "America/New_York"
+
+
+def _load_point_value(symbol: str) -> float:
+    all_cfg = json.loads(SYMBOLS_CONFIG.read_text())
+    return all_cfg.get(symbol, {}).get("point_value", 1.0)
+
+
+def _load_bars(symbol: str, timeframe: str) -> pd.DataFrame:
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_{timeframe}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No raw data at {path} — run ml/data_collection/collect_replay.py first.")
+    return pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+
+
+def run_backtest(symbol: str, cfg: StrategyConfig, days: int | None = None) -> pd.DataFrame:
+    df1 = _load_bars(symbol, "1")
+    df5 = _load_bars(symbol, "5")
+
+    if days is not None:
+        cutoff = int(df1["time"].max()) - days * 86400
+        df1 = df1[df1["time"] >= cutoff].reset_index(drop=True)
+
+    df1["ema9"] = df1["close"].ewm(span=cfg.ma9.ema_period, adjust=False).mean()
+    et1 = pd.to_datetime(df1["time"], unit="s", utc=True).dt.tz_convert(ET)
+    et5 = pd.to_datetime(df5["time"], unit="s", utc=True).dt.tz_convert(ET)
+    tf5_close_offset = 5 * 60
+
+    tracker = LevelTracker(cfg.session, cfg.swing, cfg.asian_range)
+    engine = StrategyEngine(cfg, symbol, _load_point_value(symbol))
+
+    asian_start = _parse_hm(cfg.session.asian_session_start)
+    asian_end = _parse_hm(cfg.session.asian_session_end)
+
+    j = 0  # pointer into df5
+    n5 = len(df5)
+    records = []
+
+    for i in range(len(df1)):
+        t = int(df1["time"].iloc[i])
+        while j < n5 and int(df5["time"].iloc[j]) + tf5_close_offset <= t:
+            bar5 = {"time": int(df5["time"].iloc[j]), "open": df5["open"].iloc[j], "high": df5["high"].iloc[j],
+                    "low": df5["low"].iloc[j], "close": df5["close"].iloc[j]}
+            tracker.update(bar5, et5.iloc[j])
+            j += 1
+
+        levels = tracker.get_levels(cfg.levels)
+        tod = et1.iloc[i].hour * 60 + et1.iloc[i].minute
+        in_asian = _in_window(tod, asian_start, asian_end)
+
+        bar1 = {"time": t, "open": df1["open"].iloc[i], "high": df1["high"].iloc[i],
+                "low": df1["low"].iloc[i], "close": df1["close"].iloc[i]}
+        recs = engine.on_bar(bar1, float(df1["ema9"].iloc[i]), levels, in_asian)
+        records.extend(recs)
+
+    if len(df1):
+        last_bar = {"time": int(df1["time"].iloc[-1]), "close": float(df1["close"].iloc[-1])}
+        records.extend(engine.force_close_all(last_bar))
+
+    rows = [r.__dict__ for r in records]
+    out = pd.DataFrame(rows)
+    if not out.empty:
+        for col in ("timestamp", "break_timestamp", "reclaim_timestamp", "ema9_trigger_timestamp", "exit_timestamp"):
+            if col in out.columns:
+                out[col.replace("timestamp", "et")] = pd.to_datetime(out[col], unit="s", utc=True).dt.tz_convert(ET)
+        out = out.sort_values("timestamp").reset_index(drop=True)
+    return out
+
+
+def summarize(df: pd.DataFrame) -> dict:
+    if df.empty:
+        return {"n_setups": 0}
+    status_counts = df["setup_status"].value_counts().to_dict()
+    reason_counts = df["invalid_reason"].dropna().value_counts().to_dict()
+    filled = df[df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])]
+    summary = {
+        "n_setups_logged": len(df),
+        "status_counts": status_counts,
+        "rejection_reasons": reason_counts,
+        "n_trades_filled": len(filled),
+    }
+    if len(filled):
+        wins = filled[filled["pnl_points"] > 0]
+        gross_profit = filled.loc[filled["pnl_dollars"] > 0, "pnl_dollars"].sum()
+        gross_loss = -filled.loc[filled["pnl_dollars"] < 0, "pnl_dollars"].sum()
+        summary.update({
+            "win_rate": float(len(wins) / len(filled)),
+            "total_pnl_dollars": float(filled["pnl_dollars"].sum()),
+            "avg_r_multiple": float(filled["r_multiple"].mean()),
+            "profit_factor": float(gross_profit / gross_loss) if gross_loss > 0 else None,
+            "by_direction": filled.groupby("direction")["pnl_dollars"].agg(["count", "sum", "mean"]).to_dict("index"),
+        })
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=None, help="limit to the most recent N days (default: all available)")
+    parser.add_argument("--out", help="output CSV path (default: ~/data/afb-backtests/{symbol}_setups.csv)")
+    args = parser.parse_args()
+
+    cfg = StrategyConfig()
+    df = run_backtest(args.symbol, cfg, args.days)
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+    out_path = Path(args.out) if args.out else OUT_DIR / f"{stem}_setups.csv"
+    df.to_csv(out_path, index=False)
+    print(f"Wrote {len(df)} setup records to {out_path}", file=sys.stderr)
+
+    print(json.dumps(summarize(df), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/asian_failed_breakout/config.py
+++ b/strategies/asian_failed_breakout/config.py
@@ -1,0 +1,165 @@
+"""
+All tunable parameters for the Asian failed-breakout strategy, grouped by
+concern so setup-detection thresholds stay separate from risk management
+(per the design brief) and every threshold can be swept in a later
+optimization pass without touching engine code.
+
+Defaults are order-of-magnitude reasonable for MGC1! (micro gold, tick_size
+0.10, point_value $10/point — see ml/config/symbols.json) on a 1m/5m chart,
+not fitted to anything. Treat them as a starting point for the backtest, not
+a claim about what's optimal.
+"""
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SessionConfig:
+    """All times ET. Asian/NY windows can wrap past midnight (asian) or not
+    (ny) — same wrap-aware convention as ml/features/session_context.py."""
+    asian_session_start: str = "18:00"
+    asian_session_end: str = "02:00"
+    ny_session_start: str = "09:30"
+    ny_session_end: str = "16:00"
+    # Globex day rollover for "previous day" high/low — matches the 18:00 ET
+    # convention already used throughout ml/features/*.
+    globex_day_rollover_hour: int = 18
+    # Setups may only be *initiated* (IDLE -> APPROACHING_LEVEL) inside the
+    # Asian session window. An in-progress setup is allowed to resolve past
+    # the window's end (bounded by its own max-bars timeouts below) unless
+    # force_expire_at_session_end forces it closed at the boundary.
+    force_expire_at_session_end: bool = True
+
+
+@dataclass
+class LevelToggles:
+    pdh: bool = True
+    pdl: bool = True
+    prev_ny_high: bool = True
+    prev_ny_low: bool = True
+    swing_high: bool = True
+    swing_low: bool = True
+    asian_range_high: bool = True
+    asian_range_low: bool = True
+
+
+@dataclass
+class SwingConfig:
+    """Fractal swing detection on the 5m chart: a bar is a confirmed swing
+    high once it's the max high within `lookback_bars` bars on both sides
+    (confirmation therefore lags the actual peak by `lookback_bars` bars —
+    unavoidable and correct, a swing isn't "significant" until price has
+    moved away from it)."""
+    lookback_bars_5m: int = 6
+    min_prominence_points: float = 2.0
+    max_tracked_swings: int = 3
+
+
+@dataclass
+class AsianRangeConfig:
+    # Don't treat the current Asian session's own range high/low as a usable
+    # level until at least this many 5m bars have closed since the session
+    # opened — "once sufficiently established" from the brief, made concrete.
+    min_bars_5m_before_use: int = 6
+
+
+@dataclass
+class ApproachConfig:
+    # How close price must come to an enabled level to log APPROACHING_LEVEL
+    # and lock it in as the active candidate for that side. Purely a
+    # bookkeeping/logging predecessor to the break itself — a level can also
+    # be broken directly on the bar that first reaches it.
+    proximity_points: float = 1.5
+
+
+@dataclass
+class SweepConfig:
+    # Minimum penetration beyond the level required to count as a real
+    # break/sweep rather than a level being merely tagged.
+    min_penetration_points: float = 0.3
+
+
+@dataclass
+class ObserveConfig:
+    """Failed-breakdown/failed-breakout evidence, evaluated bar-by-bar after
+    the break. Reclaim of the level (checked in the same window) is itself
+    treated as the strongest possible evidence of failure and ends the
+    OBSERVING state immediately — see engine.py."""
+    max_bars_to_reclaim: int = 15
+    # "Price stops making meaningful new lows/highs": once a bar fails to
+    # extend the sweep extreme by at least min_new_extreme_progress_points
+    # for this many consecutive bars, that counts as stalling.
+    stall_bars_required: int = 2
+    min_new_extreme_progress_points: float = 0.2
+    # "Price quickly returns toward the broken level": close comes back
+    # within this distance of the level (without yet fully reclaiming it).
+    return_proximity_points: float = 1.0
+    # Failed-breakdown evidence is satisfied by ANY of (stall detected) OR
+    # (quick return detected) OR (reclaim itself) — not all required.
+
+
+@dataclass
+class AcceptanceConfig:
+    """Positive evidence that price is ACCEPTING the break rather than
+    failing it — checked every bar from LEVEL_BROKEN through LEVEL_RECLAIMED.
+    Any one breach invalidates the setup outright (setup_status=INVALID),
+    distinct from simply timing out (setup_status=EXPIRED)."""
+    max_closes_beyond_level: int = 3
+    max_distance_from_level_points: float = 3.0
+    max_further_penetration_points: float = 2.0  # beyond the original sweep extreme
+
+
+@dataclass
+class ReclaimConfig:
+    mode: str = "close"  # "close" or "wick"
+
+
+@dataclass
+class MA9Config:
+    ema_period: int = 9
+    max_bars_to_trigger: int = 15
+    require_micro_structure_confirmation: bool = False
+    micro_structure_lookback_bars: int = 10
+
+
+@dataclass
+class OrderFlowConfig:
+    """No footprint/CVD/large-trade data source exists anywhere in this
+    codebase yet (TradingView Desktop via CDP exposes OHLCV only — see
+    ml/features/indicators.py's docstring). This layer is therefore fully
+    optional and OFF by default; wire a real feed into
+    engine.OrderFlowSnapshot before enabling it. It must only ever adjust a
+    confidence score, never independently trigger a trade."""
+    enabled: bool = False
+    min_confidence_to_boost: float = 0.5
+
+
+@dataclass
+class RiskConfig:
+    """Kept fully separate from setup-detection thresholds above, per the
+    design brief, so risk can be re-tuned without touching what counts as a
+    valid setup."""
+    stop_buffer_points: float = 0.2
+    max_risk_points: float = 6.0
+    target_mode: str = "fixed_r"  # "fixed_r" or "fixed_price"
+    target_r_multiple: float = 2.0
+    target_price_points: float | None = None
+    partial_r_multiple: float = 1.0
+    partial_fraction: float = 0.5
+    move_stop_to_breakeven_after_partial: bool = True
+    runner_target_r_multiple: float = 3.0
+
+
+@dataclass
+class StrategyConfig:
+    session: SessionConfig = field(default_factory=SessionConfig)
+    levels: LevelToggles = field(default_factory=LevelToggles)
+    swing: SwingConfig = field(default_factory=SwingConfig)
+    asian_range: AsianRangeConfig = field(default_factory=AsianRangeConfig)
+    approach: ApproachConfig = field(default_factory=ApproachConfig)
+    sweep: SweepConfig = field(default_factory=SweepConfig)
+    observe: ObserveConfig = field(default_factory=ObserveConfig)
+    acceptance: AcceptanceConfig = field(default_factory=AcceptanceConfig)
+    reclaim: ReclaimConfig = field(default_factory=ReclaimConfig)
+    ma9: MA9Config = field(default_factory=MA9Config)
+    order_flow: OrderFlowConfig = field(default_factory=OrderFlowConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)

--- a/strategies/asian_failed_breakout/engine.py
+++ b/strategies/asian_failed_breakout/engine.py
@@ -1,0 +1,479 @@
+"""
+The state machine itself. One StrategyEngine tracks two independent
+SetupCandidate trackers (long and short) plus a list of OpenTrade objects for
+setups that have already triggered — direction is not mutually exclusive,
+since "approaching an important low" and "approaching an important high" are
+genuinely independent things that can both be true at once (e.g. price
+chopping inside a range with both edges nearby).
+
+Design principle from the brief: a level being broken is not itself a
+signal. Nothing here fires an entry until BOTH the level has been reclaimed
+AND the 1m EMA9 has been reclaimed/lost afterward. Order flow (engine
+accepts an OrderFlowSnapshot per bar if the caller has one) can only ever
+raise or lower a confidence score attached to the log record — it never
+gates state transitions on its own, per the design brief's explicit "MUST
+NOT be mandatory."
+"""
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from .config import StrategyConfig
+
+
+class State(str, Enum):
+    IDLE = "IDLE"
+    APPROACHING_LEVEL = "APPROACHING_LEVEL"
+    LEVEL_BROKEN = "LEVEL_BROKEN"
+    OBSERVING = "OBSERVING"
+    LEVEL_RECLAIMED = "LEVEL_RECLAIMED"
+    WAITING_FOR_MA9 = "WAITING_FOR_MA9"
+    ENTRY_TRIGGERED = "ENTRY_TRIGGERED"
+    INVALID = "INVALID"
+    EXPIRED = "EXPIRED"
+
+_LONG_LEVEL_FIELDS = ("pdl", "prev_ny_low", "swing_low", "asian_range_low")
+_SHORT_LEVEL_FIELDS = ("pdh", "prev_ny_high", "swing_high", "asian_range_high")
+
+
+@dataclass
+class OrderFlowSnapshot:
+    """No real feed exists yet (see config.OrderFlowConfig's docstring) — all
+    fields are Optional and default to unset. confidence_score() returns a
+    neutral 0.5 (no adjustment) whenever the relevant inputs are missing,
+    rather than fabricating a directional read from absent data."""
+    bid_ask_footprint: Optional[float] = None
+    cvd_delta: Optional[float] = None
+    absorption_detected: Optional[bool] = None
+    large_trade_bias: Optional[float] = None
+    stacked_imbalance: Optional[bool] = None
+
+    def confidence_score(self, direction: str) -> float:
+        # Priority per the design brief: Price Response > Absorption > CVD >
+        # Large Trades > Stacked Imbalance. Price response is already what
+        # the state machine itself measures (reclaim + MA9), so this score
+        # only layers the remaining four, highest-priority-available wins.
+        if self.absorption_detected is not None:
+            return 0.8 if self.absorption_detected else 0.3
+        if self.cvd_delta is not None:
+            favorable = (self.cvd_delta < 0) if direction == "long" else (self.cvd_delta > 0)
+            return 0.7 if favorable else 0.35
+        if self.large_trade_bias is not None:
+            favorable = (self.large_trade_bias > 0) if direction == "long" else (self.large_trade_bias < 0)
+            return 0.65 if favorable else 0.4
+        if self.stacked_imbalance is not None:
+            return 0.6 if self.stacked_imbalance else 0.45
+        return 0.5
+
+
+@dataclass
+class SetupLogRecord:
+    timestamp: int
+    symbol: str
+    session: str
+    direction: str
+    important_level_type: str
+    important_level_price: float
+    break_price: Optional[float] = None
+    maximum_penetration: Optional[float] = None
+    break_timestamp: Optional[int] = None
+    reclaim_timestamp: Optional[int] = None
+    ema9_trigger_timestamp: Optional[int] = None
+    entry_price: Optional[float] = None
+    sweep_extreme: Optional[float] = None
+    stop_price: Optional[float] = None
+    risk_distance: Optional[float] = None
+    bars_between_break_and_reclaim: Optional[int] = None
+    bars_between_reclaim_and_entry: Optional[int] = None
+    order_flow_confirmation: Optional[float] = None
+    setup_status: str = "PENDING"
+    invalid_reason: Optional[str] = None
+    exit_price: Optional[float] = None
+    exit_timestamp: Optional[int] = None
+    pnl_points: Optional[float] = None
+    pnl_dollars: Optional[float] = None
+    r_multiple: Optional[float] = None
+
+
+@dataclass
+class _Candidate:
+    direction: str
+    state: State = State.IDLE
+    level_type: Optional[str] = None
+    level_price: Optional[float] = None
+    approach_time: Optional[int] = None
+    break_price: Optional[float] = None
+    break_time: Optional[int] = None
+    break_extreme_initial: Optional[float] = None
+    sweep_extreme: Optional[float] = None
+    max_penetration: float = 0.0
+    bars_since_break: int = 0
+    bars_since_reclaim: int = 0
+    closes_beyond_level_count: int = 0
+    stall_bars: int = 0
+    reclaim_time: Optional[int] = None
+
+    def reset(self):
+        self.__init__(direction=self.direction)
+
+
+@dataclass
+class OpenTrade:
+    direction: str
+    entry_price: float
+    entry_time: int
+    stop_price: float
+    initial_risk: float
+    partial_target_price: float
+    final_target_price: float
+    setup_record: SetupLogRecord
+    partial_taken: bool = False
+    remaining_fraction: float = 1.0
+    realized_pnl_points: float = 0.0
+
+
+class StrategyEngine:
+    """Generic sweep/failed-breakout state machine — not actually tied to
+    the Asian session. Which level names it looks for on the long vs. short
+    side is injectable (default: the Asian strategy's own PDL/prev-NY-low/
+    swing-low/asian-range-low set) so a different session's level tracker
+    (e.g. the NY-session one, using opening-range levels instead) can reuse
+    this exact engine rather than duplicating the whole state machine."""
+    def __init__(self, cfg: StrategyConfig, symbol: str, point_value: float,
+                 long_level_fields: tuple = _LONG_LEVEL_FIELDS, short_level_fields: tuple = _SHORT_LEVEL_FIELDS,
+                 session_label: str = "asian"):
+        self.cfg = cfg
+        self.symbol = symbol
+        self.point_value = point_value
+        self.long_level_fields = long_level_fields
+        self.short_level_fields = short_level_fields
+        self.session_label = session_label
+        self.candidates = {"long": _Candidate("long"), "short": _Candidate("short")}
+        self.open_trades: list[OpenTrade] = []
+        self._prev_close = None
+        self._prev_ema9 = None
+        self._micro_high_buf: list[float] = []
+        self._micro_low_buf: list[float] = []
+
+    def on_bar(self, bar: dict, ema9: float, levels: dict, in_active_session: bool,
+               order_flow: Optional[OrderFlowSnapshot] = None) -> list[SetupLogRecord]:
+        """bar: {time, open, high, low, close}. Returns any log records
+        (rejected setups and/or completed trades) finalized on this bar."""
+        records: list[SetupLogRecord] = []
+
+        self._micro_high_buf.append(bar["high"])
+        self._micro_low_buf.append(bar["low"])
+        lookback = self.cfg.ma9.micro_structure_lookback_bars
+        self._micro_high_buf = self._micro_high_buf[-lookback:]
+        self._micro_low_buf = self._micro_low_buf[-lookback:]
+
+        # trade management first — an open trade's exit doesn't depend on
+        # the setup-detection state machine at all past entry
+        still_open = []
+        for trade in self.open_trades:
+            rec = self._update_trade(trade, bar)
+            if rec is not None:
+                records.append(rec)
+            else:
+                still_open.append(trade)
+        self.open_trades = still_open
+
+        for direction in ("long", "short"):
+            rec = self._step(direction, bar, ema9, levels, in_active_session, order_flow)
+            if rec is not None:
+                records.append(rec)
+
+        self._prev_close = bar["close"]
+        self._prev_ema9 = ema9
+        return records
+
+    # ------------------------------------------------------------------
+    def _level_fields(self, direction: str):
+        return self.long_level_fields if direction == "long" else self.short_level_fields
+
+    def _step(self, direction: str, bar: dict, ema9: float, levels: dict,
+              in_active_session: bool, order_flow: Optional[OrderFlowSnapshot]) -> Optional[SetupLogRecord]:
+        c = self.candidates[direction]
+        is_long = direction == "long"
+
+        if (self.cfg.session.force_expire_at_session_end and not in_active_session
+                and c.state not in (State.IDLE, State.ENTRY_TRIGGERED)):
+            rec = self._finalize(c, State.EXPIRED, "SETUP_EXPIRED")
+            c.reset()
+            return rec
+
+        if c.state == State.LEVEL_BROKEN:
+            c.state = State.OBSERVING
+        elif c.state == State.LEVEL_RECLAIMED:
+            c.state = State.WAITING_FOR_MA9
+
+        if c.state == State.IDLE:
+            if not in_active_session:
+                return None  # setups may only be initiated inside the Asian session window
+            return self._try_start(c, direction, is_long, bar, levels)
+
+        if c.state == State.APPROACHING_LEVEL:
+            return self._check_approach(c, is_long, bar)
+
+        if c.state == State.OBSERVING:
+            return self._check_observing(c, is_long, bar)
+
+        if c.state == State.WAITING_FOR_MA9:
+            return self._check_ma9(c, direction, is_long, bar, ema9, order_flow)
+
+        return None
+
+    def _try_start(self, c: _Candidate, direction: str, is_long: bool, bar: dict, levels: dict):
+        best_type, best_price, best_dist = None, None, None
+        for name in self._level_fields(direction):
+            price = levels.get(name)
+            if price is None:
+                continue
+            dist = (bar["close"] - price) if is_long else (price - bar["close"])
+            dist = abs(dist)
+            if best_dist is None or dist < best_dist:
+                best_type, best_price, best_dist = name, price, dist
+
+        if best_type is None or best_dist > self.cfg.approach.proximity_points * 4:
+            return None  # nothing nearby worth tracking yet
+
+        c.level_type, c.level_price, c.approach_time = best_type, best_price, bar["time"]
+        c.state = State.APPROACHING_LEVEL
+        return self._check_approach(c, is_long, bar)
+
+    def _check_approach(self, c: _Candidate, is_long: bool, bar: dict):
+        pen = self.cfg.sweep.min_penetration_points
+        broken = (bar["low"] < c.level_price - pen) if is_long else (bar["high"] > c.level_price + pen)
+        if broken:
+            extreme = bar["low"] if is_long else bar["high"]
+            c.break_price = bar["close"]
+            c.break_time = bar["time"]
+            c.break_extreme_initial = extreme
+            c.sweep_extreme = extreme
+            c.max_penetration = abs(c.level_price - extreme)
+            c.bars_since_break = 0
+            c.state = State.LEVEL_BROKEN
+            return None
+
+        dist = abs(bar["close"] - c.level_price)
+        if dist > self.cfg.approach.proximity_points * 2:
+            c.reset()  # drifted away without breaking — give up on this candidate
+        return None
+
+    def _check_observing(self, c: _Candidate, is_long: bool, bar: dict):
+        c.bars_since_break += 1
+        obs = self.cfg.observe
+
+        extreme_now = bar["low"] if is_long else bar["high"]
+        pushed_further = (extreme_now < c.sweep_extreme) if is_long else (extreme_now > c.sweep_extreme)
+        if pushed_further:
+            progress = abs(c.sweep_extreme - extreme_now)
+            c.sweep_extreme = extreme_now
+            c.max_penetration = abs(c.level_price - c.sweep_extreme)
+            c.stall_bars = 0 if progress >= obs.min_new_extreme_progress_points else c.stall_bars + 1
+        else:
+            c.stall_bars += 1
+
+        if (is_long and bar["close"] < c.level_price) or (not is_long and bar["close"] > c.level_price):
+            c.closes_beyond_level_count += 1
+
+        acc = self.cfg.acceptance
+        distance_from_level = abs(c.level_price - bar["close"]) if (
+            (is_long and bar["close"] < c.level_price) or (not is_long and bar["close"] > c.level_price)
+        ) else 0.0
+        further_penetration = abs(c.break_extreme_initial - c.sweep_extreme)
+
+        if (c.closes_beyond_level_count > acc.max_closes_beyond_level
+                or distance_from_level > acc.max_distance_from_level_points
+                or further_penetration > acc.max_further_penetration_points):
+            reason = "INVALID_ACCEPTANCE_BELOW_LEVEL" if is_long else "INVALID_ACCEPTANCE_ABOVE_LEVEL"
+            rec = self._finalize(c, State.INVALID, reason)
+            c.reset()
+            return rec
+
+        if self.cfg.reclaim.mode == "close":
+            reclaimed = (bar["close"] > c.level_price) if is_long else (bar["close"] < c.level_price)
+        else:  # wick
+            reclaimed = (bar["high"] > c.level_price) if is_long else (bar["low"] < c.level_price)
+
+        if reclaimed:
+            c.reclaim_time = bar["time"]
+            c.bars_since_reclaim = 0
+            c.state = State.LEVEL_RECLAIMED
+            return None
+
+        if c.bars_since_break >= obs.max_bars_to_reclaim:
+            rec = self._finalize(c, State.EXPIRED, "NO_LEVEL_RECLAIM")
+            c.reset()
+            return rec
+        return None
+
+    def _check_ma9(self, c: _Candidate, direction: str, is_long: bool, bar: dict, ema9: float,
+                    order_flow: Optional[OrderFlowSnapshot]):
+        c.bars_since_reclaim += 1
+
+        if (is_long and bar["close"] < c.level_price) or (not is_long and bar["close"] > c.level_price):
+            c.closes_beyond_level_count += 1
+            if c.closes_beyond_level_count > self.cfg.acceptance.max_closes_beyond_level:
+                reason = "INVALID_ACCEPTANCE_BELOW_LEVEL" if is_long else "INVALID_ACCEPTANCE_ABOVE_LEVEL"
+                rec = self._finalize(c, State.INVALID, reason)
+                c.reset()
+                return rec
+
+        if self._prev_close is None or self._prev_ema9 is None:
+            return None
+
+        if is_long:
+            ma9_condition = self._prev_close <= self._prev_ema9 and bar["close"] > ema9
+        else:
+            ma9_condition = self._prev_close >= self._prev_ema9 and bar["close"] < ema9
+
+        if ma9_condition and self.cfg.ma9.require_micro_structure_confirmation:
+            prior_highs = self._micro_high_buf[:-1]  # exclude current bar itself
+            prior_lows = self._micro_low_buf[:-1]
+            if is_long:
+                recent_lower_high = max(prior_highs) if prior_highs else bar["close"]
+                ma9_condition = bar["close"] > recent_lower_high
+            else:
+                recent_higher_low = min(prior_lows) if prior_lows else bar["close"]
+                ma9_condition = bar["close"] < recent_higher_low
+
+        if ma9_condition:
+            entry_price = bar["close"]
+            stop = (c.sweep_extreme - self.cfg.risk.stop_buffer_points) if is_long else \
+                   (c.sweep_extreme + self.cfg.risk.stop_buffer_points)
+            risk_distance = abs(entry_price - stop)
+
+            if risk_distance <= 0 or risk_distance > self.cfg.risk.max_risk_points:
+                rec = self._finalize(c, State.INVALID, "RISK_TOO_LARGE")
+                rec.ema9_trigger_timestamp = bar["time"]
+                rec.stop_price = stop
+                rec.risk_distance = risk_distance
+                c.reset()
+                return rec
+
+            rk = self.cfg.risk
+            if rk.target_mode == "fixed_price" and rk.target_price_points is not None:
+                final_target = entry_price + rk.target_price_points if is_long else entry_price - rk.target_price_points
+            else:
+                final_target = entry_price + rk.target_r_multiple * risk_distance if is_long else \
+                                entry_price - rk.target_r_multiple * risk_distance
+            partial_target = entry_price + rk.partial_r_multiple * risk_distance if is_long else \
+                              entry_price - rk.partial_r_multiple * risk_distance
+
+            record = SetupLogRecord(
+                timestamp=c.approach_time, symbol=self.symbol, session=self.session_label,
+                direction=direction, important_level_type=c.level_type, important_level_price=c.level_price,
+                break_price=c.break_price, maximum_penetration=c.max_penetration,
+                break_timestamp=c.break_time, reclaim_timestamp=c.reclaim_time,
+                ema9_trigger_timestamp=bar["time"], entry_price=entry_price, sweep_extreme=c.sweep_extreme,
+                stop_price=stop, risk_distance=risk_distance,
+                bars_between_break_and_reclaim=self._bars_between(c.break_time, c.reclaim_time),
+                bars_between_reclaim_and_entry=c.bars_since_reclaim,
+                order_flow_confirmation=(order_flow.confidence_score(direction) if
+                                          (self.cfg.order_flow.enabled and order_flow) else None),
+                setup_status="OPEN",
+            )
+            self.open_trades.append(OpenTrade(
+                direction=direction, entry_price=entry_price, entry_time=bar["time"], stop_price=stop,
+                initial_risk=risk_distance, partial_target_price=partial_target, final_target_price=final_target,
+                setup_record=record,
+            ))
+            c.reset()
+            return None
+
+        if c.bars_since_reclaim >= self.cfg.ma9.max_bars_to_trigger:
+            rec = self._finalize(c, State.EXPIRED, "NO_MA9_CONFIRMATION")
+            c.reset()
+            return rec
+        return None
+
+    def _finalize(self, c: _Candidate, status: State, reason: str) -> SetupLogRecord:
+        return SetupLogRecord(
+            timestamp=c.approach_time, symbol=self.symbol, session=self.session_label,
+            direction=c.direction, important_level_type=c.level_type or "", important_level_price=c.level_price or 0.0,
+            break_price=c.break_price, maximum_penetration=c.max_penetration or None,
+            break_timestamp=c.break_time, reclaim_timestamp=c.reclaim_time,
+            sweep_extreme=c.sweep_extreme,
+            bars_between_break_and_reclaim=self._bars_between(c.break_time, c.reclaim_time),
+            setup_status=status.value, invalid_reason=reason,
+        )
+
+    @staticmethod
+    def _bars_between(t1, t2, bar_seconds: int = 60):
+        if t1 is None or t2 is None:
+            return None
+        return int(round((t2 - t1) / bar_seconds))
+
+    # ------------------------------------------------------------------
+    def _update_trade(self, trade: OpenTrade, bar: dict) -> Optional[SetupLogRecord]:
+        is_long = trade.direction == "long"
+        rk = self.cfg.risk
+
+        def close_remaining(price, ts):
+            total_pnl_points = self._blended_pnl(trade, price)
+            rec = trade.setup_record
+            rec.exit_price = price
+            rec.exit_timestamp = ts
+            rec.pnl_points = total_pnl_points
+            rec.pnl_dollars = total_pnl_points * self.point_value
+            rec.r_multiple = total_pnl_points / trade.initial_risk if trade.initial_risk else None
+            rec.setup_status = "FILLED"
+            return rec
+
+        if not trade.partial_taken:
+            stop_hit = bar["low"] <= trade.stop_price if is_long else bar["high"] >= trade.stop_price
+            target_hit = bar["high"] >= trade.partial_target_price if is_long else bar["low"] <= trade.partial_target_price
+            if stop_hit and target_hit:
+                # same-bar ambiguity — conservative, assume stop first (same
+                # convention as ml/labels/triple_barrier.py)
+                return close_remaining(trade.stop_price, bar["time"])
+            if stop_hit:
+                return close_remaining(trade.stop_price, bar["time"])
+            if target_hit:
+                trade.partial_taken = True
+                trade.remaining_fraction = 1.0 - rk.partial_fraction
+                trade.realized_pnl_points = rk.partial_fraction * abs(trade.partial_target_price - trade.entry_price)
+                if rk.move_stop_to_breakeven_after_partial:
+                    trade.stop_price = trade.entry_price
+                return None
+        else:
+            stop_hit = bar["low"] <= trade.stop_price if is_long else bar["high"] >= trade.stop_price
+            target_hit = bar["high"] >= trade.final_target_price if is_long else bar["low"] <= trade.final_target_price
+            if stop_hit and target_hit:
+                return close_remaining(trade.stop_price, bar["time"])
+            if stop_hit:
+                return close_remaining(trade.stop_price, bar["time"])
+            if target_hit:
+                return close_remaining(trade.final_target_price, bar["time"])
+        return None
+
+    @staticmethod
+    def _blended_pnl(trade: OpenTrade, final_price: float) -> float:
+        """Per-unit points PnL. Before a partial: just entry-to-exit
+        distance. After a partial: the already-locked-in partial leg
+        (realized_pnl_points, fraction-weighted at the time it was taken)
+        plus the remaining fraction's own entry-to-final-exit distance."""
+        is_long = trade.direction == "long"
+        full_leg = (final_price - trade.entry_price) if is_long else (trade.entry_price - final_price)
+        if not trade.partial_taken:
+            return full_leg
+        return trade.realized_pnl_points + trade.remaining_fraction * full_leg
+
+    def force_close_all(self, last_bar: dict) -> list[SetupLogRecord]:
+        """Mark-to-market any still-open trades at the end of the backtest
+        window — otherwise they'd silently vanish from the log."""
+        records = []
+        for trade in self.open_trades:
+            price = last_bar["close"]
+            total_pnl_points = self._blended_pnl(trade, price)
+            rec = trade.setup_record
+            rec.exit_price = price
+            rec.exit_timestamp = last_bar["time"]
+            rec.pnl_points = total_pnl_points
+            rec.pnl_dollars = total_pnl_points * self.point_value
+            rec.r_multiple = total_pnl_points / trade.initial_risk if trade.initial_risk else None
+            rec.setup_status = "OPEN_AT_BACKTEST_END"
+            records.append(rec)
+        self.open_trades = []
+        return records

--- a/strategies/asian_failed_breakout/levels.py
+++ b/strategies/asian_failed_breakout/levels.py
@@ -1,0 +1,188 @@
+"""
+Tracks "important levels" incrementally from 5-minute bars, causally — each
+level is only ever derived from 5m bars that have already CLOSED as of the
+point the engine asks for it. No merge_asof, no batch precompute over the
+whole frame; this class is fed one closed 5m bar at a time during the
+backtest walk specifically so there's no way for a future bar to leak into
+a level (see ml/features/build_dataset.py's history for why that class of
+bug is worth being paranoid about).
+
+Levels tracked:
+  pdh / pdl                 — previous COMPLETE Globex day's high/low
+                               (18:00 ET rollover, matching ml/features/*)
+  prev_ny_high / prev_ny_low— previous COMPLETE NY session's high/low
+  swing_high / swing_low    — most recent confirmed fractal swings (lagged
+                               by swing.lookback_bars_5m bars by construction)
+  asian_range_high / _low   — current Asian session's range so far, only
+                               exposed once enough bars have accumulated
+"""
+import datetime as _dt
+from dataclasses import dataclass
+
+from .config import AsianRangeConfig, SessionConfig, SwingConfig
+
+
+def _parse_hm(s: str) -> int:
+    h, m = s.split(":")
+    return int(h) * 60 + int(m)
+
+
+def _in_window(tod_min: int, start_min: int, end_min: int) -> bool:
+    if start_min <= end_min:
+        return start_min <= tod_min < end_min
+    return tod_min >= start_min or tod_min < end_min  # wraps past midnight
+
+
+def _tod_minutes(et_ts) -> int:
+    return et_ts.hour * 60 + et_ts.minute
+
+
+def _globex_day_id(et_ts, rollover_hour: int):
+    shifted = et_ts - _dt.timedelta(hours=rollover_hour)
+    return shifted.date()
+
+
+@dataclass
+class _SwingPoint:
+    price: float
+    time: int
+
+
+class LevelTracker:
+    def __init__(self, session_cfg: SessionConfig, swing_cfg: SwingConfig, asian_cfg: AsianRangeConfig):
+        self.session_cfg = session_cfg
+        self.swing_cfg = swing_cfg
+        self.asian_cfg = asian_cfg
+
+        self._asian_start_min = _parse_hm(session_cfg.asian_session_start)
+        self._asian_end_min = _parse_hm(session_cfg.asian_session_end)
+        self._ny_start_min = _parse_hm(session_cfg.ny_session_start)
+        self._ny_end_min = _parse_hm(session_cfg.ny_session_end)
+        self._rollover_hour = session_cfg.globex_day_rollover_hour
+
+        self._globex_day = None
+        self._day_high = None
+        self._day_low = None
+        self.pdh = None
+        self.pdl = None
+
+        self._ny_date = None
+        self._in_ny_session = False
+        self._ny_high = None
+        self._ny_low = None
+        self.prev_ny_high = None
+        self.prev_ny_low = None
+
+        self._asian_day = None
+        self._asian_bar_count = 0
+        self.asian_range_high = None
+        self.asian_range_low = None
+
+        self._buf: list[dict] = []  # rolling 5m bar buffer for swing confirmation
+        self._recent_swing_highs: list[_SwingPoint] = []
+        self._recent_swing_lows: list[_SwingPoint] = []
+
+    def update(self, bar: dict, et_ts) -> None:
+        """bar: {time, open, high, low, close}. et_ts: tz-aware ET timestamp
+        of this (already-closed) 5m bar."""
+        self._update_globex_day(bar, et_ts)
+        self._update_ny_session(bar, et_ts)
+        self._update_asian_range(bar, et_ts)
+        self._update_swings(bar, et_ts)
+
+    # -- Globex-day PDH/PDL -------------------------------------------------
+    def _update_globex_day(self, bar, et_ts):
+        day = _globex_day_id(et_ts, self._rollover_hour)
+        if self._globex_day is None:
+            self._globex_day = day
+            self._day_high, self._day_low = bar["high"], bar["low"]
+            return
+        if day != self._globex_day:
+            self.pdh, self.pdl = self._day_high, self._day_low
+            self._globex_day = day
+            self._day_high, self._day_low = bar["high"], bar["low"]
+        else:
+            self._day_high = max(self._day_high, bar["high"])
+            self._day_low = min(self._day_low, bar["low"])
+
+    # -- Previous NY session high/low ---------------------------------------
+    def _update_ny_session(self, bar, et_ts):
+        tod = _tod_minutes(et_ts)
+        in_session = _in_window(tod, self._ny_start_min, self._ny_end_min)
+        date = et_ts.date()
+        if in_session:
+            if not self._in_ny_session or date != self._ny_date:
+                self._ny_date = date
+                self._ny_high, self._ny_low = bar["high"], bar["low"]
+            else:
+                self._ny_high = max(self._ny_high, bar["high"])
+                self._ny_low = min(self._ny_low, bar["low"])
+            self._in_ny_session = True
+        else:
+            if self._in_ny_session:
+                self.prev_ny_high, self.prev_ny_low = self._ny_high, self._ny_low
+            self._in_ny_session = False
+
+    # -- Current Asian session range -----------------------------------------
+    def _update_asian_range(self, bar, et_ts):
+        tod = _tod_minutes(et_ts)
+        day = _globex_day_id(et_ts, self._rollover_hour)
+        if day != self._asian_day:
+            self._asian_day = day
+            self._asian_bar_count = 0
+            self.asian_range_high = None
+            self.asian_range_low = None
+        if _in_window(tod, self._asian_start_min, self._asian_end_min):
+            self._asian_bar_count += 1
+            if self.asian_range_high is None:
+                self.asian_range_high, self.asian_range_low = bar["high"], bar["low"]
+            else:
+                self.asian_range_high = max(self.asian_range_high, bar["high"])
+                self.asian_range_low = min(self.asian_range_low, bar["low"])
+
+    # -- Swing highs/lows (fractal, lagged by lookback_bars_5m) -------------
+    def _update_swings(self, bar, et_ts):
+        n = self.swing_cfg.lookback_bars_5m
+        self._buf.append({"high": bar["high"], "low": bar["low"], "time": bar["time"]})
+        window = 2 * n + 1
+        if len(self._buf) < window:
+            return
+        if len(self._buf) > window:
+            self._buf.pop(0)
+        center = self._buf[n]
+        highs = [b["high"] for b in self._buf]
+        lows = [b["low"] for b in self._buf]
+        edge_max = max(highs[0], highs[-1])
+        edge_min = min(lows[0], lows[-1])
+
+        if center["high"] == max(highs) and center["high"] - edge_max >= self.swing_cfg.min_prominence_points:
+            self._recent_swing_highs.append(_SwingPoint(center["high"], center["time"]))
+            self._recent_swing_highs = self._recent_swing_highs[-self.swing_cfg.max_tracked_swings:]
+        if center["low"] == min(lows) and edge_min - center["low"] >= self.swing_cfg.min_prominence_points:
+            self._recent_swing_lows.append(_SwingPoint(center["low"], center["time"]))
+            self._recent_swing_lows = self._recent_swing_lows[-self.swing_cfg.max_tracked_swings:]
+
+    @property
+    def swing_high(self):
+        return self._recent_swing_highs[-1].price if self._recent_swing_highs else None
+
+    @property
+    def swing_low(self):
+        return self._recent_swing_lows[-1].price if self._recent_swing_lows else None
+
+    def get_levels(self, toggles) -> dict[str, float]:
+        """Only levels that are both enabled AND currently known (not None)
+        — e.g. pdh is None until the first full Globex day has completed,
+        asian_range_high/low are None until enough bars have accumulated."""
+        asian_ready = self._asian_bar_count >= self.asian_cfg.min_bars_5m_before_use
+        candidates = {
+            "pdh": self.pdh if toggles.pdh else None,
+            "pdl": self.pdl if toggles.pdl else None,
+            "prev_ny_high": self.prev_ny_high if toggles.prev_ny_high else None,
+            "prev_ny_low": self.prev_ny_low if toggles.prev_ny_low else None,
+            "swing_high": self.swing_high if toggles.swing_high else None,
+            "swing_low": self.swing_low if toggles.swing_low else None,
+            "asian_range_high": self.asian_range_high if (toggles.asian_range_high and asian_ready) else None,
+            "asian_range_low": self.asian_range_low if (toggles.asian_range_low and asian_ready) else None,
+        }
+        return {k: v for k, v in candidates.items() if v is not None}

--- a/strategies/asian_failed_breakout/plot_trades.py
+++ b/strategies/asian_failed_breakout/plot_trades.py
@@ -1,0 +1,165 @@
+"""
+Plots the liquidity-sweep strategy's trades over the most recent N days, one
+PNG per calendar day (ET) — separate files, not a multi-page PDF, so each
+day can be opened/zoomed independently. Each trade's swept level (PDH/PDL or
+a confirmed swing point) is drawn as a line ending at the trade's entry time
+— it shows what was known BEFORE the trade, not a claim that the level still
+matters afterward.
+
+The Asian session's own still-developing range (asian_range_high/low) is
+excluded from eligible levels for this symbol/session by default — it's the
+current session's own live-extending range, not a genuinely prior reference,
+so a "sweep" of it is close to tautological (confirmed empirically earlier
+this session: it fires more than PDH/PDL/swing combined). Normal MGC sweeps
+are PDH/PDL or prior swing points.
+
+Execution is on 1m bars (that's what's plotted); levels/location come from
+5m bars (not plotted directly — only the specific level price(s) that
+actually got traded are drawn, via each trade's own important_level_price).
+
+Run as a module from the repo root:
+    python -m strategies.asian_failed_breakout.plot_trades --symbol MGC1! --days 7 --tier scalp
+"""
+import argparse
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .backtest import ET, _load_bars, run_backtest
+from .config import StrategyConfig
+
+OUT_DIR = Path.home() / "data" / "afb-backtests" / "plots"
+
+TIERS = {
+    "scalp": {"target_points": 10.0, "max_risk_points": 5.0},
+    "swing": {"target_points": 20.0, "max_risk_points": 10.0},
+}
+
+LEVEL_COLOR = "#1f77b4"
+
+
+def build_config(tier: str, exclude_asian_range: bool = True) -> StrategyConfig:
+    cfg = StrategyConfig()
+    cfg.risk.target_mode = "fixed_price"
+    cfg.risk.target_price_points = TIERS[tier]["target_points"]
+    cfg.risk.max_risk_points = TIERS[tier]["max_risk_points"]
+    if exclude_asian_range:
+        cfg.levels.asian_range_high = False
+        cfg.levels.asian_range_low = False
+    return cfg
+
+
+def plot_day(ax, day_price: pd.DataFrame, day_times: pd.Series, day_trades: pd.DataFrame, date: str):
+    ax.plot(day_times, day_price["close"], color="black", linewidth=0.8, zorder=1)
+
+    x_start = day_times.iloc[0]
+    for _, t in day_trades.iterrows():
+        if pd.isna(t["important_level_price"]):
+            continue
+        level_price = float(t["important_level_price"])
+        entry_dt = pd.to_datetime(t["ema9_trigger_timestamp"], unit="s", utc=True).tz_convert(ET)
+        # line runs from the start of the day through to this trade's entry
+        # — the level was only known up to that point, not a claim it still
+        # holds afterward.
+        ax.plot([x_start, entry_dt], [level_price, level_price], color=LEVEL_COLOR, linewidth=1.0,
+                linestyle=":", zorder=2, alpha=0.8)
+        ax.annotate(f"{t['important_level_type']} {level_price:.2f}", (entry_dt, level_price),
+                    fontsize=7, color=LEVEL_COLOR, xytext=(-4, 4), textcoords="offset points", ha="right")
+
+    for _, t in day_trades.iterrows():
+        # ema9_trigger_timestamp is the actual entry bar (matches entry_price)
+        entry_dt = pd.to_datetime(t["ema9_trigger_timestamp"], unit="s", utc=True).tz_convert(ET)
+        exit_dt = pd.to_datetime(t["exit_timestamp"], unit="s", utc=True).tz_convert(ET)
+        win = t["pnl_points"] > 0
+        color = "#2CA02C" if win else "#D62728"
+        marker_entry = "^" if t["direction"] == "long" else "v"
+        ax.scatter([entry_dt], [t["entry_price"]], marker=marker_entry, color=color, s=120, zorder=5,
+                   edgecolors="black", linewidths=0.6)
+        ax.scatter([exit_dt], [t["exit_price"]], marker="x", color=color, s=100, zorder=5)
+        ax.plot([entry_dt, exit_dt], [t["entry_price"], t["exit_price"]], "--", color=color, linewidth=1.1,
+                zorder=4, alpha=0.85)
+        ax.annotate(f"{t['pnl_points']:+.1f}pt", (exit_dt, t["exit_price"]), fontsize=7, color=color,
+                    xytext=(4, 4), textcoords="offset points")
+
+    n_long = (day_trades["direction"] == "long").sum()
+    n_short = (day_trades["direction"] == "short").sum()
+    n_win = (day_trades["pnl_points"] > 0).sum()
+    n_loss = (day_trades["pnl_points"] <= 0).sum()
+    day_pnl = day_trades["pnl_dollars"].sum()
+
+    legend_elems = [
+        plt.Line2D([0], [0], marker="^", color="w", markerfacecolor="gray", markeredgecolor="black", markersize=9, label="long entry"),
+        plt.Line2D([0], [0], marker="v", color="w", markerfacecolor="gray", markeredgecolor="black", markersize=9, label="short entry"),
+        plt.Line2D([0], [0], marker="x", color="gray", markersize=8, label="exit", linestyle="None"),
+        plt.Line2D([0], [0], color="#2CA02C", linewidth=2, label="win"),
+        plt.Line2D([0], [0], color="#D62728", linewidth=2, label="loss"),
+        plt.Line2D([0], [0], color=LEVEL_COLOR, linewidth=1.2, linestyle=":", label="swept level"),
+    ]
+    ax.legend(handles=legend_elems, loc="upper left", fontsize=8)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M", tz=ET))
+    ax.set_title(f"{date} — {len(day_trades)} trades ({n_long}L/{n_short}S, {n_win}W/{n_loss}L, PNL ${day_pnl:+.0f})")
+    ax.set_ylabel("price")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--tier", choices=list(TIERS), default="scalp")
+    parser.add_argument("--include-empty-days", action="store_true", help="also plot days with zero trades")
+    parser.add_argument("--out-dir", help="output directory for the PNGs")
+    args = parser.parse_args()
+
+    cfg = build_config(args.tier)
+    trades_df = run_backtest(args.symbol, cfg, days=args.days)
+    filled = trades_df[trades_df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])].copy()
+
+    price_df = _load_bars(args.symbol, "1")
+    cutoff = int(price_df["time"].max()) - args.days * 86400
+    price_df = price_df[price_df["time"] >= cutoff].reset_index(drop=True)
+    price_et = pd.to_datetime(price_df["time"], unit="s", utc=True).dt.tz_convert(ET)
+    price_df["date"] = price_et.dt.strftime("%Y-%m-%d")
+
+    filled["entry_date"] = pd.to_datetime(filled["ema9_trigger_timestamp"], unit="s", utc=True).dt.tz_convert(ET).dt.strftime("%Y-%m-%d")
+
+    dates = sorted(price_df["date"].unique())
+    out_dir = Path(args.out_dir) if args.out_dir else OUT_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+
+    written = []
+    for date in dates:
+        day_trades = filled[filled["entry_date"] == date]
+        if day_trades.empty and not args.include_empty_days:
+            continue
+
+        day_mask = price_df["date"] == date
+        day_price = price_df[day_mask]
+        day_times = price_et[day_mask]
+
+        fig, ax = plt.subplots(figsize=(14, 7))
+        if day_trades.empty:
+            ax.plot(day_times, day_price["close"], color="black", linewidth=0.8)
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M", tz=ET))
+            ax.set_title(f"{date} — 0 trades")
+            ax.set_ylabel("price")
+        else:
+            plot_day(ax, day_price, day_times, day_trades, date)
+        fig.tight_layout()
+
+        out_path = out_dir / f"{stem}_{args.tier}_{date}.png"
+        fig.savefig(out_path, dpi=130)
+        plt.close(fig)
+        written.append(out_path)
+
+    print(f"Wrote {len(written)} PNGs ({len(filled)} total trades) to {out_dir}")
+    for p in written:
+        print(p)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/fabio_strategy/__init__.py
+++ b/strategies/fabio_strategy/__init__.py
@@ -1,0 +1,12 @@
+"""
+Fabio-style intraday strategy: Context -> Location -> Price Reaction ->
+Trigger -> Trade. Two primary setups (trend-pullback continuation, failed-
+breakout reversal) gated by a 5m-bar market-state classifier
+(BULLISH_DIRECTIONAL / BEARISH_DIRECTIONAL / BALANCE), with a TRANSITION
+state that stops the strategy from chasing a structural break — it must
+wait for a bounce/pullback to actually fail before treating a level break
+as a new trend, not just react to the break itself.
+
+Run a backtest:
+    python -m strategies.fabio_strategy.backtest --symbol MNQ1! --tier swing --session ny
+"""

--- a/strategies/fabio_strategy/backtest.py
+++ b/strategies/fabio_strategy/backtest.py
@@ -1,0 +1,263 @@
+"""
+Backtest runner: loads 1m+5m raw bars, computes VWAP/EMA9/EMA20 (1m) and
+VWAP/EMA9/market-state/balance-range (5m), joins the 5m-derived columns
+onto 1m bars using the same close-time-aligned causal join fixed earlier
+this session in ml/features/build_dataset.py (a 1m bar only ever sees a 5m
+bar that had actually closed by that point — never the in-progress one),
+feeds the important-location tracker 5m bars incrementally, and walks 1m
+bars through FabioEngine.
+
+Segments results by symbol / session / time-of-day / market-state /
+direction / setup-type rather than a single combined number, per the
+brief's explicit "do not combine all trades into one performance number."
+
+Run as a module from the repo root:
+    python -m strategies.fabio_strategy.backtest --symbol MNQ1! --session ny --tier swing
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from ..ny_open_strategies.common import (ET, RAW_DIR, _in_window, load_point_value)
+from .config import FabioConfig
+from .engine import FabioEngine
+from .levels import LocationTracker
+from .market_state import compute_market_state
+
+OUT_DIR = Path.home() / "data" / "fabio-backtests"
+
+SESSION_NAMES = ("asia", "london", "ny_premarket", "ny_open", "ny_pm")
+
+
+def _load_bars(symbol: str, timeframe: str) -> pd.DataFrame:
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_{timeframe}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No raw data at {path} — run ml/data_collection/collect_replay.py first.")
+    return pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+
+
+def _add_vwap_ema(df: pd.DataFrame, session_start_hour: int = 18) -> pd.DataFrame:
+    session_id = (df["et"] - pd.Timedelta(hours=session_start_hour)).dt.floor("D")
+    typical = (df["high"] + df["low"] + df["close"]) / 3
+    tp_vol = typical * df["volume"]
+    cum_vol = df.groupby(session_id.values)["volume"].cumsum()
+    cum_tp_vol = tp_vol.groupby(session_id.values).cumsum()
+    vwap = cum_tp_vol / cum_vol.replace(0, np.nan)
+    df["vwap"] = vwap
+    df["ema9"] = df["close"].ewm(span=9, adjust=False).mean()
+    df["ema20"] = df["close"].ewm(span=20, adjust=False).mean()
+    return df
+
+
+def _session_windows(cfg: FabioConfig):
+    from .levels import _parse_hm
+    s = cfg.sessions
+    return {
+        "asia": (_parse_hm(s.asia_start), _parse_hm(s.asia_end), 0),
+        "london": (_parse_hm(s.london_start), _parse_hm(s.london_end), 0),
+        "ny_premarket": (_parse_hm(s.ny_premarket_start), _parse_hm(s.ny_premarket_end), 0),
+        "ny_open": (_parse_hm(s.ny_open_start), _parse_hm(s.ny_open_end), s.ny_open_min_delay_minutes),
+        "ny_pm": (_parse_hm(s.ny_pm_start), _parse_hm(s.ny_pm_end), 0),
+    }
+
+
+def _session_and_tradeable(tod_min: int, cfg: FabioConfig):
+    windows = _session_windows(cfg)
+    toggles = cfg.session_toggles
+    enabled = {
+        "asia": toggles.asia_enabled, "london": toggles.london_enabled,
+        "ny_premarket": toggles.ny_premarket_enabled, "ny_open": toggles.ny_open_enabled,
+        "ny_pm": toggles.ny_pm_enabled,
+    }
+    for name, (start, end, delay) in windows.items():
+        if not enabled[name]:
+            continue
+        if _in_window(tod_min, start, end):
+            minutes_since_open = (tod_min - start) % 1440
+            return name, minutes_since_open >= delay
+    return "none", False
+
+
+SESSION_GROUPS = {
+    "asia": {"asia"},
+    "ny": {"ny_premarket", "ny_open", "ny_pm"},
+}
+
+
+def run_backtest(symbol: str, cfg: FabioConfig, days: int | None = None,
+                  session_filter: set[str] | None = None) -> pd.DataFrame:
+    df1 = _load_bars(symbol, "1")
+    df5 = _load_bars(symbol, "5")
+    if days is not None:
+        cutoff = int(df1["time"].max()) - days * 86400
+        df1 = df1[df1["time"] >= cutoff].reset_index(drop=True)
+
+    df1["et"] = pd.to_datetime(df1["time"], unit="s", utc=True).dt.tz_convert(ET)
+    df1["tod_min"] = df1["et"].dt.hour * 60 + df1["et"].dt.minute
+    _add_vwap_ema(df1, cfg.sessions.globex_day_rollover_hour)
+
+    df5["et"] = pd.to_datetime(df5["time"], unit="s", utc=True).dt.tz_convert(ET)
+    _add_vwap_ema(df5, cfg.sessions.globex_day_rollover_hour)
+    df5 = compute_market_state(df5, cfg)
+    n5w = cfg.balance.range_lookback_bars_5m
+    df5["balance_range_high"] = df5["high"].rolling(n5w).max()
+    df5["balance_range_low"] = df5["low"].rolling(n5w).min()
+
+    tracker = LocationTracker(cfg)
+    engine = FabioEngine(cfg, symbol, load_point_value(symbol))
+
+    j, n5 = 0, len(df5)
+    tf5_close_offset = 300
+    cur_state, cur_bh, cur_bl = "BALANCE", None, None
+    records = []
+
+    for i in range(len(df1)):
+        t = int(df1["time"].iloc[i])
+        while j < n5 and int(df5["time"].iloc[j]) + tf5_close_offset <= t:
+            bar5 = {"time": int(df5["time"].iloc[j]), "open": df5["open"].iloc[j], "high": df5["high"].iloc[j],
+                    "low": df5["low"].iloc[j], "close": df5["close"].iloc[j]}
+            tracker.update(bar5, pd.Timestamp(df5["et"].iloc[j]))
+            cur_state = df5["raw_market_state"].iloc[j]
+            cur_bh = df5["balance_range_high"].iloc[j]
+            cur_bl = df5["balance_range_low"].iloc[j]
+            j += 1
+
+        tod = int(df1["tod_min"].iloc[i])
+        session, tradeable = _session_and_tradeable(tod, cfg)
+        if session_filter and session not in session_filter:
+            # still run trade management / in-flight setups even outside the
+            # filtered session so open trades resolve correctly — just block
+            # new entries via tradeable=False
+            tradeable = False
+
+        levels = tracker.get_levels(cfg.important_levels)
+        balance_range = {"high": cur_bh, "low": cur_bl} if (cur_bh is not None and not pd.isna(cur_bh)) else None
+
+        bar1 = {"time": t, "open": df1["open"].iloc[i], "high": df1["high"].iloc[i],
+                "low": df1["low"].iloc[i], "close": df1["close"].iloc[i]}
+        recs = engine.on_bar(bar1, cur_state, float(df1["vwap"].iloc[i]), float(df1["ema9"].iloc[i]),
+                              float(df1["ema20"].iloc[i]), levels, balance_range, session, tradeable)
+        for r in recs:
+            r.session = r.session or session
+        records.extend(recs)
+
+    if len(df1):
+        last_bar = {"time": int(df1["time"].iloc[-1]), "close": float(df1["close"].iloc[-1])}
+        records.extend(engine.force_close_all(last_bar))
+
+    out = pd.DataFrame([r.__dict__ for r in records])
+    if not out.empty:
+        for col in ("timestamp", "level_broken", "level_reclaimed", "ema9_trigger", "exit_timestamp", "pullback_start"):
+            if col in out.columns:
+                out[col.replace("timestamp", "et").replace("_broken", "_broken_et")
+                    .replace("_reclaimed", "_reclaimed_et").replace("_trigger", "_trigger_et")
+                    .replace("_start", "_start_et")] = pd.to_datetime(out[col], unit="s", utc=True).dt.tz_convert(ET)
+        out = out.sort_values("timestamp", na_position="first").reset_index(drop=True)
+        et_ts = pd.to_datetime(out["timestamp"], unit="s", utc=True).dt.tz_convert(ET)
+        out["hour_et"] = et_ts.dt.hour
+    return out
+
+
+def segmented_metrics(df: pd.DataFrame) -> dict:
+    """Per the brief: never one combined number. Computes the same metric
+    set for every segment along symbol / session / time-of-day (hour) /
+    market_state / direction / setup_type independently."""
+    if df.empty:
+        return {"n_setups": 0}
+    filled = df[df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])].copy()
+
+    def metrics_for(sub: pd.DataFrame) -> dict:
+        if sub.empty:
+            return {"n": 0}
+        wins = sub[sub["pnl_points"] > 0]
+        losses = sub[sub["pnl_points"] <= 0]
+        gross_profit = sub.loc[sub["pnl_dollars"] > 0, "pnl_dollars"].sum()
+        gross_loss = -sub.loc[sub["pnl_dollars"] < 0, "pnl_dollars"].sum()
+        equity = sub["pnl_dollars"].cumsum()
+        running_max = equity.cummax()
+        drawdown = (equity - running_max).min() if len(equity) else 0.0
+        # max consecutive losses
+        is_loss = (sub["pnl_points"] <= 0).astype(int).tolist()
+        max_consec, cur = 0, 0
+        for v in is_loss:
+            cur = cur + 1 if v else 0
+            max_consec = max(max_consec, cur)
+        return {
+            "n": len(sub),
+            "win_rate": float(len(wins) / len(sub)),
+            "avg_win": float(wins["pnl_dollars"].mean()) if len(wins) else None,
+            "avg_loss": float(losses["pnl_dollars"].mean()) if len(losses) else None,
+            "profit_factor": float(gross_profit / gross_loss) if gross_loss > 0 else None,
+            "expectancy_dollars": float(sub["pnl_dollars"].mean()),
+            "avg_r": float(sub["r_multiple"].mean()) if sub["r_multiple"].notna().any() else None,
+            "median_r": float(sub["r_multiple"].median()) if sub["r_multiple"].notna().any() else None,
+            "max_drawdown_dollars": float(drawdown),
+            "max_consecutive_losses": max_consec,
+            "avg_mae_points": float(sub["mae_points"].mean()) if "mae_points" in sub and sub["mae_points"].notna().any() else None,
+            "avg_mfe_points": float(sub["mfe_points"].mean()) if "mfe_points" in sub and sub["mfe_points"].notna().any() else None,
+        }
+
+    result = {"overall": metrics_for(filled)}
+    for dim in ("session", "market_state", "direction", "setup_type"):
+        if dim in filled.columns:
+            result[f"by_{dim}"] = {str(k): metrics_for(g) for k, g in filled.groupby(dim)}
+    if "hour_et" in filled.columns:
+        result["by_hour_et"] = {str(k): metrics_for(g) for k, g in filled.groupby("hour_et")}
+
+    status_counts = df["setup_status"].value_counts().to_dict()
+    reason_counts = df["rejection_reason"].dropna().value_counts().to_dict()
+    result["status_counts"] = status_counts
+    result["rejection_reasons"] = reason_counts
+    return result
+
+
+# scalp/swing risk caps at RR=2.0, sized to reproduce the point magnitudes
+# already established earlier in this conversation's other sweeps (MNQ
+# swing ~100pt target, MGC swing ~20pt target) via risk*rr = target.
+TIER_MAX_RISK = {
+    "MNQ1!": {"scalp": 10.0, "swing": 50.0},
+    "MGC1!": {"scalp": 5.0, "swing": 10.0},
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MNQ1!")
+    parser.add_argument("--days", type=int, default=None)
+    parser.add_argument("--session", choices=list(SESSION_NAMES) + list(SESSION_GROUPS) + ["all"], default="all")
+    parser.add_argument("--tier", choices=["scalp", "swing"], default=None,
+                         help="convenience: sets --max-risk from TIER_MAX_RISK for this symbol")
+    parser.add_argument("--max-risk", type=float, default=None)
+    parser.add_argument("--rr", type=float, default=2.0)
+    args = parser.parse_args()
+
+    cfg = FabioConfig()
+    cfg.risk.rr_ratio = args.rr
+    if args.tier is not None:
+        cfg.risk.max_risk_points = TIER_MAX_RISK.get(args.symbol, TIER_MAX_RISK["MNQ1!"])[args.tier]
+    if args.max_risk is not None:
+        cfg.risk.max_risk_points = args.max_risk
+
+    if args.session == "all":
+        session_filter = None
+    elif args.session in SESSION_GROUPS:
+        session_filter = SESSION_GROUPS[args.session]
+    else:
+        session_filter = {args.session}
+    df = run_backtest(args.symbol, cfg, args.days, session_filter)
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+    out_path = OUT_DIR / f"{stem}_fabio.csv"
+    df.to_csv(out_path, index=False)
+    print(f"Wrote {len(df)} records to {out_path}", file=sys.stderr)
+    print(json.dumps(segmented_metrics(df), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/fabio_strategy/compare.py
+++ b/strategies/fabio_strategy/compare.py
@@ -1,0 +1,50 @@
+"""
+Runs the Fabio strategy across symbol x session x tier and prints one
+comparison table (overall metrics only — the full segmented breakdown for
+any individual run is available via backtest.py directly / the CSV logs).
+
+Run as a module from the repo root:
+    python -m strategies.fabio_strategy.compare
+"""
+import json
+import sys
+
+from .backtest import SESSION_GROUPS, TIER_MAX_RISK, run_backtest, segmented_metrics
+from .config import FabioConfig
+
+SYMBOLS = ("MNQ1!", "MGC1!")
+SESSIONS = ("asia", "ny")
+TIERS = ("scalp", "swing")
+
+
+def main():
+    rows = []
+    all_results = {}
+    for symbol in SYMBOLS:
+        for session in SESSIONS:
+            for tier in TIERS:
+                cfg = FabioConfig()
+                cfg.risk.rr_ratio = 2.0
+                cfg.risk.max_risk_points = TIER_MAX_RISK[symbol][tier]
+                df = run_backtest(symbol, cfg, days=None, session_filter=SESSION_GROUPS[session])
+                metrics = segmented_metrics(df)
+                key = f"{symbol} | {session} | {tier}"
+                all_results[key] = metrics
+                overall = metrics.get("overall", {})
+                rows.append((symbol, session, tier, overall))
+
+    print(json.dumps(all_results, indent=2, default=str))
+
+    print("\n=== Fabio strategy — symbol x session x tier (RR=2.0) ===", file=sys.stderr)
+    print(f"{'symbol':<8} {'session':<7} {'tier':<7} {'n':>5} {'win%':>7} {'PF':>7} {'avgR':>7} {'exp$':>8}", file=sys.stderr)
+    for symbol, session, tier, o in rows:
+        n = o.get("n", 0)
+        wr = f"{o.get('win_rate', 0) * 100:.1f}" if o.get("win_rate") is not None else "-"
+        pf = f"{o.get('profit_factor'):.2f}" if o.get("profit_factor") is not None else "-"
+        avgr = f"{o.get('avg_r'):.2f}" if o.get("avg_r") is not None else "-"
+        exp = f"{o.get('expectancy_dollars'):.2f}" if o.get("expectancy_dollars") is not None else "-"
+        print(f"{symbol:<8} {session:<7} {tier:<7} {n:>5} {wr:>7} {pf:>7} {avgr:>7} {exp:>8}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/fabio_strategy/config.py
+++ b/strategies/fabio_strategy/config.py
@@ -1,0 +1,184 @@
+"""
+All tunable parameters, grouped by concern (per the brief's "keep risk
+management separate from setup detection"). Every threshold here is a
+starting point, not a fitted value — same convention as the other two
+strategy families built this session.
+"""
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SessionWindows:
+    """All times ET. Asia wraps past midnight. ny_open_min_delay_minutes is
+    the configurable "minimum delay after cash open before trading" from
+    the brief's session-logic section."""
+    asia_start: str = "18:00"
+    asia_end: str = "02:00"
+    london_start: str = "03:00"
+    london_end: str = "08:00"
+    ny_premarket_start: str = "04:00"
+    ny_premarket_end: str = "09:29"
+    ny_open_start: str = "09:30"
+    ny_open_end: str = "11:30"
+    ny_pm_start: str = "11:30"
+    ny_pm_end: str = "16:00"
+    ny_open_min_delay_minutes: int = 15
+    globex_day_rollover_hour: int = 18
+
+
+@dataclass
+class SessionToggles:
+    asia_enabled: bool = True
+    london_enabled: bool = True
+    ny_premarket_enabled: bool = True
+    ny_open_enabled: bool = True
+    ny_pm_enabled: bool = True
+
+
+@dataclass
+class MarketStateConfig:
+    """5m-bar scoring model. Each of the 4 components is a simple boolean;
+    bull_score/bear_score count how many hold. Reaching the threshold (out
+    of 4) classifies the bar as directional; otherwise BALANCE. Not
+    requiring textbook HH-HL/LH-LL structure per the brief — this scoring
+    model works even when swing structure hasn't cleanly formed yet
+    (pre-market, Asian session)."""
+    ema9_slope_lookback_bars: int = 10
+    return_lookback_bars: int = 10
+    impulse_lookback_bars: int = 20
+    directional_score_threshold: int = 3  # out of 4
+
+
+@dataclass
+class SwingConfig:
+    lookback_bars_5m: int = 6
+    min_prominence_points: float = 2.0
+    max_tracked_swings: int = 3
+
+
+@dataclass
+class LocationToggles:
+    """Which location filters count as valid "the pullback failed near a
+    meaningful place" evidence for Setup A (trend-pullback continuation).
+    hvn_volume_area stays permanently off — this repo has no volume-profile
+    computation to back it; the toggle exists so the field is present when
+    that's built, not to fake a value now."""
+    ema9: bool = True
+    ema20: bool = True
+    vwap: bool = True
+    prior_breakout_level: bool = True
+    prior_swing: bool = True
+    hvn_volume_area: bool = False
+    location_tolerance_points: float = 1.0
+
+
+@dataclass
+class ImportantLevelToggles:
+    """Locations Setup B (failed-breakout reversal) and the balance-extreme
+    setup are allowed to fade. "Prior session high/low" per the brief is
+    implemented concretely as PDH/PDL plus the named Asian/London ranges,
+    not a generic catch-all."""
+    pdh: bool = True
+    pdl: bool = True
+    asian_range_high: bool = True
+    asian_range_low: bool = True
+    london_range_high: bool = True
+    london_range_low: bool = True
+    swing_high: bool = True
+    swing_low: bool = True
+
+
+@dataclass
+class PullbackConfig:
+    max_bars_to_failure: int = 15
+    stall_bars_required: int = 2
+    min_new_extreme_progress_points: float = 0.2
+    max_bars_to_ema9_trigger: int = 15
+    max_pullback_depth_points: float = 999.0  # a pullback that travels this far without failing is abandoned, not chased
+
+
+@dataclass
+class BreakoutConfig:
+    min_penetration_points: float = 0.3
+    max_bars_to_reclaim: int = 15
+    stall_bars_required: int = 2
+    min_new_extreme_progress_points: float = 0.2
+    # Separate from locations.location_tolerance_points (which governs Setup
+    # A's EMA9/EMA20/VWAP pullback-location check) — important levels like
+    # PDH/PDL sit at very different scales than an EMA touch, so sharing one
+    # tolerance would force both to trade off against each other.
+    approach_tolerance_points: float = 1.0
+
+
+@dataclass
+class AcceptanceConfig:
+    """Mandatory per the brief — the breakout-acceptance filter, same shape
+    as strategies/asian_failed_breakout's, reused here for both Setup B and
+    the transition-resolution logic (a breakdown being "accepted" IS the
+    bounce-failure event that confirms a new bearish direction)."""
+    max_closes_beyond_level: int = 3
+    max_distance_from_level_points: float = 3.0
+    max_further_penetration_points: float = 2.0
+
+
+@dataclass
+class TransitionConfig:
+    """Governs how long the strategy waits for a bounce/pullback to resolve
+    (fail or hold) after a level breaks against the prevailing state before
+    giving up and reverting to normal state scoring — prevents an
+    unresolved transition from permanently locking out new setups."""
+    max_bars_to_resolve: int = 40
+
+
+@dataclass
+class BalanceConfig:
+    range_lookback_bars_5m: int = 24  # ~2h on 5m — rolling window defining "the balance range" while state==BALANCE
+    min_range_points: float = 2.0
+    target_mode: str = "midpoint"  # "midpoint" or "opposite_extreme"
+
+
+@dataclass
+class MA9Config:
+    ema_period: int = 9
+    require_micro_structure_confirmation: bool = False
+    micro_structure_lookback_bars: int = 10
+    # Setup B's own reclaim -> EMA9-trigger timeout — was previously
+    # borrowing PullbackConfig.max_bars_to_ema9_trigger (Setup A's field),
+    # which meant tuning one setup's timeout silently changed the other's.
+    max_bars_to_trigger: int = 15
+
+
+@dataclass
+class OrderFlowConfig:
+    """No footprint/CVD/large-trade/ATAS feed exists in this codebase (see
+    the sweep strategies' identical note) — optional, off by default, and
+    can only ever adjust a confidence score, never independently trigger."""
+    enabled: bool = False
+
+
+@dataclass
+class RiskConfig:
+    stop_buffer_points: float = 0.2
+    max_risk_points: float = 10.0
+    rr_ratio: float = 2.0  # 1:2 RR, per the explicit instruction this strategy was requested under
+    partial_r_multiple: float = 1.0
+    partial_fraction: float = 0.5
+    move_stop_to_breakeven_after_partial: bool = True
+
+
+@dataclass
+class FabioConfig:
+    sessions: SessionWindows = field(default_factory=SessionWindows)
+    session_toggles: SessionToggles = field(default_factory=SessionToggles)
+    market_state: MarketStateConfig = field(default_factory=MarketStateConfig)
+    swing: SwingConfig = field(default_factory=SwingConfig)
+    locations: LocationToggles = field(default_factory=LocationToggles)
+    important_levels: ImportantLevelToggles = field(default_factory=ImportantLevelToggles)
+    pullback: PullbackConfig = field(default_factory=PullbackConfig)
+    breakout: BreakoutConfig = field(default_factory=BreakoutConfig)
+    acceptance: AcceptanceConfig = field(default_factory=AcceptanceConfig)
+    transition: TransitionConfig = field(default_factory=TransitionConfig)
+    balance: BalanceConfig = field(default_factory=BalanceConfig)
+    ma9: MA9Config = field(default_factory=MA9Config)
+    order_flow: OrderFlowConfig = field(default_factory=OrderFlowConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)

--- a/strategies/fabio_strategy/engine.py
+++ b/strategies/fabio_strategy/engine.py
@@ -1,0 +1,575 @@
+"""
+Core state machine. Three setup families, all gated by market state (never
+"isolated indicator" triggers per the brief):
+
+  Setup A (trend-pullback continuation) — only active in
+  BULLISH_DIRECTIONAL (long) / BEARISH_DIRECTIONAL (short). First EMA9 loss
+  in an uptrend starts a pullback watch, NOT a short (brief section 9) —
+  _PullbackCandidate only ever trades WITH the prevailing state.
+
+  Setup B (failed-breakout reversal) — fades important levels (PDH/PDL,
+  Asian/London range, swing points), direction gated by state: only fade a
+  broken LOW back up while state is bullish, only fade a broken HIGH back
+  down while bearish. Reuses asian_failed_breakout's proven _Candidate/State
+  machinery directly rather than re-deriving the same
+  break->observe->reclaim->trigger logic.
+
+  Balance-extreme fades reuse the exact same _ReversalCandidate mechanism,
+  fed the rolling balance-range high/low instead of the fixed important-
+  level list, active only while raw state == BALANCE — per the brief's
+  section 16, ONLY range-extreme fades are considered in BALANCE, not the
+  general important-level list, so the two level sources are mutually
+  exclusive per bar (never both active at once).
+
+TRANSITION: while a Setup-B candidate is fading a level break AGAINST the
+current directional state (e.g. bullish state, support just broke), the
+*effective* state reported for that bar is TRANSITION — this blocks new
+Setup-A pullback-continuation entries in the old direction (brief section
+15's "do not chase"). If that candidate's acceptance filter fires INVALID
+(the break gets accepted, i.e. the bounce/pullback-recovery attempt failed)
+the transition resolves to the OPPOSITE directional state for a bounded
+window, unlocking Setup-A entries in the new direction. If the candidate
+instead reaches ENTRY (reclaim + EMA9 held), the transition resolves back
+to the original state — the trend survived the test.
+"""
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from ..asian_failed_breakout.engine import State as RevState
+from ..asian_failed_breakout.engine import _Candidate as _ReversalCandidate
+from ..ny_open_strategies.common import OpenTrade, RiskParams, TradeLogRecord, force_close as _common_force_close
+from ..ny_open_strategies.common import update_open_trade as _common_update_trade
+
+SETUP_TYPES = ("TREND_PULLBACK_LONG", "TREND_PULLBACK_SHORT", "FAILED_BREAKDOWN_LONG",
+               "FAILED_BREAKOUT_SHORT", "BALANCE_EXTREME_LONG", "BALANCE_EXTREME_SHORT")
+
+_LONG_IMPORTANT_LEVELS = ("pdl", "asian_range_low", "london_range_low", "swing_low")
+_SHORT_IMPORTANT_LEVELS = ("pdh", "asian_range_high", "london_range_high", "swing_high")
+
+
+class PBState(str, Enum):
+    IDLE = "IDLE"
+    WAITING_FOR_FAILURE = "WAITING_FOR_FAILURE"
+
+
+@dataclass
+class FabioLogRecord:
+    timestamp: int
+    symbol: str
+    session: str
+    market_state: str
+    setup_type: str
+    direction: str
+    price: float
+    vwap: Optional[float] = None
+    ema9: Optional[float] = None
+    ema20: Optional[float] = None
+    important_level_type: Optional[str] = None
+    important_level_price: Optional[float] = None
+    pullback_start: Optional[int] = None
+    pullback_extreme: Optional[float] = None
+    breakout_extreme: Optional[float] = None
+    level_broken: Optional[int] = None
+    level_reclaimed: Optional[int] = None
+    ema9_trigger: Optional[int] = None
+    bars_in_setup: Optional[int] = None
+    entry_price: Optional[float] = None
+    stop_price: Optional[float] = None
+    target_price: Optional[float] = None
+    risk_distance: Optional[float] = None
+    optional_cvd: Optional[float] = None
+    optional_absorption: Optional[float] = None
+    optional_large_trade: Optional[float] = None
+    optional_stacked_imbalance: Optional[float] = None
+    setup_status: str = "PENDING"
+    rejection_reason: Optional[str] = None
+    exit_price: Optional[float] = None
+    exit_timestamp: Optional[int] = None
+    pnl_points: Optional[float] = None
+    pnl_dollars: Optional[float] = None
+    r_multiple: Optional[float] = None
+    mae_points: Optional[float] = None
+    mfe_points: Optional[float] = None
+
+
+@dataclass
+class _PullbackCandidate:
+    direction: str
+    state: PBState = PBState.IDLE
+    start_time: Optional[int] = None
+    origin_extreme: Optional[float] = None  # extreme at pullback start — anchor for max_pullback_depth_points
+    extreme: Optional[float] = None
+    bars_since_start: int = 0
+    stall_bars: int = 0
+    location_confirmed: bool = False
+    location_type: Optional[str] = None
+    location_price: Optional[float] = None
+
+    def reset(self):
+        self.__init__(direction=self.direction)
+
+
+@dataclass
+class _TrackedTrade:
+    trade: OpenTrade
+    record: FabioLogRecord
+    mae_points: float = 0.0
+    mfe_points: float = 0.0
+
+
+class FabioEngine:
+    def __init__(self, cfg, symbol: str, point_value: float):
+        self.cfg = cfg
+        self.symbol = symbol
+        self.point_value = point_value
+        self.pullback = {"long": _PullbackCandidate("long"), "short": _PullbackCandidate("short")}
+        self.reversal = {"long": _ReversalCandidate("long"), "short": _ReversalCandidate("short")}
+        rk = cfg.risk
+        self.risk_params = RiskParams(stop_buffer_points=rk.stop_buffer_points, max_risk_points=rk.max_risk_points,
+                                       target_r_multiple=rk.rr_ratio, partial_r_multiple=rk.partial_r_multiple,
+                                       partial_fraction=rk.partial_fraction,
+                                       move_stop_to_breakeven_after_partial=rk.move_stop_to_breakeven_after_partial)
+        self.open_trades: list[_TrackedTrade] = []
+        self._prev_close = None
+        self._prev_ema9 = None
+        self._micro_high_buf: list[float] = []
+        self._micro_low_buf: list[float] = []
+        self._last_accepted_breakout_level: Optional[float] = None
+        # transition override: while set, effective state overrides the raw
+        # 5m-scored state for this many more bars (brief section 14) —
+        # "TRANSITION" itself is reported when a reversal candidate is
+        # actively fading a break against the prevailing state.
+        self._transition_state: Optional[str] = None
+        self._transition_bars_left: int = 0
+
+    # ------------------------------------------------------------------
+    def effective_state(self, raw_state: str) -> str:
+        long_rev, short_rev = self.reversal["long"], self.reversal["short"]
+        fading_against_bull = raw_state == "BULLISH_DIRECTIONAL" and long_rev.state not in (RevState.IDLE, RevState.APPROACHING_LEVEL)
+        fading_against_bear = raw_state == "BEARISH_DIRECTIONAL" and short_rev.state not in (RevState.IDLE, RevState.APPROACHING_LEVEL)
+        if fading_against_bull or fading_against_bear:
+            return "TRANSITION"
+        if self._transition_bars_left > 0:
+            return self._transition_state
+        return raw_state
+
+    def on_bar(self, bar: dict, raw_state: str, vwap: float, ema9: float, ema20: Optional[float],
+               important_levels: dict, balance_range: Optional[dict], session: str,
+               tradeable: bool = True) -> list[FabioLogRecord]:
+        """tradeable: False during a configured session's no-trade delay
+        window (or outside any enabled session) — blocks NEW setup starts
+        (IDLE -> in-progress) but never interrupts a candidate or open trade
+        already in flight, same convention as the other two strategy
+        families."""
+        records: list[FabioLogRecord] = []
+        rk = self.risk_params
+
+        self._micro_high_buf.append(bar["high"])
+        self._micro_low_buf.append(bar["low"])
+        lookback = self.cfg.ma9.micro_structure_lookback_bars
+        self._micro_high_buf = self._micro_high_buf[-lookback:]
+        self._micro_low_buf = self._micro_low_buf[-lookback:]
+
+        if self._transition_bars_left > 0:
+            self._transition_bars_left -= 1
+
+        # --- trade management -------------------------------------------------
+        still_open = []
+        for t in self.open_trades:
+            is_long = t.trade.direction == "long"
+            adverse = (t.trade.entry_price - bar["low"]) if is_long else (bar["high"] - t.trade.entry_price)
+            favorable = (bar["high"] - t.trade.entry_price) if is_long else (t.trade.entry_price - bar["low"])
+            t.mae_points = max(t.mae_points, adverse)
+            t.mfe_points = max(t.mfe_points, favorable)
+            rec = _common_update_trade(t.trade, bar, rk, self.point_value)
+            if rec is not None:
+                self._finalize_trade(t, rec)  # copies exit/pnl/R plus t.mae_points/t.mfe_points onto t.record
+                records.append(t.record)
+            else:
+                still_open.append(t)
+        self.open_trades = still_open
+
+        # --- Setup B / balance-extreme reversal candidates ---------------------
+        if raw_state == "BALANCE" and balance_range:
+            levels_for_reversal = {"balance_range_low": balance_range.get("low"),
+                                    "balance_range_high": balance_range.get("high")}
+            long_fields, short_fields = ("balance_range_low",), ("balance_range_high",)
+        else:
+            levels_for_reversal = important_levels
+            long_fields, short_fields = _LONG_IMPORTANT_LEVELS, _SHORT_IMPORTANT_LEVELS
+
+        for direction, fields in (("long", long_fields), ("short", short_fields)):
+            allowed = (
+                (raw_state == "BALANCE") or
+                (direction == "long" and raw_state in ("BULLISH_DIRECTIONAL",)) or
+                (direction == "short" and raw_state in ("BEARISH_DIRECTIONAL",)) or
+                # a candidate already in flight keeps running even if state
+                # just flipped — it's the mechanism that RESOLVES the flip
+                (self.reversal[direction].state != RevState.IDLE)
+            )
+            rec = self._step_reversal(direction, allowed, tradeable, fields, levels_for_reversal, bar, ema9, session)
+            if rec is not None:
+                records.append(rec)
+                if rec.setup_status == "INVALID" and rec.rejection_reason == "BREAKOUT_ACCEPTED":
+                    # the break got accepted -> transition resolves to the
+                    # OPPOSITE of whatever this candidate was defending
+                    self._transition_state = "BEARISH_DIRECTIONAL" if direction == "long" else "BULLISH_DIRECTIONAL"
+                    self._transition_bars_left = self.cfg.transition.max_bars_to_resolve
+
+        # --- Setup A pullback continuation -------------------------------------
+        # Computed AFTER the Setup-B loop above (not before it) so a level
+        # break that happens on THIS bar is reflected in the TRANSITION gate
+        # immediately, rather than one bar late — otherwise Setup A could
+        # start a new pullback-continuation watch on the very bar structure
+        # broke, exactly the "chasing" the brief's TRANSITION state exists
+        # to prevent.
+        state = self.effective_state(raw_state)
+        for direction in ("long", "short"):
+            active_state = "BULLISH_DIRECTIONAL" if direction == "long" else "BEARISH_DIRECTIONAL"
+            allowed = state == active_state
+            if not allowed:
+                self.pullback[direction].reset()
+                continue
+            rec = self._step_pullback(direction, bar, ema9, ema20, vwap, important_levels, session, tradeable)
+            if rec is not None:
+                records.append(rec)
+
+        self._prev_close = bar["close"]
+        self._prev_ema9 = ema9
+        return records
+
+    # ------------------------------------------------------------------
+    def _finalize_trade(self, t: _TrackedTrade, generic_rec) -> None:
+        r = t.record
+        r.exit_price = generic_rec.exit_price
+        r.exit_timestamp = generic_rec.exit_time
+        r.pnl_points = generic_rec.pnl_points
+        r.pnl_dollars = generic_rec.pnl_dollars
+        r.r_multiple = generic_rec.r_multiple
+        r.setup_status = generic_rec.status
+        r.mae_points = t.mae_points
+        r.mfe_points = t.mfe_points
+
+    def force_close_all(self, last_bar: dict) -> list[FabioLogRecord]:
+        out = []
+        for t in self.open_trades:
+            generic = _common_force_close(t.trade, last_bar, self.point_value)
+            self._finalize_trade(t, generic)
+            out.append(t.record)
+        self.open_trades = []
+        return out
+
+    def _open_trade(self, direction: str, setup_type: str, entry_price: float, stop: float, bar: dict,
+                     record_kwargs: dict) -> None:
+        risk_distance = abs(entry_price - stop)
+        rk = self.cfg.risk
+        rr = rk.rr_ratio
+        is_long = direction == "long"
+        partial_target = entry_price + rk.partial_r_multiple * risk_distance if is_long else \
+                          entry_price - rk.partial_r_multiple * risk_distance
+        final_target = entry_price + rr * risk_distance if is_long else entry_price - rr * risk_distance
+
+        record = FabioLogRecord(symbol=self.symbol, direction=direction, setup_type=setup_type,
+                                 entry_price=entry_price, stop_price=stop, target_price=final_target,
+                                 risk_distance=risk_distance, setup_status="OPEN", **record_kwargs)
+        # OpenTrade.record is mutated directly by the shared update_open_trade/
+        # force_close in ny_open_strategies.common — it needs a real
+        # TradeLogRecord (not our FabioLogRecord, different schema), used
+        # only as scratch space; _finalize_trade copies the fields we care
+        # about onto `record` (our actual FabioLogRecord) when the trade closes.
+        placeholder = TradeLogRecord(strategy="fabio", symbol=self.symbol, direction=direction, signal_time=bar["time"])
+        trade = OpenTrade(direction=direction, entry_price=entry_price, entry_time=bar["time"], stop_price=stop,
+                           initial_risk=risk_distance, partial_target_price=partial_target,
+                           final_target_price=final_target, record=placeholder)
+        self.open_trades.append(_TrackedTrade(trade=trade, record=record))
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _is_balance_level(level_type: Optional[str]) -> bool:
+        """Whether a candidate is a balance-range fade rather than an
+        important-level reversal — derived from the candidate's OWN
+        level_type (set once, at candidate creation) rather than recomputed
+        from the current bar's raw_state. A candidate started while
+        raw_state=="BALANCE" stays a balance-extreme fade for its whole
+        lifetime even if raw_state later flips to directional while it's
+        still in flight — otherwise it can flip labels (and, worse, leak a
+        balance-range price into Setup A's prior_breakout_level filter as if
+        it were a genuinely accepted important-level breakout)."""
+        return level_type is not None and level_type.startswith("balance_range")
+
+    def _step_reversal(self, direction: str, allowed: bool, tradeable: bool, level_fields: tuple, levels: dict,
+                        bar: dict, ema9: float, session: str) -> Optional[FabioLogRecord]:
+        c = self.reversal[direction]
+        is_long = direction == "long"
+        cfg = self.cfg
+
+        if c.state == RevState.IDLE and (not allowed or not tradeable):
+            return None
+
+        if c.state == RevState.LEVEL_BROKEN:
+            c.state = RevState.OBSERVING
+        elif c.state == RevState.LEVEL_RECLAIMED:
+            c.state = RevState.WAITING_FOR_MA9
+
+        if c.state == RevState.IDLE:
+            best_type, best_price, best_dist = None, None, None
+            for name in level_fields:
+                price = levels.get(name)
+                if price is None:
+                    continue
+                dist = abs(bar["close"] - price)
+                if best_dist is None or dist < best_dist:
+                    best_type, best_price, best_dist = name, price, dist
+            if best_type is None or best_dist > cfg.breakout.approach_tolerance_points * 4:
+                return None
+            c.level_type, c.level_price, c.approach_time = best_type, best_price, bar["time"]
+            c.state = RevState.APPROACHING_LEVEL
+            # fall through to evaluate the break on this same bar
+
+        if c.state == RevState.APPROACHING_LEVEL:
+            pen = cfg.breakout.min_penetration_points
+            broken = (bar["low"] < c.level_price - pen) if is_long else (bar["high"] > c.level_price + pen)
+            if broken:
+                extreme = bar["low"] if is_long else bar["high"]
+                c.break_price, c.break_time = bar["close"], bar["time"]
+                c.break_extreme_initial = extreme
+                c.sweep_extreme = extreme
+                c.max_penetration = abs(c.level_price - extreme)
+                c.bars_since_break = 0
+                c.state = RevState.LEVEL_BROKEN
+                return None
+            if abs(bar["close"] - c.level_price) > cfg.breakout.approach_tolerance_points * 2:
+                c.reset()
+            return None
+
+        if c.state == RevState.OBSERVING:
+            c.bars_since_break += 1
+            extreme_now = bar["low"] if is_long else bar["high"]
+            pushed = (extreme_now < c.sweep_extreme) if is_long else (extreme_now > c.sweep_extreme)
+            if pushed:
+                progress = abs(c.sweep_extreme - extreme_now)
+                c.sweep_extreme = extreme_now
+                c.max_penetration = abs(c.level_price - c.sweep_extreme)
+                c.stall_bars = 0 if progress >= cfg.breakout.min_new_extreme_progress_points else c.stall_bars + 1
+            else:
+                c.stall_bars += 1
+
+            beyond = (bar["close"] < c.level_price) if is_long else (bar["close"] > c.level_price)
+            if beyond:
+                c.closes_beyond_level_count += 1
+            distance = abs(c.level_price - bar["close"]) if beyond else 0.0
+            further = abs(c.break_extreme_initial - c.sweep_extreme)
+            acc = cfg.acceptance
+            if (c.closes_beyond_level_count > acc.max_closes_beyond_level
+                    or distance > acc.max_distance_from_level_points
+                    or further > acc.max_further_penetration_points):
+                rec = self._finalize_reversal(c, "INVALID", "BREAKOUT_ACCEPTED", direction, session)
+                c.reset()
+                return rec
+
+            reclaimed = (bar["close"] > c.level_price) if is_long else (bar["close"] < c.level_price)
+            if reclaimed:
+                c.reclaim_time = bar["time"]
+                c.bars_since_reclaim = 0
+                c.state = RevState.LEVEL_RECLAIMED
+                return None
+            if c.bars_since_break >= cfg.breakout.max_bars_to_reclaim:
+                rec = self._finalize_reversal(c, "EXPIRED", "SETUP_EXPIRED", direction, session)
+                c.reset()
+                return rec
+            return None
+
+        if c.state == RevState.WAITING_FOR_MA9:
+            c.bars_since_reclaim += 1
+            beyond = (bar["close"] < c.level_price) if is_long else (bar["close"] > c.level_price)
+            if beyond:
+                c.closes_beyond_level_count += 1
+                if c.closes_beyond_level_count > cfg.acceptance.max_closes_beyond_level:
+                    rec = self._finalize_reversal(c, "INVALID", "BREAKOUT_ACCEPTED", direction, session)
+                    c.reset()
+                    return rec
+
+            if self._prev_close is None or self._prev_ema9 is None:
+                return None
+            trigger = (self._prev_close <= self._prev_ema9 and bar["close"] > ema9) if is_long else \
+                      (self._prev_close >= self._prev_ema9 and bar["close"] < ema9)
+            if trigger:
+                is_balance = self._is_balance_level(c.level_type)
+                entry_price = bar["close"]
+                stop = (c.sweep_extreme - cfg.risk.stop_buffer_points) if is_long else \
+                       (c.sweep_extreme + cfg.risk.stop_buffer_points)
+                risk_distance = abs(entry_price - stop)
+                if risk_distance <= 0 or risk_distance > cfg.risk.max_risk_points:
+                    rec = self._finalize_reversal(c, "INVALID", "RISK_TOO_LARGE", direction, session)
+                    c.reset()
+                    return rec
+                setup_type = ("BALANCE_EXTREME_LONG" if is_balance else "FAILED_BREAKDOWN_LONG") if is_long else \
+                             ("BALANCE_EXTREME_SHORT" if is_balance else "FAILED_BREAKOUT_SHORT")
+                self._open_trade(direction, setup_type, entry_price, stop, bar, dict(
+                    timestamp=c.approach_time, session=session, market_state=("BALANCE" if is_balance else "TRANSITION"),
+                    price=entry_price, important_level_type=c.level_type, important_level_price=c.level_price,
+                    breakout_extreme=c.sweep_extreme, level_broken=c.break_time, level_reclaimed=c.reclaim_time,
+                    ema9_trigger=bar["time"], ema9=ema9,
+                    bars_in_setup=self._bars_between(c.approach_time, bar["time"]),
+                ))
+                if not is_balance:
+                    # the level held (reclaim + EMA9 confirmed) -> the trend
+                    # survived the test; clear any pending transition and
+                    # remember this level as the new "prior breakout level"
+                    # location filter for Setup A pullbacks.
+                    self._last_accepted_breakout_level = c.level_price
+                    self._transition_bars_left = 0
+                c.reset()
+                return None
+            if c.bars_since_reclaim >= cfg.ma9.max_bars_to_trigger:
+                rec = self._finalize_reversal(c, "EXPIRED", "SETUP_EXPIRED", direction, session)
+                c.reset()
+                return rec
+            return None
+        return None
+
+    def _finalize_reversal(self, c: _ReversalCandidate, status: str, reason: str, direction: str,
+                            session: str) -> FabioLogRecord:
+        is_long = direction == "long"
+        is_balance = self._is_balance_level(c.level_type)
+        setup_type = ("BALANCE_EXTREME_LONG" if is_balance else "FAILED_BREAKDOWN_LONG") if is_long else \
+                     ("BALANCE_EXTREME_SHORT" if is_balance else "FAILED_BREAKOUT_SHORT")
+        return FabioLogRecord(
+            timestamp=c.approach_time, symbol=self.symbol, session=session,
+            market_state=("BALANCE" if is_balance else "TRANSITION"), setup_type=setup_type, direction=direction,
+            price=c.level_price, important_level_type=c.level_type, important_level_price=c.level_price,
+            breakout_extreme=c.sweep_extreme, level_broken=c.break_time, level_reclaimed=c.reclaim_time,
+            bars_in_setup=self._bars_between(c.approach_time, c.break_time),
+            setup_status=status, rejection_reason=reason,
+        )
+
+    # ------------------------------------------------------------------
+    def _step_pullback(self, direction: str, bar: dict, ema9: float, ema20: Optional[float], vwap: float,
+                        important_levels: dict, session: str, tradeable: bool) -> Optional[FabioLogRecord]:
+        c = self.pullback[direction]
+        is_long = direction == "long"
+        cfg = self.cfg
+
+        if c.state == PBState.IDLE:
+            if not tradeable or self._prev_close is None or self._prev_ema9 is None:
+                return None
+            crossed = (self._prev_close >= self._prev_ema9 and bar["close"] < ema9) if is_long else \
+                      (self._prev_close <= self._prev_ema9 and bar["close"] > ema9)
+            if crossed:
+                c.state = PBState.WAITING_FOR_FAILURE
+                c.start_time = bar["time"]
+                c.origin_extreme = c.extreme = bar["low"] if is_long else bar["high"]
+                c.bars_since_start = 0
+                c.location_confirmed, c.location_type, c.location_price = False, None, None
+            return None
+
+        # WAITING_FOR_FAILURE
+        c.bars_since_start += 1
+        extreme_now = bar["low"] if is_long else bar["high"]
+        pushed = (extreme_now < c.extreme) if is_long else (extreme_now > c.extreme)
+        if pushed:
+            progress = abs(c.extreme - extreme_now)
+            c.extreme = extreme_now
+            c.stall_bars = 0 if progress >= cfg.pullback.min_new_extreme_progress_points else c.stall_bars + 1
+        else:
+            c.stall_bars += 1
+
+        if not c.location_confirmed:
+            loc_type, loc_price = self._check_location(c.extreme, ema9, ema20, vwap, important_levels)
+            if loc_type:
+                c.location_confirmed, c.location_type, c.location_price = True, loc_type, loc_price
+
+        depth = abs(c.extreme - c.origin_extreme)
+        if (c.bars_since_start >= cfg.pullback.max_bars_to_failure
+                or depth > cfg.pullback.max_pullback_depth_points):
+            rec = FabioLogRecord(timestamp=c.start_time, symbol=self.symbol, session=session,
+                                  market_state="BULLISH_DIRECTIONAL" if is_long else "BEARISH_DIRECTIONAL",
+                                  setup_type="TREND_PULLBACK_LONG" if is_long else "TREND_PULLBACK_SHORT",
+                                  direction=direction, price=bar["close"], pullback_start=c.start_time,
+                                  pullback_extreme=c.extreme, bars_in_setup=c.bars_since_start,
+                                  setup_status="EXPIRED", rejection_reason="SETUP_EXPIRED")
+            c.reset()
+            return rec
+
+        if self._prev_close is None or self._prev_ema9 is None:
+            return None
+        trigger = (self._prev_close <= self._prev_ema9 and bar["close"] > ema9) if is_long else \
+                  (self._prev_close >= self._prev_ema9 and bar["close"] < ema9)
+        if trigger and cfg.ma9.require_micro_structure_confirmation:
+            # Optional confirmation per the brief section 7: current_close >
+            # recent_micro_lower_high (long) / < recent_micro_higher_low
+            # (short) — using bars strictly before this trigger bar so the
+            # trigger bar's own high/low can't confirm itself.
+            prior_highs = self._micro_high_buf[:-1]
+            prior_lows = self._micro_low_buf[:-1]
+            if is_long:
+                trigger = bool(prior_highs) and bar["close"] > max(prior_highs)
+            else:
+                trigger = bool(prior_lows) and bar["close"] < min(prior_lows)
+        if not trigger:
+            return None
+
+        if not c.location_confirmed:
+            rec = FabioLogRecord(timestamp=c.start_time, symbol=self.symbol, session=session,
+                                  market_state="BULLISH_DIRECTIONAL" if is_long else "BEARISH_DIRECTIONAL",
+                                  setup_type="TREND_PULLBACK_LONG" if is_long else "TREND_PULLBACK_SHORT",
+                                  direction=direction, price=bar["close"], pullback_start=c.start_time,
+                                  pullback_extreme=c.extreme, bars_in_setup=c.bars_since_start,
+                                  setup_status="INVALID", rejection_reason="NO_IMPORTANT_LOCATION")
+            c.reset()
+            return rec
+
+        entry_price = bar["close"]
+        stop = (c.extreme - cfg.risk.stop_buffer_points) if is_long else (c.extreme + cfg.risk.stop_buffer_points)
+        risk_distance = abs(entry_price - stop)
+        setup_type = "TREND_PULLBACK_LONG" if is_long else "TREND_PULLBACK_SHORT"
+        if risk_distance <= 0 or risk_distance > cfg.risk.max_risk_points:
+            rec = FabioLogRecord(timestamp=c.start_time, symbol=self.symbol, session=session,
+                                  market_state="BULLISH_DIRECTIONAL" if is_long else "BEARISH_DIRECTIONAL",
+                                  setup_type=setup_type, direction=direction, price=entry_price,
+                                  pullback_start=c.start_time, pullback_extreme=c.extreme,
+                                  important_level_type=c.location_type, important_level_price=c.location_price,
+                                  stop_price=stop, risk_distance=risk_distance, bars_in_setup=c.bars_since_start,
+                                  setup_status="INVALID", rejection_reason="RISK_TOO_LARGE")
+            c.reset()
+            return rec
+
+        self._open_trade(direction, setup_type, entry_price, stop, bar, dict(
+            timestamp=c.start_time, session=session,
+            market_state="BULLISH_DIRECTIONAL" if is_long else "BEARISH_DIRECTIONAL",
+            price=entry_price, important_level_type=c.location_type, important_level_price=c.location_price,
+            pullback_start=c.start_time, pullback_extreme=c.extreme, ema9_trigger=bar["time"], ema9=ema9,
+            vwap=vwap, ema20=ema20, bars_in_setup=c.bars_since_start,
+        ))
+        c.reset()
+        return None
+
+    def _check_location(self, price: float, ema9: float, ema20: Optional[float], vwap: float,
+                         important_levels: Optional[dict] = None):
+        tol = self.cfg.locations.location_tolerance_points
+        loc = self.cfg.locations
+        if loc.ema9 and abs(price - ema9) <= tol:
+            return "ema9", ema9
+        if loc.ema20 and ema20 is not None and abs(price - ema20) <= tol:
+            return "ema20", ema20
+        if loc.vwap and abs(price - vwap) <= tol:
+            return "vwap", vwap
+        if loc.prior_breakout_level and self._last_accepted_breakout_level is not None \
+                and abs(price - self._last_accepted_breakout_level) <= tol:
+            return "prior_breakout_level", self._last_accepted_breakout_level
+        if loc.prior_swing and important_levels:
+            # a long pullback's extreme is a low, so a nearby swing_low is
+            # the relevant reference; a short pullback's extreme is a high,
+            # checked against swing_high.
+            for name in ("swing_low", "swing_high"):
+                swing_price = important_levels.get(name)
+                if swing_price is not None and abs(price - swing_price) <= tol:
+                    return name, swing_price
+        return None, None
+
+    @staticmethod
+    def _bars_between(t1, t2, bar_seconds: int = 60):
+        if t1 is None or t2 is None:
+            return None
+        return int(round((t2 - t1) / bar_seconds))

--- a/strategies/fabio_strategy/levels.py
+++ b/strategies/fabio_strategy/levels.py
@@ -1,0 +1,86 @@
+"""
+Important-location tracker: PDH/PDL, current Asian range, current London
+range, and confirmed swing highs/lows — all fed 5m bars incrementally and
+causal (a location is only visible once the 5m bar that updates it has
+actually closed).
+
+Reuses strategies/asian_failed_breakout/levels.py's LevelTracker directly
+for PDH/PDL, Asian range, and swing points (same PDH/PDL/Asian-range/swing
+concepts, no reason to duplicate them) and adds a small London-range
+tracker alongside it, using the same wrap-aware window/Globex-day utilities.
+"""
+from dataclasses import dataclass
+
+from ..asian_failed_breakout.config import AsianRangeConfig, SessionConfig as AsianSessionConfig, SwingConfig
+from ..asian_failed_breakout.levels import LevelTracker as _AsianStyleLevelTracker
+from ..asian_failed_breakout.levels import _globex_day_id, _in_window, _parse_hm
+
+
+class LocationTracker:
+    def __init__(self, cfg):
+        s = cfg.sessions
+        asian_session_cfg = AsianSessionConfig(
+            asian_session_start=s.asia_start, asian_session_end=s.asia_end,
+            globex_day_rollover_hour=s.globex_day_rollover_hour,
+        )
+        self._base = _AsianStyleLevelTracker(asian_session_cfg, cfg.swing, AsianRangeConfig(min_bars_5m_before_use=1))
+
+        self._london_start_min = _parse_hm(s.london_start)
+        self._london_end_min = _parse_hm(s.london_end)
+        self._rollover_hour = s.globex_day_rollover_hour
+        self._london_day = None
+        self.london_range_high = None
+        self.london_range_low = None
+
+    def update(self, bar: dict, et_ts) -> None:
+        self._base.update(bar, et_ts)
+
+        day = _globex_day_id(et_ts, self._rollover_hour)
+        if day != self._london_day:
+            self._london_day = day
+            self.london_range_high = None
+            self.london_range_low = None
+        tod = et_ts.hour * 60 + et_ts.minute
+        if _in_window(tod, self._london_start_min, self._london_end_min):
+            if self.london_range_high is None:
+                self.london_range_high, self.london_range_low = bar["high"], bar["low"]
+            else:
+                self.london_range_high = max(self.london_range_high, bar["high"])
+                self.london_range_low = min(self.london_range_low, bar["low"])
+
+    @property
+    def pdh(self):
+        return self._base.pdh
+
+    @property
+    def pdl(self):
+        return self._base.pdl
+
+    @property
+    def asian_range_high(self):
+        return self._base.asian_range_high
+
+    @property
+    def asian_range_low(self):
+        return self._base.asian_range_low
+
+    @property
+    def swing_high(self):
+        return self._base.swing_high
+
+    @property
+    def swing_low(self):
+        return self._base.swing_low
+
+    def get_levels(self, toggles) -> dict:
+        candidates = {
+            "pdh": self.pdh if toggles.pdh else None,
+            "pdl": self.pdl if toggles.pdl else None,
+            "asian_range_high": self.asian_range_high if toggles.asian_range_high else None,
+            "asian_range_low": self.asian_range_low if toggles.asian_range_low else None,
+            "london_range_high": self.london_range_high if toggles.london_range_high else None,
+            "london_range_low": self.london_range_low if toggles.london_range_low else None,
+            "swing_high": self.swing_high if toggles.swing_high else None,
+            "swing_low": self.swing_low if toggles.swing_low else None,
+        }
+        return {k: v for k, v in candidates.items() if v is not None}

--- a/strategies/fabio_strategy/market_state.py
+++ b/strategies/fabio_strategy/market_state.py
@@ -1,0 +1,58 @@
+"""
+5m-bar market-state classifier: BULLISH_DIRECTIONAL / BEARISH_DIRECTIONAL /
+BALANCE, via the scoring model from the brief. Deliberately NOT requiring
+textbook HH-HL/LH-LL swing structure — the four components (price vs VWAP,
+EMA9 slope, recent return, impulse-count dominance) all work even when
+clean swing structure hasn't formed (pre-market, Asian session), which is
+exactly the brief's stated reason for avoiding a structure-based classifier.
+
+This is pure vectorized pandas over 5m bars (causal — every component only
+looks backward), with a separate join step (fabio_strategy/backtest.py)
+responsible for making sure a 1m bar only ever sees a 5m state that had
+actually closed by that point, using the same close-time-aligned discipline
+established earlier this session for build_dataset.py's lookahead fix.
+"""
+import numpy as np
+import pandas as pd
+
+
+def compute_market_state(df5: pd.DataFrame, cfg) -> pd.DataFrame:
+    """df5 must already have 'vwap' and 'ema9' columns."""
+    df5 = df5.copy()
+    ms = cfg.market_state
+
+    price_above_vwap = df5["close"] > df5["vwap"]
+    price_below_vwap = df5["close"] < df5["vwap"]
+
+    ema9_slope = df5["ema9"].diff(ms.ema9_slope_lookback_bars)
+    ema9_slope_positive = ema9_slope > 0
+    ema9_slope_negative = ema9_slope < 0
+
+    recent_return = df5["close"].diff(ms.return_lookback_bars)
+    recent_return_positive = recent_return > 0
+    recent_return_negative = recent_return < 0
+
+    bar_dir = np.sign(df5["close"] - df5["open"])
+    up_impulses = (bar_dir > 0).rolling(ms.impulse_lookback_bars).sum()
+    down_impulses = (bar_dir < 0).rolling(ms.impulse_lookback_bars).sum()
+    bullish_impulse_dominance = up_impulses > down_impulses
+    bearish_impulse_dominance = down_impulses > up_impulses
+
+    bull_score = (price_above_vwap.astype(int) + ema9_slope_positive.astype(int)
+                  + recent_return_positive.astype(int) + bullish_impulse_dominance.astype(int))
+    bear_score = (price_below_vwap.astype(int) + ema9_slope_negative.astype(int)
+                  + recent_return_negative.astype(int) + bearish_impulse_dominance.astype(int))
+
+    state = pd.Series("BALANCE", index=df5.index, dtype=object)
+    is_bull = bull_score >= ms.directional_score_threshold
+    is_bear = bear_score >= ms.directional_score_threshold
+    state[is_bull & ~is_bear] = "BULLISH_DIRECTIONAL"
+    state[is_bear & ~is_bull] = "BEARISH_DIRECTIONAL"
+    both = is_bull & is_bear  # shouldn't happen given the mutually-exclusive components, but guard anyway
+    state[both & (bull_score >= bear_score)] = "BULLISH_DIRECTIONAL"
+    state[both & (bear_score > bull_score)] = "BEARISH_DIRECTIONAL"
+
+    df5["bull_score"] = bull_score
+    df5["bear_score"] = bear_score
+    df5["raw_market_state"] = state
+    return df5

--- a/strategies/news_aggregator.py
+++ b/strategies/news_aggregator.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+News aggregator — tracks headline-level events that can move futures during
+thin Asian-hours liquidity: Trump statements, Iran/Middle East news, oil price
+moves, Fed/rate headlines. Uses Google News RSS (no API key) + yfinance for
+oil price. Pure stdlib XML parsing — no feedparser dependency required.
+
+Usage:
+    python3 news_aggregator.py [--max-per-topic 5]
+
+Output (stdout, JSON):
+    {
+      "topics": {
+        "trump":  [ { "title": "...", "link": "...", "published": "...", "source": "..." }, ... ],
+        "iran":   [ ... ],
+        "fed":    [ ... ],
+        "geopolitical": [ ... ]
+      },
+      "oil": { "WTI": { "price": 78.2, "changePct": 1.3 }, "Brent": { ... } }
+    }
+"""
+import sys
+import json
+import argparse
+import urllib.request
+import urllib.parse
+import xml.etree.ElementTree as ET
+
+import yfinance as yf
+
+TOPICS = {
+    "trump":        "Trump statement OR Trump tweet OR Trump announcement",
+    "iran":         "Iran OR Strait of Hormuz OR Middle East conflict",
+    "fed":          "Federal Reserve rate decision OR FOMC",
+    "geopolitical": "war OR sanctions OR military strike",
+}
+
+OIL_TICKERS = {"WTI": "CL=F", "Brent": "BZ=F"}
+
+GOOGLE_NEWS_RSS = "https://news.google.com/rss/search?q={query}&hl=en-US&gl=US&ceid=US:en"
+TIMEOUT_SEC = 8
+
+
+def fetch_topic(query, max_items):
+    url = GOOGLE_NEWS_RSS.format(query=urllib.parse.quote(query))
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+            data = resp.read()
+        root = ET.fromstring(data)
+        items = []
+        for item in root.findall("./channel/item")[:max_items]:
+            title = (item.findtext("title") or "").strip()
+            link = (item.findtext("link") or "").strip()
+            pub_date = (item.findtext("pubDate") or "").strip()
+            source_el = item.find("source")
+            source = source_el.text if source_el is not None else ""
+            items.append({"title": title, "link": link, "published": pub_date, "source": source})
+        return items
+    except Exception as e:
+        return [{"error": str(e)}]
+
+
+def fetch_oil():
+    out = {}
+    for label, ticker in OIL_TICKERS.items():
+        try:
+            t = yf.Ticker(ticker)
+            hist = t.history(period="5d", interval="1d")
+            if hist is None or hist.empty or len(hist) < 2:
+                out[label] = {"error": "no data"}
+                continue
+            last = float(hist["Close"].iloc[-1])
+            prev = float(hist["Close"].iloc[-2])
+            out[label] = {
+                "price": round(last, 2),
+                "changePct": round((last - prev) / prev * 100, 2),
+            }
+        except Exception as e:
+            out[label] = {"error": str(e)}
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-per-topic", type=int, default=5)
+    args = parser.parse_args()
+
+    topics = {key: fetch_topic(query, args.max_per_topic) for key, query in TOPICS.items()}
+    oil = fetch_oil()
+
+    print(json.dumps({"topics": topics, "oil": oil}))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/ny_open_strategies/__init__.py
+++ b/strategies/ny_open_strategies/__init__.py
@@ -1,0 +1,11 @@
+"""
+NY-session strategy family: VWAP mean-reversion, liquidity-sweep reversal,
+MA9 trend-following, and opening-range breakout. All four are scoped to the
+NY session (09:30-16:00 ET) with entries blocked during the first 15 minutes
+after the open (configurable) — the open is far more volatile than the rest
+of the session and isn't a regime any of these rules were designed for.
+
+Run any single strategy's backtest as a module, e.g.:
+    python -m strategies.ny_open_strategies.vwap_reversion --symbol MGC1!
+    python -m strategies.ny_open_strategies.backtest_all --symbol MGC1!
+"""

--- a/strategies/ny_open_strategies/backtest_all.py
+++ b/strategies/ny_open_strategies/backtest_all.py
@@ -1,0 +1,59 @@
+"""
+Runs all four NY-session strategies (VWAP reversion, MA9 trend-following,
+opening range breakout, liquidity-sweep reversal) plus the Asian
+failed-breakout strategy over the same symbol/window and prints one
+comparison table — so results are read side by side rather than as four
+separate JSON blobs.
+
+Run as a module from the repo root:
+    python -m strategies.ny_open_strategies.backtest_all --symbol MGC1! --days 30
+"""
+import argparse
+import json
+import sys
+
+from ..asian_failed_breakout.backtest import run_backtest as run_asian
+from ..asian_failed_breakout.backtest import summarize as summarize_asian
+from ..asian_failed_breakout.config import StrategyConfig as AsianConfig
+from . import liquidity_sweep_reversal as ny_sweep
+from . import ma9_trend_following as ma9
+from . import opening_range_breakout as orb
+from . import vwap_reversion as vwap
+from .common import summarize as summarize_generic
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=None)
+    parser.add_argument("--skip-asian", action="store_true", help="skip the Asian failed-breakout strategy")
+    args = parser.parse_args()
+
+    results = {}
+
+    if not args.skip_asian:
+        df = run_asian(args.symbol, AsianConfig(), args.days)
+        results["asian_failed_breakout"] = summarize_asian(df)
+
+    df_ny = ny_sweep.run_backtest(args.symbol, AsianConfig(), args.days)
+    results["ny_liquidity_sweep_reversal"] = ny_sweep.summarize(df_ny)
+
+    results["vwap_reversion"] = summarize_generic(vwap.run_backtest(args.symbol, vwap.VWAPReversionConfig(), args.days))
+    results["ma9_trend_following"] = summarize_generic(ma9.run_backtest(args.symbol, ma9.MA9TrendConfig(), args.days))
+    results["opening_range_breakout"] = summarize_generic(orb.run_backtest(args.symbol, orb.ORBConfig(), args.days))
+
+    print(json.dumps(results, indent=2, default=str))
+
+    print("\n=== Summary ===", file=sys.stderr)
+    print(f"{'strategy':<28} {'trades':>7} {'win%':>7} {'PF':>7} {'avgR':>7} {'total$':>10}", file=sys.stderr)
+    for name, r in results.items():
+        n = r.get("n_trades_filled", 0)
+        wr = f"{r.get('win_rate', 0) * 100:.1f}" if r.get("win_rate") is not None else "-"
+        pf = f"{r.get('profit_factor'):.2f}" if r.get("profit_factor") is not None else "-"
+        avgr = f"{r.get('avg_r_multiple'):.2f}" if r.get("avg_r_multiple") is not None else "-"
+        total = f"{r.get('total_pnl_dollars'):.0f}" if r.get("total_pnl_dollars") is not None else "-"
+        print(f"{name:<28} {n:>7} {wr:>7} {pf:>7} {avgr:>7} {total:>10}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/ny_open_strategies/common.py
+++ b/strategies/ny_open_strategies/common.py
@@ -1,0 +1,276 @@
+"""
+Shared data loading, indicators, and trade-management machinery for the
+NY-session strategy family. The partial/runner/breakeven trade management
+here mirrors strategies/asian_failed_breakout/engine.py's OpenTrade handling
+(same blended-PnL logic) but is kept standalone rather than imported, since
+these strategies aren't otherwise coupled to that module's Asian-specific
+SetupLogRecord.
+"""
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+RAW_DIR = Path.home() / "data" / "ml-raw"
+SYMBOLS_CONFIG = Path(__file__).resolve().parent.parent.parent / "ml" / "config" / "symbols.json"
+OUT_DIR = Path.home() / "data" / "ny-strategy-backtests"
+ET = "America/New_York"
+
+NY_SESSION_START_MIN = 9 * 60 + 30
+NY_SESSION_END_MIN = 16 * 60
+ASIAN_SESSION_START_MIN = 18 * 60  # wraps past midnight — matches sessions.json / asian_failed_breakout's convention
+ASIAN_SESSION_END_MIN = 2 * 60
+
+SESSION_WINDOWS = {
+    "ny": (NY_SESSION_START_MIN, NY_SESSION_END_MIN),
+    "asian": (ASIAN_SESSION_START_MIN, ASIAN_SESSION_END_MIN),
+}
+
+
+def _in_window(tod_min, start_min: int, end_min: int):
+    if start_min <= end_min:
+        return (tod_min >= start_min) & (tod_min < end_min)
+    return (tod_min >= start_min) | (tod_min < end_min)  # wraps past midnight
+
+
+def _session_group_id(et: pd.Series, session: str) -> pd.Series:
+    """Grouping key for "which occurrence of this session does this bar
+    belong to" — plain calendar date works for NY (never crosses midnight),
+    but Asian (18:00-02:00 ET) needs the same 18:00 Globex-day rollover used
+    throughout strategies/asian_failed_breakout, or a session that starts at
+    23:50 and one that starts at 00:10 the same real trading session would
+    get split into two different groups."""
+    if session == "asian":
+        return (et - pd.Timedelta(hours=18)).dt.floor("D")
+    return et.dt.date
+
+
+def load_point_value(symbol: str) -> float:
+    all_cfg = json.loads(SYMBOLS_CONFIG.read_text())
+    return all_cfg.get(symbol, {}).get("point_value", 1.0)
+
+
+def load_1m_bars(symbol: str, days: Optional[int] = None, no_trade_minutes: int = 15,
+                  orb_minutes: int = 15, session: str = "ny") -> pd.DataFrame:
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_1.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No raw 1m data at {path} — run ml/data_collection/collect_replay.py first.")
+    df = pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+    if days is not None:
+        cutoff = int(df["time"].max()) - days * 86400
+        df = df[df["time"] >= cutoff].reset_index(drop=True)
+
+    df["et"] = pd.to_datetime(df["time"], unit="s", utc=True).dt.tz_convert(ET)
+    df["tod_min"] = df["et"].dt.hour * 60 + df["et"].dt.minute
+    df["calendar_date"] = df["et"].dt.date
+    df["ema9"] = df["close"].ewm(span=9, adjust=False).mean()
+
+    add_session_vwap(df)
+    add_session_window(df, session, no_trade_minutes)
+    add_opening_range(df, session, orb_minutes)
+    return df
+
+
+def add_session_vwap(df: pd.DataFrame, session_start_hour: int = 18) -> pd.DataFrame:
+    """Session-anchored cumulative VWAP + volume-weighted std, same formula
+    as ml/features/indicators.py's add_session_vwap — reimplemented locally
+    (not imported) so this strategies/ package has no dependency on ml/."""
+    session_id = (df["et"] - pd.Timedelta(hours=session_start_hour)).dt.floor("D")
+    typical = (df["high"] + df["low"] + df["close"]) / 3
+    tp_vol = typical * df["volume"]
+    cum_vol = df.groupby(session_id.values)["volume"].cumsum()
+    cum_tp_vol = tp_vol.groupby(session_id.values).cumsum()
+    vwap = cum_tp_vol / cum_vol.replace(0, np.nan)
+    sq_dev = ((typical - vwap) ** 2) * df["volume"]
+    cum_sq_dev = sq_dev.groupby(session_id.values).cumsum()
+    variance = cum_sq_dev / cum_vol.replace(0, np.nan)
+    std = np.sqrt(variance)
+    df["vwap"] = vwap
+    df["vwap_std"] = std
+    df["dist_from_vwap_sigma"] = (df["close"] - vwap) / std.replace(0, np.nan)
+    return df
+
+
+def add_session_window(df: pd.DataFrame, session: str, no_trade_minutes: int) -> pd.DataFrame:
+    """Generic replacement for the old NY-only add_ny_windows — same
+    semantics, parametrized by session ("ny" or "asian") so the same
+    strategy code can be evaluated in either session. `tradeable`/
+    `in_session` are the generic column names; `ny_tradeable`/`in_ny_session`
+    are also written for backward compatibility with any code still reading
+    the old NY-specific names, but only carry real values when session="ny"
+    (they're just aliases, not computed independently)."""
+    start_min, end_min = SESSION_WINDOWS[session]
+    tod = df["tod_min"]
+    in_session = _in_window(tod, start_min, end_min)
+    minutes_since_open = (tod - start_min) % 1440
+    in_no_trade_window = in_session & (minutes_since_open < no_trade_minutes)
+    # The one flag every strategy in this family gates entries on: inside
+    # the session but past the first `no_trade_minutes` — too volatile to
+    # trade right at the open, per the explicit instruction this whole
+    # family was built under (applied to both sessions for consistency).
+    tradeable = in_session & (~in_no_trade_window)
+    df["in_session"] = in_session
+    df["in_no_trade_window"] = in_no_trade_window
+    df["tradeable"] = tradeable
+    if session == "ny":
+        df["in_ny_session"] = in_session
+        df["in_ny_no_trade_window"] = in_no_trade_window
+        df["ny_tradeable"] = tradeable
+    return df
+
+
+def add_opening_range(df: pd.DataFrame, session: str, orb_minutes: int) -> pd.DataFrame:
+    """High/low of the first `orb_minutes` after the session opens, per
+    occurrence of that session (see _session_group_id): NaN before the range
+    starts, tracking (cummax/cummin) during it, then explicitly forward-
+    filled to stay frozen at the final value for the rest of the session —
+    groupby().cummax() does NOT carry a value forward through NaN rows on
+    its own (verified directly: it leaves them NaN), despite plain
+    Series.cummax()'s skipna behavior suggesting otherwise, so the ffill()
+    here isn't redundant."""
+    start_min, _ = SESSION_WINDOWS[session]
+    minutes_since_open = (df["tod_min"] - start_min) % 1440
+    in_range_window = minutes_since_open < orb_minutes
+    grp = _session_group_id(df["et"], session)
+    df["orb_high"] = df["high"].where(in_range_window).groupby(grp).cummax().groupby(grp).ffill()
+    df["orb_low"] = df["low"].where(in_range_window).groupby(grp).cummin().groupby(grp).ffill()
+    df["orb_formed"] = minutes_since_open >= orb_minutes
+    return df
+
+
+@dataclass
+class RiskParams:
+    stop_buffer_points: float = 0.2
+    max_risk_points: float = 6.0
+    target_r_multiple: float = 2.0
+    partial_r_multiple: float = 1.0
+    partial_fraction: float = 0.5
+    move_stop_to_breakeven_after_partial: bool = True
+
+
+@dataclass
+class TradeLogRecord:
+    strategy: str
+    symbol: str
+    direction: str
+    signal_time: int
+    entry_price: Optional[float] = None
+    entry_time: Optional[int] = None
+    stop_price: Optional[float] = None
+    target_price: Optional[float] = None
+    exit_price: Optional[float] = None
+    exit_time: Optional[int] = None
+    risk_distance: Optional[float] = None
+    pnl_points: Optional[float] = None
+    pnl_dollars: Optional[float] = None
+    r_multiple: Optional[float] = None
+    status: str = "PENDING"
+    reject_reason: Optional[str] = None
+    note: Optional[str] = None
+
+
+@dataclass
+class OpenTrade:
+    direction: str
+    entry_price: float
+    entry_time: int
+    stop_price: float
+    initial_risk: float
+    partial_target_price: float
+    final_target_price: float
+    record: TradeLogRecord
+    partial_taken: bool = False
+    remaining_fraction: float = 1.0
+    realized_pnl_points: float = 0.0
+
+
+def blended_pnl(trade: OpenTrade, final_price: float) -> float:
+    is_long = trade.direction == "long"
+    full_leg = (final_price - trade.entry_price) if is_long else (trade.entry_price - final_price)
+    if not trade.partial_taken:
+        return full_leg
+    return trade.realized_pnl_points + trade.remaining_fraction * full_leg
+
+
+def _finalize(trade: OpenTrade, price: float, ts: int, point_value: float, status: str) -> TradeLogRecord:
+    total = blended_pnl(trade, price)
+    rec = trade.record
+    rec.exit_price = price
+    rec.exit_time = ts
+    rec.pnl_points = total
+    rec.pnl_dollars = total * point_value
+    rec.r_multiple = total / trade.initial_risk if trade.initial_risk else None
+    rec.status = status
+    return rec
+
+
+def update_open_trade(trade: OpenTrade, bar: dict, risk: RiskParams, point_value: float) -> Optional[TradeLogRecord]:
+    """Same-bar stop+target ambiguity resolves to stop-first (conservative),
+    matching ml/labels/triple_barrier.py's convention."""
+    is_long = trade.direction == "long"
+    if not trade.partial_taken:
+        stop_hit = bar["low"] <= trade.stop_price if is_long else bar["high"] >= trade.stop_price
+        target_hit = bar["high"] >= trade.partial_target_price if is_long else bar["low"] <= trade.partial_target_price
+        if stop_hit:
+            return _finalize(trade, trade.stop_price, bar["time"], point_value, "FILLED")
+        if target_hit:
+            trade.partial_taken = True
+            trade.remaining_fraction = 1.0 - risk.partial_fraction
+            trade.realized_pnl_points = risk.partial_fraction * abs(trade.partial_target_price - trade.entry_price)
+            if risk.move_stop_to_breakeven_after_partial:
+                trade.stop_price = trade.entry_price
+            return None
+    else:
+        stop_hit = bar["low"] <= trade.stop_price if is_long else bar["high"] >= trade.stop_price
+        target_hit = bar["high"] >= trade.final_target_price if is_long else bar["low"] <= trade.final_target_price
+        if stop_hit:
+            return _finalize(trade, trade.stop_price, bar["time"], point_value, "FILLED")
+        if target_hit:
+            return _finalize(trade, trade.final_target_price, bar["time"], point_value, "FILLED")
+    return None
+
+
+def force_close(trade: OpenTrade, last_bar: dict, point_value: float) -> TradeLogRecord:
+    return _finalize(trade, last_bar["close"], last_bar["time"], point_value, "OPEN_AT_BACKTEST_END")
+
+
+def summarize(records: list[TradeLogRecord]) -> dict:
+    if not records:
+        return {"n_signals": 0}
+    df = pd.DataFrame([r.__dict__ for r in records])
+    status_counts = df["status"].value_counts().to_dict()
+    reason_counts = df["reject_reason"].dropna().value_counts().to_dict()
+    filled = df[df["status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])]
+    out = {"n_signals": len(df), "status_counts": status_counts, "reject_reasons": reason_counts,
+           "n_trades_filled": len(filled)}
+    if len(filled):
+        wins = filled[filled["pnl_points"] > 0]
+        gross_profit = filled.loc[filled["pnl_dollars"] > 0, "pnl_dollars"].sum()
+        gross_loss = -filled.loc[filled["pnl_dollars"] < 0, "pnl_dollars"].sum()
+        out.update({
+            "win_rate": float(len(wins) / len(filled)),
+            "total_pnl_dollars": float(filled["pnl_dollars"].sum()),
+            "avg_r_multiple": float(filled["r_multiple"].mean()),
+            "profit_factor": float(gross_profit / gross_loss) if gross_loss > 0 else None,
+            "by_direction": filled.groupby("direction")["pnl_dollars"].agg(["count", "sum", "mean"]).to_dict("index"),
+        })
+    return out
+
+
+def write_csv(records: list[TradeLogRecord], symbol: str, strategy_name: str) -> Path:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = OUT_DIR / f"{stem}_{strategy_name}.csv"
+    rows = [r.__dict__ for r in records]
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        for col in ("signal_time", "entry_time", "exit_time"):
+            if col in df.columns:
+                df[col.replace("time", "et")] = pd.to_datetime(df[col], unit="s", utc=True).dt.tz_convert(ET)
+        df = df.sort_values("signal_time").reset_index(drop=True)
+    df.to_csv(path, index=False)
+    return path

--- a/strategies/ny_open_strategies/liquidity_sweep_reversal.py
+++ b/strategies/ny_open_strategies/liquidity_sweep_reversal.py
@@ -1,0 +1,237 @@
+"""
+NY-session liquidity-sweep reversal: the exact same failed-breakout state
+machine as strategies/asian_failed_breakout (imported directly — that
+engine was written to be generic, not duplicated here), reconfigured for
+NY-relevant levels: PDH/PDL, the overnight Asian range, the London range,
+and the NY pre-market range. New setups may only start once ny_tradeable is
+True — i.e. never inside the no-trade opening window.
+
+Deliberately does NOT include swing points or the 15-minute opening range —
+found directly by tracing a real case (MNQ1! 2026-08-21, a ~250pt trending
+crash around 10:00 ET): the engine kept picking opening_range_low as the
+level to fade, six separate times, purely because it happened to be the
+CLOSEST level to price each time a new candidate started (the state machine
+only tracks one candidate per direction at once) — correctly rejected every
+time by the acceptance filter since it was a real trend, not a failed
+breakdown, but it meant PDL/asian_range_low, the more meaningful levels
+that move ALSO swept through, never got their own chance to be evaluated.
+Narrowing to only the levels below matches what MGC/MNQ sweeps normally
+react to (PDH/PDL and session ranges), not a level that's redefined every
+single day and often sits closer to price by coincidence.
+
+"Already swept" exclusion: a level is only offered as a fade candidate while
+it is still UNTOUCHED — i.e. price has not already traded beyond it at any
+earlier point since that level's current value was established (a level
+swept once during Asian or London hours has already had its liquidity taken;
+fading it a second time isn't the same setup). This is tracked independently
+of the state machine's own candidate (which only starts watching a level
+once it's approached) — every bar checks every currently-known level for a
+first-touch sweep and marks it "used" from that point on, whether or not the
+strategy happened to be watching it. The one sweep that's still eligible is
+the first one — if that first sweep happens during NY hours, it's exactly
+the live setup this strategy exists to trade; only a PRIOR sweep (Asian,
+London, pre-market) disqualifies a level for the rest of that level's
+lifetime (until it resets — all four level types roll over once per Globex
+day).
+
+Direction logic (unchanged, just restated): a swept HIGH that fails to hold
+-> SHORT once reclaimed + EMA9-confirmed; a swept LOW that fails to hold ->
+LONG once reclaimed + EMA9-confirmed. Never a signal on the sweep itself.
+
+Run as a module from the repo root:
+    python -m strategies.ny_open_strategies.liquidity_sweep_reversal --symbol MGC1! --days 30
+"""
+import argparse
+import json
+import sys
+
+import pandas as pd
+
+from ..asian_failed_breakout.config import StrategyConfig
+from ..asian_failed_breakout.engine import StrategyEngine
+from ..asian_failed_breakout.levels import LevelTracker, _globex_day_id, _in_window, _parse_hm
+from .common import ET, OUT_DIR, RAW_DIR, add_session_window, load_point_value
+
+NY_LONG_LEVEL_FIELDS = ("pdl", "asian_range_low", "london_range_low", "ny_premarket_low")
+NY_SHORT_LEVEL_FIELDS = ("pdh", "asian_range_high", "london_range_high", "ny_premarket_high")
+
+# Levels whose min-penetration sweep threshold gates "already touched" —
+# reuses the same value the reversal engine itself uses to define a sweep,
+# so "already swept" means the same thing here as it does inside the engine.
+_SWEEP_DIRECTION = {  # True = level is a "low" (touched when price trades BELOW it)
+    "pdl": True, "pdh": False,
+    "asian_range_low": True, "asian_range_high": False,
+    "london_range_low": True, "london_range_high": False,
+    "ny_premarket_low": True, "ny_premarket_high": False,
+}
+
+
+class _SessionRangeTracker:
+    """Generic session-range tracker (high/low within a configurable ET
+    window, resetting once per Globex day) — used here for both London
+    (03:00-08:00) and NY pre-market (04:00-09:29). Same pattern as
+    strategies/fabio_strategy/levels.py's LocationTracker; not imported from
+    there to keep this package's own dependency graph shallow (it already
+    depends on asian_failed_breakout; adding a second, larger sibling
+    package as a dependency for ~15 lines of logic isn't worth it)."""
+    def __init__(self, start: str, end: str, rollover_hour: int = 18):
+        self._start_min = _parse_hm(start)
+        self._end_min = _parse_hm(end)
+        self._rollover_hour = rollover_hour
+        self._day = None
+        self.high = None
+        self.low = None
+
+    def update(self, bar: dict, et_ts) -> None:
+        day = _globex_day_id(et_ts, self._rollover_hour)
+        if day != self._day:
+            self._day = day
+            self.high = None
+            self.low = None
+        tod = et_ts.hour * 60 + et_ts.minute
+        if _in_window(tod, self._start_min, self._end_min):
+            if self.high is None:
+                self.high, self.low = bar["high"], bar["low"]
+            else:
+                self.high = max(self.high, bar["high"])
+                self.low = min(self.low, bar["low"])
+
+
+def _load_bars(symbol: str, timeframe: str) -> pd.DataFrame:
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_{timeframe}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No raw data at {path} — run ml/data_collection/collect_replay.py first.")
+    return pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+
+
+def run_backtest(symbol: str, cfg: StrategyConfig, days: int | None = None,
+                  no_trade_minutes: int = 15) -> pd.DataFrame:
+    df1 = _load_bars(symbol, "1")
+    df5 = _load_bars(symbol, "5")
+    if days is not None:
+        cutoff = int(df1["time"].max()) - days * 86400
+        df1 = df1[df1["time"] >= cutoff].reset_index(drop=True)
+
+    df1["ema9"] = df1["close"].ewm(span=cfg.ma9.ema_period, adjust=False).mean()
+    df1["et"] = pd.to_datetime(df1["time"], unit="s", utc=True).dt.tz_convert(ET)
+    df1["tod_min"] = df1["et"].dt.hour * 60 + df1["et"].dt.minute
+    df1["calendar_date"] = df1["et"].dt.date
+    add_session_window(df1, "ny", no_trade_minutes)
+
+    et5 = pd.to_datetime(df5["time"], unit="s", utc=True).dt.tz_convert(ET)
+    tf5_close_offset = 5 * 60
+
+    rollover = cfg.session.globex_day_rollover_hour
+    tracker = LevelTracker(cfg.session, cfg.swing, cfg.asian_range)
+    london_tracker = _SessionRangeTracker("03:00", "08:00", rollover)
+    premarket_tracker = _SessionRangeTracker("04:00", "09:29", rollover)
+    engine = StrategyEngine(cfg, symbol, load_point_value(symbol),
+                             long_level_fields=NY_LONG_LEVEL_FIELDS, short_level_fields=NY_SHORT_LEVEL_FIELDS,
+                             session_label="ny")
+
+    pen = cfg.sweep.min_penetration_points
+    last_value: dict[str, float] = {}
+    already_swept: dict[str, bool] = {}
+
+    j, n5 = 0, len(df5)
+    records = []
+    for i in range(len(df1)):
+        t = int(df1["time"].iloc[i])
+        while j < n5 and int(df5["time"].iloc[j]) + tf5_close_offset <= t:
+            bar5 = {"time": int(df5["time"].iloc[j]), "open": df5["open"].iloc[j], "high": df5["high"].iloc[j],
+                    "low": df5["low"].iloc[j], "close": df5["close"].iloc[j]}
+            ts5 = et5.iloc[j]
+            tracker.update(bar5, ts5)
+            london_tracker.update(bar5, ts5)
+            j += 1
+        # NY pre-market is tracked on 1m bars directly (5m granularity would
+        # be too coarse for a 5.5-hour window that itself feeds into an
+        # early-morning setup) — updated every 1m bar, not gated behind the
+        # 5m close-alignment used for the other trackers above.
+        premarket_tracker.update({"high": df1["high"].iloc[i], "low": df1["low"].iloc[i]}, df1["et"].iloc[i])
+
+        # "Already swept" exclusion applies to all four level types (PDH/PDL,
+        # Asian range, London range, NY pre-market range) — a level is only
+        # offered while price hasn't already traded beyond it since it was
+        # last established.
+        sweep_tracked_levels = {"pdl": tracker.pdl, "pdh": tracker.pdh,
+                                 "asian_range_low": tracker.asian_range_low, "asian_range_high": tracker.asian_range_high,
+                                 "london_range_low": london_tracker.low, "london_range_high": london_tracker.high,
+                                 "ny_premarket_low": premarket_tracker.low, "ny_premarket_high": premarket_tracker.high}
+        sweep_tracked_levels = {k: v for k, v in sweep_tracked_levels.items()
+                                 if v is not None and not (isinstance(v, float) and pd.isna(v))}
+
+        bar_high, bar_low = df1["high"].iloc[i], df1["low"].iloc[i]
+        levels = {}
+        for name, value in sweep_tracked_levels.items():
+            if last_value.get(name) != value:
+                # the level's underlying value moved (new day/session) ->
+                # it's a fresh, untouched level again regardless of history.
+                last_value[name] = value
+                already_swept[name] = False
+            is_low_side = _SWEEP_DIRECTION[name]
+            touched_now = (bar_low < value - pen) if is_low_side else (bar_high > value + pen)
+            if not already_swept.get(name, False):
+                levels[name] = value  # still fresh as of BEFORE this bar — eligible
+            if touched_now:
+                already_swept[name] = True  # mark used (whether or not it was offered above)
+
+        bar1 = {"time": t, "open": df1["open"].iloc[i], "high": bar_high, "low": bar_low, "close": df1["close"].iloc[i]}
+        recs = engine.on_bar(bar1, float(df1["ema9"].iloc[i]), levels, bool(df1["ny_tradeable"].iloc[i]))
+        records.extend(recs)
+
+    if len(df1):
+        last_bar = {"time": int(df1["time"].iloc[-1]), "close": float(df1["close"].iloc[-1])}
+        records.extend(engine.force_close_all(last_bar))
+
+    out = pd.DataFrame([r.__dict__ for r in records])
+    if not out.empty:
+        for col in ("timestamp", "break_timestamp", "reclaim_timestamp", "ema9_trigger_timestamp", "exit_timestamp"):
+            if col in out.columns:
+                out[col.replace("timestamp", "et")] = pd.to_datetime(out[col], unit="s", utc=True).dt.tz_convert(ET)
+        out = out.sort_values("timestamp").reset_index(drop=True)
+    return out
+
+
+def summarize(df: pd.DataFrame) -> dict:
+    if df.empty:
+        return {"n_setups": 0}
+    status_counts = df["setup_status"].value_counts().to_dict()
+    reason_counts = df["invalid_reason"].dropna().value_counts().to_dict()
+    filled = df[df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])]
+    summary = {"n_setups_logged": len(df), "status_counts": status_counts, "rejection_reasons": reason_counts,
+               "n_trades_filled": len(filled)}
+    if len(filled):
+        wins = filled[filled["pnl_points"] > 0]
+        gross_profit = filled.loc[filled["pnl_dollars"] > 0, "pnl_dollars"].sum()
+        gross_loss = -filled.loc[filled["pnl_dollars"] < 0, "pnl_dollars"].sum()
+        summary.update({
+            "win_rate": float(len(wins) / len(filled)),
+            "total_pnl_dollars": float(filled["pnl_dollars"].sum()),
+            "avg_r_multiple": float(filled["r_multiple"].mean()),
+            "profit_factor": float(gross_profit / gross_loss) if gross_loss > 0 else None,
+            "by_direction": filled.groupby("direction")["pnl_dollars"].agg(["count", "sum", "mean"]).to_dict("index"),
+        })
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=None)
+    args = parser.parse_args()
+
+    cfg = StrategyConfig()
+    df = run_backtest(args.symbol, cfg, args.days)
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+    out_path = OUT_DIR / f"{stem}_ny_liquidity_sweep_reversal.csv"
+    df.to_csv(out_path, index=False)
+    print(f"Wrote {len(df)} setup records to {out_path}", file=sys.stderr)
+    print(json.dumps(summarize(df), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/ny_open_strategies/ma9_trend_following.py
+++ b/strategies/ny_open_strategies/ma9_trend_following.py
@@ -1,0 +1,138 @@
+"""
+MA9 trend-following (continuation, not reversal): trade WITH a rising/falling
+1m EMA9, entering on a shallow pullback that touches the EMA9 and then closes
+back away from it in the trend direction — the inverse premise of the sweep
+strategies (there, price failing at an extreme is the signal; here, an
+established trend continuing through a pullback is the signal).
+
+Trend: EMA9 has moved at least min_slope_points over slope_lookback_bars,
+       and price is on the trend side of it.
+Pullback + continuation: low (long) / high (short) touched within
+       pullback_tolerance_points of EMA9 at some point in the last
+       pullback_lookback_bars bars (not this bar), and this bar closes back
+       above/below EMA9 with a same-direction candle.
+
+Run as a module from the repo root:
+    python -m strategies.ny_open_strategies.ma9_trend_following --symbol MGC1! --days 30
+"""
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+
+from .common import (OpenTrade, RiskParams, TradeLogRecord, force_close, load_1m_bars, load_point_value,
+                      summarize, update_open_trade, write_csv)
+
+
+@dataclass
+class MA9TrendConfig:
+    slope_lookback_bars: int = 10
+    min_slope_points: float = 0.5
+    pullback_lookback_bars: int = 5
+    pullback_tolerance_points: float = 0.3
+    no_trade_minutes: int = 15
+    target_mode: str = "fixed_r"  # "fixed_r" or "fixed_price"
+    target_price_points: float | None = None
+    risk: RiskParams = field(default_factory=lambda: RiskParams(target_r_multiple=2.0, partial_r_multiple=1.0))
+
+
+def run_backtest(symbol: str, cfg: MA9TrendConfig, days: int | None = None, session: str = "ny"):
+    df = load_1m_bars(symbol, days=days, no_trade_minutes=cfg.no_trade_minutes, session=session)
+    point_value = load_point_value(symbol)
+
+    ema9 = df["ema9"]
+    slope = ema9.diff(cfg.slope_lookback_bars)
+    trend_up = (slope > cfg.min_slope_points) & (df["close"] > ema9)
+    trend_down = (slope < -cfg.min_slope_points) & (df["close"] < ema9)
+
+    # Separate up/down touch definitions: for a long pullback we only care
+    # the LOW came down near ema9; for a short pullback, the HIGH came up
+    # near ema9.
+    touched_from_above = df["low"] <= ema9 + cfg.pullback_tolerance_points  # pulled back down to ema9 in an uptrend
+    touched_from_below = df["high"] >= ema9 - cfg.pullback_tolerance_points  # pulled back up to ema9 in a downtrend
+    recent_touch_up = touched_from_above.rolling(cfg.pullback_lookback_bars).max().shift(1).fillna(0).astype(bool)
+    recent_touch_down = touched_from_below.rolling(cfg.pullback_lookback_bars).max().shift(1).fillna(0).astype(bool)
+
+    rolling_min_low = df["low"].rolling(cfg.pullback_lookback_bars).min()
+    rolling_max_high = df["high"].rolling(cfg.pullback_lookback_bars).max()
+
+    records: list[TradeLogRecord] = []
+    open_trades: list[OpenTrade] = []
+    n = len(df)
+
+    for i in range(n):
+        bar = {"time": int(df["time"].iloc[i]), "open": df["open"].iloc[i], "high": df["high"].iloc[i],
+               "low": df["low"].iloc[i], "close": df["close"].iloc[i]}
+
+        still_open = []
+        for trade in open_trades:
+            rec = update_open_trade(trade, bar, cfg.risk, point_value)
+            (records.append(rec) if rec else still_open.append(trade))
+        open_trades = still_open
+
+        if not bool(df["tradeable"].iloc[i]) or i < max(cfg.slope_lookback_bars, cfg.pullback_lookback_bars):
+            continue
+
+        has_long_open = any(t.direction == "long" for t in open_trades)
+        has_short_open = any(t.direction == "short" for t in open_trades)
+
+        long_signal = (not has_long_open and bool(trend_up.iloc[i]) and bool(recent_touch_up.iloc[i])
+                       and bar["close"] > float(ema9.iloc[i]) and bar["close"] > bar["open"])
+        short_signal = (not has_short_open and bool(trend_down.iloc[i]) and bool(recent_touch_down.iloc[i])
+                        and bar["close"] < float(ema9.iloc[i]) and bar["close"] < bar["open"])
+
+        for direction, signal in (("long", long_signal), ("short", short_signal)):
+            if not signal:
+                continue
+            is_long = direction == "long"
+            extreme = rolling_min_low.iloc[i] if is_long else rolling_max_high.iloc[i]
+            stop = extreme - cfg.risk.stop_buffer_points if is_long else extreme + cfg.risk.stop_buffer_points
+            entry_price = bar["close"]
+            risk_distance = abs(entry_price - stop)
+
+            rec = TradeLogRecord(strategy="ma9_trend_following", symbol=symbol, direction=direction,
+                                  signal_time=bar["time"], entry_price=entry_price, entry_time=bar["time"],
+                                  stop_price=stop, risk_distance=risk_distance,
+                                  note=f"ema9_slope={float(slope.iloc[i]):.2f}")
+            if risk_distance <= 0 or risk_distance > cfg.risk.max_risk_points:
+                rec.status, rec.reject_reason = "REJECTED", "RISK_TOO_LARGE"
+                records.append(rec)
+                continue
+
+            partial_target = entry_price + cfg.risk.partial_r_multiple * risk_distance if is_long else \
+                              entry_price - cfg.risk.partial_r_multiple * risk_distance
+            if cfg.target_mode == "fixed_price" and cfg.target_price_points is not None:
+                final_target = entry_price + cfg.target_price_points if is_long else entry_price - cfg.target_price_points
+            else:
+                final_target = entry_price + cfg.risk.target_r_multiple * risk_distance if is_long else \
+                                entry_price - cfg.risk.target_r_multiple * risk_distance
+            rec.target_price = final_target
+            rec.status = "OPEN"
+            open_trades.append(OpenTrade(direction=direction, entry_price=entry_price, entry_time=bar["time"],
+                                          stop_price=stop, initial_risk=risk_distance,
+                                          partial_target_price=partial_target, final_target_price=final_target,
+                                          record=rec))
+
+    if n:
+        last_bar = {"time": int(df["time"].iloc[-1]), "close": float(df["close"].iloc[-1])}
+        for trade in open_trades:
+            records.append(force_close(trade, last_bar, point_value))
+
+    return records
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=None)
+    args = parser.parse_args()
+
+    cfg = MA9TrendConfig()
+    records = run_backtest(args.symbol, cfg, args.days)
+    path = write_csv(records, args.symbol, "ma9_trend_following")
+    print(f"Wrote {len(records)} records to {path}", file=sys.stderr)
+    print(json.dumps(summarize(records), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/ny_open_strategies/opening_range_breakout.py
+++ b/strategies/ny_open_strategies/opening_range_breakout.py
@@ -1,0 +1,133 @@
+"""
+Opening range breakout: the range formed in the first `orb_minutes` after NY
+open (default 15 — the same window every strategy in this family is barred
+from *trading* in) is used purely to define the range, then breakouts of it
+are traded starting once the range closes.
+
+Long: first close above orb_high after the range has formed.
+Short: first close below orb_low after the range has formed.
+Stop: opposite side of the opening range (classic ORB convention), plus
+      buffer — rejected via max_risk_points if the range itself is too wide.
+Target: fixed-R by default, or the "measured move" (range height projected
+      from the breakout point) if target_mode="measured_move".
+At most one long and one short entry per calendar day (a fresh breakout
+attempt after being stopped out same-day isn't part of this base rule).
+
+Run as a module from the repo root:
+    python -m strategies.ny_open_strategies.opening_range_breakout --symbol MGC1! --days 30
+"""
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from .common import (OpenTrade, RiskParams, TradeLogRecord, force_close, load_1m_bars, load_point_value,
+                      summarize, update_open_trade, write_csv)
+
+
+@dataclass
+class ORBConfig:
+    orb_minutes: int = 15
+    no_trade_minutes: int = 15  # kept equal to orb_minutes by convention — see module docstring
+    target_mode: str = "fixed_r"  # "fixed_r", "measured_move", or "fixed_price"
+    target_price_points: float | None = None
+    # Stop is the opposite side of the opening range — checked empirically
+    # against the actual data (median ~15pt, up to ~38pt on wide-range days)
+    # since the sweep strategy's 6pt default gate rejected every signal here.
+    risk: RiskParams = field(default_factory=lambda: RiskParams(target_r_multiple=2.0, partial_r_multiple=1.0,
+                                                                  max_risk_points=20.0))
+
+
+def run_backtest(symbol: str, cfg: ORBConfig, days: int | None = None, session: str = "ny"):
+    df = load_1m_bars(symbol, days=days, no_trade_minutes=cfg.no_trade_minutes, orb_minutes=cfg.orb_minutes,
+                       session=session)
+    point_value = load_point_value(symbol)
+
+    records: list[TradeLogRecord] = []
+    open_trades: list[OpenTrade] = []
+    traded_today = {"long": None, "short": None}  # calendar_date last traded, per direction
+    n = len(df)
+
+    for i in range(n):
+        bar = {"time": int(df["time"].iloc[i]), "open": df["open"].iloc[i], "high": df["high"].iloc[i],
+               "low": df["low"].iloc[i], "close": df["close"].iloc[i]}
+        date = df["calendar_date"].iloc[i]
+
+        still_open = []
+        for trade in open_trades:
+            rec = update_open_trade(trade, bar, cfg.risk, point_value)
+            (records.append(rec) if rec else still_open.append(trade))
+        open_trades = still_open
+
+        if not bool(df["tradeable"].iloc[i]) or not bool(df["orb_formed"].iloc[i]):
+            continue
+        orb_high, orb_low = df["orb_high"].iloc[i], df["orb_low"].iloc[i]
+        if pd.isna(orb_high) or pd.isna(orb_low):
+            continue
+
+        prev_close = df["close"].iloc[i - 1]
+        long_signal = (traded_today["long"] != date and bar["close"] > orb_high and prev_close <= orb_high)
+        short_signal = (traded_today["short"] != date and bar["close"] < orb_low and prev_close >= orb_low)
+
+        for direction, signal in (("long", long_signal), ("short", short_signal)):
+            if not signal:
+                continue
+            is_long = direction == "long"
+            entry_price = bar["close"]
+            stop = orb_low - cfg.risk.stop_buffer_points if is_long else orb_high + cfg.risk.stop_buffer_points
+            risk_distance = abs(entry_price - stop)
+
+            rec = TradeLogRecord(strategy="opening_range_breakout", symbol=symbol, direction=direction,
+                                  signal_time=bar["time"], entry_price=entry_price, entry_time=bar["time"],
+                                  stop_price=stop, risk_distance=risk_distance,
+                                  note=f"orb_high={orb_high:.2f} orb_low={orb_low:.2f}")
+            traded_today[direction] = date  # counts against the daily cap even if rejected — one attempt/day
+            if risk_distance <= 0 or risk_distance > cfg.risk.max_risk_points:
+                rec.status, rec.reject_reason = "REJECTED", "RISK_TOO_LARGE"
+                records.append(rec)
+                continue
+
+            range_height = orb_high - orb_low
+            if cfg.target_mode == "measured_move":
+                final_target = entry_price + range_height if is_long else entry_price - range_height
+            elif cfg.target_mode == "fixed_price" and cfg.target_price_points is not None:
+                final_target = entry_price + cfg.target_price_points if is_long else entry_price - cfg.target_price_points
+            else:
+                final_target = entry_price + cfg.risk.target_r_multiple * risk_distance if is_long else \
+                                entry_price - cfg.risk.target_r_multiple * risk_distance
+            partial_target = entry_price + cfg.risk.partial_r_multiple * risk_distance if is_long else \
+                              entry_price - cfg.risk.partial_r_multiple * risk_distance
+
+            rec.target_price = final_target
+            rec.status = "OPEN"
+            open_trades.append(OpenTrade(direction=direction, entry_price=entry_price, entry_time=bar["time"],
+                                          stop_price=stop, initial_risk=risk_distance,
+                                          partial_target_price=partial_target, final_target_price=final_target,
+                                          record=rec))
+
+    if n:
+        last_bar = {"time": int(df["time"].iloc[-1]), "close": float(df["close"].iloc[-1])}
+        for trade in open_trades:
+            records.append(force_close(trade, last_bar, point_value))
+
+    return records
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=None)
+    parser.add_argument("--target-mode", choices=["fixed_r", "measured_move"], default="fixed_r")
+    args = parser.parse_args()
+
+    cfg = ORBConfig(target_mode=args.target_mode)
+    records = run_backtest(args.symbol, cfg, args.days)
+    path = write_csv(records, args.symbol, "opening_range_breakout")
+    print(f"Wrote {len(records)} records to {path}", file=sys.stderr)
+    print(json.dumps(summarize(records), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/ny_open_strategies/plot_trades.py
+++ b/strategies/ny_open_strategies/plot_trades.py
@@ -1,0 +1,110 @@
+"""
+Same day-by-day trade plotting as strategies/asian_failed_breakout/plot_trades.py,
+for the NY-session liquidity-sweep-reversal engine (MNQ1!'s best condition:
+NY hours, swing-sized target). Reuses that module's plot_day (engine-agnostic
+— it just reads the shared SetupLogRecord column names) rather than
+duplicating the plotting code.
+
+Unlike the Asian engine, the NY engine's asian_range_high/low level refers to
+the *completed* overnight Asian range (not a still-developing one — Asian
+session has already ended by the time NY hours start), so it's kept as an
+eligible level here; only the Asian engine's own still-developing range gets
+excluded.
+
+Run as a module from the repo root:
+    python -m strategies.ny_open_strategies.plot_trades --symbol MNQ1! --days 7 --tier swing
+"""
+import argparse
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from ..asian_failed_breakout.config import StrategyConfig
+from ..asian_failed_breakout.plot_trades import LEVEL_COLOR, plot_day
+from .common import RAW_DIR, ET
+from .liquidity_sweep_reversal import run_backtest
+
+OUT_DIR = Path.home() / "data" / "ny-strategy-backtests" / "plots"
+
+TIERS = {
+    "scalp": {"target_points": 30.0, "max_risk_points": 10.0},
+    "swing": {"target_points": 100.0, "max_risk_points": 30.0},
+}
+
+
+def build_config(tier: str) -> StrategyConfig:
+    cfg = StrategyConfig()
+    cfg.risk.target_mode = "fixed_price"
+    cfg.risk.target_price_points = TIERS[tier]["target_points"]
+    cfg.risk.max_risk_points = TIERS[tier]["max_risk_points"]
+    return cfg
+
+
+def _load_bars(symbol: str, timeframe: str) -> pd.DataFrame:
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_{timeframe}.parquet"
+    return pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MNQ1!")
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--tier", choices=list(TIERS), default="swing")
+    parser.add_argument("--include-empty-days", action="store_true", help="also plot days with zero trades")
+    parser.add_argument("--out-dir", help="output directory for the PNGs")
+    args = parser.parse_args()
+
+    cfg = build_config(args.tier)
+    trades_df = run_backtest(args.symbol, cfg, days=args.days)
+    filled = trades_df[trades_df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])].copy()
+
+    price_df = _load_bars(args.symbol, "1")
+    cutoff = int(price_df["time"].max()) - args.days * 86400
+    price_df = price_df[price_df["time"] >= cutoff].reset_index(drop=True)
+    price_et = pd.to_datetime(price_df["time"], unit="s", utc=True).dt.tz_convert(ET)
+    price_df["date"] = price_et.dt.strftime("%Y-%m-%d")
+
+    filled["entry_date"] = pd.to_datetime(filled["ema9_trigger_timestamp"], unit="s", utc=True).dt.tz_convert(ET).dt.strftime("%Y-%m-%d")
+
+    dates = sorted(price_df["date"].unique())
+    out_dir = Path(args.out_dir) if args.out_dir else OUT_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+
+    written = []
+    for date in dates:
+        day_trades = filled[filled["entry_date"] == date]
+        if day_trades.empty and not args.include_empty_days:
+            continue
+
+        day_mask = price_df["date"] == date
+        day_price = price_df[day_mask]
+        day_times = price_et[day_mask]
+
+        fig, ax = plt.subplots(figsize=(14, 7))
+        if day_trades.empty:
+            ax.plot(day_times, day_price["close"], color="black", linewidth=0.8)
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M", tz=ET))
+            ax.set_title(f"{date} — 0 trades")
+            ax.set_ylabel("price")
+        else:
+            plot_day(ax, day_price, day_times, day_trades, date)
+        fig.tight_layout()
+
+        out_path = out_dir / f"{stem}_{args.tier}_{date}.png"
+        fig.savefig(out_path, dpi=130)
+        plt.close(fig)
+        written.append(out_path)
+
+    print(f"Wrote {len(written)} PNGs ({len(filled)} total trades) to {out_dir}")
+    for p in written:
+        print(p)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/ny_open_strategies/vwap_reversion.py
+++ b/strategies/ny_open_strategies/vwap_reversion.py
@@ -1,0 +1,205 @@
+"""
+VWAP mean-reversion: fade the touch of a VWAP +/- N-sigma band, optionally
+requiring confluence with an actual liquidity sweep of a known important
+level (PDH/PDL, prior NY session high/low, a recent swing high/low, or the
+current Asian range) — not just "far from VWAP," but "far from VWAP AND
+that stretch took out a level worth defending." Reuses the exact same
+LevelTracker as strategies/asian_failed_breakout (5m-bar-based, causal —
+same discipline as that module: a level is only visible once the 5m bar
+that defines it has actually closed).
+
+NOTE on prior evidence in this repo: earlier ML analysis this session found
+that, at a ~30-60min horizon with wide fixed TP/SL, distance from VWAP
+predicted *continuation* rather than reversion in this data (see the
+Aug-22 conversation's VWAP-distance decile breakdown). Entering directly at
+the sigma touch — with no confirmation that price has actually turned —
+is exactly the shape of signal that finding argues against. The level-sweep
+filter is one way to test whether adding that confluence recovers an edge
+the raw sigma-touch alone doesn't have; read the backtest numbers as a test
+of that question, not as settled proof either way.
+
+Long: dist_from_vwap_sigma crosses down through -entry_sigma this bar
+      (first touch, edge-triggered), AND (if require_level_sweep) a
+      low-side level was swept within level_sweep_lookback_bars.
+Short: mirror, crossing up through +entry_sigma with a high-side sweep.
+Stop: (entry_sigma + stop_sigma_buffer) sigma beyond VWAP — a volatility-
+      scaled stop, since a fixed point buffer doesn't make sense across
+      different sigma thresholds or symbols.
+Target: VWAP itself (snapshotted at signal time), or fixed_price if
+        cfg.target_mode="fixed_price" is set (used for the swing-target
+        sweep).
+
+Run as a module from the repo root:
+    python -m strategies.ny_open_strategies.vwap_reversion --symbol MGC1! --days 30
+    python -m strategies.ny_open_strategies.vwap_reversion --symbol MGC1! --entry-sigma 2.5
+    python -m strategies.ny_open_strategies.vwap_reversion --symbol MGC1! --no-level-sweep-filter
+"""
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from ..asian_failed_breakout.config import AsianRangeConfig, LevelToggles, SessionConfig, SwingConfig
+from ..asian_failed_breakout.levels import LevelTracker
+from .common import (ET, OpenTrade, RAW_DIR, RiskParams, TradeLogRecord, force_close, load_1m_bars,
+                      load_point_value, summarize, update_open_trade, write_csv)
+
+HIGH_SIDE_LEVELS = ("pdh", "prev_ny_high", "swing_high", "asian_range_high")
+LOW_SIDE_LEVELS = ("pdl", "prev_ny_low", "swing_low", "asian_range_low")
+
+
+@dataclass
+class VWAPReversionConfig:
+    entry_sigma: float = 2.0  # try 2.5 too — see main()'s --entry-sigma
+    stop_sigma_buffer: float = 0.5  # stop placed (entry_sigma + this) sigma beyond vwap
+    no_trade_minutes: int = 15
+    # partial_fraction=1.0: a single VWAP target, no partial/runner split,
+    # since "return to the mean" is one natural target, not two.
+    risk: RiskParams = field(default_factory=lambda: RiskParams(partial_fraction=1.0, max_risk_points=30.0))
+    target_mode: str = "vwap"  # "vwap" (default) or "fixed_price" — see run_backtest
+    target_price_points: float | None = None
+
+    # Confluence filter: don't take the VWAP-sigma touch on its own — require
+    # it to coincide with an actual sweep of a known level. asian_range_high/
+    # low is excluded by default: it's the currently-forming session's own
+    # still-extending range, so "swept" it is close to tautological (any
+    # fresh local extreme trivially exceeds the running max/min so far) —
+    # confirmed empirically (it fired more than the genuinely prior levels
+    # combined). "Prior high or low" per the brief means PDH/PDL, the
+    # previous NY session's high/low, and confirmed swing points.
+    require_level_sweep: bool = True
+    level_sweep_lookback_bars: int = 5
+    levels: LevelToggles = field(default_factory=lambda: LevelToggles(asian_range_high=False, asian_range_low=False))
+    session: SessionConfig = field(default_factory=SessionConfig)
+    swing: SwingConfig = field(default_factory=SwingConfig)
+    asian_range: AsianRangeConfig = field(default_factory=AsianRangeConfig)
+
+
+def _load_5m_bars(symbol: str) -> pd.DataFrame:
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_5.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No raw 5m data at {path} — run ml/data_collection/collect_replay.py first.")
+    return pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+
+
+def run_backtest(symbol: str, cfg: VWAPReversionConfig, days: int | None = None, session: str = "ny"):
+    df = load_1m_bars(symbol, days=days, no_trade_minutes=cfg.no_trade_minutes, session=session)
+    point_value = load_point_value(symbol)
+
+    sigma_series = df["dist_from_vwap_sigma"]
+    prev_sigma = sigma_series.shift(1)
+
+    tracker = None
+    df5 = et5 = None
+    j = n5 = 0
+    bars_since_high_sweep = 10 ** 9
+    bars_since_low_sweep = 10 ** 9
+    if cfg.require_level_sweep:
+        tracker = LevelTracker(cfg.session, cfg.swing, cfg.asian_range)
+        df5 = _load_5m_bars(symbol)
+        et5 = pd.to_datetime(df5["time"], unit="s", utc=True).dt.tz_convert(ET)
+        n5 = len(df5)
+
+    records: list[TradeLogRecord] = []
+    open_trades: list[OpenTrade] = []
+
+    n = len(df)
+    for i in range(n):
+        t = int(df["time"].iloc[i])
+        bar = {"time": t, "open": df["open"].iloc[i], "high": df["high"].iloc[i],
+               "low": df["low"].iloc[i], "close": df["close"].iloc[i]}
+
+        still_open = []
+        for trade in open_trades:
+            rec = update_open_trade(trade, bar, cfg.risk, point_value)
+            (records.append(rec) if rec else still_open.append(trade))
+        open_trades = still_open
+
+        if cfg.require_level_sweep:
+            while j < n5 and int(df5["time"].iloc[j]) + 300 <= t:
+                bar5 = {"time": int(df5["time"].iloc[j]), "open": df5["open"].iloc[j], "high": df5["high"].iloc[j],
+                        "low": df5["low"].iloc[j], "close": df5["close"].iloc[j]}
+                tracker.update(bar5, et5.iloc[j])
+                j += 1
+
+            levels = tracker.get_levels(cfg.levels)
+            swept_high = any(bar["high"] > levels[name] for name in HIGH_SIDE_LEVELS if name in levels)
+            swept_low = any(bar["low"] < levels[name] for name in LOW_SIDE_LEVELS if name in levels)
+            bars_since_high_sweep = 0 if swept_high else bars_since_high_sweep + 1
+            bars_since_low_sweep = 0 if swept_low else bars_since_low_sweep + 1
+
+        if not bool(df["tradeable"].iloc[i]) or i < 1:
+            continue
+
+        sigma = sigma_series.iloc[i]
+        p_sigma = prev_sigma.iloc[i]
+        vwap = df["vwap"].iloc[i]
+        vwap_std = df["vwap_std"].iloc[i]
+        if pd.isna(sigma) or pd.isna(p_sigma) or pd.isna(vwap) or pd.isna(vwap_std):
+            continue
+
+        has_long_open = any(t2.direction == "long" for t2 in open_trades)
+        has_short_open = any(t2.direction == "short" for t2 in open_trades)
+
+        # edge-triggered: only the bar that first crosses the threshold
+        long_signal = not has_long_open and sigma <= -cfg.entry_sigma < p_sigma
+        short_signal = not has_short_open and sigma >= cfg.entry_sigma > p_sigma
+
+        if cfg.require_level_sweep:
+            long_signal = long_signal and bars_since_low_sweep <= cfg.level_sweep_lookback_bars
+            short_signal = short_signal and bars_since_high_sweep <= cfg.level_sweep_lookback_bars
+
+        for direction, signal in (("long", long_signal), ("short", short_signal)):
+            if not signal:
+                continue
+            is_long = direction == "long"
+            stop_sigma = cfg.entry_sigma + cfg.stop_sigma_buffer
+            stop = vwap - stop_sigma * vwap_std if is_long else vwap + stop_sigma * vwap_std
+            entry_price = bar["close"]
+            risk_distance = abs(entry_price - stop)
+            if cfg.target_mode == "fixed_price" and cfg.target_price_points is not None:
+                target = entry_price + cfg.target_price_points if is_long else entry_price - cfg.target_price_points
+            else:
+                target = vwap
+
+            rec = TradeLogRecord(strategy="vwap_reversion", symbol=symbol, direction=direction,
+                                  signal_time=bar["time"], entry_price=entry_price, entry_time=bar["time"],
+                                  stop_price=stop, target_price=target, risk_distance=risk_distance,
+                                  note=f"vwap_sigma_at_signal={sigma:.2f}")
+            if risk_distance <= 0 or risk_distance > cfg.risk.max_risk_points:
+                rec.status, rec.reject_reason = "REJECTED", "RISK_TOO_LARGE"
+                records.append(rec)
+                continue
+            rec.status = "OPEN"
+            open_trades.append(OpenTrade(direction=direction, entry_price=entry_price, entry_time=bar["time"],
+                                          stop_price=stop, initial_risk=risk_distance,
+                                          partial_target_price=target, final_target_price=target, record=rec))
+
+    if n:
+        last_bar = {"time": int(df["time"].iloc[-1]), "close": float(df["close"].iloc[-1])}
+        for trade in open_trades:
+            records.append(force_close(trade, last_bar, point_value))
+
+    return records
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=None)
+    parser.add_argument("--entry-sigma", type=float, default=2.0)
+    parser.add_argument("--no-level-sweep-filter", action="store_true", help="disable the level-sweep confluence filter")
+    args = parser.parse_args()
+
+    cfg = VWAPReversionConfig(entry_sigma=args.entry_sigma, require_level_sweep=not args.no_level_sweep_filter)
+    records = run_backtest(args.symbol, cfg, args.days)
+    path = write_csv(records, args.symbol, "vwap_reversion")
+    print(f"Wrote {len(records)} records to {path}", file=sys.stderr)
+    print(json.dumps(summarize(records), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/regime-agent.js
+++ b/strategies/regime-agent.js
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * Regime Agent — MNQ / MGC ranging vs trending, time-comparison display
+ *
+ * Run: node strategies/regime-agent.js [--interval 1000] [--symbols MNQ,MGC]
+ *
+ * Display: NOW | −1 min | −5 min | −10 min (one column per time snapshot)
+ * Polling: every ~1s, but screen only redraws when something changes
+ */
+
+import { analyzeRegime } from '../src/core/regime.js';
+import { parseArgs } from 'node:util';
+
+const { values: argv } = parseArgs({
+  options: {
+    interval: { type: 'string', short: 'i', default: '1000' },
+    symbols:  { type: 'string', short: 's', default: '' },
+  },
+  strict: false,
+});
+
+const INTERVAL    = Math.max(300, Number(argv.interval) || 1000);
+const FILTER_SYMS = argv.symbols ? argv.symbols.split(',').map(s => s.trim().toUpperCase()) : [];
+
+// Time offsets to compare against (seconds)
+const TIME_COLS = [
+  { label: 'NOW',   offset: 0 },
+  { label: '−1 m',  offset: 60 },
+  { label: '−5 m',  offset: 300 },
+  { label: '−10 m', offset: 600 },
+];
+
+// ── ANSI ─────────────────────────────────────────────────────────────────────
+const R   = '\x1b[0m';
+const B   = '\x1b[1m';
+const DIM = '\x1b[2m';
+const RED = '\x1b[31m'; const GRN = '\x1b[32m'; const YEL = '\x1b[33m';
+const CYN = '\x1b[36m'; const MAG = '\x1b[35m';
+const BG_MAG = '\x1b[45m'; const BG_CYN = '\x1b[46m'; const BG_YEL = '\x1b[43m';
+
+function lj(s, n) {
+  // strip ANSI codes for length calculation
+  const raw = String(s).replace(/\x1b\[[0-9;]*m/g, '');
+  const pad = Math.max(0, n - raw.length);
+  return String(s) + ' '.repeat(pad);
+}
+function fmt(n, dec) {
+  if (n == null) return '--';
+  dec = dec != null ? dec : 2;
+  return Number(n).toLocaleString('en-US', { minimumFractionDigits: dec, maximumFractionDigits: dec });
+}
+function ts() { return new Date().toLocaleTimeString('en-US', { hour12: false }); }
+function hhmm(unixMs) {
+  return new Date(unixMs).toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+}
+
+// ── History buffer ────────────────────────────────────────────────────────────
+// Stores { ts: Date.now(), panes: [...] } snapshots for the last 12 minutes
+const MAX_HISTORY_MS = 12 * 60 * 1000;
+const history = [];  // newest last
+
+function pushHistory(result) {
+  history.push({ ts: result.ts || Date.now(), panes: result.panes });
+  // prune old entries
+  const cutoff = Date.now() - MAX_HISTORY_MS;
+  while (history.length > 0 && history[0].ts < cutoff) history.shift();
+}
+
+// Find snapshot closest to (now - offsetSec * 1000)
+function snapshotAt(offsetSec) {
+  if (history.length === 0) return null;
+  const target = Date.now() - offsetSec * 1000;
+  let best = null, bestDelta = Infinity;
+  for (const h of history) {
+    const d = Math.abs(h.ts - target);
+    if (d < bestDelta) { bestDelta = d; best = h; }
+  }
+  return best;
+}
+
+// Find pane by symbol substring from a snapshot
+function findPane(snapshot, sym) {
+  if (!snapshot) return null;
+  return snapshot.panes.find(p => (p.symbol || '').toUpperCase().includes(sym.toUpperCase())) || null;
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+const COL_W = 14;  // width of each time column
+
+function regimeStr(p) {
+  if (!p || p.error) return DIM + 'no data' + R;
+  if (p.regime === 'TRENDING') {
+    const arrow = p.trendDir === 'UP' ? '↑' : p.trendDir === 'DOWN' ? '↓' : '';
+    return BG_CYN + B + ' TREND' + arrow + ' ' + R;
+  }
+  if (p.regime === 'RANGING')       return BG_MAG + B + ' RANGE  ' + R;
+  if (p.regime === 'TRANSITIONING') return BG_YEL + B + ' MIXED  ' + R;
+  return '--';
+}
+
+function confStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const c = p.confidence;
+  const col = c >= 75 ? B : c >= 55 ? '' : DIM;
+  return col + c + '%' + R;
+}
+
+function scoreStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const s = p.adjustedScore;
+  const col = s >= 62 ? CYN : s <= 35 ? MAG : YEL;
+  return col + s + '/100' + R;
+}
+
+function bosStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const st = p.layers.structure;
+  if (st.bos === 'up')   return GRN + 'BOS ↑' + R;
+  if (st.bos === 'down') return RED + 'BOS ↓' + R;
+  if (st.choch)          return YEL + 'CHoCH' + R;
+  return DIM + 'no BOS' + R;
+}
+
+function seqStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const t = p.layers.structure.priorTrend;
+  if (t === 'up')   return GRN + 'HH-HL ↑' + R;
+  if (t === 'down') return RED + 'LH-LL ↓' + R;
+  return DIM + 'mixed' + R;
+}
+
+function atrStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const r = p.layers.priceAction.atrRatio;
+  if (r == null) return DIM + '--' + R;
+  const col = r > 1.3 ? CYN : r < 0.85 ? MAG : '';
+  return col + r.toFixed(2) + R;
+}
+
+function bodyStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const b = p.layers.priceAction.bodyRatio;
+  if (b == null) return DIM + '--' + R;
+  const col = b > 0.55 ? GRN : b < 0.35 ? RED : '';
+  return col + b.toFixed(2) + R;
+}
+
+function vwapStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const d = p.layers.priceAction.vwapDev;
+  if (d == null) return DIM + 'n/a' + R;
+  const col = d > 0.5 ? CYN : d < 0.2 ? MAG : '';
+  return col + d.toFixed(2) + '%' + R;
+}
+
+function volStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const v = p.layers.volume.ratio;
+  if (v == null) return DIM + '--' + R;
+  const col = v > 1.3 ? GRN : v < 0.7 ? DIM : '';
+  return col + v.toFixed(2) + R;
+}
+
+function weeklyVolStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  const v = p.layers.volume.weeklyRatio;
+  if (v == null) return DIM + 'n/a' + R;
+  const col = v > 1.4 ? GRN : v < 0.7 ? DIM : '';
+  return col + v.toFixed(2) + 'x' + R;
+}
+
+function actionStr(p) {
+  if (!p || p.error || !p.tradeBias) return DIM + '--' + R;
+  const tb = p.tradeBias;
+  const arrow = tb.direction === 'UP' ? '↑' : tb.direction === 'DOWN' ? '↓' : '';
+  if (tb.action === 'CONTINUE') {
+    const col = tb.strength === 'STRONG' ? GRN : tb.strength === 'WEAK' ? DIM : '';
+    return col + B + 'CONTINUE' + arrow + R + ' ' + DIM + tb.strength + R;
+  }
+  if (tb.action === 'FADE') {
+    const col = tb.strength === 'STRONG' ? RED : tb.strength === 'WEAK' ? DIM : YEL;
+    return col + B + 'FADE' + arrow + R + ' ' + DIM + tb.strength + R;
+  }
+  return DIM + 'WAIT' + R;
+}
+
+function actionReasonStr(p) {
+  if (!p || p.error || !p.tradeBias) return DIM + '--' + R;
+  return DIM + p.tradeBias.reason + R;
+}
+
+function priceStr(p) {
+  if (!p || p.error) return DIM + '--' + R;
+  return fmt(p.close);
+}
+
+function reversalStr(p) {
+  if (!p || p.error || !p.reversal) return DIM + '--' + R;
+  const rv = p.reversal;
+  if (!rv.probability) return DIM + 'none' + R;
+  const dir   = rv.direction === 'UP' ? GRN + '↑' + R : rv.direction === 'DOWN' ? RED + '↓' + R : '';
+  const prob  = rv.probability === 'HIGH'   ? RED   + B + 'HIGH'   + R :
+                rv.probability === 'MEDIUM' ? YEL   + B + 'MED'    + R :
+                                              DIM    +    'LOW'     + R;
+  return prob + ' ' + dir;
+}
+
+function reversalTriggersStr(p) {
+  if (!p || p.error || !p.reversal || !p.reversal.triggers.length) return DIM + '--' + R;
+  return DIM + p.reversal.triggers.join(',') + R;
+}
+
+// ── Render ────────────────────────────────────────────────────────────────────
+
+// One block per symbol: rows = metrics, cols = time snapshots
+function renderBlock(sym, panes, snapshots) {
+  // panes[i] is the pane data for TIME_COLS[i] (or null)
+  // snapshots[i] is the raw snapshot object with .ts
+  const lines = [];
+  const LABEL_W = 12;
+
+  // symbol header — show actual wall-clock time of each snapshot
+  const symHeader = B + sym + R;
+  const colHeaders = TIME_COLS.map((tc, i) => {
+    const snap = snapshots[i];
+    const label = snap ? hhmm(snap.ts) : tc.label;
+    return lj(DIM + label + R, COL_W);
+  }).join('  ');
+  lines.push(lj(symHeader, LABEL_W + 2) + colHeaders);
+
+  // row helper
+  function row(label, fn) {
+    const vals = panes.map(p => lj(fn(p), COL_W)).join('  ');
+    lines.push(lj(DIM + label + R, LABEL_W + 6) + vals);  // +6 for DIM/R bytes
+  }
+
+  lines.push(DIM + '─'.repeat(LABEL_W + 2 + (COL_W + 2) * TIME_COLS.length) + R);
+  row('Regime',    regimeStr);
+  row('Conf',      confStr);
+  row('Score',     scoreStr);
+  lines.push(DIM + '·'.repeat(LABEL_W + 2 + (COL_W + 2) * TIME_COLS.length) + R);
+  row('Structure', bosStr);
+  row('Sequence',  seqStr);
+  row('ATR ratio', atrStr);
+  row('Body/Wick', bodyStr);
+  row('VWAP dev',  vwapStr);
+  row('Vol ratio', volStr);
+  row('Wk-hr Vol', weeklyVolStr);
+  lines.push(DIM + '·'.repeat(LABEL_W + 2 + (COL_W + 2) * TIME_COLS.length) + R);
+  row('Price',     priceStr);
+  lines.push(DIM + '·'.repeat(LABEL_W + 2 + (COL_W + 2) * TIME_COLS.length) + R);
+  row('Reversal',  reversalStr);
+  row('  Triggers',reversalTriggersStr);
+  lines.push(DIM + '·'.repeat(LABEL_W + 2 + (COL_W + 2) * TIME_COLS.length) + R);
+  row('Action',    actionStr);
+  row('  Reason',   actionReasonStr);
+
+  return lines;
+}
+
+function render(symbols) {
+  const snapshots = TIME_COLS.map(tc => snapshotAt(tc.offset));
+  const lines = [];
+
+  // Header
+  const hdr = B + 'REGIME AGENT' + R + DIM + '  ' + ts() +
+    '  session ' + (snapshots[0]?.panes?.[0]?.session || '?') +
+    '  poll ' + INTERVAL + 'ms' + R;
+  lines.push(hdr);
+  lines.push('');
+
+  for (const sym of symbols) {
+    const panes = snapshots.map(snap => snap ? findPane(snap, sym) : null);
+    lines.push(...renderBlock(sym, panes, snapshots));
+    lines.push('');
+  }
+
+  // State change history at the bottom
+  if (stateLog.length > 0) {
+    lines.push(DIM + 'Regime changes:' + R);
+    for (const entry of stateLog) lines.push('  ' + entry);
+  }
+
+  // Clear screen and redraw from top
+  process.stdout.write('\x1b[2J\x1b[0;0H');
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+// ── State change log ──────────────────────────────────────────────────────────
+const prevStates = {};
+const stateLog = [];  // last 8 regime transitions, shown at bottom of display
+
+function checkStateChanges(panes) {
+  for (const p of panes) {
+    if (!p || p.error) continue;
+    const sym = p.symbol;
+    const cur = p.regime + ':' + (p.trendDir || '');
+    if (prevStates[sym] && prevStates[sym] !== cur) {
+      const was = prevStates[sym].split(':')[0];
+      const now = regimeStr(p);
+      stateLog.push(
+        DIM + ts() + R + '  ' + B + (p.symbol || sym) + R +
+        '  ' + DIM + was + R + ' → ' + now +
+        '  conf ' + p.confidence + '%  score ' + p.adjustedScore
+      );
+      if (stateLog.length > 8) stateLog.shift();
+    }
+    prevStates[sym] = cur;
+  }
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────────────
+function shutdown() {
+  process.stdout.write('\nStopped.\n');
+  process.exit(0);
+}
+process.on('SIGINT',  shutdown);
+process.on('SIGTERM', shutdown);
+
+process.stderr.write(
+  '\x1b[2m⚠  tradingview-mcp  |  Not affiliated with TradingView Inc.\n' +
+  '   Use subject to TradingView Terms of Use.\x1b[0m\n\n'
+);
+
+// Determine which symbols to show
+const displaySymbols = FILTER_SYMS.length ? FILTER_SYMS : ['MGC', 'MNQ'];
+
+process.stdout.write(
+  B + 'Regime Agent' + R + ' starting — ' + displaySymbols.join(' + ') +
+  '  poll ' + INTERVAL + 'ms  (Ctrl+C to stop)\n\n'
+);
+
+let errors = 0;
+
+async function tick() {
+  let result;
+  try {
+    result = await analyzeRegime();
+    errors = 0;
+  } catch (err) {
+    errors++;
+    if (errors === 1 || errors % 20 === 0) {
+      process.stdout.write('\x1b[K' + DIM + '[' + ts() + '] error: ' + err.message + R + '\n');
+      renderedLines = 0;
+    }
+    return;
+  }
+
+  if (!result?.panes?.length) return;
+
+  pushHistory(result);
+  checkStateChanges(result.panes);
+  render(displaySymbols);
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+(async function loop() {
+  while (true) {
+    const t0 = Date.now();
+    await tick();
+    await sleep(Math.max(0, INTERVAL - (Date.now() - t0)));
+  }
+})();

--- a/strategies/session_tier_sweep.py
+++ b/strategies/session_tier_sweep.py
@@ -1,0 +1,111 @@
+"""
+Compares every strategy across two dimensions: SESSION (asian vs ny) and
+TARGET TIER (scalp vs swing), for a given symbol.
+
+"Liquidity sweep" strategy per session uses whichever engine is actually
+native to that session — strategies/asian_failed_breakout for Asian,
+strategies/ny_open_strategies/liquidity_sweep_reversal for NY — since
+those already ARE the session-specific variants of the same state machine,
+rather than building a third redundant copy.
+
+Run as a module from the repo root:
+    python -m strategies.session_tier_sweep --symbol MNQ1! --scalp 30 10 --swing 100 30
+    python -m strategies.session_tier_sweep --symbol MGC1! --scalp 10 5 --swing 20 10
+"""
+import argparse
+import json
+import sys
+
+from .asian_failed_breakout.backtest import run_backtest as run_asian
+from .asian_failed_breakout.backtest import summarize as summarize_asian
+from .asian_failed_breakout.config import StrategyConfig as AsianConfig
+from .ny_open_strategies import liquidity_sweep_reversal as ny_sweep
+from .ny_open_strategies import ma9_trend_following as ma9
+from .ny_open_strategies import opening_range_breakout as orb
+from .ny_open_strategies import vwap_reversion as vwap
+from .ny_open_strategies.common import summarize as summarize_generic
+
+
+def sweep_asian_cfg(target_points, max_risk_points) -> AsianConfig:
+    cfg = AsianConfig()
+    cfg.risk.target_mode = "fixed_price"
+    cfg.risk.target_price_points = target_points
+    cfg.risk.max_risk_points = max_risk_points
+    return cfg
+
+
+def run_liquidity_sweep(symbol: str, session: str, tier: dict):
+    cfg = sweep_asian_cfg(tier["target_points"], tier["max_risk_points"])
+    if session == "asian":
+        df = run_asian(symbol, cfg, days=None)
+        return summarize_asian(df)
+    else:
+        df = ny_sweep.run_backtest(symbol, cfg, days=None)
+        return ny_sweep.summarize(df)
+
+
+def run_vwap(symbol: str, session: str, tier: dict):
+    cfg = vwap.VWAPReversionConfig(target_mode="fixed_price", target_price_points=tier["target_points"])
+    cfg.risk.max_risk_points = tier["max_risk_points"]
+    return summarize_generic(vwap.run_backtest(symbol, cfg, days=None, session=session))
+
+
+def run_ma9(symbol: str, session: str, tier: dict):
+    cfg = ma9.MA9TrendConfig(target_mode="fixed_price", target_price_points=tier["target_points"])
+    cfg.risk.max_risk_points = tier["max_risk_points"]
+    return summarize_generic(ma9.run_backtest(symbol, cfg, days=None, session=session))
+
+
+def run_orb(symbol: str, session: str, tier: dict):
+    cfg = orb.ORBConfig(target_mode="fixed_price", target_price_points=tier["target_points"])
+    cfg.risk.max_risk_points = tier["max_risk_points"]
+    return summarize_generic(orb.run_backtest(symbol, cfg, days=None, session=session))
+
+
+STRATEGIES = {
+    "liquidity_sweep": run_liquidity_sweep,
+    "vwap_reversion": run_vwap,
+    "ma9_trend_following": run_ma9,
+    "opening_range_breakout": run_orb,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MNQ1!")
+    parser.add_argument("--scalp", nargs=2, type=float, metavar=("TARGET_PTS", "MAX_RISK_PTS"), default=[30.0, 10.0])
+    parser.add_argument("--swing", nargs=2, type=float, metavar=("TARGET_PTS", "MAX_RISK_PTS"), default=[100.0, 30.0])
+    args = parser.parse_args()
+
+    symbol = args.symbol
+    tiers = {
+        "scalp": {"target_points": args.scalp[0], "max_risk_points": args.scalp[1]},
+        "swing": {"target_points": args.swing[0], "max_risk_points": args.swing[1]},
+    }
+
+    results = {}
+    for strat_name, fn in STRATEGIES.items():
+        for session in ("asian", "ny"):
+            for tier_name, tier in tiers.items():
+                key = f"{strat_name} | {session} | {tier_name}"
+                results[key] = fn(symbol, session, tier)
+
+    print(json.dumps(results, indent=2, default=str))
+
+    print(f"\n=== {symbol} — strategy x session x tier "
+          f"(scalp={tiers['scalp']['target_points']:.0f}pt/{tiers['scalp']['max_risk_points']:.0f}pt, "
+          f"swing={tiers['swing']['target_points']:.0f}pt/{tiers['swing']['max_risk_points']:.0f}pt) ===", file=sys.stderr)
+    print(f"{'strategy':<24} {'session':<7} {'tier':<7} {'trades':>7} {'win%':>7} {'PF':>7} {'avgR':>7} {'total$':>10}",
+          file=sys.stderr)
+    for key, r in results.items():
+        strat, session, tier = [s.strip() for s in key.split("|")]
+        n = r.get("n_trades_filled", 0)
+        wr = f"{r.get('win_rate', 0) * 100:.1f}" if r.get("win_rate") is not None else "-"
+        pf = f"{r.get('profit_factor'):.2f}" if r.get("profit_factor") is not None else "-"
+        avgr = f"{r.get('avg_r_multiple'):.2f}" if r.get("avg_r_multiple") is not None else "-"
+        total = f"{r.get('total_pnl_dollars'):.0f}" if r.get("total_pnl_dollars") is not None else "-"
+        print(f"{strat:<24} {session:<7} {tier:<7} {n:>7} {wr:>7} {pf:>7} {avgr:>7} {total:>10}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/swing_sweep.py
+++ b/strategies/swing_sweep.py
@@ -1,0 +1,101 @@
+"""
+Reconfigures every strategy in strategies/asian_failed_breakout and
+strategies/ny_open_strategies for SWING-sized targets instead of their
+original intraday-scale ones, and reports which strategy/condition
+combination actually produces working swing trades.
+
+Swing targets (points are symbol-agnostic — MNQ1! is used as the data
+source for "NQ" and MGC1! for "GC" since that's what's collected; the point
+target itself applies the same to the full-size contract, just scaled by a
+different point_value):
+    MNQ1! ("NQ"): target 100pt, stop capped at 30pt   (R ~3.3)
+    MGC1! ("GC"): target 20pt,  stop capped at 10pt   (R ~2.0)
+
+For the two state-machine strategies (asian_failed_breakout,
+ny_liquidity_sweep_reversal) this is just RiskConfig.target_mode=
+"fixed_price" + target_price_points + max_risk_points — no entry-detection
+logic changes. For vwap_reversion / ma9_trend_following /
+opening_range_breakout, same idea via each strategy's own target_mode field.
+Entry/setup DETECTION windows are left at their original (short, ~15-bar)
+scale on purpose: what's being tested is "does a structurally-identical
+signal sometimes run 100/20 points before it runs 30/10 the other way," not
+a redesign of how each strategy finds its entries.
+
+Run as a module from the repo root:
+    python -m strategies.swing_sweep
+"""
+import json
+import sys
+
+from .asian_failed_breakout.backtest import run_backtest as run_asian
+from .asian_failed_breakout.backtest import summarize as summarize_asian
+from .asian_failed_breakout.config import StrategyConfig as AsianConfig
+from .ny_open_strategies import liquidity_sweep_reversal as ny_sweep
+from .ny_open_strategies import ma9_trend_following as ma9
+from .ny_open_strategies import opening_range_breakout as orb
+from .ny_open_strategies import vwap_reversion as vwap
+from .ny_open_strategies.common import summarize as summarize_generic
+
+SWING = {
+    "MNQ1!": {"target_points": 100.0, "max_risk_points": 30.0},
+    "MGC1!": {"target_points": 20.0, "max_risk_points": 10.0},
+}
+
+
+def swing_asian_cfg(target_points, max_risk_points) -> AsianConfig:
+    cfg = AsianConfig()
+    cfg.risk.target_mode = "fixed_price"
+    cfg.risk.target_price_points = target_points
+    cfg.risk.max_risk_points = max_risk_points
+    return cfg
+
+
+def run_all(symbol: str) -> dict:
+    sw = SWING[symbol]
+    results = {}
+
+    cfg_asian = swing_asian_cfg(sw["target_points"], sw["max_risk_points"])
+    df = run_asian(symbol, cfg_asian, days=None)
+    results["asian_failed_breakout"] = summarize_asian(df)
+
+    cfg_ny = swing_asian_cfg(sw["target_points"], sw["max_risk_points"])
+    df_ny = ny_sweep.run_backtest(symbol, cfg_ny, days=None)
+    results["ny_liquidity_sweep_reversal"] = ny_sweep.summarize(df_ny)
+
+    vwap_cfg = vwap.VWAPReversionConfig(target_mode="fixed_price", target_price_points=sw["target_points"])
+    vwap_cfg.risk.max_risk_points = sw["max_risk_points"]
+    results["vwap_reversion"] = summarize_generic(vwap.run_backtest(symbol, vwap_cfg, days=None))
+
+    ma9_cfg = ma9.MA9TrendConfig(target_mode="fixed_price", target_price_points=sw["target_points"])
+    ma9_cfg.risk.max_risk_points = sw["max_risk_points"]
+    results["ma9_trend_following"] = summarize_generic(ma9.run_backtest(symbol, ma9_cfg, days=None))
+
+    orb_cfg = orb.ORBConfig(target_mode="fixed_price")
+    orb_cfg.risk.max_risk_points = sw["max_risk_points"]
+    orb_cfg.target_price_points = sw["target_points"]  # ORBConfig itself carries this field per its own module
+    results["opening_range_breakout"] = summarize_generic(orb.run_backtest(symbol, orb_cfg, days=None))
+
+    return results
+
+
+def main():
+    all_results = {}
+    for symbol in SWING:
+        all_results[symbol] = run_all(symbol)
+
+    print(json.dumps(all_results, indent=2, default=str))
+
+    print("\n=== Swing-target summary ===", file=sys.stderr)
+    print(f"{'symbol':<8} {'strategy':<28} {'trades':>7} {'win%':>7} {'PF':>7} {'avgR':>7} {'total$':>10}", file=sys.stderr)
+    for symbol, results in all_results.items():
+        for name, r in results.items():
+            n = r.get("n_trades_filled", 0)
+            wr = f"{r.get('win_rate', 0) * 100:.1f}" if r.get("win_rate") is not None else "-"
+            pf = f"{r.get('profit_factor'):.2f}" if r.get("profit_factor") is not None else "-"
+            avgr = f"{r.get('avg_r_multiple'):.2f}" if r.get("avg_r_multiple") is not None else "-"
+            total = f"{r.get('total_pnl_dollars'):.0f}" if r.get("total_pnl_dollars") is not None else "-"
+            print(f"{symbol:<8} {name:<28} {n:>7} {wr:>7} {pf:>7} {avgr:>7} {total:>10}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/trading-agent.js
+++ b/strategies/trading-agent.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Trading Agent — real-time regime detection + signal alerts
+ *
+ * Run: node strategies/trading-agent.js [--interval 1000]
+ *
+ * What it does:
+ *   • Polls TradingView every ~1s via CDP (one JS eval per tick)
+ *   • Detects regime: RANGING (ADX ≤ 25) vs TRENDING (ADX > 25)
+ *   • Ranging signals:  LIQUIDITY_SWEEP_HIGH/LOW, VWAP_UPPER2/LOWER2
+ *   • Trending signals: EMA9_TOUCH
+ *   • Displays live status header + scrolling signal log
+ */
+
+import { analyzeChart } from '../src/core/agent.js';
+import { parseArgs } from 'node:util';
+
+// ── CLI args ──────────────────────────────────────────────────────────────────
+const { values: argv } = parseArgs({
+  options: {
+    interval: { type: 'string',  short: 'i', default: '1000' },
+    quiet:    { type: 'boolean', short: 'q', default: false  },
+  },
+  strict: false,
+});
+const INTERVAL = Math.max(200, Number(argv.interval) || 1000);
+
+// ── ANSI helpers ──────────────────────────────────────────────────────────────
+const R = '\x1b[0m';
+const B = '\x1b[1m';
+const DIM = '\x1b[2m';
+const RED     = '\x1b[31m';
+const GREEN   = '\x1b[32m';
+const YELLOW  = '\x1b[33m';
+const CYAN    = '\x1b[36m';
+const MAGENTA = '\x1b[35m';
+const WHITE   = '\x1b[37m';
+const BG_RED  = '\x1b[41m';
+const BG_GRN  = '\x1b[42m';
+const BG_YEL  = '\x1b[43m';
+const BG_CYN  = '\x1b[46m';
+
+function pad(s, n) { return String(s).padEnd(n); }
+function rpad(s, n) { return String(s).padStart(n); }
+function fmt(n) { return n != null ? Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : 'N/A'; }
+function ts() { return new Date().toLocaleTimeString('en-US', { hour12: false }); }
+function barDate(unixSec) {
+  if (!unixSec) return '--';
+  return new Date(unixSec * 1000).toLocaleTimeString('en-US', { hour12: false });
+}
+
+// ── Status header (6 fixed lines, redrawn each tick) ─────────────────────────
+const HEADER_LINES = 8;
+let headerDrawn = false;
+
+function drawHeader(d) {
+  const regimeColor = d.regime === 'trending' ? CYAN : MAGENTA;
+  const regimeLabel = d.regime === 'trending'
+    ? `${CYAN}${B}◆ TRENDING${R}`
+    : `${MAGENTA}${B}◇ RANGING${R}`;
+  const adxStr = d.adx != null
+    ? (d.adx > 25 ? `${CYAN}${d.adx}${R}` : `${MAGENTA}${d.adx}${R}`)
+    : 'N/A';
+
+  const vwapStr = d.vwap
+    ? `${fmt(d.vwap.vwap)}  +2SD ${YELLOW}${fmt(d.vwap.upper2)}${R}  -2SD ${YELLOW}${fmt(d.vwap.lower2)}${R}`
+    : `${DIM}(intraday only)${R}`;
+
+  const ema9Str = d.ema9 != null ? fmt(d.ema9) : 'N/A';
+  const swingStr = `H ${YELLOW}${fmt(d.swing_high)}${R}  L ${YELLOW}${fmt(d.swing_low)}${R}`;
+
+  const lines = [
+    `${DIM}${'─'.repeat(62)}${R}`,
+    `  ${B}TRADING AGENT${R}  │  ${B}${d.symbol || '--'}${R}  │  ${d.resolution || '--'}m  │  ${ts()}`,
+    `  Price ${B}${fmt(d.close)}${R}   H ${fmt(d.high)}  L ${fmt(d.low)}`,
+    `  Regime ${regimeLabel}   ADX ${adxStr}   Bar ${barDate(d.bar_time)}`,
+    `  EMA9  ${B}${ema9Str}${R}   Swing ${swingStr}`,
+    `  VWAP  ${vwapStr}`,
+    `${DIM}${'─'.repeat(62)}${R}`,
+    '',
+  ];
+
+  if (headerDrawn) {
+    // Move cursor up HEADER_LINES lines and overwrite
+    process.stdout.write(`\x1b[${HEADER_LINES}A`);
+  }
+  process.stdout.write(lines.map(l => l + '\x1b[K\n').join(''));
+  headerDrawn = true;
+}
+
+// ── Signal rendering ──────────────────────────────────────────────────────────
+const SIGNAL_ICONS = {
+  LIQUIDITY_SWEEP_HIGH: `${BG_RED}${B}  SWEEP HIGH  ${R}`,
+  LIQUIDITY_SWEEP_LOW:  `${BG_GRN}${B}  SWEEP LOW   ${R}`,
+  VWAP_UPPER2:          `${BG_YEL}${B}  VWAP +2SD   ${R}`,
+  VWAP_LOWER2:          `${BG_YEL}${B}  VWAP -2SD   ${R}`,
+  EMA9_TOUCH:           `${BG_CYN}${B}  EMA9 TOUCH  ${R}`,
+};
+
+const BIAS_COLOR = { LONG: GREEN, SHORT: RED };
+
+function printSignal(sig) {
+  const icon  = SIGNAL_ICONS[sig.type] || `${B}[SIGNAL]${R}`;
+  const bias  = sig.bias ? `${BIAS_COLOR[sig.bias] || ''}${B}${sig.bias}${R}` : '';
+  const entry = sig.entry != null ? `entry ${B}${fmt(sig.entry)}${R}` : '';
+  const level = sig.level != null ? `level ${B}${fmt(sig.level)}${R}` : '';
+  console.log(`${DIM}${ts()}${R}  ${icon}  ${bias}  ${entry}  ${level}`);
+  console.log(`         ${sig.desc}`);
+  console.log('');
+}
+
+// ── Dedup: don't re-fire the same signal type on the same bar ─────────────────
+// Key: `${signal_type}:${bar_time}`
+const fired = new Set();
+const FIRED_TTL_MS = 60_000; // prune keys older than 1 min
+let lastPrune = Date.now();
+
+function pruneOldKeys() {
+  if (Date.now() - lastPrune < FIRED_TTL_MS) return;
+  lastPrune = Date.now();
+  // bar_time is in unix seconds; prune keys where bar is older than 1 min
+  const cutoff = Math.floor((Date.now() - FIRED_TTL_MS) / 1000);
+  for (const k of fired) {
+    const parts = k.split(':');
+    const bt = Number(parts[1]);
+    if (bt < cutoff) fired.delete(k);
+  }
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────────────
+let errors = 0;
+
+process.stderr.write(
+  `\x1b[2m⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n` +
+  `   Ensure your usage complies with TradingView's Terms of Use.\x1b[0m\n\n`
+);
+
+console.log(`${B}Trading Agent${R} starting… polling every ${INTERVAL}ms  (Ctrl+C to stop)\n`);
+
+async function tick() {
+  let data;
+  try {
+    data = await analyzeChart();
+    errors = 0;
+  } catch (err) {
+    errors++;
+    if (errors <= 3 || errors % 10 === 0) {
+      // Print error below header without disturbing it
+      process.stdout.write(`\x1b[K${DIM}[${ts()}] connection error (${errors}): ${err.message}${R}\n`);
+    }
+    return;
+  }
+
+  if (!data || data.error) {
+    process.stdout.write(`\x1b[K${DIM}[${ts()}] ${data?.error || 'null result'}${R}\n`);
+    return;
+  }
+
+  // Draw live status header
+  drawHeader(data);
+
+  // Process signals
+  pruneOldKeys();
+  for (const sig of (data.signals || [])) {
+    const key = `${sig.type}:${sig.bar_time}`;
+    if (!fired.has(key)) {
+      fired.add(key);
+      printSignal(sig);
+    }
+  }
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+let running = true;
+function shutdown() {
+  running = false;
+  process.stdout.write('\nStopped.\n');
+  process.exit(0);
+}
+process.on('SIGINT',  shutdown);
+process.on('SIGTERM', shutdown);
+
+while (running) {
+  const t0 = Date.now();
+  await tick();
+  const elapsed = Date.now() - t0;
+  const wait = Math.max(0, INTERVAL - elapsed);
+  if (running) await sleep(wait);
+}
+

--- a/strategies/trend_breakout/__init__.py
+++ b/strategies/trend_breakout/__init__.py
@@ -1,0 +1,20 @@
+"""
+Trend-breakout continuation: a standalone strategy (not a modification of
+the failed-breakout/reversal strategies elsewhere in strategies/) built to
+catch the kind of large, sustained trending move those strategies are
+specifically designed to reject.
+
+Core idea: wait for a level break to show ACCEPTANCE evidence — sustained
+closes beyond it, no reclaim, real distance travelled — the same kind of
+evidence strategies/asian_failed_breakout's engine treats as a reason to
+invalidate a fade trade, used here as the entry trigger instead. Once in,
+manage with a trailing stop (not a fixed R target) so a genuinely large move
+isn't capped early.
+
+Scoped to the specific high-participation windows this was built for: MGC's
+Asian open (~20:00-21:00 ET) and the London/NY pre-market handoff
+(~08:00-09:30 ET), and MNQ's NY open (~09:30-10:30 ET) — configurable.
+
+Run a backtest:
+    python -m strategies.trend_breakout.backtest --symbol MGC1! --days 30
+"""

--- a/strategies/trend_breakout/backtest.py
+++ b/strategies/trend_breakout/backtest.py
@@ -1,0 +1,177 @@
+"""
+Backtest runner: loads 1m bars, computes EMA9 and ATR(14) locally, tracks
+PDH/PDL plus each target window's own opening range, and walks 1m bars
+through TrendBreakoutEngine. New candidates may only start inside one of the
+three configured session windows (Asian open, London/NY pre-market handoff,
+NY open) — an already-open trade keeps trailing regardless of the window.
+
+Run as a module from the repo root:
+    python -m strategies.trend_breakout.backtest --symbol MGC1! --days 30
+    python -m strategies.trend_breakout.backtest --symbol MNQ1! --days 30 --window ny_open
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from ..asian_failed_breakout.levels import _in_window, _parse_hm
+from ..ny_open_strategies.common import ET, RAW_DIR, load_point_value
+from .config import TrendBreakoutConfig
+from .engine import TrendBreakoutEngine
+from .levels import PDHPDLTracker, WindowOpeningRangeTracker
+
+OUT_DIR = Path.home() / "data" / "trend-breakout-backtests"
+
+WINDOW_NAMES = ("asian_open", "premarket_handoff", "ny_open")
+
+
+def _load_bars(symbol: str) -> pd.DataFrame:
+    stem = symbol.replace(":", "_").replace("!", "")
+    path = RAW_DIR / f"{stem}_1.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No raw 1m data at {path} — run ml/data_collection/collect_replay.py first.")
+    return pd.read_parquet(path).sort_values("time").reset_index(drop=True)
+
+
+def _add_ema_atr(df: pd.DataFrame, atr_period: int) -> pd.DataFrame:
+    df["ema9"] = df["close"].ewm(span=9, adjust=False).mean()
+    prev_close = df["close"].shift(1)
+    tr = pd.concat([
+        df["high"] - df["low"],
+        (df["high"] - prev_close).abs(),
+        (df["low"] - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    df[f"atr_{atr_period}"] = tr.ewm(alpha=1 / atr_period, min_periods=atr_period, adjust=False).mean()
+    return df
+
+
+def _window_specs(cfg: TrendBreakoutConfig):
+    s = cfg.sessions
+    return {
+        "asian_open": (s.asian_open_start, s.asian_open_end, cfg.session_toggles.asian_open_enabled),
+        "premarket_handoff": (s.premarket_handoff_start, s.premarket_handoff_end, cfg.session_toggles.premarket_handoff_enabled),
+        "ny_open": (s.ny_open_start, s.ny_open_end, cfg.session_toggles.ny_open_enabled),
+    }
+
+
+def run_backtest(symbol: str, cfg: TrendBreakoutConfig, days: int | None = None,
+                  window_filter: str | None = None) -> pd.DataFrame:
+    df = _load_bars(symbol)
+    if days is not None:
+        cutoff = int(df["time"].max()) - days * 86400
+        df = df[df["time"] >= cutoff].reset_index(drop=True)
+
+    df["et"] = pd.to_datetime(df["time"], unit="s", utc=True).dt.tz_convert(ET)
+    df["tod_min"] = df["et"].dt.hour * 60 + df["et"].dt.minute
+    _add_ema_atr(df, cfg.trailing.atr_period)
+
+    rollover = cfg.sessions.globex_day_rollover_hour
+    pdh_pdl = PDHPDLTracker(rollover)
+    window_trackers = {
+        name: WindowOpeningRangeTracker(start, end, cfg.sessions.opening_range_minutes, rollover)
+        for name, (start, end, enabled) in _window_specs(cfg).items() if enabled
+    }
+    window_bounds = {name: (_parse_hm(start), _parse_hm(end)) for name, (start, end, enabled) in _window_specs(cfg).items()}
+
+    engine = TrendBreakoutEngine(cfg, symbol, load_point_value(symbol))
+
+    records = []
+    n = len(df)
+    for i in range(n):
+        bar = {"time": int(df["time"].iloc[i]), "open": df["open"].iloc[i], "high": df["high"].iloc[i],
+               "low": df["low"].iloc[i], "close": df["close"].iloc[i]}
+        et_ts = df["et"].iloc[i]
+        pdh_pdl.update(bar, et_ts)
+        for tracker in window_trackers.values():
+            tracker.update(bar, et_ts)
+
+        tod = int(df["tod_min"].iloc[i])
+        active_window = None
+        for name in WINDOW_NAMES:
+            if name not in window_trackers:
+                continue
+            start_min, end_min = window_bounds[name]
+            if _in_window(tod, start_min, end_min):
+                active_window = name
+                break
+        session_label = active_window or "none"
+        tradeable = active_window is not None and (window_filter is None or active_window == window_filter)
+
+        levels = {"pdh": pdh_pdl.pdh, "pdl": pdh_pdl.pdl}
+        if active_window is not None:
+            wt = window_trackers[active_window]
+            if wt.high is not None:
+                levels["opening_range_high"] = wt.high
+                levels["opening_range_low"] = wt.low
+        levels = {k: v for k, v in levels.items() if v is not None and not (isinstance(v, float) and pd.isna(v))}
+
+        atr_val = df[f"atr_{cfg.trailing.atr_period}"].iloc[i]
+        atr_val = float(atr_val) if pd.notna(atr_val) else None
+
+        recs = engine.on_bar(bar, float(df["ema9"].iloc[i]), atr_val, levels, session_label, tradeable)
+        records.extend(recs)
+
+    if n:
+        last_bar = {"time": int(df["time"].iloc[-1]), "close": float(df["close"].iloc[-1])}
+        records.extend(engine.force_close_all(last_bar))
+
+    out = pd.DataFrame([r.__dict__ for r in records])
+    if not out.empty:
+        for col in ("timestamp", "break_timestamp", "entry_timestamp", "exit_timestamp"):
+            if col in out.columns:
+                out[col.replace("timestamp", "et")] = pd.to_datetime(out[col], unit="s", utc=True).dt.tz_convert(ET)
+        out = out.sort_values("timestamp", na_position="first").reset_index(drop=True)
+    return out
+
+
+def summarize(df: pd.DataFrame) -> dict:
+    if df.empty:
+        return {"n_setups": 0}
+    status_counts = df["setup_status"].value_counts().to_dict()
+    reason_counts = df["rejection_reason"].dropna().value_counts().to_dict()
+    filled = df[df["setup_status"].isin(["FILLED", "OPEN_AT_BACKTEST_END"])]
+    summary = {"n_setups_logged": len(df), "status_counts": status_counts, "rejection_reasons": reason_counts,
+               "n_trades_filled": len(filled)}
+    if len(filled):
+        wins = filled[filled["pnl_points"] > 0]
+        gross_profit = filled.loc[filled["pnl_dollars"] > 0, "pnl_dollars"].sum()
+        gross_loss = -filled.loc[filled["pnl_dollars"] < 0, "pnl_dollars"].sum()
+        summary.update({
+            "win_rate": float(len(wins) / len(filled)),
+            "total_pnl_dollars": float(filled["pnl_dollars"].sum()),
+            "avg_r_multiple": float(filled["r_multiple"].mean()) if filled["r_multiple"].notna().any() else None,
+            "median_r_multiple": float(filled["r_multiple"].median()) if filled["r_multiple"].notna().any() else None,
+            "profit_factor": float(gross_profit / gross_loss) if gross_loss > 0 else None,
+            "avg_bars_held": float(filled["bars_held"].mean()) if filled["bars_held"].notna().any() else None,
+            "by_direction": filled.groupby("direction")["pnl_dollars"].agg(["count", "sum", "mean"]).to_dict("index"),
+            "by_session": filled.groupby("session")["pnl_dollars"].agg(["count", "sum", "mean"]).to_dict("index"),
+        })
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--symbol", default="MGC1!")
+    parser.add_argument("--days", type=int, default=None)
+    parser.add_argument("--window", choices=list(WINDOW_NAMES), default=None, help="restrict to one window only")
+    parser.add_argument("--max-risk", type=float, default=None)
+    args = parser.parse_args()
+
+    cfg = TrendBreakoutConfig()
+    if args.max_risk is not None:
+        cfg.risk.max_risk_points = args.max_risk
+
+    df = run_backtest(args.symbol, cfg, args.days, args.window)
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stem = args.symbol.replace(":", "_").replace("!", "")
+    out_path = OUT_DIR / f"{stem}_trend_breakout.csv"
+    df.to_csv(out_path, index=False)
+    print(f"Wrote {len(df)} records to {out_path}", file=sys.stderr)
+    print(json.dumps(summarize(df), indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/trend_breakout/config.py
+++ b/strategies/trend_breakout/config.py
@@ -1,0 +1,67 @@
+"""
+All tunable parameters, grouped by concern. Defaults are order-of-magnitude
+reasonable starting points, not fitted values — same convention as every
+other strategy built this session.
+"""
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SessionWindows:
+    """All times ET. New CANDIDATES may only start inside these windows —
+    an already-open trade is allowed to keep trailing past the window's end,
+    since a real trend doesn't stop just because the window that spotted it
+    closed."""
+    asian_open_start: str = "20:00"
+    asian_open_end: str = "21:00"
+    premarket_handoff_start: str = "08:00"
+    premarket_handoff_end: str = "09:30"
+    ny_open_start: str = "09:30"
+    ny_open_end: str = "10:30"
+    opening_range_minutes: int = 15  # each window's own first-N-minutes range, used as one level source
+    globex_day_rollover_hour: int = 18
+
+
+@dataclass
+class SessionToggles:
+    asian_open_enabled: bool = True
+    premarket_handoff_enabled: bool = True
+    ny_open_enabled: bool = True
+
+
+@dataclass
+class BreakoutConfig:
+    min_penetration_points: float = 0.3
+    max_bars_to_acceptance: int = 20
+    # Acceptance = the same kind of evidence the reversal strategies use to
+    # REJECT a fade, used here as the entry trigger instead: enough closes
+    # beyond the level, or enough distance travelled, without a reclaim.
+    min_closes_beyond: int = 3
+    min_acceptance_distance_points: float = 1.0
+    require_ema9_alignment: bool = True
+
+
+@dataclass
+class TrailingStopConfig:
+    atr_period: int = 14
+    initial_stop_buffer_points: float = 0.2
+    trail_atr_multiplier: float = 2.0
+    # Don't start trailing immediately — an initial stop just beyond the
+    # broken level stays in force until the trade is this many R favorable,
+    # so a trend that's barely gotten going doesn't get stopped by a normal
+    # pullback before it's proven anything.
+    activate_trail_after_r: float = 1.0
+
+
+@dataclass
+class RiskConfig:
+    max_risk_points: float = 10.0
+
+
+@dataclass
+class TrendBreakoutConfig:
+    sessions: SessionWindows = field(default_factory=SessionWindows)
+    session_toggles: SessionToggles = field(default_factory=SessionToggles)
+    breakout: BreakoutConfig = field(default_factory=BreakoutConfig)
+    trailing: TrailingStopConfig = field(default_factory=TrailingStopConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)

--- a/strategies/trend_breakout/engine.py
+++ b/strategies/trend_breakout/engine.py
@@ -1,0 +1,300 @@
+"""
+Core state machine. One candidate per direction:
+
+  IDLE -> APPROACHING -> WATCHING_ACCEPTANCE -> (ENTRY -> IN_POSITION) | INVALID | EXPIRED
+
+Long = breaking ABOVE a resistance level (PDH or the active window's opening
+range high) and continuing; short = breaking BELOW a support level (PDL or
+opening range low) and continuing. A level break alone is never a signal —
+WATCHING_ACCEPTANCE requires the same kind of evidence the reversal
+strategies elsewhere in strategies/ use to REJECT a fade (sustained closes
+beyond the level, real distance travelled, no reclaim) before it counts as
+a real trend, not a fake-out.
+
+Once IN_POSITION, there is no fixed target — only an initial stop (just
+beyond the broken level) that switches to an ATR-based trailing stop once
+the trade is favorable enough to have proven itself. This is deliberate:
+the whole point of this strategy is to not cap a genuinely large move at a
+small fixed multiple.
+"""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class State(str, Enum):
+    IDLE = "IDLE"
+    APPROACHING = "APPROACHING"
+    BROKEN = "BROKEN"
+    WATCHING_ACCEPTANCE = "WATCHING_ACCEPTANCE"
+
+
+_LONG_LEVEL_FIELDS = ("pdh", "opening_range_high")
+_SHORT_LEVEL_FIELDS = ("pdl", "opening_range_low")
+
+
+@dataclass
+class TrendBreakoutRecord:
+    timestamp: int
+    symbol: str
+    session: str
+    direction: str
+    level_type: str
+    level_price: float
+    break_price: Optional[float] = None
+    break_timestamp: Optional[int] = None
+    bars_to_acceptance: Optional[int] = None
+    entry_price: Optional[float] = None
+    entry_timestamp: Optional[int] = None
+    initial_stop: Optional[float] = None
+    risk_distance: Optional[float] = None
+    setup_status: str = "PENDING"
+    rejection_reason: Optional[str] = None
+    exit_price: Optional[float] = None
+    exit_timestamp: Optional[int] = None
+    bars_held: Optional[int] = None
+    pnl_points: Optional[float] = None
+    pnl_dollars: Optional[float] = None
+    r_multiple: Optional[float] = None
+    mae_points: Optional[float] = None
+    mfe_points: Optional[float] = None
+
+
+@dataclass
+class _Candidate:
+    direction: str
+    state: State = State.IDLE
+    level_type: Optional[str] = None
+    level_price: Optional[float] = None
+    approach_time: Optional[int] = None
+    break_price: Optional[float] = None
+    break_time: Optional[int] = None
+    bars_since_break: int = 0
+    closes_beyond_count: int = 0
+    max_distance: float = 0.0
+
+    def reset(self):
+        self.__init__(direction=self.direction)
+
+
+@dataclass
+class _OpenTrade:
+    direction: str
+    entry_price: float
+    entry_time: int
+    initial_stop: float
+    current_stop: float
+    initial_risk: float
+    record: TrendBreakoutRecord
+    trail_active: bool = False
+    extreme_since_entry: float = 0.0
+    mae_points: float = 0.0
+    mfe_points: float = 0.0
+
+
+class TrendBreakoutEngine:
+    def __init__(self, cfg, symbol: str, point_value: float):
+        self.cfg = cfg
+        self.symbol = symbol
+        self.point_value = point_value
+        self.candidates = {"long": _Candidate("long"), "short": _Candidate("short")}
+        self.open_trades: list[_OpenTrade] = []
+        self._prev_close = None
+        self._prev_ema9 = None
+
+    def on_bar(self, bar: dict, ema9: float, atr: Optional[float], levels: dict, session: str,
+               tradeable: bool) -> list[TrendBreakoutRecord]:
+        records: list[TrendBreakoutRecord] = []
+
+        still_open = []
+        for t in self.open_trades:
+            rec = self._update_trade(t, bar, atr)
+            if rec is not None:
+                records.append(rec)
+            else:
+                still_open.append(t)
+        self.open_trades = still_open
+
+        for direction, fields in (("long", _LONG_LEVEL_FIELDS), ("short", _SHORT_LEVEL_FIELDS)):
+            rec = self._step(direction, fields, levels, bar, ema9, session, tradeable)
+            if rec is not None:
+                records.append(rec)
+
+        self._prev_close = bar["close"]
+        self._prev_ema9 = ema9
+        return records
+
+    # ------------------------------------------------------------------
+    def _step(self, direction: str, level_fields: tuple, levels: dict, bar: dict, ema9: float,
+              session: str, tradeable: bool) -> Optional[TrendBreakoutRecord]:
+        c = self.candidates[direction]
+        is_long = direction == "long"
+        cfg = self.cfg
+
+        if c.state == State.IDLE and not tradeable:
+            return None
+
+        if c.state == State.BROKEN:
+            c.state = State.WATCHING_ACCEPTANCE
+
+        if c.state == State.IDLE:
+            best_type, best_price, best_dist = None, None, None
+            for name in level_fields:
+                price = levels.get(name)
+                if price is None:
+                    continue
+                dist = abs(bar["close"] - price)
+                if best_dist is None or dist < best_dist:
+                    best_type, best_price, best_dist = name, price, dist
+            if best_type is None or best_dist > cfg.breakout.min_acceptance_distance_points * 8:
+                return None
+            c.level_type, c.level_price, c.approach_time = best_type, best_price, bar["time"]
+            c.state = State.APPROACHING
+            # fall through to check the break on this same bar
+
+        if c.state == State.APPROACHING:
+            pen = cfg.breakout.min_penetration_points
+            broken = (bar["high"] > c.level_price + pen) if is_long else (bar["low"] < c.level_price - pen)
+            if broken:
+                c.break_price, c.break_time = bar["close"], bar["time"]
+                c.bars_since_break = 0
+                c.closes_beyond_count = 0
+                c.max_distance = 0.0
+                c.state = State.BROKEN
+                return None
+            if abs(bar["close"] - c.level_price) > cfg.breakout.min_acceptance_distance_points * 4:
+                c.reset()  # drifted away without breaking — not this level's moment
+            return None
+
+        if c.state == State.WATCHING_ACCEPTANCE:
+            c.bars_since_break += 1
+            beyond = (bar["close"] > c.level_price) if is_long else (bar["close"] < c.level_price)
+            if beyond:
+                c.closes_beyond_count += 1
+                dist = abs(bar["close"] - c.level_price)
+                c.max_distance = max(c.max_distance, dist)
+
+            reclaimed = (bar["close"] < c.level_price) if is_long else (bar["close"] > c.level_price)
+            if reclaimed:
+                # failed breakout — price came right back through the level,
+                # this was a fake-out, not a real trend. Same evidence the
+                # reversal strategies would treat as "reclaim" (their
+                # SUCCESS case) is this strategy's failure case.
+                rec = self._finalize(c, "INVALID", "FAILED_BREAKOUT_RECLAIMED", direction, session)
+                c.reset()
+                return rec
+
+            accepted = (c.closes_beyond_count >= cfg.breakout.min_closes_beyond
+                        or c.max_distance >= cfg.breakout.min_acceptance_distance_points)
+            if accepted:
+                if cfg.breakout.require_ema9_alignment:
+                    aligned = (bar["close"] > ema9) if is_long else (bar["close"] < ema9)
+                    if not aligned:
+                        accepted = False
+
+            if accepted:
+                entry_price = bar["close"]
+                initial_stop = (c.level_price - cfg.trailing.initial_stop_buffer_points) if is_long else \
+                                (c.level_price + cfg.trailing.initial_stop_buffer_points)
+                risk_distance = abs(entry_price - initial_stop)
+                if risk_distance <= 0 or risk_distance > cfg.risk.max_risk_points:
+                    rec = self._finalize(c, "INVALID", "RISK_TOO_LARGE", direction, session)
+                    c.reset()
+                    return rec
+
+                record = TrendBreakoutRecord(
+                    timestamp=c.approach_time, symbol=self.symbol, session=session, direction=direction,
+                    level_type=c.level_type, level_price=c.level_price, break_price=c.break_price,
+                    break_timestamp=c.break_time, bars_to_acceptance=c.bars_since_break,
+                    entry_price=entry_price, entry_timestamp=bar["time"], initial_stop=initial_stop,
+                    risk_distance=risk_distance, setup_status="OPEN",
+                )
+                self.open_trades.append(_OpenTrade(
+                    direction=direction, entry_price=entry_price, entry_time=bar["time"],
+                    initial_stop=initial_stop, current_stop=initial_stop, initial_risk=risk_distance,
+                    record=record, extreme_since_entry=entry_price,
+                ))
+                c.reset()
+                return None
+
+            if c.bars_since_break >= cfg.breakout.max_bars_to_acceptance:
+                rec = self._finalize(c, "EXPIRED", "SETUP_EXPIRED", direction, session)
+                c.reset()
+                return rec
+            return None
+        return None
+
+    def _finalize(self, c: _Candidate, status: str, reason: str, direction: str, session: str) -> TrendBreakoutRecord:
+        return TrendBreakoutRecord(
+            timestamp=c.approach_time, symbol=self.symbol, session=session, direction=direction,
+            level_type=c.level_type, level_price=c.level_price, break_price=c.break_price,
+            break_timestamp=c.break_time, bars_to_acceptance=c.bars_since_break,
+            setup_status=status, rejection_reason=reason,
+        )
+
+    # ------------------------------------------------------------------
+    def _update_trade(self, t: _OpenTrade, bar: dict, atr: Optional[float]) -> Optional[TrendBreakoutRecord]:
+        is_long = t.direction == "long"
+        cfg = self.cfg
+
+        adverse = (t.entry_price - bar["low"]) if is_long else (bar["high"] - t.entry_price)
+        favorable = (bar["high"] - t.entry_price) if is_long else (t.entry_price - bar["low"])
+        t.mae_points = max(t.mae_points, adverse)
+        t.mfe_points = max(t.mfe_points, favorable)
+
+        t.extreme_since_entry = max(t.extreme_since_entry, bar["high"]) if is_long else \
+                                 min(t.extreme_since_entry, bar["low"])
+
+        favorable_r = ((t.extreme_since_entry - t.entry_price) / t.initial_risk) if is_long else \
+                      ((t.entry_price - t.extreme_since_entry) / t.initial_risk)
+        if not t.trail_active and favorable_r >= cfg.trailing.activate_trail_after_r:
+            t.trail_active = True
+
+        if t.trail_active and atr is not None and atr > 0:
+            candidate_stop = t.extreme_since_entry - cfg.trailing.trail_atr_multiplier * atr if is_long else \
+                              t.extreme_since_entry + cfg.trailing.trail_atr_multiplier * atr
+            t.current_stop = max(t.current_stop, candidate_stop) if is_long else min(t.current_stop, candidate_stop)
+
+        stop_hit = bar["low"] <= t.current_stop if is_long else bar["high"] >= t.current_stop
+        if not stop_hit:
+            return None
+
+        exit_price = t.current_stop
+        pnl_points = (exit_price - t.entry_price) if is_long else (t.entry_price - exit_price)
+        rec = t.record
+        rec.exit_price = exit_price
+        rec.exit_timestamp = bar["time"]
+        rec.pnl_points = pnl_points
+        rec.pnl_dollars = pnl_points * self.point_value
+        rec.r_multiple = pnl_points / t.initial_risk if t.initial_risk else None
+        rec.bars_held = self._bars_between(t.entry_time, bar["time"])
+        rec.setup_status = "FILLED"
+        rec.mae_points = t.mae_points
+        rec.mfe_points = t.mfe_points
+        return rec
+
+    def force_close_all(self, last_bar: dict) -> list[TrendBreakoutRecord]:
+        out = []
+        for t in self.open_trades:
+            is_long = t.direction == "long"
+            price = last_bar["close"]
+            pnl_points = (price - t.entry_price) if is_long else (t.entry_price - price)
+            rec = t.record
+            rec.exit_price = price
+            rec.exit_timestamp = last_bar["time"]
+            rec.pnl_points = pnl_points
+            rec.pnl_dollars = pnl_points * self.point_value
+            rec.r_multiple = pnl_points / t.initial_risk if t.initial_risk else None
+            rec.bars_held = self._bars_between(t.entry_time, last_bar["time"])
+            rec.setup_status = "OPEN_AT_BACKTEST_END"
+            rec.mae_points = t.mae_points
+            rec.mfe_points = t.mfe_points
+            out.append(rec)
+        self.open_trades = []
+        return out
+
+    @staticmethod
+    def _bars_between(t1, t2, bar_seconds: int = 60):
+        if t1 is None or t2 is None:
+            return None
+        return int(round((t2 - t1) / bar_seconds))

--- a/strategies/trend_breakout/levels.py
+++ b/strategies/trend_breakout/levels.py
@@ -1,0 +1,65 @@
+"""
+Level sources: PDH/PDL (previous Globex-day high/low) plus, for whichever
+target window is currently active, that window's own opening range (first
+`opening_range_minutes` minutes) — the breakout reference for that
+session's move.
+"""
+from ..asian_failed_breakout.levels import _globex_day_id, _in_window, _parse_hm
+
+
+class PDHPDLTracker:
+    """Same Globex-day-rollover convention as
+    strategies/asian_failed_breakout/levels.py's LevelTracker, but only
+    PDH/PDL — no need to pull in that class's Asian-range/swing tracking
+    for a strategy that doesn't use them."""
+    def __init__(self, rollover_hour: int = 18):
+        self._rollover_hour = rollover_hour
+        self._day = None
+        self._day_high = None
+        self._day_low = None
+        self.pdh = None
+        self.pdl = None
+
+    def update(self, bar: dict, et_ts) -> None:
+        day = _globex_day_id(et_ts, self._rollover_hour)
+        if self._day is None:
+            self._day = day
+            self._day_high, self._day_low = bar["high"], bar["low"]
+            return
+        if day != self._day:
+            self.pdh, self.pdl = self._day_high, self._day_low
+            self._day = day
+            self._day_high, self._day_low = bar["high"], bar["low"]
+        else:
+            self._day_high = max(self._day_high, bar["high"])
+            self._day_low = min(self._day_low, bar["low"])
+
+
+class WindowOpeningRangeTracker:
+    """First `opening_minutes` minutes of a named session window, per
+    occurrence (reset once per Globex day). Updated on 1m bars directly —
+    these windows are short enough (60-90 min) that 5m granularity would be
+    too coarse relative to the 15-minute opening slice itself."""
+    def __init__(self, start: str, end: str, opening_minutes: int, rollover_hour: int = 18):
+        self._start_min = _parse_hm(start)
+        self._end_min = _parse_hm(end)
+        self._opening_minutes = opening_minutes
+        self._rollover_hour = rollover_hour
+        self._day = None
+        self.high = None
+        self.low = None
+
+    def update(self, bar: dict, et_ts) -> None:
+        day = _globex_day_id(et_ts, self._rollover_hour)
+        if day != self._day:
+            self._day = day
+            self.high = None
+            self.low = None
+        tod = et_ts.hour * 60 + et_ts.minute
+        minutes_since_open = (tod - self._start_min) % 1440
+        if _in_window(tod, self._start_min, self._end_min) and minutes_since_open < self._opening_minutes:
+            if self.high is None:
+                self.high, self.low = bar["high"], bar["low"]
+            else:
+                self.high = max(self.high, bar["high"])
+                self.low = min(self.low, bar["low"])

--- a/strategies/weekly_volume_baseline.py
+++ b/strategies/weekly_volume_baseline.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Weekly volume baseline — average 1-minute volume per hour-of-day (ET) over the
+trailing week, sourced from yfinance. This replaces the in-browser CDP volume
+calculation, which was limited to whatever bars TradingView happened to have
+buffered in memory.
+
+Usage:
+    python3 weekly_volume_baseline.py MNQ=F,MGC=F [--interval 1m] [--period 7d]
+
+Output (stdout, JSON):
+    {
+      "MNQ=F": { "0": 412.3, "1": 388.1, ..., "23": 501.9, "_samples": {"0": 35, ...} },
+      "MGC=F": { ... }
+    }
+Hour keys are ET hour-of-day (0-23), values are mean per-bar volume in that hour
+bucket across all days in the lookback window.
+"""
+import sys
+import json
+import argparse
+
+import yfinance as yf
+import pandas as pd
+
+
+def compute_baseline(ticker: str, interval: str, period: str) -> dict:
+    df = yf.download(ticker, period=period, interval=interval, progress=False)
+    if df is None or df.empty:
+        return {"error": "no data returned"}
+
+    # yfinance sometimes returns a MultiIndex column (Price, Ticker) — flatten it
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+
+    if df.index.tz is None:
+        df.index = df.index.tz_localize("UTC").tz_convert("America/New_York")
+    else:
+        df.index = df.index.tz_convert("America/New_York")
+
+    df["hour"] = df.index.hour
+    grouped = df.groupby("hour")["Volume"]
+    means = grouped.mean()
+    counts = grouped.count()
+
+    result = {str(h): round(float(means.get(h, 0.0)), 2) for h in range(24)}
+    result["_samples"] = {str(h): int(counts.get(h, 0)) for h in range(24)}
+    result["_bars_total"] = int(len(df))
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("tickers", help="comma-separated yfinance tickers, e.g. MNQ=F,MGC=F")
+    parser.add_argument("--interval", default="1m")
+    parser.add_argument("--period", default="7d")
+    args = parser.parse_args()
+
+    out = {}
+    for ticker in args.tickers.split(","):
+        ticker = ticker.strip()
+        if not ticker:
+            continue
+        try:
+            out[ticker] = compute_baseline(ticker, args.interval, args.period)
+        except Exception as e:
+            out[ticker] = {"error": str(e)}
+
+    print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`chart_snapshot` MCP tool** — collapses a multi-call chart analysis workflow (state + quote + OHLCV + study values + pine graphics) into a single CDP round-trip.
- **Signal agent** (`strategies/trading-agent.js`) — ADX-based regime detection with liquidity-sweep, VWAP±2SD, and EMA9-touch alerts.
- **Regime agent** (`strategies/regime-agent.js`, `src/core/regime.js`) — four-layer ranging-vs-trending classifier (structure/BOS-CHoCH, price action, volume, session) with a reversal-probability score and a `CONTINUE`/`FADE`/`WAIT` trade bias that explicitly separates trend continuation from liquidity raids.
- **Weekly volume baseline** (`src/core/weeklyVolume.js`, `strategies/weekly_volume_baseline.py`) — yfinance-sourced same-hour-of-week volume average, replacing an unreliable in-browser CDP baseline (limited to whatever bars TradingView had buffered, and didn't account for intraday seasonality).
- **Asian index + news context** (`src/core/asiaIndices.js`, `src/core/news.js`) — real intraday (1-minute bar) tracking of Hang Seng/Nikkei/KOSPI with change-from-open, change-from-prev-close, and drawdown-from-session-high, rolled up into an aggregate Asia→MNQ spillover-risk score. Plus Trump/Iran/Fed/geopolitical headlines (Google News RSS, no API key) and WTI/Brent oil price.
- **Live HTML dashboard** (`src/dashboard-server.js`, `public/`) — Express + vanilla-JS UI replacing the CLI ticker output. Polls CDP every 300ms for near-real-time ticks, filtered to the `MGC1!`/`MNQ1!` continuous contracts only.

## Why

The existing CLI tools required 5-8 sequential MCP tool calls (and LLM turns) to assemble a full chart read, taking ~2 minutes per analysis. `chart_snapshot` collapses that to one call. The regime/signal agents and dashboard were built on top to support continuous, real-time monitoring rather than one-shot snapshots — including cross-asset context (Asia session indices, macro news) that can move MNQ/MGC before NY open.

## What a reviewer should know

- New Python dependencies: `yfinance` (already present in this environment; not added to a requirements file since the repo has no existing Python dependency manifest).
- New Node dependency: `express` (added to `package.json`).
- `src/core/regime.js` spawns a Python subprocess (`weekly_volume_baseline.py`) on a background timer (~15 min) and caches results in memory — never blocks the live CDP polling loop except on cold start.
- `src/dashboard-server.js` polls CDP every 300ms with an in-flight guard so slow CDP calls never queue up; the regime/Asia/news caches are refreshed independently in the background and HTTP requests never block on a live CDP/yfinance/RSS call except on cold start.
- Asian index and news data quality is bounded by free data sources (yfinance intraday ~1min lag, Google News RSS) — documented as a known limitation, not a bug.

## Test plan

- [x] `chart_snapshot` tool compiles and returns a single-call snapshot matching the individual tools' output shape
- [x] Regime agent (`strategies/regime-agent.js`) verified live against TradingView CDP — correct BOS/CHoCH/sweep detection, ADX regime classification, reversal scoring, and trade-bias output observed against live MGC1!/MNQ1! data
- [x] Weekly volume baseline verified against yfinance for MNQ=F/MGC=F — hour-of-day seasonality confirmed (NY session hours show 5-10x overnight volume)
- [x] Asia indices endpoint verified against live yfinance data (HSI/N225/KOSPI), correct change-from-open/prev-close/session-high calculations and impact scoring
- [x] News aggregator verified — real Google News RSS results returned (including live Iran/Strait of Hormuz headlines)
- [x] Dashboard server verified end-to-end: `/api/regime`, `/api/asia`, `/api/news` all returning correct live data; symbol filter confirmed to only show `MGC1!`/`MNQ1!`; tick cadence confirmed ~300ms via timestamp diffs
- [ ] Manual review of dashboard UI in a browser (tested via curl/API only in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)