### PR TITLE
Visual tab switching, working tab_new/tab_close, layout picking + layout_new

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-78 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+79 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -1,8 +1,16 @@
 /**
  * Core tab management logic.
- * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
+ *
+ * TradingView Desktop's tab bar lives in a separate Electron shell window
+ * (app/window/index.html), not in the chart pages themselves. CDP-level
+ * activation (/json/activate) and synthesized Ctrl+T/Ctrl+W key events do
+ * not drive it (Electron accelerators don't fire from CDP input), so tab
+ * switching/creation/closing click the shell window's DOM directly:
+ * `.tabs-container .tab`, its close button, and `create-new-tab-button`.
+ * (Approach from issue #155 and PR #163, verified on Desktop 3.1.0.)
  */
-import { getClient, evaluate, reconnectTo, CDP_HOST, CDP_PORT } from '../connection.js';
+import CDP from 'chrome-remote-interface';
+import { getClient, reconnectTo, CDP_HOST, CDP_PORT } from '../connection.js';
 
 /**
  * List all open chart tabs (CDP page targets).
@@ -25,62 +33,121 @@ export async function list() {
 }
 
 /**
- * Open a new chart tab via keyboard shortcut (Ctrl+T / Cmd+T).
+ * Run fn with a CDP client attached to the Electron shell window that owns
+ * the tab bar. There can be several app/window/index.html targets; the shell
+ * is the one whose DOM actually contains `.tabs-container .tab`.
  */
-export async function newTab() {
-  const c = await getClient();
+async function withShell(fn) {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const candidates = targets.filter(t => t.type === 'page' && /\/window\/index\.html/i.test(t.url || ''));
 
-  // Electron/TradingView Desktop uses Ctrl+T for new tab on macOS too
-  // But some versions use Cmd+T
-  const isMac = process.platform === 'darwin';
-  const mod = isMac ? 4 : 2; // 4 = meta (Cmd), 2 = ctrl
+  for (const cand of candidates) {
+    let c = null;
+    try {
+      c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: cand.id });
+      const probe = await c.Runtime.evaluate({
+        expression: `!!document.querySelector('.tabs-container .tab')`,
+        returnByValue: true,
+      });
+      if (probe.result?.value) {
+        const out = await fn(async (expression) => {
+          const { result } = await c.Runtime.evaluate({ expression, returnByValue: true });
+          return result?.value;
+        });
+        await c.close();
+        return out;
+      }
+      await c.close();
+    } catch {
+      try { if (c) await c.close(); } catch { /* already gone */ }
+    }
+  }
+  throw new Error('TradingView shell window (tab bar) not found. Is this TradingView Desktop with tabs?');
+}
 
-  await c.Input.dispatchKeyEvent({
-    type: 'keyDown',
-    modifiers: mod,
-    key: 't',
-    code: 'KeyT',
-    windowsVirtualKeyCode: 84,
-  });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 't', code: 'KeyT' });
-
-  await new Promise(r => setTimeout(r, 2000));
-
-  // Verify a new tab appeared
-  const state = await list();
-  return { success: true, action: 'new_tab_opened', ...state };
+/** Check whether a CDP page target is the visible one. */
+async function isTargetVisible(targetId) {
+  let c = null;
+  try {
+    c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
+    const { result } = await c.Runtime.evaluate({ expression: 'document.visibilityState', returnByValue: true });
+    return result?.value === 'visible';
+  } catch {
+    return false;
+  } finally {
+    try { if (c) await c.close(); } catch { /* already gone */ }
+  }
 }
 
 /**
- * Close the current tab via keyboard shortcut (Ctrl+W / Cmd+W).
+ * Open a new chart tab by clicking the shell window's new-tab button.
+ */
+export async function newTab() {
+  const result = await withShell(async (evalIn) => {
+    const before = await evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
+    const clicked = await evalIn(`
+      (function() {
+        var btn = document.querySelector('[class*="create-new-tab"]');
+        if (!btn) return false;
+        btn.click();
+        return true;
+      })()
+    `);
+    if (!clicked) throw new Error('New-tab button not found in shell window.');
+    await new Promise(r => setTimeout(r, 1500));
+    const after = await evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
+    return { before, after };
+  });
+
+  const state = await list();
+  return {
+    success: result.after > result.before,
+    action: result.after > result.before ? 'new_tab_opened' : 'new_tab_click_had_no_effect',
+    shell_tabs_before: result.before,
+    shell_tabs_after: result.after,
+    note: 'New tabs open on a landing page; they appear in tab_list once a chart is opened in them.',
+    ...state,
+  };
+}
+
+/**
+ * Close the currently active tab by clicking its close button in the shell.
  */
 export async function closeTab() {
-  const before = await list();
-  if (before.tab_count <= 1) {
+  const before = await withShell((evalIn) => evalIn(`document.querySelectorAll('.tabs-container .tab').length`));
+  if (before <= 1) {
     throw new Error('Cannot close the last tab. Use tv_launch to restart TradingView instead.');
   }
 
-  const c = await getClient();
-  const isMac = process.platform === 'darwin';
-  const mod = isMac ? 4 : 2;
-
-  await c.Input.dispatchKeyEvent({
-    type: 'keyDown',
-    modifiers: mod,
-    key: 'w',
-    code: 'KeyW',
-    windowsVirtualKeyCode: 87,
+  const result = await withShell(async (evalIn) => {
+    const clicked = await evalIn(`
+      (function() {
+        var active = document.querySelector('.tabs-container .tab.active') || document.querySelectorAll('.tabs-container .tab')[0];
+        if (!active) return false;
+        // The close container div has no handler — the real clickable is the button inside it.
+        var close = active.querySelector('[class*="close"] button') || active.querySelector('button[class*="close"]') || active.querySelector('[class*="close"]');
+        if (!close) return false;
+        close.click();
+        return true;
+      })()
+    `);
+    if (!clicked) throw new Error('Close button not found on the active tab.');
+    await new Promise(r => setTimeout(r, 1000));
+    return evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
   });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'w', code: 'KeyW' });
 
-  await new Promise(r => setTimeout(r, 1000));
+  // Our cached CDP client may have been attached to the closed tab — re-resolve.
+  try { await getClient(); } catch { /* next tool call will reconnect */ }
 
-  const after = await list();
-  return { success: true, action: 'tab_closed', tabs_before: before.tab_count, tabs_after: after.tab_count };
+  return { success: result < before, action: 'tab_closed', tabs_before: before, tabs_after: result };
 }
 
 /**
- * Switch to a tab by index. Reconnects CDP to the new target.
+ * Switch to a chart tab by index (from tab_list). Clicks the corresponding
+ * tab in the shell window so the switch is visible, verifies the desired
+ * chart target actually became visible, then re-attaches the CDP client so
+ * subsequent reads follow it.
  */
 export async function switchTab({ index }) {
   const tabs = await list();
@@ -92,19 +159,29 @@ export async function switchTab({ index }) {
 
   const target = tabs.tabs[idx];
 
-  // Bring the tab to front in the UI...
-  try {
-    await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
-  } catch (e) {
-    throw new Error(`Failed to activate tab ${idx}: ${e.message}`);
+  if (!(await isTargetVisible(target.id))) {
+    const clicked = await withShell(async (evalIn) => {
+      const count = await evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
+      // Try the same ordinal first (shell order usually matches), then the rest.
+      const order = [...new Set([Math.min(idx, count - 1), ...Array.from({ length: count }, (_, k) => k)])];
+      for (const k of order) {
+        await evalIn(`document.querySelectorAll('.tabs-container .tab')[${k}].click()`);
+        await new Promise(r => setTimeout(r, 400));
+        if (await isTargetVisible(target.id)) return k;
+      }
+      return null;
+    });
+    if (clicked === null) {
+      throw new Error(`Clicked through all shell tabs but chart ${target.chart_id} never became visible.`);
+    }
   }
 
-  // ...and re-attach the cached CDP client so subsequent reads follow it.
+  // Re-attach the cached CDP client so subsequent reads follow the switch.
   try {
     await reconnectTo(target.id);
   } catch (e) {
-    throw new Error(`Activated tab ${idx} but failed to re-attach CDP to it: ${e.message}`);
+    throw new Error(`Tab is visible but failed to re-attach CDP to it: ${e.message}`);
   }
 
-  return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
+  return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id, visually_switched: true };
 }

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -19,14 +19,17 @@ export async function list() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
 
+  // Chart tabs plus new-tab landing pages (layout picker), so every tab in the
+  // top bar is listable and switchable.
   const tabs = targets
-    .filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
+    .filter(t => t.type === 'page' && (/tradingview\.com\/chart/i.test(t.url) || t.title === 'New tab'))
     .map((t, i) => ({
       index: i,
       id: t.id,
       title: t.title.replace(/^Live stock.*charts on /, ''),
       url: t.url,
       chart_id: t.url.match(/\/chart\/([^/?]+)/)?.[1] || null,
+      is_chart: /tradingview\.com\/chart/i.test(t.url),
     }));
 
   return { success: true, tab_count: tabs.length, tabs };
@@ -80,34 +83,166 @@ async function isTargetVisible(targetId) {
   }
 }
 
+/** Find an open new-tab landing page target (shows the layout picker). */
+async function findLandingTarget() {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  return targets.find(t => t.type === 'page' && t.title === 'New tab') || null;
+}
+
+/** Run fn with an eval helper attached to a specific target. */
+async function withTarget(targetId, fn) {
+  let c = null;
+  try {
+    c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
+    return await fn(async (expression) => {
+      const { result } = await c.Runtime.evaluate({ expression, returnByValue: true });
+      return result?.value;
+    });
+  } finally {
+    try { if (c) await c.close(); } catch { /* already gone */ }
+  }
+}
+
 /**
  * Open a new chart tab by clicking the shell window's new-tab button.
+ * With `layout`, also picks from the landing page's layout list:
+ *   layout: 'new'    -> click "Create new layout" (blank chart, saved as Unnamed)
+ *   layout: '<name>' -> open the saved layout whose title contains <name>
+ * Reuses an already-open landing tab instead of opening another one.
  */
-export async function newTab() {
-  const result = await withShell(async (evalIn) => {
-    const before = await evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
-    const clicked = await evalIn(`
+export async function newTab({ layout, name } = {}) {
+  let landing = await findLandingTarget();
+  let shellCounts = null;
+
+  if (!landing) {
+    shellCounts = await withShell(async (evalIn) => {
+      const before = await evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
+      const clicked = await evalIn(`
+        (function() {
+          var btn = document.querySelector('[class*="create-new-tab"]');
+          if (!btn) return false;
+          btn.click();
+          return true;
+        })()
+      `);
+      if (!clicked) throw new Error('New-tab button not found in shell window.');
+      await new Promise(r => setTimeout(r, 1500));
+      const after = await evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
+      return { before, after };
+    });
+    landing = await findLandingTarget();
+  }
+
+  if (!layout) {
+    const state = await list();
+    return {
+      success: shellCounts ? shellCounts.after > shellCounts.before : !!landing,
+      action: 'new_tab_opened',
+      note: 'Tab is on the layout picker. Call tab_new with layout: "new" or a saved layout name to open a chart in it.',
+      ...state,
+    };
+  }
+
+  if (!landing) throw new Error('New tab opened but its landing page target was not found.');
+
+  // Snapshot existing chart targets so we can spot the one the pick creates.
+  const beforeResp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const chartIdsBefore = new Set(
+    (await beforeResp.json())
+      .filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
+      .map(t => t.id)
+  );
+
+  const wantNew = String(layout).trim().toLowerCase() === 'new';
+  const layoutName = name || 'New layout';
+  const picked = await withTarget(landing.id, async (evalIn) => {
+    if (wantNew) {
+      // "Create new layout" opens a naming dialog; the Create button stays
+      // disabled until the name input is filled (React controlled input, so
+      // the native value setter + input event are required).
+      await evalIn(`(function(){ var b = document.querySelector('.create-new-layout-button'); if (b) b.click(); })()`);
+      await new Promise(r => setTimeout(r, 700));
+      const filled = await evalIn(`
+        (function() {
+          // The dialog's name field (not the landing page's Search box).
+          var inp = document.querySelector('input[placeholder="My layout"]');
+          if (!inp) {
+            var dlg = document.querySelector('[class*="dialog"], [role="dialog"]');
+            if (dlg) inp = dlg.querySelector('input');
+          }
+          if (!inp) return 'no-dialog-input';
+          var setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+          setter.call(inp, ${JSON.stringify(name || 'New layout')});
+          inp.dispatchEvent(new Event('input', { bubbles: true }));
+          return 'filled';
+        })()
+      `);
+      if (filled !== 'filled') throw new Error(`Create-layout dialog did not open as expected (${filled}).`);
+      await new Promise(r => setTimeout(r, 400));
+      const created = await evalIn(`
+        (function() {
+          var scope = document.querySelector('[class*="dialog"], [role="dialog"]') || document;
+          var btns = scope.querySelectorAll('button');
+          for (var i = 0; i < btns.length; i++) {
+            var t = (btns[i].textContent || '').trim().toLowerCase();
+            if (t === 'create' && !btns[i].disabled) { btns[i].click(); return true; }
+          }
+          return false;
+        })()
+      `);
+      if (!created) throw new Error('Create button not found or still disabled in the layout dialog.');
+      return layoutName;
+    }
+    const clickByTitle = `
       (function() {
-        var btn = document.querySelector('[class*="create-new-tab"]');
-        if (!btn) return false;
-        btn.click();
-        return true;
+        var q = ${JSON.stringify(String(layout).toLowerCase())};
+        var items = document.querySelectorAll('.layout-list-item');
+        for (var i = 0; i < items.length; i++) {
+          var t = items[i].querySelector('.layout-list-item-title');
+          if (t && t.textContent.trim().toLowerCase().indexOf(q) !== -1) {
+            items[i].click();
+            return t.textContent.trim();
+          }
+        }
+        return null;
       })()
-    `);
-    if (!clicked) throw new Error('New-tab button not found in shell window.');
-    await new Promise(r => setTimeout(r, 1500));
-    const after = await evalIn(`document.querySelectorAll('.tabs-container .tab').length`);
-    return { before, after };
+    `;
+    let foundTitle = await evalIn(clickByTitle);
+    if (!foundTitle) {
+      // Not in the recents — expand the full layout list and retry.
+      await evalIn(`(function(){ var b = document.querySelector('.layout-list-expand-button'); if (b) b.click(); })()`);
+      await new Promise(r => setTimeout(r, 800));
+      foundTitle = await evalIn(clickByTitle);
+    }
+    return foundTitle;
   });
 
-  const state = await list();
+  if (!picked) throw new Error(`Layout matching "${layout}" not found in the layout list.`);
+
+  // The chart loads under a NEW CDP target: the file:// landing -> https://
+  // chart navigation swaps renderer processes, so the target id changes.
+  // Wait for a chart target that wasn't there before the pick.
+  let chartTarget = null;
+  for (let i = 0; i < 30; i++) {
+    await new Promise(r => setTimeout(r, 500));
+    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+    const targets = await resp.json();
+    chartTarget = targets.find(x =>
+      x.type === 'page' && /tradingview\.com\/chart/i.test(x.url) && !chartIdsBefore.has(x.id)
+    ) || targets.find(x => x.id === landing.id && /tradingview\.com\/chart/i.test(x.url)) || null;
+    if (chartTarget) break;
+  }
+  if (!chartTarget) throw new Error(`Picked "${picked}" but no new chart target appeared.`);
+
+  // Give the chart a moment to boot, then follow it.
+  await new Promise(r => setTimeout(r, 2000));
+  await reconnectTo(chartTarget.id);
   return {
-    success: result.after > result.before,
-    action: result.after > result.before ? 'new_tab_opened' : 'new_tab_click_had_no_effect',
-    shell_tabs_before: result.before,
-    shell_tabs_after: result.after,
-    note: 'New tabs open on a landing page; they appear in tab_list once a chart is opened in them.',
-    ...state,
+    success: true,
+    action: wantNew ? 'new_layout_created' : 'layout_opened_in_new_tab',
+    layout: picked,
+    chart_id: chartTarget.url.match(/\/chart\/([^/?]+)/)?.[1] || null,
   };
 }
 

--- a/src/tools/tab.js
+++ b/src/tools/tab.js
@@ -8,8 +8,18 @@ export function registerTabTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('tab_new', 'Open a new chart tab', {}, async () => {
-    try { return jsonResult(await core.newTab()); }
+  server.tool('tab_new', 'Open a new chart tab. Optionally pick what to load in it: layout "new" creates a named blank layout, or pass a saved layout name to open it.', {
+    layout: z.string().optional().describe('"new" for a blank new layout, or a saved layout name (substring match). Omit to leave the tab on the layout picker.'),
+    name: z.string().optional().describe('Name for the new layout (used with layout: "new"; default "New layout")'),
+  }, async ({ layout, name }) => {
+    try { return jsonResult(await core.newTab({ layout, name })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('layout_new', 'Create a new named blank chart layout (opens in a new tab)', {
+    name: z.string().optional().describe('Layout name (default "New layout")'),
+  }, async ({ name }) => {
+    try { return jsonResult(await core.newTab({ layout: 'new', name })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 


### PR DESCRIPTION
## What

Two commits, verified live through the MCP stdio protocol on TradingView Desktop 3.1.0 (MSIX):

**1. Visual tab switching + working tab_new/tab_close (shell DOM approach from #155/#163)**
- The tab bar lives in a separate Electron shell window (`app/window/index.html`). `/json/activate` re-points reads but never raises the tab, and CDP-synthesized Ctrl+T/Ctrl+W don't fire Electron accelerators.
- `tab_switch` clicks the shell tab, verifies the desired target reports `visibilityState === 'visible'`, then re-attaches the CDP client — success only when the switch actually happened on screen.
- `tab_new` clicks `create-new-tab-button`; `tab_close` clicks the button inside the active tab's close container.

**2. Layout picking + creation**
- `tab_new({layout, name})`: `"new"` drives the Create-new-layout naming dialog (native value setter on the React-controlled input, then Create); any other string opens the matching saved layout, expanding "All layouts" if needed.
- New `layout_new` tool (79 tools now; CLAUDE.md count bumped).
- Picked charts load under a NEW CDP target (renderer process swap on file:// → https:// navigation) — completion detection waits for the fresh chart target, then follows it.
- `tab_list` now includes landing tabs (`is_chart` flag) so every top-bar tab is switchable.

## Live verification (user watching the screen)

- Cycled all top-bar tabs visibly: NQ1! → MNQ1! → landing → back
- Created a named layout end-to-end: dialog opened → name filled → Create → chart loaded → reads followed (`chart_id bCheGbGz`)
- Opened an existing saved layout by name ("⌚️Liquidity Matrix (left)" → NQ1! 15s chart)
- tab_close verified (3→2), original NQ1! chart restored
- Lint 0 errors, 109/109 unit tests

Fixes the remaining `tab_new` half of #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)