### PR TITLE
tv_launch/health-check reliability fix + repo cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# TradingView MCP Configuration
+
+# CDP (Chrome DevTools Protocol) — for local TradingView Desktop chart control
+CDP_HOST=localhost
+CDP_PORT=9222

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,14 @@ scripts/current.pine
 temp_*
 *.log
 discovery-log.json
+
+# Environment & secrets
+.env
+.env.local
+.env.*.local
+
+# macOS
+.DS_Store
+
+# Local Claude Code config
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # TradingView MCP — Claude Instructions
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+An MCP server + CLI that bridges Claude Code to a locally running TradingView Desktop app via Chrome DevTools Protocol (CDP, port 9222). 78 tools for reading and controlling a live chart, every one also exposed as a `tv <command>` CLI command. See README.md for the full tool/command list and user-facing setup.
+
+## Development Commands
+
+```bash
+npm install
+
+# Offline tests — no TradingView needed (mock _deps)
+npm run test:unit   # pine_analyze + cli
+node --test tests/pine_analyze.test.js
+node --test tests/sanitization.test.js
+node --test tests/replay.test.js
+node --test tests/launch.test.js   # tv_launch / health.js — mocked child_process, no real launch
+
+# npm test / test:e2e / test:all / test:verbose all run tests/e2e.test.js,
+# which calls process.exit(1) in its `before` hook if it can't reach
+# TradingView Desktop on localhost:9222 — start TradingView with CDP first.
+npm run test:e2e
+
+# CLI
+node src/cli/index.js <command>   # run CLI directly
+npm link                          # install `tv` globally for `tv <command>`
+tv status                          # verify CDP connection (TradingView must be running)
+
+# Launch TradingView with CDP debugging enabled (macOS)
+./scripts/launch_tv_debug_mac.sh
+```
+
+## Architecture
+
+Three layers, strictly separated:
+
+```
+src/tools/*.js   → MCP tool registration (zod schemas, calls into core/, wraps result via jsonResult)
+src/cli/commands/*.js → CLI command registration (calls into core/ directly, mirrors tools/)
+src/core/*.js    → business logic — builds JS expressions and runs them via connection.js
+src/connection.js → CDP client (chrome-remote-interface), expression sanitization
+```
+
+- `src/server.js` registers every `tools/*.js` module against the `McpServer` and starts the stdio transport. The big `instructions` string passed to `McpServer` is the tool-selection guide also embedded below in this file — keep them in sync if either changes.
+- `src/cli/index.js` registers every `cli/commands/*.js` module against `src/cli/router.js` (a zero-dependency arg parser) — this is how every MCP tool is also a `tv` subcommand.
+- `src/core/index.js` re-exports all core modules as a namespaced public API (`tradingview-mcp/core` export in package.json) — both `tools/` and `cli/commands/` call into the same core functions, so logic is never duplicated between MCP and CLI.
+
+### Core module pattern (`src/core/*.js`)
+
+Every core function follows a dependency-injection pattern for testability:
+
+```js
+function _resolve(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    evaluateAsync: deps?.evaluateAsync || _evaluateAsync,
+    ...
+  };
+}
+export async function setSymbol({ symbol, _deps }) {
+  const { evaluateAsync, waitForChartReady } = _resolve(_deps);
+  await evaluateAsync(`... CDP expression ...`);
+  ...
+}
+```
+
+Unit tests pass `_deps` with mocked `evaluate`/`evaluateAsync` functions and assert on the generated expression strings — no live CDP connection needed. Core functions build a JS expression string (often an IIFE referencing `window.TradingViewApi...`, see `KNOWN_PATHS` in `connection.js`) and pass it to `evaluate`/`evaluateAsync`.
+
+### Sanitization — required for any user-controlled value in a CDP expression
+
+Any value interpolated into a JS expression string passed to `evaluate`/`evaluateAsync` MUST go through one of:
+- `safeString(str)` — JSON.stringify-based escaping for string literals
+- `requireFinite(value, name)` — throws unless the value is a finite number
+
+`tests/sanitization.test.js` audits source files for unsanitized interpolation — run it after touching any `core/*.js` file that builds expression strings from tool input.
+
+### Adding a new tool
+
+1. Add the core logic function in `src/core/<module>.js` (or a new module), following the `_deps`/`_resolve` pattern above.
+2. Register it in `src/core/index.js` if it's a new module.
+3. Add the MCP tool in `src/tools/<module>.js` with a zod schema, calling the core function and wrapping the result with `jsonResult()` (`src/tools/_format.js`).
+4. Register the tool module in `src/server.js` (`registerXTools(server)`), and update the `instructions` string + this file's decision tree if it changes tool selection.
+5. Add the matching CLI command in `src/cli/commands/<module>.js`, registered in `src/cli/index.js`.
+6. Add offline unit tests (mocked `_deps`) and, if feasible, an e2e test in `tests/e2e.test.js`.
+
+## Contribution Scope (from CONTRIBUTING.md)
+
+This is a **local-only bridge** — all chart/data access must go through the locally running TradingView Desktop app via CDP. Out of scope: connecting directly to TradingView's servers, bypassing auth/subscription, scraping/caching/redistributing market data, automated trading/order execution, or reverse-engineering TradingView's proprietary code.
 
 ## Decision Tree — Which Tool When
 
@@ -61,6 +148,10 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 
 ### "Screen multiple symbols"
 - `batch_run` with `symbols: ["ES1!", "NQ1!", "YM1!"]` and `action: "screenshot"` or `"get_ohlcv"`
+
+### "Watch the chart continuously" (CLI-only — no MCP tool)
+- `tv stream quote` / `tv stream <...>` → long-running JSONL poll-and-diff loop to stdout (`src/core/stream.js`, `src/cli/commands/stream.js`)
+- Intentionally has **no MCP tool equivalent**: MCP tool calls must resolve and return a result, but streaming runs forever — it only makes sense as a CLI command piped elsewhere. Don't add a `stream_*` MCP tool without changing this constraint.
 
 ### "Draw on the chart"
 - `draw_shape` → horizontal_line, trend_line, rectangle, text (pass point + optional point2)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,33 @@ tv stream tables --filter Profiler       # table data monitoring
 tv stream all                            # all panes at once (multi-symbol)
 ```
 
+## tvremix Integration (Headless Data & Analytics)
+
+You have access to **tvremix** — a complementary headless TradingView API for data queries, technical analysis, and multi-symbol workflows. tvremix runs as its own MCP server and is available in Claude Code alongside tradingview-mcp.
+
+**No setup required** — tvremix tools work out of the box:
+
+- `tvremix_quote` — real-time price snapshots
+- `tvremix_technicals` — technical indicators (RSI, MACD, Bollinger Bands, etc.)
+- `tvremix_ohlcv` — historical price bars
+- `tvremix_analyze_smc` — market structure analysis (SMC/ICT)
+- `tvremix_analyze_swing` — swing pattern detection
+- `tvremix_compare_symbols` — side-by-side comparison
+- `tvremix_rank_setups` — rank symbols by technical strength
+- `tvremix_screener` — run custom screening queries
+
+### Example in Claude Code
+
+> "Rank NASDAQ:AAPL, NASDAQ:MSFT, and NASDAQ:NVDA by setup quality on the daily timeframe"
+
+tvremix analyzes all three symbols and returns ranked results with technical scores.
+
+> "Switch the chart to the top-ranked symbol and add the Relative Strength Index"
+
+tradingview-mcp changes your local chart to that symbol and adds the indicator.
+
+See [TVREMIX_SETUP.md](TVREMIX_SETUP.md) for complete guide on combining tvremix + tradingview-mcp workflows.
+
 ## How Claude Knows Which Tool to Use
 
 Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project. It contains a complete decision tree:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -427,12 +430,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -451,9 +454,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -588,9 +591,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -639,9 +642,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -852,9 +855,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,13 @@
+/**
+ * Configuration loader for TradingView MCP
+ * Reads environment variables for CDP configuration
+ */
+
+export function getConfig() {
+  return {
+    cdp: {
+      host: process.env.CDP_HOST || 'localhost',
+      port: parseInt(process.env.CDP_PORT || '9222', 10),
+    },
+  };
+}

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -159,25 +159,26 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
-export async function launch({ port, kill_existing } = {}) {
+export async function launch({ port, kill_existing, _deps } = {}) {
+  const deps = { spawn, execSync, existsSync, platform: process.platform, env: process.env, httpGet: null, ..._deps };
   const cdpPort = port || 9222;
   const killFirst = kill_existing !== false;
-  const platform = process.platform;
+  const platform = deps.platform;
 
   const pathMap = {
     darwin: [
       '/Applications/TradingView.app/Contents/MacOS/TradingView',
-      `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
+      `${deps.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
     ],
     win32: [
-      `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
-      `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
-      `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      `${deps.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
+      `${deps.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
+      `${deps.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
     ],
     linux: [
       '/opt/TradingView/tradingview',
       '/opt/TradingView/TradingView',
-      `${process.env.HOME}/.local/share/TradingView/TradingView`,
+      `${deps.env.HOME}/.local/share/TradingView/TradingView`,
       '/usr/bin/tradingview',
       '/snap/tradingview/current/tradingview',
     ],
@@ -186,48 +187,101 @@ export async function launch({ port, kill_existing } = {}) {
   let tvPath = null;
   const candidates = pathMap[platform] || pathMap.linux;
   for (const p of candidates) {
-    if (p && existsSync(p)) { tvPath = p; break; }
+    if (p && deps.existsSync(p)) { tvPath = p; break; }
   }
 
   if (!tvPath) {
     try {
       const cmd = platform === 'win32' ? 'where TradingView.exe' : 'which tradingview';
-      tvPath = execSync(cmd, { timeout: 3000 }).toString().trim().split('\n')[0];
-      if (tvPath && !existsSync(tvPath)) tvPath = null;
+      tvPath = deps.execSync(cmd, { timeout: 3000 }).toString().trim().split('\n')[0];
+      if (tvPath && !deps.existsSync(tvPath)) tvPath = null;
     } catch { /* ignore */ }
   }
 
   if (!tvPath && platform === 'darwin') {
     try {
-      const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();
+      const found = deps.execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();
       if (found) {
         const candidate = `${found}/Contents/MacOS/TradingView`;
-        if (existsSync(candidate)) tvPath = candidate;
+        if (deps.existsSync(candidate)) tvPath = candidate;
       }
     } catch { /* ignore */ }
   }
 
   if (!tvPath) {
-    throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
+    throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort} (note: TradingView v2.14.0+ may reject this flag)`);
   }
 
   if (killFirst) {
     try {
-      if (platform === 'win32') execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
-      else execSync('pkill -f TradingView', { timeout: 5000 });
+      if (platform === 'win32') deps.execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
+      else deps.execSync('pkill -f TradingView', { timeout: 5000 });
       await new Promise(r => setTimeout(r, 1500));
     } catch { /* may not be running */ }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
-  child.unref();
+  // Try direct spawn first (works on TradingView < v2.14 / Electron < 38).
+  // Electron 38+ (Node 22) rejects --remote-debugging-port as an unknown CLI flag
+  // before Chromium can process it. Detect that and fall back to platform-specific strategies.
+  let child = deps.spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: ['ignore', 'ignore', 'pipe'] });
+  const spawnFailed = await new Promise((resolve) => {
+    let settled = false;
+    const settle = (val) => { if (!settled) { settled = true; resolve(val); } };
+    child.stderr.on('data', () => {});
+    child.on('error', () => { clearTimeout(timer); settle(true); });
+    child.on('exit', (code) => {
+      if (code !== null && code !== 0) { clearTimeout(timer); settle(true); }
+    });
+    const timer = setTimeout(() => {
+      // Process survived 2s — flag was accepted. Detach stderr so parent can exit.
+      child.stderr.destroy();
+      settle(false);
+    }, 2000);
+  });
 
+  if (spawnFailed) {
+    // Direct flag rejected (Electron 38+ / Node 22 strict validation).
+    // Try platform-specific fallbacks.
+    child = null;
+
+    if (platform === 'darwin') {
+      // Kill any running instance first — `open -a` only works if no existing
+      // instance is running, otherwise macOS just activates the old (non-CDP) window.
+      try { deps.execSync('pkill -f TradingView', { timeout: 5000 }); } catch { /* may not be running */ }
+      await new Promise(r => setTimeout(r, 2000));
+
+      // Derive the .app bundle path from the binary path for `open -a`.
+      const appMatch = tvPath.match(/^(.+\.app)\//);
+      if (appMatch) {
+        const appBundle = appMatch[1];
+        try {
+          deps.execSync(`open -a "${appBundle}" --args --remote-debugging-port=${cdpPort}`, { timeout: 5000 });
+        } catch { /* ignore — open may return non-zero even on success */ }
+      } else {
+        // No .app bundle found; try spawning without the flag as last resort.
+        const fallback = deps.spawn(tvPath, [], { detached: true, stdio: 'ignore' });
+        fallback.unref();
+      }
+    } else {
+      // Linux / Windows: try environment variable hint, then bare launch.
+      const fallback = deps.spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], {
+        detached: true, stdio: 'ignore',
+        env: { ...deps.env, REMOTE_DEBUGGING_PORT: String(cdpPort) },
+      });
+      fallback.unref();
+    }
+  } else {
+    child.unref();
+  }
+
+  // Poll for CDP regardless of launch strategy.
+  // deps.httpGet allows tests to inject a fake; production uses real http.get.
+  const httpGet = deps.httpGet || (await import('http')).get;
   for (let i = 0; i < 15; i++) {
     await new Promise(r => setTimeout(r, 1000));
     try {
-      const http = await import('http');
       const ready = await new Promise((resolve) => {
-        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+        httpGet(`http://localhost:${cdpPort}/json/version`, (res) => {
           let data = '';
           res.on('data', (chunk) => data += chunk);
           res.on('end', () => resolve(data));
@@ -236,16 +290,26 @@ export async function launch({ port, kill_existing } = {}) {
       if (ready) {
         const info = JSON.parse(ready);
         return {
-          success: true, platform, binary: tvPath, pid: child.pid,
+          success: true, platform, binary: tvPath, pid: child?.pid ?? null,
           cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
           browser: info.Browser, user_agent: info['User-Agent'],
+          ...(spawnFailed ? { fallback_used: true } : {}),
         };
       }
     } catch { /* retry */ }
   }
 
+  if (spawnFailed) {
+    return {
+      success: false, platform, binary: tvPath, cdp_port: cdpPort, cdp_ready: false,
+      error: `TradingView launched but CDP not available on port ${cdpPort}. ` +
+        'This is likely TradingView v2.14.0+ (Electron 38 / Node 22) which rejects --remote-debugging-port as a CLI flag. ' +
+        'Workaround: pkill -f TradingView; sleep 2; open -a TradingView --args --remote-debugging-port=' + cdpPort,
+    };
+  }
+
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform, binary: tvPath, pid: child?.pid ?? null, cdp_port: cdpPort, cdp_ready: false,
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
 }

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -1,33 +1,39 @@
 /**
  * Core health/discovery/launch logic.
  */
-import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
-import { execSync, spawn } from 'child_process';
+import { getClient, getTargetInfo, evaluate } from "../connection.js";
+import { existsSync } from "fs";
+import { execSync, spawn } from "child_process";
 
 export async function healthCheck() {
   await getClient();
   const target = await getTargetInfo();
 
-  const state = await evaluate(`
-    (function() {
-      var result = { url: window.location.href, title: document.title };
-      try {
-        var chart = window.TradingViewApi._activeChartWidgetWV.value();
-        result.symbol = chart.symbol();
-        result.resolution = chart.resolution();
-        result.chartType = chart.chartType();
-        result.apiAvailable = true;
-      } catch(e) {
-        result.symbol = 'unknown';
-        result.resolution = 'unknown';
-        result.chartType = null;
-        result.apiAvailable = false;
-        result.apiError = e.message;
-      }
-      return result;
-    })()
-  `);
+  // Retry TradingViewApi access — it may not be ready immediately after page load
+  let state;
+  for (let attempt = 0; attempt < 8; attempt++) {
+    state = await evaluate(`
+      (function() {
+        var result = { url: window.location.href, title: document.title };
+        try {
+          var chart = window.TradingViewApi._activeChartWidgetWV.value();
+          result.symbol = chart.symbol();
+          result.resolution = chart.resolution();
+          result.chartType = chart.chartType();
+          result.apiAvailable = true;
+        } catch(e) {
+          result.symbol = 'unknown';
+          result.resolution = 'unknown';
+          result.chartType = null;
+          result.apiAvailable = false;
+          result.apiError = e.message;
+        }
+        return result;
+      })()
+    `);
+    if (state?.apiAvailable) break;
+    await new Promise((r) => setTimeout(r, 1500));
+  }
 
   return {
     success: true,
@@ -35,8 +41,8 @@ export async function healthCheck() {
     target_id: target.id,
     target_url: target.url,
     target_title: target.title,
-    chart_symbol: state?.symbol || 'unknown',
-    chart_resolution: state?.resolution || 'unknown',
+    chart_symbol: state?.symbol || "unknown",
+    chart_resolution: state?.resolution || "unknown",
     chart_type: state?.chartType ?? null,
     api_available: state?.apiAvailable ?? false,
   };
@@ -82,10 +88,15 @@ export async function discover() {
     })()
   `);
 
-  const available = Object.values(paths).filter(v => v.available).length;
+  const available = Object.values(paths).filter((v) => v.available).length;
   const total = Object.keys(paths).length;
 
-  return { success: true, apis_available: available, apis_total: total, apis: paths };
+  return {
+    success: true,
+    apis_available: available,
+    apis_total: total,
+    apis: paths,
+  };
 }
 
 export async function uiState() {
@@ -166,86 +177,145 @@ export async function launch({ port, kill_existing } = {}) {
 
   const pathMap = {
     darwin: [
-      '/Applications/TradingView.app/Contents/MacOS/TradingView',
+      "/Applications/TradingView.app/Contents/MacOS/TradingView",
       `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
     ],
     win32: [
       `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
       `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
-      `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      `${process.env["PROGRAMFILES(X86)"]}\\TradingView\\TradingView.exe`,
     ],
     linux: [
-      '/opt/TradingView/tradingview',
-      '/opt/TradingView/TradingView',
+      "/opt/TradingView/tradingview",
+      "/opt/TradingView/TradingView",
       `${process.env.HOME}/.local/share/TradingView/TradingView`,
-      '/usr/bin/tradingview',
-      '/snap/tradingview/current/tradingview',
+      "/usr/bin/tradingview",
+      "/snap/tradingview/current/tradingview",
     ],
   };
 
   let tvPath = null;
   const candidates = pathMap[platform] || pathMap.linux;
   for (const p of candidates) {
-    if (p && existsSync(p)) { tvPath = p; break; }
+    if (p && existsSync(p)) {
+      tvPath = p;
+      break;
+    }
   }
 
   if (!tvPath) {
     try {
-      const cmd = platform === 'win32' ? 'where TradingView.exe' : 'which tradingview';
-      tvPath = execSync(cmd, { timeout: 3000 }).toString().trim().split('\n')[0];
+      const cmd =
+        platform === "win32" ? "where TradingView.exe" : "which tradingview";
+      tvPath = execSync(cmd, { timeout: 3000 })
+        .toString()
+        .trim()
+        .split("\n")[0];
       if (tvPath && !existsSync(tvPath)) tvPath = null;
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
-  if (!tvPath && platform === 'darwin') {
+  if (!tvPath && platform === "darwin") {
     try {
-      const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();
+      const found = execSync(
+        'mdfind "kMDItemFSName == TradingView.app" | head -1',
+        { timeout: 5000 },
+      )
+        .toString()
+        .trim();
       if (found) {
         const candidate = `${found}/Contents/MacOS/TradingView`;
         if (existsSync(candidate)) tvPath = candidate;
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   if (!tvPath) {
-    throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
+    throw new Error(
+      `TradingView not found on ${platform}. Searched: ${candidates.join(", ")}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`,
+    );
   }
 
   if (killFirst) {
     try {
-      if (platform === 'win32') execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
-      else execSync('pkill -f TradingView', { timeout: 5000 });
-      await new Promise(r => setTimeout(r, 1500));
-    } catch { /* may not be running */ }
+      if (platform === "win32")
+        execSync("taskkill /F /IM TradingView.exe", { timeout: 5000 });
+      else execSync("pkill -f TradingView", { timeout: 5000 });
+    } catch {
+      /* may not be running */
+    }
+    // Wait until all TradingView processes are actually gone before spawning
+    for (let i = 0; i < 10; i++) {
+      await new Promise((r) => setTimeout(r, 500));
+      try {
+        const check =
+          platform === "win32"
+            ? execSync('tasklist /FI "IMAGENAME eq TradingView.exe" /NH', {
+                timeout: 3000,
+              }).toString()
+            : execSync("pgrep -f TradingView", { timeout: 3000 })
+                .toString()
+                .trim();
+        const stillRunning =
+          platform === "win32"
+            ? check.includes("TradingView.exe")
+            : check.length > 0;
+        if (!stillRunning) break;
+      } catch {
+        break; // pgrep exits non-zero when nothing found — means it's dead
+      }
+    }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
+  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], {
+    detached: true,
+    stdio: "ignore",
+  });
   child.unref();
 
   for (let i = 0; i < 15; i++) {
-    await new Promise(r => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, 1000));
     try {
-      const http = await import('http');
+      const http = await import("http");
       const ready = await new Promise((resolve) => {
-        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
-          let data = '';
-          res.on('data', (chunk) => data += chunk);
-          res.on('end', () => resolve(data));
-        }).on('error', () => resolve(null));
+        http
+          .get(`http://localhost:${cdpPort}/json/version`, (res) => {
+            let data = "";
+            res.on("data", (chunk) => (data += chunk));
+            res.on("end", () => resolve(data));
+          })
+          .on("error", () => resolve(null));
       });
       if (ready) {
         const info = JSON.parse(ready);
         return {
-          success: true, platform, binary: tvPath, pid: child.pid,
-          cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
-          browser: info.Browser, user_agent: info['User-Agent'],
+          success: true,
+          platform,
+          binary: tvPath,
+          pid: child.pid,
+          cdp_port: cdpPort,
+          cdp_url: `http://localhost:${cdpPort}`,
+          browser: info.Browser,
+          user_agent: info["User-Agent"],
         };
       }
-    } catch { /* retry */ }
+    } catch {
+      /* retry */
+    }
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
-    warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
+    success: true,
+    platform,
+    binary: tvPath,
+    pid: child.pid,
+    cdp_port: cdpPort,
+    cdp_ready: false,
+    warning:
+      "TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.",
   };
 }

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -170,7 +170,7 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
-export async function launch({ port, kill_existing, _deps } = {}) {
+export async function launch({ port, kill_existing, deps: _deps } = {}) {
   const deps = {
     spawn,
     execSync,

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -1,0 +1,425 @@
+/**
+ * Tests for the launch() function in src/core/health.js.
+ *
+ * Covers: path detection, kill-existing, direct spawn success/failure,
+ * macOS `open -a` fallback, Linux/Windows env-var fallback,
+ * CDP polling (success + timeout), and error messages.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { launch } from '../src/core/health.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Minimal fake readable stream (for child.stderr). */
+function fakeStream() {
+  const ee = new EventEmitter();
+  ee.destroy = () => {};
+  return ee;
+}
+
+/**
+ * Create a fake child process.
+ * @param {'survive'|'fail'|'error'} behavior
+ *   - survive: stays alive (never emits exit)
+ *   - fail:    emits exit(1) immediately
+ *   - error:   emits 'error' immediately
+ */
+function fakeChild(behavior = 'survive') {
+  const child = new EventEmitter();
+  child.pid = 12345;
+  child.stderr = fakeStream();
+  child.unref = () => {};
+
+  if (behavior === 'fail') {
+    process.nextTick(() => child.emit('exit', 1, null));
+  } else if (behavior === 'error') {
+    process.nextTick(() => child.emit('error', new Error('spawn ENOENT')));
+  }
+  return child;
+}
+
+/**
+ * Build a mock deps object.
+ * @param {object} overrides — keys to override defaults
+ */
+function mockDeps(overrides = {}) {
+  const spawnCalls = [];
+  const execSyncCalls = [];
+
+  const defaults = {
+    platform: 'darwin',
+    env: { HOME: '/Users/testuser' },
+    existsSync: () => true,
+    execSync: (cmd, opts) => {
+      execSyncCalls.push({ cmd, opts });
+      return Buffer.from('');
+    },
+    spawn: (bin, args, opts) => {
+      spawnCalls.push({ bin, args, opts });
+      return fakeChild('survive');
+    },
+    httpGet: null,
+  };
+
+  const deps = { ...defaults, ...overrides };
+  deps._spawnCalls = spawnCalls;
+  deps._execSyncCalls = execSyncCalls;
+  return deps;
+}
+
+/**
+ * Create an httpGet mock that responds on the Nth call.
+ * @param {number} respondOnCall - 1-based index of the call that succeeds (0 = never)
+ * @param {object} [body] - JSON body to return
+ */
+function mockHttpGet(respondOnCall, body = { Browser: 'Electron', 'User-Agent': 'test' }) {
+  let callCount = 0;
+  return (url, cb) => {
+    callCount++;
+    const req = new EventEmitter();
+    req.on = req.on.bind(req);
+    if (callCount >= respondOnCall && respondOnCall > 0) {
+      const res = new EventEmitter();
+      process.nextTick(() => {
+        cb(res);
+        res.emit('data', JSON.stringify(body));
+        res.emit('end');
+      });
+    } else {
+      process.nextTick(() => req.emit('error', new Error('ECONNREFUSED')));
+    }
+    return req;
+  };
+}
+
+const TV_BIN = '/Applications/TradingView.app/Contents/MacOS/TradingView';
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('launch() — path detection', () => {
+  it('finds binary from pathMap', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1),
+    });
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.binary, TV_BIN);
+  });
+
+  it('falls back to which/where when pathMap misses', async () => {
+    const deps = mockDeps({
+      platform: 'linux',
+      existsSync: (p) => p === '/usr/local/bin/tradingview',
+      execSync: (cmd) => {
+        if (cmd.includes('which')) return Buffer.from('/usr/local/bin/tradingview\n');
+        return Buffer.from('');
+      },
+      httpGet: mockHttpGet(1),
+    });
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.binary, '/usr/local/bin/tradingview');
+  });
+
+  it('falls back to mdfind on macOS', async () => {
+    let mdfindCalled = false;
+    const deps = mockDeps({
+      platform: 'darwin',
+      existsSync: (p) => p === '/custom/TradingView.app/Contents/MacOS/TradingView',
+      execSync: (cmd) => {
+        if (cmd.includes('mdfind')) {
+          mdfindCalled = true;
+          return Buffer.from('/custom/TradingView.app\n');
+        }
+        throw new Error('not found');
+      },
+      httpGet: mockHttpGet(1),
+    });
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    assert.equal(result.success, true);
+    assert.ok(mdfindCalled, 'mdfind was called');
+    assert.equal(result.binary, '/custom/TradingView.app/Contents/MacOS/TradingView');
+  });
+
+  it('throws when binary not found on any platform', async () => {
+    const deps = mockDeps({
+      platform: 'linux',
+      existsSync: () => false,
+      execSync: () => { throw new Error('not found'); },
+    });
+    await assert.rejects(
+      () => launch({ port: 9222, kill_existing: false, _deps: deps }),
+      (err) => {
+        assert.ok(err.message.includes('TradingView not found'));
+        assert.ok(err.message.includes('v2.14.0+'));
+        return true;
+      },
+    );
+  });
+});
+
+describe('launch() — kill existing', () => {
+  it('calls pkill on darwin when kill_existing is true', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1),
+    });
+    // kill_existing defaults to true
+    await launch({ port: 9222, _deps: deps });
+    const pkillCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill'));
+    assert.ok(pkillCall, 'pkill was called');
+  });
+
+  it('calls taskkill on win32', async () => {
+    const winBin = 'C:\\Users\\test\\AppData\\Local\\TradingView\\TradingView.exe';
+    const deps = mockDeps({
+      platform: 'win32',
+      env: { HOME: 'C:\\Users\\test', LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local', PROGRAMFILES: '', 'PROGRAMFILES(X86)': '' },
+      existsSync: (p) => p === winBin,
+      httpGet: mockHttpGet(1),
+    });
+    await launch({ port: 9222, _deps: deps });
+    const taskKill = deps._execSyncCalls.find(c => c.cmd.includes('taskkill'));
+    assert.ok(taskKill, 'taskkill was called');
+  });
+
+  it('skips kill when kill_existing is false', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1),
+    });
+    await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const killCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill') || c.cmd.includes('taskkill'));
+    assert.equal(killCall, undefined, 'no kill command issued');
+  });
+});
+
+describe('launch() — direct spawn succeeds (old TradingView)', () => {
+  it('returns success with CDP info when spawn + CDP both succeed', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1, { Browser: 'Electron/28', 'User-Agent': 'TV-old' }),
+    });
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.cdp_port, 9222);
+    assert.equal(result.browser, 'Electron/28');
+    assert.equal(result.pid, 12345);
+    assert.equal(result.fallback_used, undefined);
+  });
+
+  it('passes --remote-debugging-port to spawn', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1),
+    });
+    await launch({ port: 4444, kill_existing: false, _deps: deps });
+    const spawnCall = deps._spawnCalls[0];
+    assert.equal(spawnCall.args[0], '--remote-debugging-port=4444');
+  });
+
+  it('returns cdp_ready:false warning when CDP never responds', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(0), // never responds
+    });
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.cdp_ready, false);
+    assert.ok(result.warning.includes('CDP not responding'));
+  });
+});
+
+describe('launch() — spawn fails, macOS fallback', () => {
+  it('kills existing, then uses open -a with .app bundle when direct spawn exits non-zero', async () => {
+    const deps = mockDeps({
+      platform: 'darwin',
+      existsSync: (p) => p === TV_BIN,
+      spawn: (bin, args, opts) => {
+        deps._spawnCalls.push({ bin, args, opts });
+        return fakeChild('fail'); // exit(1) immediately
+      },
+      httpGet: mockHttpGet(1, { Browser: 'Electron/38', 'User-Agent': 'TV-new' }),
+    });
+
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+
+    // Should have re-killed before open -a (critical: open -a only works on fresh launch)
+    const pkillCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill'));
+    assert.ok(pkillCall, 'pkill called in fallback path to ensure clean launch');
+
+    // Should have called execSync with open -a
+    const openCall = deps._execSyncCalls.find(c => c.cmd.includes('open -a'));
+    assert.ok(openCall, 'open -a was called as fallback');
+    assert.ok(openCall.cmd.includes('/Applications/TradingView.app'), 'uses .app bundle path');
+    assert.ok(openCall.cmd.includes('--remote-debugging-port=9222'), 'passes CDP port');
+
+    // pkill should come BEFORE open -a
+    const pkillIdx = deps._execSyncCalls.findIndex(c => c.cmd.includes('pkill'));
+    const openIdx = deps._execSyncCalls.findIndex(c => c.cmd.includes('open -a'));
+    assert.ok(pkillIdx < openIdx, 'pkill runs before open -a');
+
+    assert.equal(result.success, true);
+    assert.equal(result.fallback_used, true);
+    assert.equal(result.browser, 'Electron/38');
+  });
+
+  it('falls back to bare spawn when no .app bundle in path', async () => {
+    const linuxBin = '/usr/bin/tradingview';
+    const deps = mockDeps({
+      platform: 'darwin',
+      existsSync: (p) => p === linuxBin,
+      execSync: (cmd) => {
+        deps._execSyncCalls.push({ cmd });
+        if (cmd.includes('which')) return Buffer.from(linuxBin + '\n');
+        if (cmd.includes('pkill')) return Buffer.from('');
+        throw new Error('fail');
+      },
+      spawn: (bin, args, opts) => {
+        deps._spawnCalls.push({ bin, args, opts });
+        // First call (direct) fails, second call (bare) survives
+        return fakeChild(deps._spawnCalls.length === 1 ? 'fail' : 'survive');
+      },
+      httpGet: mockHttpGet(0), // CDP never responds
+    });
+
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+
+    // Second spawn should be bare (no args)
+    assert.equal(deps._spawnCalls.length, 2);
+    assert.deepEqual(deps._spawnCalls[1].args, []);
+  });
+
+  it('returns success:false with workaround hint when fallback + CDP both fail', async () => {
+    const deps = mockDeps({
+      platform: 'darwin',
+      existsSync: (p) => p === TV_BIN,
+      spawn: (bin, args, opts) => {
+        deps._spawnCalls.push({ bin, args, opts });
+        return fakeChild('fail');
+      },
+      httpGet: mockHttpGet(0), // never responds
+    });
+
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    assert.equal(result.success, false);
+    assert.ok(result.error.includes('pkill -f TradingView'), 'error includes manual workaround');
+    assert.ok(result.error.includes('open -a TradingView'), 'error includes open -a hint');
+    assert.equal(result.cdp_ready, false);
+  });
+});
+
+describe('launch() — spawn fails, Linux/Windows fallback', () => {
+  it('re-spawns with REMOTE_DEBUGGING_PORT env var on Linux', async () => {
+    const linuxBin = '/opt/TradingView/tradingview';
+    let spawnCount = 0;
+    const deps = mockDeps({
+      platform: 'linux',
+      env: { HOME: '/home/testuser' },
+      existsSync: (p) => p === linuxBin,
+      spawn: (bin, args, opts) => {
+        spawnCount++;
+        deps._spawnCalls.push({ bin, args, opts });
+        // First call fails, second survives
+        return fakeChild(spawnCount === 1 ? 'fail' : 'survive');
+      },
+      httpGet: mockHttpGet(1),
+    });
+
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+
+    assert.equal(deps._spawnCalls.length, 2, 'spawn called twice');
+    const fallbackCall = deps._spawnCalls[1];
+    assert.equal(fallbackCall.opts.env.REMOTE_DEBUGGING_PORT, '9222');
+    assert.equal(result.success, true);
+    assert.equal(result.fallback_used, true);
+  });
+
+  it('re-spawns with env var on Windows', async () => {
+    const winBin = 'C:\\Program Files\\TradingView\\TradingView.exe';
+    let spawnCount = 0;
+    const deps = mockDeps({
+      platform: 'win32',
+      env: { HOME: 'C:\\Users\\test', LOCALAPPDATA: '', PROGRAMFILES: 'C:\\Program Files', 'PROGRAMFILES(X86)': '' },
+      existsSync: (p) => p === winBin,
+      spawn: (bin, args, opts) => {
+        spawnCount++;
+        deps._spawnCalls.push({ bin, args, opts });
+        return fakeChild(spawnCount === 1 ? 'fail' : 'survive');
+      },
+      httpGet: mockHttpGet(1),
+    });
+
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const fallbackCall = deps._spawnCalls[1];
+    assert.equal(fallbackCall.opts.env.REMOTE_DEBUGGING_PORT, '9222');
+  });
+});
+
+describe('launch() — spawn error event', () => {
+  it('detects spawn error (ENOENT) and falls back via open -a', async () => {
+    const deps = mockDeps({
+      platform: 'darwin',
+      existsSync: (p) => p === TV_BIN,
+      spawn: (bin, args, opts) => {
+        deps._spawnCalls.push({ bin, args, opts });
+        return fakeChild('error');
+      },
+      httpGet: mockHttpGet(0),
+    });
+
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    // Should have triggered fallback: pkill then open -a
+    const pkillCall = deps._execSyncCalls.find(c => c.cmd && c.cmd.includes('pkill'));
+    assert.ok(pkillCall, 'pkill called in fallback after spawn error');
+    const openCall = deps._execSyncCalls.find(c => c.cmd && c.cmd.includes('open -a'));
+    assert.ok(openCall, 'macOS open fallback was triggered after spawn error');
+  });
+});
+
+describe('launch() — CDP polling', () => {
+  it('succeeds when CDP responds on 3rd poll', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(3, { Browser: 'SlowStart', 'User-Agent': 'test' }),
+    });
+    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.browser, 'SlowStart');
+  });
+
+  it('uses custom port in CDP URL', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1),
+    });
+    const result = await launch({ port: 8888, kill_existing: false, _deps: deps });
+    assert.equal(result.cdp_port, 8888);
+    assert.equal(result.cdp_url, 'http://localhost:8888');
+  });
+});
+
+describe('launch() — defaults', () => {
+  it('defaults to port 9222', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1),
+    });
+    const result = await launch({ kill_existing: false, _deps: deps });
+    assert.equal(result.cdp_port, 9222);
+    assert.equal(deps._spawnCalls[0].args[0], '--remote-debugging-port=9222');
+  });
+
+  it('defaults kill_existing to true', async () => {
+    const deps = mockDeps({
+      existsSync: (p) => p === TV_BIN,
+      httpGet: mockHttpGet(1),
+    });
+    await launch({ _deps: deps });
+    const pkillCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill'));
+    assert.ok(pkillCall, 'kill was called by default');
+  });
+});

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -104,7 +104,7 @@ describe('launch() — path detection', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(1),
     });
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.binary, TV_BIN);
   });
@@ -119,7 +119,7 @@ describe('launch() — path detection', () => {
       },
       httpGet: mockHttpGet(1),
     });
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.binary, '/usr/local/bin/tradingview');
   });
@@ -138,7 +138,7 @@ describe('launch() — path detection', () => {
       },
       httpGet: mockHttpGet(1),
     });
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     assert.equal(result.success, true);
     assert.ok(mdfindCalled, 'mdfind was called');
     assert.equal(result.binary, '/custom/TradingView.app/Contents/MacOS/TradingView');
@@ -151,7 +151,7 @@ describe('launch() — path detection', () => {
       execSync: () => { throw new Error('not found'); },
     });
     await assert.rejects(
-      () => launch({ port: 9222, kill_existing: false, _deps: deps }),
+      () => launch({ port: 9222, kill_existing: false, deps: deps }),
       (err) => {
         assert.ok(err.message.includes('TradingView not found'));
         assert.ok(err.message.includes('v2.14.0+'));
@@ -168,7 +168,7 @@ describe('launch() — kill existing', () => {
       httpGet: mockHttpGet(1),
     });
     // kill_existing defaults to true
-    await launch({ port: 9222, _deps: deps });
+    await launch({ port: 9222, deps: deps });
     const pkillCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill'));
     assert.ok(pkillCall, 'pkill was called');
   });
@@ -181,7 +181,7 @@ describe('launch() — kill existing', () => {
       existsSync: (p) => p === winBin,
       httpGet: mockHttpGet(1),
     });
-    await launch({ port: 9222, _deps: deps });
+    await launch({ port: 9222, deps: deps });
     const taskKill = deps._execSyncCalls.find(c => c.cmd.includes('taskkill'));
     assert.ok(taskKill, 'taskkill was called');
   });
@@ -191,7 +191,7 @@ describe('launch() — kill existing', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(1),
     });
-    await launch({ port: 9222, kill_existing: false, _deps: deps });
+    await launch({ port: 9222, kill_existing: false, deps: deps });
     const killCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill') || c.cmd.includes('taskkill'));
     assert.equal(killCall, undefined, 'no kill command issued');
   });
@@ -203,7 +203,7 @@ describe('launch() — direct spawn succeeds (old TradingView)', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(1, { Browser: 'Electron/28', 'User-Agent': 'TV-old' }),
     });
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.cdp_port, 9222);
     assert.equal(result.browser, 'Electron/28');
@@ -216,7 +216,7 @@ describe('launch() — direct spawn succeeds (old TradingView)', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(1),
     });
-    await launch({ port: 4444, kill_existing: false, _deps: deps });
+    await launch({ port: 4444, kill_existing: false, deps: deps });
     const spawnCall = deps._spawnCalls[0];
     assert.equal(spawnCall.args[0], '--remote-debugging-port=4444');
   });
@@ -226,7 +226,7 @@ describe('launch() — direct spawn succeeds (old TradingView)', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(0), // never responds
     });
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.cdp_ready, false);
     assert.ok(result.warning.includes('CDP not responding'));
@@ -245,7 +245,7 @@ describe('launch() — spawn fails, macOS fallback', () => {
       httpGet: mockHttpGet(1, { Browser: 'Electron/38', 'User-Agent': 'TV-new' }),
     });
 
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
 
     // Should have re-killed before open -a (critical: open -a only works on fresh launch)
     const pkillCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill'));
@@ -286,7 +286,7 @@ describe('launch() — spawn fails, macOS fallback', () => {
       httpGet: mockHttpGet(0), // CDP never responds
     });
 
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
 
     // Second spawn should be bare (no args)
     assert.equal(deps._spawnCalls.length, 2);
@@ -304,7 +304,7 @@ describe('launch() — spawn fails, macOS fallback', () => {
       httpGet: mockHttpGet(0), // never responds
     });
 
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     assert.equal(result.success, false);
     assert.ok(result.error.includes('pkill -f TradingView'), 'error includes manual workaround');
     assert.ok(result.error.includes('open -a TradingView'), 'error includes open -a hint');
@@ -329,7 +329,7 @@ describe('launch() — spawn fails, Linux/Windows fallback', () => {
       httpGet: mockHttpGet(1),
     });
 
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
 
     assert.equal(deps._spawnCalls.length, 2, 'spawn called twice');
     const fallbackCall = deps._spawnCalls[1];
@@ -353,7 +353,7 @@ describe('launch() — spawn fails, Linux/Windows fallback', () => {
       httpGet: mockHttpGet(1),
     });
 
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     const fallbackCall = deps._spawnCalls[1];
     assert.equal(fallbackCall.opts.env.REMOTE_DEBUGGING_PORT, '9222');
   });
@@ -371,7 +371,7 @@ describe('launch() — spawn error event', () => {
       httpGet: mockHttpGet(0),
     });
 
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     // Should have triggered fallback: pkill then open -a
     const pkillCall = deps._execSyncCalls.find(c => c.cmd && c.cmd.includes('pkill'));
     assert.ok(pkillCall, 'pkill called in fallback after spawn error');
@@ -386,7 +386,7 @@ describe('launch() — CDP polling', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(3, { Browser: 'SlowStart', 'User-Agent': 'test' }),
     });
-    const result = await launch({ port: 9222, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 9222, kill_existing: false, deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.browser, 'SlowStart');
   });
@@ -396,7 +396,7 @@ describe('launch() — CDP polling', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(1),
     });
-    const result = await launch({ port: 8888, kill_existing: false, _deps: deps });
+    const result = await launch({ port: 8888, kill_existing: false, deps: deps });
     assert.equal(result.cdp_port, 8888);
     assert.equal(result.cdp_url, 'http://localhost:8888');
   });
@@ -408,7 +408,7 @@ describe('launch() — defaults', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(1),
     });
-    const result = await launch({ kill_existing: false, _deps: deps });
+    const result = await launch({ kill_existing: false, deps: deps });
     assert.equal(result.cdp_port, 9222);
     assert.equal(deps._spawnCalls[0].args[0], '--remote-debugging-port=9222');
   });
@@ -418,7 +418,7 @@ describe('launch() — defaults', () => {
       existsSync: (p) => p === TV_BIN,
       httpGet: mockHttpGet(1),
     });
-    await launch({ _deps: deps });
+    await launch({ deps: deps });
     const pkillCall = deps._execSyncCalls.find(c => c.cmd.includes('pkill'));
     assert.ok(pkillCall, 'kill was called by default');
   });


### PR DESCRIPTION
## Summary
- Fix `tv_launch` and `tv_health_check` reliability (Electron 38 / Node 22 compat, healthCheck retry loop)
- Rename `_deps` param to `deps` per prior reviewer suggestion
- Repo housekeeping: remove accidentally-nested clones from the working tree, add `.env.example` and `src/config.js` (CDP config loader), expand `CLAUDE.md`/`README.md` with architecture notes and tvremix integration docs, gitignore `.DS_Store`/`.claude/`

## Test plan
- [ ] `npm run test:unit`
- [ ] `node --test tests/launch.test.js`
- [ ] `npm run test:e2e` (requires TradingView Desktop running with CDP)