### PR TITLE
Fix chart_manage_indicator ignoring inputs on add (#249)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -89,18 +89,57 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;
 
   if (action === 'add') {
-    const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
     const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
     await evaluate(`
       (function() {
         var chart = ${CHART_API};
-        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputArr)});
+        chart.createStudy(${safeString(indicator)}, false, false, []);
       })()
     `);
     await new Promise(r => setTimeout(r, 1500));
     const after = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
     const newIds = (after || []).filter(id => !(before || []).includes(id));
-    return { success: newIds.length > 0, action: 'add', indicator, entity_id: newIds[0] || null, new_study_count: newIds.length };
+    const entityId = newIds[0] || null;
+
+    // createStudy's inputs argument is unreliable across builds (#249): the
+    // study is created with defaults regardless. Apply overrides afterward
+    // via the study's own getInputValues/setInputValues, then read back to
+    // report what actually took.
+    let appliedInputs;
+    if (entityId && inputs && Object.keys(inputs).length) {
+      const result = await evaluate(`
+        (function() {
+          var chart = ${CHART_API};
+          var study = chart.getStudyById(${safeString(entityId)});
+          if (!study || typeof study.getInputValues !== 'function') return { error: 'inputs unsupported for this study' };
+          var current = study.getInputValues();
+          var overrides = ${JSON.stringify(inputs)};
+          var applied = {}, unknown = [];
+          var byId = {};
+          for (var i = 0; i < current.length; i++) byId[current[i].id] = true;
+          for (var k in overrides) {
+            if (byId[k]) { for (var j = 0; j < current.length; j++) { if (current[j].id === k) current[j].value = overrides[k]; } applied[k] = overrides[k]; }
+            else unknown.push(k);
+          }
+          study.setInputValues(current);
+          var after = study.getInputValues();
+          var confirmed = {};
+          for (var m = 0; m < after.length; m++) { if (applied.hasOwnProperty(after[m].id)) confirmed[after[m].id] = after[m].value; }
+          return { confirmed: confirmed, unknown: unknown };
+        })()
+      `);
+      if (result?.error) appliedInputs = { error: result.error };
+      else appliedInputs = { applied: result?.confirmed || {}, ...(result?.unknown?.length && { unknown_inputs: result.unknown }) };
+    }
+
+    return {
+      success: newIds.length > 0,
+      action: 'add',
+      indicator,
+      entity_id: entityId,
+      new_study_count: newIds.length,
+      ...(appliedInputs && { inputs: appliedInputs }),
+    };
   } else if (action === 'remove') {
     if (!entity_id) throw new Error('entity_id required for remove action. Use chart_get_state to find study IDs.');
     await evaluate(`

--- a/tests/chart_indicator.test.js
+++ b/tests/chart_indicator.test.js
@@ -1,0 +1,62 @@
+/**
+ * Tests for manageIndicator input application in src/core/chart.js (#249).
+ * Verifies that inputs are applied post-create via setInputValues (not the
+ * unreliable createStudy 4th arg) and that unknown keys are reported.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { manageIndicator } from '../src/core/chart.js';
+
+// A mock evaluate that simulates a chart with one study whose inputs are
+// getInputValues/setInputValues-backed. Tracks the study's current inputs.
+function mockChart({ defaults }) {
+  const state = { studyInputs: defaults.map((d) => ({ ...d })), created: false };
+  const evaluate = async (expr) => {
+    if (/getAllStudies\(\)\.map/.test(expr)) {
+      return state.created ? ['study_1'] : [];
+    }
+    if (/createStudy/.test(expr)) { state.created = true; return undefined; }
+    if (/getInputValues[\s\S]*setInputValues/.test(expr)) {
+      // Emulate the applied-inputs IIFE: parse the overrides object literal.
+      const m = expr.match(/var overrides = (\{[\s\S]*?\});/);
+      const overrides = m ? JSON.parse(m[1]) : {};
+      const applied = {}, unknown = [];
+      const ids = new Set(state.studyInputs.map((i) => i.id));
+      for (const k of Object.keys(overrides)) {
+        if (ids.has(k)) { state.studyInputs.find((i) => i.id === k).value = overrides[k]; applied[k] = overrides[k]; }
+        else unknown.push(k);
+      }
+      const confirmed = {};
+      for (const i of state.studyInputs) if (k_in(applied, i.id)) confirmed[i.id] = i.value;
+      return { confirmed, unknown };
+    }
+    return undefined;
+  };
+  const k_in = (obj, k) => Object.prototype.hasOwnProperty.call(obj, k);
+  return { _deps: { evaluate }, state };
+}
+
+describe('manageIndicator add — input application (#249)', () => {
+  it('applies overrides and confirms them via read-back', async () => {
+    const { _deps, state } = mockChart({ defaults: [{ id: 'length', value: 9 }, { id: 'source', value: 'close' }] });
+    const r = await manageIndicator({ action: 'add', indicator: 'Moving Average Exponential', inputs: JSON.stringify({ length: 99, source: 'open' }), _deps });
+    assert.equal(r.success, true);
+    assert.equal(r.entity_id, 'study_1');
+    assert.deepEqual(r.inputs.applied, { length: 99, source: 'open' });
+    assert.equal(state.studyInputs.find((i) => i.id === 'length').value, 99);
+  });
+
+  it('reports unknown input keys without failing', async () => {
+    const { _deps } = mockChart({ defaults: [{ id: 'length', value: 9 }] });
+    const r = await manageIndicator({ action: 'add', indicator: 'X', inputs: JSON.stringify({ length: 20, bogus: 5 }), _deps });
+    assert.deepEqual(r.inputs.applied, { length: 20 });
+    assert.deepEqual(r.inputs.unknown_inputs, ['bogus']);
+  });
+
+  it('adds without inputs cleanly (no inputs field)', async () => {
+    const { _deps } = mockChart({ defaults: [{ id: 'length', value: 9 }] });
+    const r = await manageIndicator({ action: 'add', indicator: 'Volume', _deps });
+    assert.equal(r.success, true);
+    assert.equal(r.inputs, undefined);
+  });
+});


### PR DESCRIPTION
## Problem

`chart_manage_indicator({action:"add", indicator:"...", inputs:{length:99}})` silently ignored the inputs — the study always got default values. Root cause: `createStudy`'s 4th argument (input values) doesn't reliably apply across TradingView builds. Confirmed live: EMA added with `{length:99}` came out at the default 9.

## Fix

Create the study with defaults, then apply overrides via the study's own `getInputValues()`/`setInputValues()` — the same API `indicator_set_inputs` already uses successfully — and read the values back so the response reports exactly what took. Unknown input keys are returned in `inputs.unknown_inputs` instead of being silently dropped.

## Verified live (Desktop 3.1.0)

- EMA added with `{length:99, source:"open"}` → independent read-back shows `length=99, source=open`
- `{bogusKey:5}` → reported as `unknown_inputs: ["bogusKey"]`, other keys still applied
- Added `tests/chart_indicator.test.js` (DI mock, 3 cases); 112/112 unit tests pass; lint clean

Supersedes #227 (same bug, object-inputs approach). Fixes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)