### PR TITLE
Overhaul watchlist tools: fix add/get, add remove + bulk add (#164, #111)

### DIFF
--- a/src/cli/commands/watchlist.js
+++ b/src/cli/commands/watchlist.js
@@ -2,7 +2,7 @@ import { register } from '../router.js';
 import * as core from '../../core/watchlist.js';
 
 register('watchlist', {
-  description: 'Watchlist tools (get, add)',
+  description: 'Watchlist tools (get, add, add-bulk, remove)',
   subcommands: new Map([
     ['get', {
       description: 'Get watchlist symbols',
@@ -13,6 +13,20 @@ register('watchlist', {
       handler: (opts, positionals) => {
         if (!positionals[0]) throw new Error('Symbol required. Usage: tv watchlist add AAPL');
         return core.add({ symbol: positionals[0] });
+      },
+    }],
+    ['add-bulk', {
+      description: 'Add multiple symbols to the watchlist',
+      handler: (opts, positionals) => {
+        if (!positionals.length) throw new Error('Symbols required. Usage: tv watchlist add-bulk AAPL MSFT');
+        return core.addBulk({ symbols: positionals });
+      },
+    }],
+    ['remove', {
+      description: 'Remove one or more symbols from the watchlist',
+      handler: (opts, positionals) => {
+        if (!positionals.length) throw new Error('Symbols required. Usage: tv watchlist remove AAPL MSFT');
+        return core.remove({ symbols: positionals });
       },
     }],
   ]),

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -62,18 +62,23 @@ export async function openPanel({ panel, action }) {
     if (result && result.error) throw new Error(result.error);
     return { success: true, panel, action, was_open: result?.was_open ?? false, performed: result?.performed ?? 'unknown' };
   } else {
+    // Newer TV builds renamed the right-rail buttons (watchlist is now
+    // data-name="base", aria "Watchlist, details, and news"; alerts is
+    // data-name="alerts") — keep legacy selectors as fallbacks.
     const selectorMap = {
-      'watchlist': { dataName: 'base-watchlist-widget-button', ariaLabel: 'Watchlist' },
-      'alerts': { dataName: 'alerts-button', ariaLabel: 'Alerts' },
-      'trading': { dataName: 'trading-button', ariaLabel: 'Trading Panel' },
+      'watchlist': { dataNames: ['base-watchlist-widget-button', 'base'], ariaLabels: ['Watchlist', 'Watchlist, details, and news'] },
+      'alerts': { dataNames: ['alerts-button', 'alerts'], ariaLabels: ['Alerts'] },
+      'trading': { dataNames: ['trading-button'], ariaLabels: ['Trading Panel'] },
     };
     const sel = selectorMap[panel];
     const result = await evaluate(`
       (function() {
-        var dataName = ${JSON.stringify(sel.dataName)};
-        var ariaLabel = ${JSON.stringify(sel.ariaLabel)};
+        var dataNames = ${JSON.stringify(sel.dataNames)};
+        var ariaLabels = ${JSON.stringify(sel.ariaLabels)};
         var action = ${JSON.stringify(action)};
-        var btn = document.querySelector('[data-name="' + dataName + '"]') || document.querySelector('[aria-label="' + ariaLabel + '"]');
+        var btn = null;
+        for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
+        for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
         if (!btn) return { error: 'Button not found for panel: ' + ${JSON.stringify(panel)} };
         var isActive = btn.getAttribute('aria-pressed') === 'true' || btn.classList.contains('isActive') || btn.classList.toString().indexOf('active') !== -1 || btn.classList.toString().indexOf('Active') !== -1;
         var rightArea = document.querySelector('[class*="layout__area--right"]');

--- a/src/core/watchlist.js
+++ b/src/core/watchlist.js
@@ -1,132 +1,238 @@
 /**
  * Core watchlist logic.
- * Uses TradingView's internal widget API with DOM fallback.
+ * Reads via DOM rows (panel auto-opened when needed). Removal uses
+ * TradingView's symbols_list REST API from the page context (cookie auth),
+ * mirroring the proven alerts REST pattern. Add drives the Add-symbol
+ * search UI so bare tickers resolve the same way they do for a human.
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
-export async function get() {
-  // Try internal API first — reads from the active watchlist widget
-  const symbols = await evaluate(`
-    (function() {
-      // Method 1: Try the watchlist widget's internal data
-      try {
-        var rightArea = document.querySelector('[class*="layout__area--right"]');
-        if (!rightArea || rightArea.offsetWidth < 50) return { symbols: [], source: 'panel_closed' };
-      } catch(e) {}
+// TV renamed the right-rail button: current builds use data-name="base" with
+// aria-label "Watchlist, details, and news"; older builds used
+// data-name="base-watchlist-widget-button" / aria-label "Watchlist".
+const WL_BUTTON_JS = `(document.querySelector('[data-name="base-watchlist-widget-button"]')
+  || document.querySelector('[aria-label="Watchlist, details, and news"]')
+  || document.querySelector('[aria-label^="Watchlist"]'))`;
 
-      // Method 2: Read data-symbol-full attributes from watchlist rows
-      var results = [];
-      var seen = {};
+// The watchlist widget lazy-loads after the panel opens; a fixed 500ms wait
+// raced it (issue #164). Poll until its Add-symbol button or rows exist.
+async function ensureWatchlistOpen(maxWaitMs = 5000) {
+  const state = await evaluate(`
+    (function() {
+      var btn = ${WL_BUTTON_JS};
+      if (!btn) return { error: 'Watchlist button not found' };
+      var pressed = btn.getAttribute('aria-pressed') === 'true';
+      var widgetReady = !!(document.querySelector('[data-name="add-symbol-button"]')
+        || document.querySelector('[class*="layout__area--right"] [data-symbol-full]'));
+      if (!pressed || !widgetReady) { if (!pressed) btn.click(); return { opened: !pressed }; }
+      return { opened: false, ready: true };
+    })()
+  `);
+  if (state?.error) throw new Error(state.error);
+  if (state?.ready) return { opened: false };
+
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline) {
+    const ready = await evaluate(`
+      !!(document.querySelector('[data-name="add-symbol-button"]')
+        || document.querySelector('[class*="layout__area--right"] [data-symbol-full]'))
+    `);
+    if (ready) return { opened: !!state?.opened };
+    await new Promise(r => setTimeout(r, 250));
+  }
+  throw new Error('Watchlist panel did not become ready. Is a watchlist widget configured in the right panel?');
+}
+
+// Active watchlist metadata (id, name, symbols) read from the React fiber
+// tree — needed for the REST endpoints. Approach from PR #65.
+async function getActiveListInfo() {
+  return evaluate(`
+    (function() {
+      var panel = document.querySelector('[class*="layout__area--right"]');
+      if (!panel) return null;
+      var rows = panel.querySelectorAll('[data-symbol-full]');
+      if (!rows.length) return null;
+      var row = rows[0];
+      var reactKey = Object.keys(row).find(function(k) { return k.indexOf('__reactFiber') === 0; });
+      if (!reactKey) return null;
+      var fiber = row[reactKey];
+      var count = 0;
+      while (fiber && count < 45) {
+        if (fiber.memoizedProps && fiber.memoizedProps.current && fiber.memoizedProps.current.id) {
+          var cur = fiber.memoizedProps.current;
+          return { id: cur.id, name: cur.name, symbols: cur.symbols || [] };
+        }
+        fiber = fiber.return;
+        count++;
+      }
+      return null;
+    })()
+  `);
+}
+
+export async function get() {
+  await ensureWatchlistOpen();
+
+  // Positional cell mapping (name, last, change, change%, volume) with
+  // Unicode-minus normalization. The old regex classifier dropped every
+  // negative value (TV renders U+2212, not ASCII '-') and all tick-notation
+  // prices like 106'28'7 — issue #111.
+  const data = await evaluate(`
+    (function() {
+      function norm(t) { return t.replace(/\\u2212/g, '-').trim(); }
       var container = document.querySelector('[class*="layout__area--right"]');
       if (!container) return { symbols: [], source: 'no_container' };
-
-      // Find all elements with symbol data attributes
+      var results = [];
+      var seen = {};
       var symbolEls = container.querySelectorAll('[data-symbol-full]');
       for (var i = 0; i < symbolEls.length; i++) {
         var sym = symbolEls[i].getAttribute('data-symbol-full');
         if (!sym || seen[sym]) continue;
         seen[sym] = true;
-
-        // Find the row and extract price data
         var row = symbolEls[i].closest('[class*="row"]') || symbolEls[i].parentElement;
         var cells = row ? row.querySelectorAll('[class*="cell"], [class*="column"]') : [];
-        var nums = [];
-        for (var j = 0; j < cells.length; j++) {
-          var t = cells[j].textContent.trim();
-          if (t && /^[\\-+]?[\\d,]+\\.?\\d*%?$/.test(t.replace(/[\\s,]/g, ''))) nums.push(t);
-        }
-        results.push({ symbol: sym, last: nums[0] || null, change: nums[1] || null, change_percent: nums[2] || null });
+        var texts = [];
+        for (var j = 0; j < cells.length; j++) texts.push(norm(cells[j].textContent));
+        results.push({
+          symbol: sym,
+          last: texts[1] || null,
+          change: texts[2] || null,
+          change_percent: texts[3] || null,
+          volume: texts[4] || null,
+        });
       }
-
-      if (results.length > 0) return { symbols: results, source: 'data_attributes' };
-
-      // Method 3: Scan for ticker-like text in the right panel
-      var items = container.querySelectorAll('[class*="symbolName"], [class*="tickerName"], [class*="symbol-"]');
-      for (var k = 0; k < items.length; k++) {
-        var text = items[k].textContent.trim();
-        if (text && /^[A-Z][A-Z0-9.:!]{0,20}$/.test(text) && !seen[text]) {
-          seen[text] = true;
-          results.push({ symbol: text, last: null, change: null, change_percent: null });
-        }
-      }
-
-      return { symbols: results, source: results.length > 0 ? 'text_scan' : 'empty' };
+      return { symbols: results, source: results.length ? 'dom_rows' : 'empty' };
     })()
   `);
 
+  const listInfo = await getActiveListInfo();
   return {
     success: true,
-    count: symbols?.symbols?.length || 0,
-    source: symbols?.source || 'unknown',
-    symbols: symbols?.symbols || [],
+    count: data?.symbols?.length || 0,
+    source: data?.source || 'unknown',
+    ...(listInfo && { list_id: listInfo.id, list_name: listInfo.name }),
+    symbols: data?.symbols || [],
   };
 }
 
 export async function add({ symbol }) {
-  // Use keyboard shortcut to open symbol search in watchlist, type symbol, press Enter
   const c = await getClient();
+  await ensureWatchlistOpen();
 
-  // First ensure watchlist panel is open
-  const panelState = await evaluate(`
-    (function() {
-      var btn = document.querySelector('[data-name="base-watchlist-widget-button"]')
-        || document.querySelector('[aria-label*="Watchlist"]');
-      if (!btn) return { error: 'Watchlist button not found' };
-      var isActive = btn.getAttribute('aria-pressed') === 'true'
-        || btn.classList.toString().indexOf('Active') !== -1
-        || btn.classList.toString().indexOf('active') !== -1;
-      if (!isActive) { btn.click(); return { opened: true }; }
-      return { opened: false };
-    })()
-  `);
-
-  if (panelState?.error) throw new Error(panelState.error);
-  if (panelState?.opened) await new Promise(r => setTimeout(r, 500));
-
-  // Click the "Add symbol" button (various selectors)
   const addClicked = await evaluate(`
     (function() {
-      var selectors = [
-        '[data-name="add-symbol-button"]',
-        '[aria-label="Add symbol"]',
-        '[aria-label*="Add symbol"]',
-        'button[class*="addSymbol"]',
-      ];
-      for (var s = 0; s < selectors.length; s++) {
-        var btn = document.querySelector(selectors[s]);
-        if (btn && btn.offsetParent !== null) { btn.click(); return { found: true, selector: selectors[s] }; }
+      var btn = document.querySelector('[data-name="add-symbol-button"]')
+        || document.querySelector('[aria-label="Add symbol"]')
+        || document.querySelector('[aria-label*="Add symbol"]');
+      if (!btn || btn.offsetParent === null) return { found: false };
+      btn.click();
+      return { found: true };
+    })()
+  `);
+  if (!addClicked?.found) throw new Error('Add symbol button not found in watchlist panel');
+  await new Promise(r => setTimeout(r, 400));
+
+  await c.Input.insertText({ text: symbol });
+  await new Promise(r => setTimeout(r, 700));
+  await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 });
+  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Enter', code: 'Enter' });
+  await new Promise(r => setTimeout(r, 400));
+  await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape' });
+  await new Promise(r => setTimeout(r, 400));
+
+  // Verify the row actually appeared instead of reporting blind success.
+  const bare = symbol.split(':').pop().toUpperCase();
+  const verified = await evaluate(`
+    (function() {
+      var rows = document.querySelectorAll('[class*="layout__area--right"] [data-symbol-full]');
+      for (var i = 0; i < rows.length; i++) {
+        var s = rows[i].getAttribute('data-symbol-full') || '';
+        if (s.toUpperCase() === ${JSON.stringify(symbol.toUpperCase())} || s.split(':').pop().toUpperCase() === ${JSON.stringify(bare)}) return s;
       }
-      // Fallback: find + button in right panel
-      var container = document.querySelector('[class*="layout__area--right"]');
-      if (container) {
-        var buttons = container.querySelectorAll('button');
-        for (var i = 0; i < buttons.length; i++) {
-          var ariaLabel = buttons[i].getAttribute('aria-label') || '';
-          if (/add.*symbol/i.test(ariaLabel) || buttons[i].textContent.trim() === '+') {
-            buttons[i].click();
-            return { found: true, method: 'fallback' };
-          }
-        }
-      }
-      return { found: false };
+      return null;
     })()
   `);
 
-  if (!addClicked?.found) throw new Error('Add symbol button not found in watchlist panel');
-  await new Promise(r => setTimeout(r, 300));
+  return { success: !!verified, symbol, added_as: verified, action: verified ? 'added' : 'not_verified' };
+}
 
-  // Type the symbol into the search input
-  await c.Input.insertText({ text: symbol });
-  await new Promise(r => setTimeout(r, 500));
+export async function addBulk({ symbols }) {
+  const results = [];
+  for (const symbol of symbols) {
+    try {
+      const r = await add({ symbol });
+      results.push({ symbol, success: r.success, added_as: r.added_as });
+    } catch (err) {
+      results.push({ symbol, success: false, error: err.message });
+    }
+  }
+  const added = results.filter(r => r.success).length;
+  return { success: added > 0, added, failed: results.length - added, results };
+}
 
-  // Press Enter to select the first result
-  await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Enter', code: 'Enter' });
-  await new Promise(r => setTimeout(r, 300));
+export async function remove({ symbols }) {
+  await ensureWatchlistOpen();
+  const listInfo = await getActiveListInfo();
+  if (!listInfo) throw new Error('Cannot read active watchlist metadata (React fiber probe failed)');
 
-  // Press Escape to close search
-  await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape' });
+  // Match requested symbols (bare or EXCHANGE:SYMBOL) against the list.
+  const toRemove = [];
+  const skipped = [];
+  for (const sym of symbols) {
+    if (sym.includes(':')) {
+      if (listInfo.symbols.includes(sym)) toRemove.push(sym);
+      else skipped.push(sym);
+    } else {
+      const match = listInfo.symbols.find(s => s.split(':').pop().toUpperCase() === sym.toUpperCase());
+      if (match) toRemove.push(match);
+      else skipped.push(sym);
+    }
+  }
+  if (!toRemove.length) {
+    return { success: false, removed: [], skipped, error: 'No matching symbols in the active watchlist' };
+  }
 
-  return { success: true, symbol, action: 'added' };
+  // Page-context fetch — browser attaches session cookies automatically.
+  const resp = await evaluateAsync(`
+    fetch('https://www.tradingview.com/api/v1/symbols_list/custom/' + ${JSON.stringify(listInfo.id)} + '/remove/', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      body: JSON.stringify(${JSON.stringify(toRemove)}),
+    })
+      .then(function(r) { return r.text().then(function(t) { return { status: r.status, ok: r.ok, body: t.substring(0, 300) }; }); })
+      .catch(function(e) { return { status: 0, ok: false, body: String(e) }; })
+  `);
+
+  if (!resp?.ok) {
+    throw new Error(`Watchlist remove REST call failed (HTTP ${resp?.status}): ${resp?.body}`);
+  }
+
+  // The desktop widget doesn't live-sync API removals — remount it by
+  // toggling the panel, then verify the rows are actually gone.
+  await evaluate(`(function() { var btn = ${WL_BUTTON_JS}; if (btn) btn.click(); })()`);
+  await new Promise(r => setTimeout(r, 400));
+  await evaluate(`(function() { var btn = ${WL_BUTTON_JS}; if (btn) btn.click(); })()`);
+
+  let stillPresent = toRemove;
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+    stillPresent = await evaluate(`
+      (function() {
+        var rows = document.querySelectorAll('[class*="layout__area--right"] [data-symbol-full]');
+        var present = {};
+        for (var i = 0; i < rows.length; i++) present[rows[i].getAttribute('data-symbol-full')] = true;
+        return ${JSON.stringify(toRemove)}.filter(function(s) { return present[s]; });
+      })()
+    `) || [];
+    if (stillPresent.length === 0) break;
+  }
+
+  return {
+    success: true, removed: toRemove, skipped,
+    verified: stillPresent.length === 0,
+    list_id: listInfo.id, list_name: listInfo.name, api: 'rest',
+  };
 }

--- a/src/tools/watchlist.js
+++ b/src/tools/watchlist.js
@@ -23,4 +23,18 @@ export function registerWatchlistTools(server) {
       return jsonResult({ success: false, error: err.message }, true);
     }
   });
+
+  server.tool('watchlist_add_bulk', 'Add multiple symbols to the TradingView watchlist', {
+    symbols: z.array(z.string()).describe('Symbols to add (e.g., ["AAPL", "ES1!", "NYMEX:CL1!"])'),
+  }, async ({ symbols }) => {
+    try { return jsonResult(await core.addBulk({ symbols })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('watchlist_remove', 'Remove one or more symbols from the active TradingView watchlist', {
+    symbols: z.array(z.string()).describe('Symbols to remove — bare (AAPL) or full (NASDAQ:AAPL)'),
+  }, async ({ symbols }) => {
+    try { return jsonResult(await core.remove({ symbols })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
 }


### PR DESCRIPTION
See commit message — verified live end-to-end (28-row read with correct negatives/bond ticks, add AAPL→NASDAQ:AAPL verified, REST remove verified with widget remount). Fiber-probe + REST approach credited to @drm-collab's #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)