### PR TITLE
Fix getChartApi is not defined in 4 drawing functions

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -45,6 +45,7 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
 }
 
 export async function listDrawings() {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -57,6 +58,7 @@ export async function listDrawings() {
 }
 
 export async function getProperties({ entity_id }) {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -86,6 +88,7 @@ export async function getProperties({ entity_id }) {
 }
 
 export async function removeOne({ entity_id }) {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -107,6 +110,7 @@ export async function removeOne({ entity_id }) {
 }
 
 export async function clearAll() {
+  const { evaluate, getChartApi } = _resolve();
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };


### PR DESCRIPTION
The DI refactor (commit f23eb1b) added _resolve() to drawShape() but missed listDrawings(), getProperties(), removeOne(), and clearAll(). These 4 functions called getChartApi() directly, which was not in scope after the refactor, causing "getChartApi is not defined" at runtime.

Fix: add `const { evaluate, getChartApi } = _resolve();` to each function.
