### PR TITLE
Make CDP host/port configurable via env vars, shared across modules

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -2,10 +2,11 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
-// 127.0.0.1, not localhost: on some Windows machines localhost resolves to ::1
-// first, and Electron's --remote-debugging-port only listens on IPv4.
-const CDP_HOST = '127.0.0.1';
-const CDP_PORT = 9222;
+// Overridable via TV_CDP_HOST/TV_CDP_PORT (or CDP_HOST/CDP_PORT) env vars.
+// Default is 127.0.0.1, not localhost: on some Windows machines localhost
+// resolves to ::1 first, and Electron's --remote-debugging-port only listens on IPv4.
+export const CDP_HOST = process.env.TV_CDP_HOST || process.env.CDP_HOST || '127.0.0.1';
+export const CDP_PORT = Number(process.env.TV_CDP_PORT || process.env.CDP_PORT) || 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -1,7 +1,7 @@
 /**
  * Core health/discovery/launch logic.
  */
-import { getClient, getTargetInfo, evaluate } from '../connection.js';
+import { getClient, getTargetInfo, evaluate, CDP_HOST, CDP_PORT } from '../connection.js';
 import { existsSync, cpSync, rmSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { dirname, basename, join } from 'path';
@@ -176,11 +176,9 @@ function _resolveLaunchDeps(deps) {
 }
 
 async function _probeCdp(cdpPort) {
-  // 127.0.0.1, not localhost: on some Windows machines localhost resolves to ::1
-  // first, and Electron's debug server only listens on IPv4.
   const http = await import('http');
   return new Promise((resolve) => {
-    const req = http.get(`http://127.0.0.1:${cdpPort}/json/version`, (res) => {
+    const req = http.get(`http://${CDP_HOST}:${cdpPort}/json/version`, (res) => {
       let data = '';
       res.on('data', (chunk) => data += chunk);
       res.on('end', () => resolve(data));
@@ -248,7 +246,7 @@ function _copyMsixPackageLocal(tvPath, { cpSync, rmSync, readdirSync, existsSync
 
 export async function launch({ port, kill_existing, _deps } = {}) {
   const deps = _resolveLaunchDeps(_deps);
-  const cdpPort = port || 9222;
+  const cdpPort = port || CDP_PORT;
   const killFirst = kill_existing !== false;
   const platform = process.platform;
 
@@ -350,7 +348,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (info) {
     return {
       success: true, platform, binary: tvPath, pid: child.pid,
-      cdp_port: cdpPort, cdp_url: `http://127.0.0.1:${cdpPort}`,
+      cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
       ...(usedLocalCopy && { msix_local_copy: true }),
     };

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,10 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
-
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+import { getClient, evaluate, CDP_HOST, CDP_PORT } from '../connection.js';
 
 /**
  * List all open chart tabs (CDP page targets).


### PR DESCRIPTION
## Summary

`TV_CDP_HOST`/`TV_CDP_PORT` (or `CDP_HOST`/`CDP_PORT` — both conventions from the community PRs are accepted) now override the CDP endpoint everywhere: `connection.js` exports the resolved constants, `tab.js` imports them instead of redefining its own hardcoded copies (the inconsistency in #165), and `tv_launch`'s default port + readiness probe honor them too.

Supersedes #250, #217, #94, #92 — all four now conflict with the `127.0.0.1` default from #317; this PR combines their ideas (thanks @vsupanchalraj, @rufusalester, @richroberts-prog, @rqcampos).

## Verification

- Live: default connects to the running TradingView (tab_list returns 2 tabs); `TV_CDP_PORT=9333` fails to connect as expected
- `npm run lint`: 0 errors; 109/109 unit tests pass

Fixes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)