### PR TITLE
Fix tab_switch: re-attach the CDP client to the activated target

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -64,13 +64,15 @@ export async function getClient() {
   return connect();
 }
 
-export async function connect() {
+export async function connect(targetId = null) {
   let lastError;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const target = await findChartTarget();
+      const target = targetId ? await findTargetById(targetId) : await findChartTarget();
       if (!target) {
-        throw new Error('No TradingView chart target found. Is TradingView open with a chart?');
+        throw new Error(targetId
+          ? `CDP target ${targetId} not found — is the tab still open?`
+          : 'No TradingView chart target found. Is TradingView open with a chart?');
       }
       targetInfo = target;
       client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
@@ -90,6 +92,21 @@ export async function connect() {
   throw new Error(`CDP connection failed after ${MAX_RETRIES} attempts: ${lastError?.message}`);
 }
 
+/**
+ * Re-attach the cached CDP client to a specific target id.
+ * Used by tab_switch so subsequent reads (chart_get_state, data_get_*,
+ * quote_get, screenshots) follow the activated tab instead of staying
+ * glued to the target picked at first connect.
+ */
+export async function reconnectTo(targetId) {
+  if (client) {
+    try { await client.close(); } catch { /* already gone */ }
+    client = null;
+    targetInfo = null;
+  }
+  return connect(targetId);
+}
+
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
@@ -97,6 +114,12 @@ async function findChartTarget() {
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
     || null;
+}
+
+async function findTargetById(id) {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  return targets.find(t => t.id === id) || null;
 }
 
 export async function getTargetInfo() {

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,7 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate, CDP_HOST, CDP_PORT } from '../connection.js';
+import { getClient, evaluate, reconnectTo, CDP_HOST, CDP_PORT } from '../connection.js';
 
 /**
  * List all open chart tabs (CDP page targets).
@@ -92,12 +92,19 @@ export async function switchTab({ index }) {
 
   const target = tabs.tabs[idx];
 
-  // Use CDP Target.activateTarget to bring the tab to front
+  // Bring the tab to front in the UI...
   try {
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
-    const text = await resp.text();
-    return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
+    await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
   } catch (e) {
     throw new Error(`Failed to activate tab ${idx}: ${e.message}`);
   }
+
+  // ...and re-attach the cached CDP client so subsequent reads follow it.
+  try {
+    await reconnectTo(target.id);
+  } catch (e) {
+    throw new Error(`Activated tab ${idx} but failed to re-attach CDP to it: ${e.message}`);
+  }
+
+  return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
 }


### PR DESCRIPTION
## Problem

`tab_switch` activated the tab via `/json/activate/<id>` but never re-pointed the cached CDP client, so all subsequent reads silently kept hitting the tab picked at first connect. Reproduced live before fixing: switched to a second chart tab, `tv_health_check` still reported the first tab's chart.

## Fix

- `connection.js`: `connect()` accepts an optional `targetId` (with `findTargetById`), and a new exported `reconnectTo(targetId)` closes the cached client and re-attaches through the existing retry loop
- `tab.js`: `switchTab` activates the tab, then `reconnectTo`s it

Supersedes #304, #264, #160, #170 — same idea in all four (modeled on #160's, the cleanest); all now conflict with the shared-constants change from #318. Thanks @mwc58W, @AnDeVerin, @bbem1985, @creativepulsenow.

## Verified live (two chart tabs open)

- Before: switch to tab `Ur0qmn8C` → reads still on `eR6RKNgC` (NQ1!)
- After: switch → reads follow `Ur0qmn8C` (MNQ1!), switch back → `eR6RKNgC` (NQ1!)
- Lint 0 errors, 109/109 unit tests

Also confirmed live that `tab_new` does NOT create a tab (Ctrl+T via CDP never reaches Electron's tab handler) — that half of #155 remains open; #163's multi-target approach is the likely candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)