### PR TITLE
Make MSIX launch work on all Windows machines: local-copy CDP fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "tv": "node src/cli/index.js",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -6,8 +6,9 @@ set PORT=%1
 if "%PORT%"=="" set PORT=9222
 
 REM Kill existing TradingView instances
+REM (ping -n is used for waits throughout: timeout /t aborts when stdin is redirected)
 taskkill /F /IM TradingView.exe >nul 2>&1
-timeout /t 2 /nobreak >nul
+ping -n 3 127.0.0.1 >nul
 
 REM Auto-detect TradingView install location
 set "TV_EXE="
@@ -46,17 +47,28 @@ echo Starting with --remote-debugging-port=%PORT%...
 start "" "%TV_EXE%" --remote-debugging-port=%PORT%
 
 echo Waiting for CDP to become available...
-timeout /t 5 /nobreak >nul
+ping -n 6 127.0.0.1 >nul
 
+REM Use 127.0.0.1 rather than localhost: on some machines localhost resolves to
+REM IPv6 ::1, which Electron's debug server does not listen on.
+set TRIES=0
 :check
-curl -s http://localhost:%PORT%/json/version >nul 2>&1
-if %errorlevel% neq 0 (
-    echo Still waiting...
-    timeout /t 2 /nobreak >nul
-    goto check
+curl -s http://127.0.0.1:%PORT%/json/version >nul 2>&1
+if %errorlevel% equ 0 goto ready
+set /a TRIES+=1
+if %TRIES% geq 30 (
+    echo.
+    echo Error: TradingView is running but CDP never became available on port %PORT%.
+    echo Some Windows MSIX builds block the debug port. Use the tv_launch MCP tool,
+    echo which falls back to launching from a local copy of the package.
+    exit /b 1
 )
+echo Still waiting...
+ping -n 3 127.0.0.1 >nul
+goto check
 
+:ready
 echo.
-echo CDP ready at http://localhost:%PORT%
-curl -s http://localhost:%PORT%/json/version
+echo CDP ready at http://127.0.0.1:%PORT%
+curl -s http://127.0.0.1:%PORT%/json/version
 echo.

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,7 +2,9 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
-const CDP_HOST = 'localhost';
+// 127.0.0.1, not localhost: on some Windows machines localhost resolves to ::1
+// first, and Electron's --remote-debugging-port only listens on IPv4.
+const CDP_HOST = '127.0.0.1';
 const CDP_PORT = 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -2,8 +2,9 @@
  * Core health/discovery/launch logic.
  */
 import { getClient, getTargetInfo, evaluate } from '../connection.js';
-import { existsSync } from 'fs';
+import { existsSync, cpSync, rmSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
+import { dirname, basename, join } from 'path';
 
 export async function healthCheck() {
   await getClient();
@@ -159,7 +160,94 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
-export async function launch({ port, kill_existing } = {}) {
+const WINDOWS_APPS_RE = /\\WindowsApps\\/i;
+
+function _resolveLaunchDeps(deps) {
+  return {
+    spawn: deps?.spawn || spawn,
+    execSync: deps?.execSync || execSync,
+    existsSync: deps?.existsSync || existsSync,
+    cpSync: deps?.cpSync || cpSync,
+    rmSync: deps?.rmSync || rmSync,
+    readdirSync: deps?.readdirSync || readdirSync,
+    delay: deps?.delay || ((ms) => new Promise((r) => setTimeout(r, ms))),
+    probeCdp: deps?.probeCdp || _probeCdp,
+  };
+}
+
+async function _probeCdp(cdpPort) {
+  // 127.0.0.1, not localhost: on some Windows machines localhost resolves to ::1
+  // first, and Electron's debug server only listens on IPv4.
+  const http = await import('http');
+  return new Promise((resolve) => {
+    const req = http.get(`http://127.0.0.1:${cdpPort}/json/version`, (res) => {
+      let data = '';
+      res.on('data', (chunk) => data += chunk);
+      res.on('end', () => resolve(data));
+    });
+    req.on('error', () => resolve(null));
+    req.setTimeout(2000, () => { req.destroy(); resolve(null); });
+  });
+}
+
+function _spawnDetached(spawnFn, exe, args) {
+  const child = spawnFn(exe, args, { detached: true, stdio: 'ignore' });
+  child.unref();
+  return child;
+}
+
+// Resolves once with an error string if the process fails/exits within graceMs,
+// or with null if it survives that long.
+function _spawnFailedEarly(child, graceMs = 1500) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => { cleanup(); resolve(null); }, graceMs);
+    const onError = (e) => { cleanup(); resolve(e.code || e.message || 'spawn error'); };
+    const onExit = (code) => { cleanup(); resolve(`exited immediately (code ${code})`); };
+    const cleanup = () => { clearTimeout(timer); child.off?.('error', onError); child.off?.('exit', onExit); };
+    child.on('error', onError);
+    child.on('exit', onExit);
+  });
+}
+
+async function _waitForCdp({ cdpPort, attempts, delay, probeCdp }) {
+  for (let i = 0; i < attempts; i++) {
+    await delay(1000);
+    try {
+      const ready = await probeCdp(cdpPort);
+      if (ready) return JSON.parse(ready);
+    } catch { /* retry */ }
+  }
+  return null;
+}
+
+/**
+ * Some Windows builds block CDP for MSIX-packaged apps: direct spawn from
+ * WindowsApps gets EACCES, and even COM activation passes the flag but the
+ * debug port never binds (issues #42, #75, #128). Running the same files from
+ * a plain directory outside WindowsApps works and keeps the user's session,
+ * so copy the package into LOCALAPPDATA once per version and launch that.
+ */
+function _copyMsixPackageLocal(tvPath, { cpSync, rmSync, readdirSync, existsSync }) {
+  const srcDir = dirname(tvPath);
+  const pkgName = basename(srcDir);
+  const cacheRoot = join(process.env.LOCALAPPDATA || '', 'tradingview-mcp');
+  const dstDir = join(cacheRoot, pkgName);
+  const dstExe = join(dstDir, 'TradingView.exe');
+  if (!existsSync(dstExe)) {
+    try {
+      for (const entry of readdirSync(cacheRoot)) {
+        if (entry !== pkgName && /^TradingView\./i.test(entry)) {
+          rmSync(join(cacheRoot, entry), { recursive: true, force: true });
+        }
+      }
+    } catch { /* cache root may not exist yet */ }
+    cpSync(srcDir, dstDir, { recursive: true });
+  }
+  return dstExe;
+}
+
+export async function launch({ port, kill_existing, _deps } = {}) {
+  const deps = _resolveLaunchDeps(_deps);
   const cdpPort = port || 9222;
   const killFirst = kill_existing !== false;
   const platform = process.platform;
@@ -186,7 +274,7 @@ export async function launch({ port, kill_existing } = {}) {
   let tvPath = null;
   const candidates = pathMap[platform] || pathMap.linux;
   for (const p of candidates) {
-    if (p && existsSync(p)) { tvPath = p; break; }
+    if (p && deps.existsSync(p)) { tvPath = p; break; }
   }
 
   if (!tvPath && platform === 'win32') {
@@ -194,10 +282,10 @@ export async function launch({ port, kill_existing } = {}) {
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
       const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
-      const installDir = execSync(ps, { timeout: 5000 }).toString().trim();
+      const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;
-        if (existsSync(candidate)) tvPath = candidate;
+        if (deps.existsSync(candidate)) tvPath = candidate;
       }
     } catch { /* ignore */ }
   }
@@ -205,17 +293,17 @@ export async function launch({ port, kill_existing } = {}) {
   if (!tvPath) {
     try {
       const cmd = platform === 'win32' ? 'where TradingView.exe' : 'which tradingview';
-      tvPath = execSync(cmd, { timeout: 3000 }).toString().trim().split('\n')[0];
-      if (tvPath && !existsSync(tvPath)) tvPath = null;
+      tvPath = deps.execSync(cmd, { timeout: 3000 }).toString().trim().split('\n')[0];
+      if (tvPath && !deps.existsSync(tvPath)) tvPath = null;
     } catch { /* ignore */ }
   }
 
   if (!tvPath && platform === 'darwin') {
     try {
-      const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();
+      const found = deps.execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();
       if (found) {
         const candidate = `${found}/Contents/MacOS/TradingView`;
-        if (existsSync(candidate)) tvPath = candidate;
+        if (deps.existsSync(candidate)) tvPath = candidate;
       }
     } catch { /* ignore */ }
   }
@@ -224,41 +312,53 @@ export async function launch({ port, kill_existing } = {}) {
     throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
   }
 
-  if (killFirst) {
+  const killExisting = async () => {
     try {
-      if (platform === 'win32') execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
-      else execSync('pkill -f TradingView', { timeout: 5000 });
-      await new Promise(r => setTimeout(r, 1500));
+      if (platform === 'win32') deps.execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
+      else deps.execSync('pkill -f TradingView', { timeout: 5000 });
+      await deps.delay(1500);
     } catch { /* may not be running */ }
+  };
+
+  if (killFirst) await killExisting();
+
+  const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
+  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  let info = null;
+  let usedLocalCopy = false;
+
+  if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
+    const earlyFailure = await _spawnFailedEarly(child);
+    if (!earlyFailure) {
+      info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+    }
+    if (!info) {
+      // Direct WindowsApps launch was blocked or CDP never bound — fall back to
+      // a local copy of the package (see _copyMsixPackageLocal).
+      const localExe = _copyMsixPackageLocal(tvPath, deps);
+      await killExisting();
+      child = _spawnDetached(deps.spawn, localExe, cdpArgs);
+      tvPath = localExe;
+      usedLocalCopy = true;
+    }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
-  child.unref();
+  if (!info) {
+    info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+  }
 
-  for (let i = 0; i < 15; i++) {
-    await new Promise(r => setTimeout(r, 1000));
-    try {
-      const http = await import('http');
-      const ready = await new Promise((resolve) => {
-        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
-          let data = '';
-          res.on('data', (chunk) => data += chunk);
-          res.on('end', () => resolve(data));
-        }).on('error', () => resolve(null));
-      });
-      if (ready) {
-        const info = JSON.parse(ready);
-        return {
-          success: true, platform, binary: tvPath, pid: child.pid,
-          cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
-          browser: info.Browser, user_agent: info['User-Agent'],
-        };
-      }
-    } catch { /* retry */ }
+  if (info) {
+    return {
+      success: true, platform, binary: tvPath, pid: child.pid,
+      cdp_port: cdpPort, cdp_url: `http://127.0.0.1:${cdpPort}`,
+      browser: info.Browser, user_agent: info['User-Agent'],
+      ...(usedLocalCopy && { msix_local_copy: true }),
+    };
   }
 
   return {
     success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    ...(usedLocalCopy && { msix_local_copy: true }),
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
 }

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -1,0 +1,150 @@
+/**
+ * Tests for launch() in src/core/health.js.
+ * Covers Windows MSIX handling: direct WindowsApps spawn, local-copy fallback
+ * when spawn fails or CDP never binds, copy reuse, and classic-path launches.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { launch } from '../src/core/health.js';
+
+const MSIX_EXE = 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\\TradingView.exe';
+const LOCAL_COPY_EXE = `${process.env.LOCALAPPDATA || ''}\\tradingview-mcp\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\\TradingView.exe`;
+const CDP_VERSION = JSON.stringify({ Browser: 'Chrome/140', 'User-Agent': 'TVDesktop/3.1.0' });
+
+// ── Mock helpers ─────────────────────────────────────────────────────────
+
+function mockChild({ failWith } = {}) {
+  const child = new EventEmitter();
+  child.pid = 12345;
+  child.unref = () => {};
+  if (failWith) queueMicrotask(() => child.emit('error', Object.assign(new Error(failWith), { code: failWith })));
+  return child;
+}
+
+/**
+ * Build a _deps bundle simulating a win32 MSIX environment.
+ * @param {object} opts
+ *   spawnFailures — spawn paths (substring) that emit EACCES
+ *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
+ *   copyExists   — local copy already present
+ */
+function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } = {}) {
+  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
+  const deps = {
+    existsSync: (p) => {
+      if (p === MSIX_EXE) return true;
+      if (p.includes('tradingview-mcp')) return copyExists || state.copies.length > 0;
+      return false;
+    },
+    execSync: (cmd) => {
+      if (cmd.includes('Get-AppxPackage')) {
+        return 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\n';
+      }
+      if (cmd.includes('taskkill')) { state.killed++; return ''; }
+      throw new Error(`unexpected execSync: ${cmd}`);
+    },
+    spawn: (exe) => {
+      state.spawned.push(exe);
+      const fail = spawnFailures.some((s) => exe.includes(s));
+      if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
+      return mockChild(fail ? { failWith: 'EACCES' } : {});
+    },
+    cpSync: (src, dst) => { state.copies.push({ src, dst }); },
+    rmSync: (p) => { state.removed.push(p); },
+    readdirSync: () => ['TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj'],
+    delay: async () => {},
+    probeCdp: async () => (state.cdpUp ? CDP_VERSION : null),
+  };
+  return { deps, state };
+}
+
+// launch() only takes the MSIX code path on win32; skip elsewhere.
+const onWindows = process.platform === 'win32';
+
+describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
+  it('direct WindowsApps spawn that binds CDP does not copy', async () => {
+    const { deps, state } = msixDeps({ cdpBindsFor: ['WindowsApps'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.binary, MSIX_EXE);
+    assert.equal(result.msix_local_copy, undefined);
+    assert.equal(state.copies.length, 0);
+    assert.equal(result.cdp_url, 'http://127.0.0.1:9222');
+  });
+
+  it('EACCES on direct spawn falls back to local copy', async () => {
+    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.binary, LOCAL_COPY_EXE);
+    assert.equal(state.copies.length, 1);
+    assert.match(state.copies[0].src, /WindowsApps/);
+    // stale cached version of another release is cleaned up first
+    assert.equal(state.removed.length, 1);
+    assert.match(state.removed[0], /3\.0\.0\.7652/);
+    // the CDP-less direct instance is killed before relaunching from the copy
+    assert.ok(state.killed >= 2);
+  });
+
+  it('CDP never binding on direct spawn falls back to local copy', async () => {
+    const { deps, state } = msixDeps({ cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(state.spawned.length, 2);
+    assert.match(state.spawned[0], /WindowsApps/);
+    assert.match(state.spawned[1], /tradingview-mcp/);
+  });
+
+  it('reuses an existing local copy without re-copying', async () => {
+    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'], copyExists: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(state.copies.length, 0);
+  });
+
+  it('returns cdp_ready:false warning when nothing binds', async () => {
+    const { deps } = msixDeps({});
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.cdp_ready, false);
+    assert.equal(result.msix_local_copy, true);
+    assert.ok(result.warning);
+  });
+});
+
+describe('launch() — classic install path', { skip: !onWindows }, () => {
+  it('launches classic LOCALAPPDATA install without MSIX logic', async () => {
+    const classicExe = `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`;
+    const state = { spawned: [], cdpUp: false };
+    const deps = {
+      existsSync: (p) => p === classicExe,
+      execSync: (cmd) => { if (cmd.includes('taskkill')) return ''; throw new Error(`unexpected: ${cmd}`); },
+      spawn: (exe) => { state.spawned.push(exe); state.cdpUp = true; return mockChild(); },
+      cpSync: () => { throw new Error('should not copy'); },
+      rmSync: () => {},
+      readdirSync: () => [],
+      delay: async () => {},
+      probeCdp: async () => (state.cdpUp ? CDP_VERSION : null),
+    };
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.binary, classicExe);
+    assert.equal(result.msix_local_copy, undefined);
+    assert.deepEqual(state.spawned, [classicExe]);
+  });
+
+  it('throws a helpful error when TradingView is not found', async () => {
+    const deps = {
+      existsSync: () => false,
+      execSync: () => { throw new Error('not found'); },
+      spawn: () => { throw new Error('should not spawn'); },
+      cpSync: () => {}, rmSync: () => {}, readdirSync: () => [],
+      delay: async () => {}, probeCdp: async () => null,
+    };
+    await assert.rejects(() => launch({ _deps: deps }), /TradingView not found/);
+  });
+});


### PR DESCRIPTION
## Why

Detection of Microsoft Store installs was fixed in #52/#316, but reading through every open Windows report showed a second failure class. Machines split into two groups:

1. **Direct spawn works** (verified live: Win 11 Pro, TV 3.1.0) — spawning `WindowsApps\...\TradingView.exe --remote-debugging-port` works and CDP binds.
2. **Direct spawn blocked** (#42, #75, #128) — spawn gets `EACCES`, and even `IApplicationActivationManager` COM activation passes the flag into the process command line **without the port ever binding** — so the COM-activation PRs (#178, #254, #201, #135, #110) don't fix this class either.

The workaround with three independent user confirmations in #128: copy the package directory out of `WindowsApps` and run that exe directly.

## What

- `launch()` tries the direct spawn first. If it fails early or CDP doesn't bind in 15s, it copies the package to `%LOCALAPPDATA%\tradingview-mcp\<package>` (one-time per version, ~330MB, stale versions pruned) and relaunches from the copy. Result includes `msix_local_copy: true` when the fallback was used.
- All CDP traffic now uses `127.0.0.1` instead of `localhost` (on some Windows boxes `localhost` resolves to `::1` first, which Electron's debug server doesn't listen on — credit @Mukul-kepl26 in #237).
- `launch_tv_debug.bat`: `ping -n` waits (`timeout /t` aborts under redirected stdin — credit #288/#273), capped CDP wait loop with a helpful error, `127.0.0.1` probes.
- DI + `tests/launch.test.js`: direct launch, EACCES fallback, no-bind fallback, copy reuse, classic installs, not-found error. Also wired the existing sanitization/replay suites into `test:unit`/`test:all` (they were never running — closes the gap reported in #274/#253/#229).

## Verification (live, real MSIX install)

- TradingView.Desktop 3.1.0.7818 (MSIX, Electron 38.2.2), Windows 11 Pro:
  - Direct path: `tv_launch` via MCP stdio → CDP handshake OK, no copy triggered
  - Copy path (forced manually): 334MB copy → launch from local copy → CDP binds → **login, layout, and chart state fully preserved**
  - `tv_health_check` via MCP after the `127.0.0.1` change → connected
  - Reworked `.bat` → detection + launch + CDP ready, no redirection errors
- Unit tests: 109/109 pass

Fixes #42, #75, #99, #122, #128, #203, #23, #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)