### PR TITLE
Auto-unhide hidden strategies in strategy data tools

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -24,11 +24,7 @@ const FIND_STRATEGY_JS = `
   function _reportOf(s) {
     try { var rd = s.reportData(); if (rd && typeof rd.value === 'function') rd = rd.value(); return rd; } catch (e) { return null; }
   }
-  // Returns { strat, report } — prefers a strategy whose report is actually
-  // computed (the one selected in the Strategy Tester panel). With multiple
-  // strategies on the chart, only the selected one has non-null reportData,
-  // so returning the first strategy blindly reads the wrong (empty) one.
-  function findStrategy() {
+  function findStrategies() {
     var chart = ${CHART_API}._chartWidget;
     var sources = chart.model().model().dataSources();
     var strategies = [];
@@ -40,6 +36,14 @@ const FIND_STRATEGY_JS = `
         strategies.push({ s: s, name: mi ? mi.description : null });
       }
     }
+    return strategies;
+  }
+  // Returns { strat, report } — prefers a strategy whose report is actually
+  // computed (the one selected in the Strategy Tester panel). With multiple
+  // strategies on the chart, only the selected one has non-null reportData,
+  // so returning the first strategy blindly reads the wrong (empty) one.
+  function findStrategy() {
+    var strategies = findStrategies();
     // Prefer one with a computed report (has .performance).
     for (var j = 0; j < strategies.length; j++) {
       var rd = _reportOf(strategies[j].s);
@@ -48,6 +52,29 @@ const FIND_STRATEGY_JS = `
     // None computed — return the first so callers can hint "open the panel".
     if (strategies.length) return { strat: strategies[0].s, report: null, name: strategies[0].name, strategy_count: strategies.length };
     return null;
+  }
+  // TradingView never computes a report for a hidden strategy (crossed-out eye
+  // in the legend), so a hidden one looks identical to "panel not opened yet".
+  // Unhide any hidden strategies and report their names so callers can tell
+  // the user what changed.
+  function unhideStrategies() {
+    var unhidden = [];
+    var strategies = findStrategies();
+    for (var i = 0; i < strategies.length; i++) {
+      var s = strategies[i].s;
+      try {
+        var vis = null;
+        try { vis = s.properties().visible.value(); } catch (e) {}
+        if (vis !== false) continue;
+        var done = false;
+        try { s.properties().visible.setValue(true); done = true; } catch (e) {}
+        if (!done) {
+          try { var st = ${CHART_API}.getStudyById(s.id()); if (st) { st.setVisible(true); done = true; } } catch (e) {}
+        }
+        if (done) unhidden.push(strategies[i].name || 'strategy');
+      } catch (e) {}
+    }
+    return unhidden;
   }
 `;
 
@@ -176,19 +203,24 @@ export async function getIndicator({ entity_id }) {
 }
 
 // #173: TradingView doesn't compute strategy report/orders until the Strategy
-// Tester panel is opened. Ensure it's open (via bottomWidgetBar) and wait for
-// a strategy's reportData to populate, so the strategy read tools work even
-// when the panel started closed.
+// Tester panel is opened — and never computes one for a hidden strategy.
+// Ensure the panel is open (via bottomWidgetBar), unhide any hidden
+// strategies, and wait for reportData to populate, so the strategy read tools
+// work even when the panel started closed or the strategy was hidden.
+// Returns { status, unhidden } — unhidden lists strategies made visible.
 async function ensureStrategyTesterReady(maxWaitMs = 6000) {
-  await evaluate(`
+  const unhidden = await evaluate(`
     (function() {
+      ${FIND_STRATEGY_JS}
       try {
         var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
         if (bwb && typeof bwb.showWidget === 'function') bwb.showWidget('backtesting');
       } catch (e) {}
+      return unhideStrategies();
     })()
   `);
   const deadline = Date.now() + maxWaitMs;
+  let status = 'timeout';
   while (Date.now() < deadline) {
     const ready = await evaluate(`
       (function() {
@@ -198,14 +230,14 @@ async function ensureStrategyTesterReady(maxWaitMs = 6000) {
         return f.report && f.report.performance ? 'ready' : 'pending';
       })()
     `);
-    if (ready === 'ready' || ready === 'no-strategy') return ready;
+    if (ready === 'ready' || ready === 'no-strategy') { status = ready; break; }
     await new Promise(r => setTimeout(r, 500));
   }
-  return 'timeout';
+  return { status, unhidden: unhidden || [] };
 }
 
 export async function getStrategyResults() {
-  await ensureStrategyTesterReady();
+  const ready = await ensureStrategyTesterReady();
   const results = await evaluate(`
     (function() {
       ${FIND_STRATEGY_JS}
@@ -213,7 +245,7 @@ export async function getStrategyResults() {
         var found = findStrategy();
         if (!found) return {metrics: {}, source: 'internal_api', error: 'No strategy found on chart. Add a strategy first (e.g. indicator_add with a "... Strategy" script).'};
         var rd = found.report;
-        if (!rd || !rd.performance) return {metrics: {}, source: 'internal_api', error: 'Strategy report not computed yet. Open the Strategy Tester panel (ui_open_panel strategy-tester) and retry.'};
+        if (!rd || !rd.performance) return {metrics: {}, source: 'internal_api', error: 'Strategy report not computed yet. Retry in a few seconds; if it persists, check the Strategy Tester panel is open (ui_open_panel strategy-tester) and the strategy is not hidden on the chart.'};
         var perf = rd.performance;
         var all = perf.all || {};
         // Headline metrics, named to match the Strategy Tester "Key stats".
@@ -245,12 +277,19 @@ export async function getStrategyResults() {
       } catch(e) { return {metrics: {}, source: 'internal_api', error: e.message}; }
     })()
   `);
-  return { success: Object.keys(results?.metrics || {}).length > 0, metric_count: Object.keys(results?.metrics || {}).length, strategy: results?.strategy, currency: results?.currency, source: results?.source, metrics: results?.metrics || {}, error: results?.error };
+  return {
+    success: Object.keys(results?.metrics || {}).length > 0,
+    metric_count: Object.keys(results?.metrics || {}).length,
+    strategy: results?.strategy, currency: results?.currency, source: results?.source,
+    metrics: results?.metrics || {},
+    ...(ready.unhidden.length && { unhidden_strategies: ready.unhidden, note: 'Strategy was hidden on the chart; it was made visible so the report could compute.' }),
+    error: results?.error,
+  };
 }
 
 export async function getTrades({ max_trades } = {}) {
   const limit = Math.min(max_trades || 20, MAX_TRADES);
-  await ensureStrategyTesterReady();
+  const ready = await ensureStrategyTesterReady();
   const trades = await evaluate(`
     (function() {
       ${FIND_STRATEGY_JS}
@@ -283,11 +322,17 @@ export async function getTrades({ max_trades } = {}) {
       } catch(e) { return {trades: [], source: 'internal_api', error: e.message}; }
     })()
   `);
-  return { success: (trades?.trades?.length || 0) > 0, trade_count: trades?.trades?.length || 0, total_orders: trades?.total_orders ?? 0, source: trades?.source, trades: trades?.trades || [], error: trades?.error };
+  return {
+    success: (trades?.trades?.length || 0) > 0,
+    trade_count: trades?.trades?.length || 0, total_orders: trades?.total_orders ?? 0,
+    source: trades?.source, trades: trades?.trades || [],
+    ...(ready.unhidden.length && { unhidden_strategies: ready.unhidden, note: 'Strategy was hidden on the chart; it was made visible so orders could compute.' }),
+    error: trades?.error,
+  };
 }
 
 export async function getEquity() {
-  await ensureStrategyTesterReady();
+  const ready = await ensureStrategyTesterReady();
   const equity = await evaluate(`
     (function() {
       ${FIND_STRATEGY_JS}
@@ -308,7 +353,13 @@ export async function getEquity() {
       } catch(e) { return {data: [], source: 'internal_api', error: e.message}; }
     })()
   `);
-  return { success: (equity?.data?.length || 0) > 0, data_points: equity?.data?.length || 0, source: equity?.source, data: equity?.data || [], buy_hold_points: equity?.buy_hold_points, note: equity?.note, error: equity?.error };
+  return {
+    success: (equity?.data?.length || 0) > 0,
+    data_points: equity?.data?.length || 0, source: equity?.source, data: equity?.data || [],
+    buy_hold_points: equity?.buy_hold_points, note: equity?.note,
+    ...(ready.unhidden.length && { unhidden_strategies: ready.unhidden }),
+    error: equity?.error,
+  };
 }
 
 export async function getQuote({ symbol } = {}) {

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -18,12 +18,12 @@ export function registerDataTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('data_get_strategy_results', 'Get strategy performance metrics from Strategy Tester', {}, async () => {
+  server.tool('data_get_strategy_results', 'Get strategy performance metrics from Strategy Tester. Auto-opens the panel and auto-unhides a hidden strategy (TradingView never computes reports for hidden strategies); result includes unhidden_strategies when that happened.', {}, async () => {
     try { return jsonResult(await core.getStrategyResults()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('data_get_trades', 'Get trade list from Strategy Tester', {
+  server.tool('data_get_trades', 'Get trade list from Strategy Tester. Auto-opens the panel and auto-unhides a hidden strategy.', {
     max_trades: z.coerce.number().optional().describe('Maximum trades to return'),
   }, async ({ max_trades }) => {
     try { return jsonResult(await core.getTrades({ max_trades })); }


### PR DESCRIPTION
## Why

Found during a live test sweep: TradingView never computes a strategy report for a **hidden** strategy (crossed-out eye in the legend). A hidden strategy made `data_get_strategy_results` / `data_get_trades` / `data_get_equity` fail with the same "report not computed yet, open the panel" error as a closed Strategy Tester panel — misleading, since opening the panel doesn't help.

## What

- `ensureStrategyTesterReady()` scans strategy sources for `properties().visible === false` and unhides them (with a `getStudyById().setVisible(true)` fallback) before polling for the report, alongside the existing panel auto-open.
- Results include `unhidden_strategies: [...]` and a `note` when this happened, so the caller knows the chart was changed.
- The "not computed" error message now mentions the hidden-strategy case.
- Tool descriptions document the auto-unhide behavior.

## Verification (live)

Hid "0-5 Box Strategy Tester Q4 '25" on a real chart, then a single `data_get_strategy_results` call via MCP stdio returned all 19 metrics with `unhidden_strategies` reported. Lint 0 errors, unit tests 112/112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)