### PR TITLE
Distinguish same-name studies in study_values + fix indicator remove schema (#143)

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -520,7 +520,13 @@ export async function getStudyValues() {
               }
             }
           } catch(e) {}
-          if (Object.keys(values).length > 0) results.push({ name: name, values: values });
+          // Include id + inputs so multiple instances of the same indicator
+          // (e.g. two EMAs with different lengths) are distinguishable (#143).
+          var id = null;
+          try { id = s.id ? s.id() : null; } catch(e) {}
+          var inputs = null;
+          try { var ip = s.inputs ? s.inputs() : null; if (ip && Object.keys(ip).length) inputs = ip; } catch(e) {}
+          if (Object.keys(values).length > 0) results.push({ id: id, name: name, inputs: inputs, values: values });
         } catch(e) {}
       }
       return results;

--- a/src/tools/chart.js
+++ b/src/tools/chart.js
@@ -31,12 +31,14 @@ export function registerChartTools(server) {
 
   server.tool('chart_manage_indicator', 'Add or remove an indicator/study on the chart', {
     action: z.enum(['add', 'remove']).describe('Action: add or remove'),
-    indicator: z.string().describe('Full indicator name: "Relative Strength Index", "MACD", "Volume", "Moving Average", "Bollinger Bands", "Moving Average Exponential". Short names like RSI/EMA do NOT work.'),
-    entity_id: z.string().optional().describe('Entity ID to remove (from chart_get_state). Required for remove.'),
+    indicator: z.string().optional().describe('Full indicator name (required for add): "Relative Strength Index", "MACD", "Volume", "Moving Average", "Bollinger Bands", "Moving Average Exponential". Short names like RSI/EMA do NOT work. Not needed for remove.'),
+    entity_id: z.string().optional().describe('Entity ID (from chart_get_state). Required for remove.'),
     inputs: z.string().optional().describe('JSON string of input overrides for the indicator (e.g., \'{"length": 20}\')'),
   }, async ({ action, indicator, entity_id, inputs }) => {
-    try { return jsonResult(await core.manageIndicator({ action, indicator, entity_id, inputs })); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    try {
+      if (action === 'add' && !indicator) throw new Error('indicator name is required for add action.');
+      return jsonResult(await core.manageIndicator({ action, indicator, entity_id, inputs }));
+    } catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
   server.tool('chart_get_visible_range', 'Get the visible date range (unix timestamps) and bars range on the chart', {}, async () => {


### PR DESCRIPTION
study_values now returns each study's `id` and `inputs`, so two EMAs (or any same-named indicators) are distinguishable — verified live: length 20 → MA 29,906.72, length 50 → MA 29,906.42. Also made `chart_manage_indicator`'s `indicator` optional (remove only needs `entity_id`; the required schema was rejecting valid remove calls). Lint 0 errors, tests pass.

Fixes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)