### PR TITLE
Fix launch_tv_debug.bat for MSIX/Store installs via Get-AppxPackage

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -17,7 +17,14 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
+REM Check MSIX / Windows Store installs.
+REM Get-AppxPackage resolves the install without elevation; enumerating
+REM %PROGRAMFILES%\WindowsApps with dir requires admin rights, so keep it as a fallback.
+if "%TV_EXE%"=="" (
+    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
+        if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
+    )
+)
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
 )


### PR DESCRIPTION
## Summary

Companion to #52 (just merged), which fixed MSIX/Windows Store detection in `tv_launch` (health.js). This fixes the same gap in `scripts/launch_tv_debug.bat`.

The existing WindowsApps fallback used `dir /s /b "%PROGRAMFILES%\WindowsApps\..."`, which requires elevation to enumerate the WindowsApps root and silently fails for normal users. `Get-AppxPackage` queries the package registry instead and works without admin rights. The old `dir` fallback is kept as a last resort.

## Verification

Tested end-to-end on a real Microsoft Store install (TradingView Desktop 3.1.0 MSIX, Electron 38.2.2, Windows 11):

- `Get-AppxPackage` resolves the exe under `C:\Program Files\WindowsApps\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\` without elevation
- Direct spawn with `--remote-debugging-port=9222` works — the MSIX build does **not** reject the CDP flag (contrary to reports in #42)
- Script output: detection → launch → `CDP ready at http://localhost:9222` with a live `/json/version` response

Addresses the launcher-script half of #203, #128, #122, #99, #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)