### PR TITLE
Add .claude/launch.json for previewing the MCP server and test suites

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "mcp-server (stdio, no port)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "port": null
+    },
+    {
+      "name": "test:all",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test:all"],
+      "port": null
+    },
+    {
+      "name": "test:e2e",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test:e2e"],
+      "port": null
+    },
+    {
+      "name": "test:unit",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test:unit"],
+      "port": null
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
Added `.claude/launch.json` with launch configurations for:
- `mcp-server` — runs `npm start` (the stdio MCP server)
- `test:all`, `test:e2e`, `test:unit` — the existing npm test scripts

## Why
Lets Claude Code's preview tooling (`preview_start`) launch these processes directly instead of requiring manual `npm` commands.

## Notes for reviewers
- The main server (`npm start`) uses `StdioServerTransport` — it communicates over stdio, not HTTP, so there is no browser-previewable port. The `port` field is set to `null` for all entries.
- No source code changed; this only adds tooling config.
