### PR TITLE
Indicator/strategy search + add tools, and a git-pull update check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-79 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+81 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -6,6 +6,42 @@ import { existsSync, cpSync, rmSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { dirname, basename, join } from 'path';
 
+// Best-effort git-pull update check: compare local HEAD to origin's default
+// branch on GitHub. Never throws — returns null on any failure (offline,
+// detached HEAD, not a git checkout) so it can't break the health check.
+let _updateCache = null;
+async function checkForUpdate() {
+  if (_updateCache && (Date.now() - _updateCache.at) < 3600_000) return _updateCache.value;
+  let value = null;
+  try {
+    const localSha = execSync('git rev-parse HEAD', { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    const remoteUrl = execSync('git config --get remote.origin.url', { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    const m = remoteUrl.match(/github\.com[:/](.+?)(?:\.git)?$/);
+    if (localSha && m) {
+      const repo = m[1];
+      const http = await import('https');
+      const remoteSha = await new Promise((resolve) => {
+        const req = http.get({
+          host: 'api.github.com', path: `/repos/${repo}/commits/HEAD`,
+          headers: { 'User-Agent': 'tradingview-mcp', Accept: 'application/vnd.github.sha' },
+        }, (res) => { let d = ''; res.on('data', (c) => d += c); res.on('end', () => resolve(res.statusCode === 200 ? d.trim() : null)); });
+        req.on('error', () => resolve(null));
+        req.setTimeout(3000, () => { req.destroy(); resolve(null); });
+      });
+      if (remoteSha) {
+        value = {
+          update_available: remoteSha !== localSha,
+          local_commit: localSha.slice(0, 8),
+          latest_commit: remoteSha.slice(0, 8),
+          ...(remoteSha !== localSha && { hint: 'Run `git pull` and restart the MCP server to update.' }),
+        };
+      }
+    }
+  } catch { /* best-effort */ }
+  _updateCache = { at: Date.now(), value };
+  return value;
+}
+
 export async function healthCheck() {
   await getClient();
   const target = await getTargetInfo();
@@ -30,6 +66,8 @@ export async function healthCheck() {
     })()
   `);
 
+  const update = await checkForUpdate();
+
   return {
     success: true,
     cdp_connected: true,
@@ -40,6 +78,7 @@ export async function healthCheck() {
     chart_resolution: state?.resolution || 'unknown',
     chart_type: state?.chartType ?? null,
     api_available: state?.apiAvailable ?? false,
+    ...(update && { update }),
   };
 }
 

--- a/src/core/indicators.js
+++ b/src/core/indicators.js
@@ -4,6 +4,160 @@
 import { evaluate, safeString } from '../connection.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
+const DIALOG = '[data-name="indicators-dialog"]';
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Read result rows out of the open Indicators dialog. The results pane is a
+// VIRTUALIZED list of absolutely-positioned rows: section headers contain an
+// <h3> (title-case: "My scripts", "Technicals", …), result rows don't. Rows
+// are read by that stable structure, NOT the hashed class names
+// (container-HtNLE8A5, …) which change on every TradingView build. Titles are
+// read from the row's whole textContent (search highlighting fragments the
+// text into multiple <span>s, so leaf-node matching would break).
+const READ_RESULTS_JS = `
+  (function() {
+    var dlg = document.querySelector('${DIALOG}');
+    if (!dlg) return { open: false };
+    var scroll = dlg.querySelector('[class*="scroll"]') || dlg;
+    var rows = scroll.querySelectorAll('[class*="container"]');
+    var results = [], section = null;
+    for (var i = 0; i < rows.length; i++) {
+      var r = rows[i];
+      var h3 = r.querySelector('h3');
+      if (h3 && r.contains(h3) && h3.parentElement === r) { section = (h3.textContent || '').trim(); continue; }
+      var titleEl = r.querySelector('[class*="title"]');
+      if (!titleEl) continue;
+      var title = (titleEl.textContent || '').trim();
+      if (!title) continue;
+      results.push({ title: title, section: section });
+    }
+    return { open: true, results: results };
+  })()
+`;
+
+async function openDialog() {
+  const opened = await evaluate(`
+    (function() {
+      if (document.querySelector('${DIALOG}')) return 'already';
+      var btn = document.querySelector('[data-name="open-indicators-dialog"]');
+      if (!btn) return 'no-button';
+      btn.click();
+      return 'clicked';
+    })()
+  `);
+  if (opened === 'no-button') throw new Error('Indicators toolbar button not found.');
+  for (let i = 0; i < 20; i++) {
+    await delay(200);
+    const ready = await evaluate(`!!document.querySelector('${DIALOG} input')`);
+    if (ready) return;
+  }
+  throw new Error('Indicators dialog did not open.');
+}
+
+async function typeQuery(query) {
+  await evaluate(`
+    (function() {
+      var inp = document.querySelector('${DIALOG} input');
+      if (!inp) return false;
+      inp.focus();
+      var setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+      setter.call(inp, ${safeString(query)});
+      inp.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    })()
+  `);
+  await delay(1200);
+}
+
+async function closeDialog() {
+  await evaluate(`
+    (function() {
+      var dlg = document.querySelector('${DIALOG}');
+      if (!dlg) return;
+      var close = dlg.querySelector('[data-name="close"], [class*="close"] button, button[class*="close"]');
+      if (close) { close.click(); return; }
+    })()
+  `);
+  await delay(300);
+}
+
+/**
+ * Search TradingView's Indicators dialog — covers built-ins, strategies,
+ * community/public scripts, and your saved scripts (everything the manual
+ * search box returns).
+ */
+export async function searchStudies({ query, limit } = {}) {
+  if (!query || !String(query).trim()) throw new Error('query is required.');
+  const cap = limit || 25;
+  await openDialog();
+  await typeQuery(query);
+  const res = await evaluate(READ_RESULTS_JS);
+  await closeDialog();
+  if (!res || !res.open) throw new Error('Indicators dialog closed unexpectedly during search.');
+  const results = (res.results || []).map(({ title, section }) => ({ title, section })).slice(0, cap);
+  return { success: true, query, count: results.length, results };
+}
+
+/**
+ * Search then add a study by clicking its result row. `match` (default =
+ * query) is matched case-insensitively against result titles; the first
+ * matching row is added. Verifies a new study landed on the chart.
+ */
+export async function addStudyFromSearch({ query, match, section } = {}) {
+  if (!query || !String(query).trim()) throw new Error('query is required.');
+  const want = String(match || query).trim();
+
+  const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s){return s.id;})`);
+
+  await openDialog();
+  await typeQuery(query);
+
+  const clicked = await evaluate(`
+    (function() {
+      var dlg = document.querySelector('${DIALOG}');
+      if (!dlg) return { error: 'dialog closed' };
+      var scroll = dlg.querySelector('[class*="scroll"]') || dlg;
+      var want = ${safeString(want.toLowerCase())};
+      var wantSection = ${section ? safeString(String(section).toLowerCase()) : 'null'};
+      var rows = scroll.querySelectorAll('[class*="container"]');
+      var section = null, exact = null, contains = null;
+      for (var i = 0; i < rows.length; i++) {
+        var r = rows[i];
+        var h3 = r.querySelector('h3');
+        if (h3 && h3.parentElement === r) { section = (h3.textContent || '').trim().toLowerCase(); continue; }
+        if (wantSection && section !== wantSection) continue;
+        var titleEl = r.querySelector('[class*="title"]');
+        if (!titleEl) continue;
+        var t = (titleEl.textContent || '').trim();
+        var tl = t.toLowerCase();
+        if (tl === want && !exact) exact = { row: r, title: t, section: section };
+        if (tl.indexOf(want) !== -1 && !contains) contains = { row: r, title: t, section: section };
+      }
+      var pick = exact || contains;
+      if (!pick) return { error: 'No result matching "' + want + '" found.' };
+      pick.row.click();
+      return { clicked: pick.title, section: pick.section };
+    })()
+  `);
+
+  if (clicked && clicked.error) { await closeDialog(); throw new Error(clicked.error); }
+
+  await delay(1500);
+  await closeDialog();
+
+  const after = await evaluate(`${CHART_API}.getAllStudies().map(function(s){return { id: s.id, name: s.getStudyMeta ? s.getStudyMeta().description : (s.name || null) };})`);
+  const beforeSet = new Set(before || []);
+  const added = (after || []).filter((s) => !beforeSet.has(s.id));
+
+  return {
+    success: added.length > 0,
+    added_from_search: clicked?.clicked || null,
+    section: clicked?.section || null,
+    entity_id: added[0]?.id || null,
+    added_count: added.length,
+  };
+}
 
 export async function setInputs({ entity_id, inputs: inputsRaw }) {
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;

--- a/src/tools/indicators.js
+++ b/src/tools/indicators.js
@@ -18,4 +18,21 @@ export function registerIndicatorTools(server) {
     try { return jsonResult(await core.toggleVisibility({ entity_id, visible })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
+
+  server.tool('indicator_search', 'Search TradingView\'s Indicators dialog for indicators, strategies, and community/public scripts by keyword. Returns matching titles grouped by section (Technicals, Community, My scripts, etc.).', {
+    query: z.string().describe('Search keyword, e.g. "RSI", "supertrend", "order block"'),
+    limit: z.coerce.number().optional().describe('Max results to return (default 25)'),
+  }, async ({ query, limit }) => {
+    try { return jsonResult(await core.searchStudies({ query, limit })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('indicator_add', 'Search the Indicators dialog and add a result to the chart by name. Works for strategies and community scripts, not just built-ins. Returns the new study entity_id.', {
+    query: z.string().describe('Search keyword to find the indicator/strategy'),
+    match: z.string().optional().describe('Exact title to add (default: the query). Case-insensitive; falls back to first title containing it.'),
+    section: z.string().optional().describe('Restrict to a section: "Technicals", "Community", "My scripts", etc.'),
+  }, async ({ query, match, section }) => {
+    try { return jsonResult(await core.addStudyFromSearch({ query, match, section })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
 }


### PR DESCRIPTION
## What

Two new indicator tools + a self-update hint, all verified live through the MCP protocol on TradingView Desktop 3.1.0.

### `indicator_search` / `indicator_add`
Drive TradingView's Indicators dialog (the `/` search box) so they cover **built-ins, strategies, community/public scripts, and your saved scripts** — everything the manual search returns. `chart_manage_indicator`/`createStudy` can only reach built-in studies by exact name, with no search.

- `indicator_search({query, limit})` → titles grouped by section (Technicals, Community, My scripts, …)
- `indicator_add({query, match, section})` → clicks the matching result, verifies a new study landed, returns its `entity_id`

The results pane is a **virtualized** list of absolutely-positioned rows. Rows are read by stable structure — section headers carry an `<h3>`, result rows don't; titles come from the row's `textContent` (search highlighting fragments the title into `<span>`s, so leaf-text matching breaks). No hashed class names are hardcoded (`container-HtNLE8A5` etc. change every build).

### `tv_health_check` update block
Compares local `HEAD` to the GitHub repo's latest commit and reports `update_available` + a `git pull` hint, since this is a git-clone install with no auto-update. Best-effort: offline / non-git / API failure → the block is simply omitted, never throws. Cached 1h.

## Verified live

- `indicator_search "RSI"` → built-in (Relative Strength Index, Connors RSI, Stochastic RSI) + community (RSI Candles, etc.)
- `indicator_search "supertrend"` → indicators **and** strategies
- `indicator_add "Relative Strength Index"` and `"Supertrend Strategy"` → both landed on the chart (confirmed via chart_get_state), then removed
- `tv_health_check` → returns real local/latest SHAs
- 81 tools; lint 0 errors; 109/109 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)