### PR TITLE
Sync package-lock.json bin metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {


### PR DESCRIPTION
## Summary
- Regenerates `package-lock.json` metadata for the `tv` bin entry that's already declared in `package.json` (`"bin": {"tv": "src/cli/index.js"}`) but was missing from the lockfile's package metadata.

## Why
Running a fresh `npm install` picks up this drift automatically; committing it keeps the lockfile in sync with `package.json` so future installs are reproducible without a diff.

## Test plan
- [x] `npm install` runs clean with no further lockfile changes