### PR TITLE
fix: correct tool count from 68 to 78 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+78 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` line 3 said **68 tools** — the stale count from an earlier version of the project
- `server.js` and `README.md` both correctly document **78 tools**
- Verified by counting `server.tool(` calls across all files in `src/tools/`: **78 matches**

## Test plan

- [ ] Grep `src/tools/` for `server.tool(` and confirm count is 78
- [ ] Confirm `CLAUDE.md`, `README.md`, and `server.js` all now agree on 78

🤖 Generated with [Claude Code](https://claude.com/claude-code)