### PR TITLE
Add wait_for_render option to capture_screenshot (issue #144)

### DIFF
--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -2,6 +2,7 @@
  * Core screenshot/capture logic.
  */
 import { getClient, evaluate, getChartCollection } from '../connection.js';
+import { waitForChartRender } from '../wait.js';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -9,11 +10,13 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCREENSHOT_DIR = join(dirname(dirname(__dirname)), 'screenshots');
 
-export async function captureScreenshot({ region, filename, method } = {}) {
+export async function captureScreenshot({ region, filename, method, waitForRender = false } = {}) {
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
+  if (waitForRender) await waitForChartRender();
+
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const fname = (filename || `tv_${region}_${ts}`).replace(/[\/\\]/g, '_').replace(/\.\./g, '_');
+  const fname = (filename || `tv_${region || 'full'}_${ts}`).replace(/[\/\\]/g, '_').replace(/\.\./g, '_');
   const filePath = join(SCREENSHOT_DIR, `${fname}.png`);
 
   if (method === 'api') {
@@ -21,7 +24,7 @@ export async function captureScreenshot({ region, filename, method } = {}) {
       const colPath = await getChartCollection();
       await evaluate(`${colPath}.takeScreenshot()`);
       return {
-        success: true, method: 'api',
+        success: true, method: 'api', waited_for_render: !!waitForRender,
         note: 'takeScreenshot() triggered — TradingView will save/show the screenshot via its own UI',
       };
     } catch {
@@ -65,6 +68,7 @@ export async function captureScreenshot({ region, filename, method } = {}) {
 
   return {
     success: true, method: 'cdp', file_path: filePath, region,
+    waited_for_render: !!waitForRender,
     size_bytes: Buffer.from(data, 'base64').length,
   };
 }

--- a/src/tools/capture.js
+++ b/src/tools/capture.js
@@ -7,8 +7,9 @@ export function registerCaptureTools(server) {
     region: z.string().optional().describe('Region to capture: full, chart, strategy_tester (default full)'),
     filename: z.string().optional().describe('Custom filename (without extension)'),
     method: z.string().optional().describe('Capture method: cdp (Page.captureScreenshot) or api (chartWidgetCollection.takeScreenshot) (default cdp)'),
-  }, async ({ region, filename, method }) => {
-    try { return jsonResult(await core.captureScreenshot({ region, filename, method })); }
+    wait_for_render: z.boolean().optional().describe('Wait for the chart canvas to stabilize before capturing. Use after chart_set_symbol or chart_set_timeframe to avoid stale frames.'),
+  }, async ({ region, filename, method, wait_for_render }) => {
+    try { return jsonResult(await core.captureScreenshot({ region, filename, method, waitForRender: wait_for_render })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }

--- a/src/wait.js
+++ b/src/wait.js
@@ -70,3 +70,57 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
   // Timeout — return true anyway, caller should verify
   return false;
 }
+
+/**
+ * Wait for the chart to finish (re)rendering — used before screenshots so a
+ * capture right after chart_set_symbol / chart_set_timeframe doesn't grab a
+ * stale frame (issue #144). Waits for any loading spinner to clear, then for
+ * the symbol/resolution/canvas signature to hold stable across 3 polls.
+ */
+export async function waitForChartRender(timeout = 5000) {
+  const start = Date.now();
+  let lastSignature = null;
+  let stableCount = 0;
+
+  while (Date.now() - start < timeout) {
+    const state = await evaluate(`
+      (function() {
+        var canvas = document.querySelector('[data-name="pane-canvas"] canvas')
+          || document.querySelector('[data-name="pane-canvas"]')
+          || document.querySelector('canvas');
+        var rect = canvas ? canvas.getBoundingClientRect() : null;
+        var symbol = '', resolution = '';
+        try {
+          var chart = window.TradingViewApi._activeChartWidgetWV.value();
+          symbol = chart.symbol();
+          resolution = chart.resolution();
+        } catch(e) {}
+        var spinner = document.querySelector('[class*="loader"]')
+          || document.querySelector('[class*="loading"]')
+          || document.querySelector('[data-name="loading"]');
+        return {
+          symbol: symbol,
+          resolution: resolution,
+          isLoading: !!(spinner && spinner.offsetParent !== null),
+          canvasWidth: rect ? Math.round(rect.width) : 0,
+          canvasHeight: rect ? Math.round(rect.height) : 0
+        };
+      })()
+    `);
+
+    if (!state || state.isLoading || !state.canvasWidth || !state.canvasHeight) {
+      stableCount = 0;
+      await new Promise(r => setTimeout(r, POLL_INTERVAL));
+      continue;
+    }
+
+    const signature = [state.symbol, state.resolution, state.canvasWidth, state.canvasHeight].join('|');
+    if (signature === lastSignature) stableCount++;
+    else { stableCount = 0; lastSignature = signature; }
+
+    if (stableCount >= 3) return true;
+    await new Promise(r => setTimeout(r, POLL_INTERVAL));
+  }
+
+  return false;
+}


### PR DESCRIPTION
Reimplementation of #148 (by @tlcreativeart-hub) against current main — see commit message. Verified live: symbol change → immediate capture returns fully-rendered frame. Lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)