### PR TITLE
fix(tab): make tab_switch actually re-point the CDP read session

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -132,6 +132,34 @@ export async function disconnect() {
   }
 }
 
+/**
+ * Re-point the cached CDP connection to a specific target id.
+ * Closes the current client (if any) and attaches to the given target, so all
+ * subsequent read/eval tools operate on that tab. Used by tab_switch to make
+ * the connection actually follow the switched-to tab.
+ */
+export async function reconnectTo(targetId) {
+  if (client) {
+    try { await client.close(); } catch {}
+    client = null;
+    targetInfo = null;
+  }
+
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const target = targets.find(t => t.id === targetId);
+  if (!target) {
+    throw new Error(`Target ${targetId} not found in /json/list — is the tab still open?`);
+  }
+
+  targetInfo = target;
+  client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
+  await client.Runtime.enable();
+  await client.Page.enable();
+  await client.DOM.enable();
+  return { id: target.id, url: target.url };
+}
+
 // --- Direct API path helpers ---
 // Each returns the STRING expression path after verifying it exists.
 // Callers use the returned string in their own evaluate() calls.

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,7 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
+import { getClient, evaluate, reconnectTo } from '../connection.js';
 
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
@@ -95,12 +95,19 @@ export async function switchTab({ index }) {
 
   const target = tabs.tabs[idx];
 
-  // Use CDP Target.activateTarget to bring the tab to front
+  // Bring the tab to front visually...
   try {
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
-    const text = await resp.text();
-    return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
+    await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
   } catch (e) {
     throw new Error(`Failed to activate tab ${idx}: ${e.message}`);
   }
+
+  // ...and re-point the cached CDP connection so all subsequent reads follow it.
+  try {
+    await reconnectTo(target.id);
+  } catch (e) {
+    throw new Error(`Activated tab ${idx} but failed to attach CDP to it: ${e.message}`);
+  }
+
+  return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
 }


### PR DESCRIPTION
## What

`switchTab()`'s doc comment claims *"Reconnects CDP to the new target"*, but the implementation only called `/json/activate` to bring the tab visually to the front. The cached CDP client in `connection.js` was never re-pointed, so every read/eval tool (`chart_get_state`, `watchlist_get`, `quote_get`, `data_*`, `pine_*`, `capture_screenshot`, …) kept operating on whichever target was grabbed at server startup — even after a successful `tab_switch`. With multiple tabs of the same chart layout open, there was no way to read a specific tab.

## Fix

- Add `reconnectTo(targetId)` in `src/connection.js`: closes the current client and attaches a fresh CDP session (Runtime/Page/DOM enabled) to the given target, updating the module-level `client` + `targetInfo`.
- `switchTab()` in `src/core/tab.js` calls it after `/json/activate`, so subsequent reads follow the switched-to tab.

## Testing

Verified live against TradingView Desktop with two tabs of the *same* layout open (WM vs AAPL). After `tab_switch`, `chart_get_state` and `watchlist_get` return the correct symbol and watchlist for the target tab; switching back toggles correctly. 4/4 assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
