### PR TITLE
Add REST-based alert tools: alert_create_webhook, alert_modify_price, alert_delete_one

### DIFF
--- a/scripts/live-test-alert-rest.mjs
+++ b/scripts/live-test-alert-rest.mjs
@@ -1,0 +1,55 @@
+/**
+ * live-test-alert-rest.mjs — LIVE end-to-end test of the REST alert tools
+ * (alert_create_webhook / alert_modify_price / alert_delete_one core logic).
+ *
+ * Requires TradingView Desktop running with CDP on :9222.
+ * Creates a throwaway BATS:F alert, modifies its price, deletes it.
+ * NEVER touches existing alerts. Run:  node scripts/live-test-alert-rest.mjs
+ * Pass --clipboard to also test message_from_clipboard (put text on the
+ * clipboard first).
+ */
+import { createWebhook, modifyPrice, deleteOne, list } from '../src/core/alerts.js';
+import { disconnect } from '../src/connection.js';
+
+const useClipboard = process.argv.includes('--clipboard');
+
+function fail(step, detail) {
+  console.error(`FAIL at ${step}: ${JSON.stringify(detail)}`);
+  process.exitCode = 1;
+}
+
+try {
+  const before = await list();
+  console.log(`alerts before: ${before.alert_count}`);
+
+  // 1) create
+  const created = await createWebhook({
+    symbol: 'BATS:F',
+    price: 1.0,
+    ...(useClipboard ? { message_from_clipboard: true } : { message: 'MCP-PATCH-LIVE-TEST — safe to delete' }),
+    webhook_url: null,
+    popup: false,
+  });
+  console.log('create:', JSON.stringify(created));
+  if (!created.success || created.alert.trigger_value !== 1) { fail('create', created); throw new Error('abort'); }
+  const id1 = created.alert.alert_id;
+
+  // 2) modify price (recreate+delete; id changes)
+  const modified = await modifyPrice({ alert_id: id1, price: 1.25 });
+  console.log('modify:', JSON.stringify(modified));
+  if (!modified.success || modified.alert.trigger_value !== 1.25 || !modified.old_deleted) { fail('modify', modified); }
+  const id2 = modified.success ? modified.alert.alert_id : id1;
+
+  // 3) delete
+  const deleted = await deleteOne({ alert_id: id2 });
+  console.log('delete:', JSON.stringify(deleted));
+  if (!deleted.success || deleted.verified_gone !== true) { fail('delete', deleted); }
+
+  const after = await list();
+  console.log(`alerts after: ${after.alert_count} (must equal before: ${before.alert_count})`);
+  if (after.alert_count !== before.alert_count) { fail('leftover-check', { before: before.alert_count, after: after.alert_count }); }
+
+  if (process.exitCode !== 1) console.log('ALL LIVE TESTS PASSED');
+} finally {
+  await disconnect();
+}

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -103,6 +103,182 @@ export async function list() {
   return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
 }
 
+// ---- pricealerts REST helpers ----------------------------------------------
+// Endpoints validated live 2026-07-04 by capturing TradingView's own requests:
+//   POST https://pricealerts.tradingview.com/create_alert?log_username=<user>
+//     body: JSON.stringify({ payload: { conditions:[...], symbol, resolution,
+//           message, sound_file, sound_duration, popup, auto_deactivate, email,
+//           sms_over_email, mobile_push, web_hook, name, expiration, active,
+//           ignore_warnings } })  — NO Content-Type header (avoids CORS preflight;
+//           sync XHR and application/json both FAIL from page context).
+//   POST .../delete_alerts  body: { payload: { alert_ids: [id, ...] } }
+// The create response `r` is the POST-WRITE alert object — trust it over a
+// follow-up list_alerts, which can serve stale values right after a write.
+// NOTE: the create response reports active:false momentarily; the alert shows
+// active:true in list_alerts within seconds (verified live) — not a failure.
+// modify_restart_alert exists but its payload format is unproven; price changes
+// are implemented as delete + recreate instead (alert_id changes by design).
+
+function symbolSpec(symbol) {
+  return '=' + JSON.stringify({ adjustment: 'splits', 'currency-id': 'USD', symbol: String(symbol).toUpperCase() });
+}
+
+async function restPost(path, payload) {
+  const result = await evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/${path}?log_username='
+        + encodeURIComponent((window.user && window.user.username) || ''), {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify({ payload: ${JSON.stringify(payload)} })
+    })
+      .then(function(r) { return r.json(); })
+      .catch(function(e) { return { s: 'fetch_error', errmsg: e.message }; })
+  `);
+  return result;
+}
+
+/** Summarize an alert object WITHOUT echoing the full message — webhook alert
+ *  messages carry a shared secret that must never appear in tool output. */
+function summarize(raw) {
+  if (!raw) return null;
+  const cond = raw.condition || (raw.conditions && raw.conditions[0]) || {};
+  const valueSeries = (cond.series || []).find(s => s.type === 'value');
+  return {
+    alert_id: raw.alert_id,
+    symbol: raw.symbol,
+    trigger_value: valueSeries ? valueSeries.value : null,
+    frequency: cond.frequency,
+    web_hook: raw.web_hook || null,
+    once_only: !!raw.auto_deactivate,
+    expiration: raw.expiration || 'open-ended',
+    active: raw.active,
+    message_length: raw.message ? String(raw.message).length : 0,
+  };
+}
+
+/**
+ * Create a price-crossing alert with a webhook in ONE call — no dialog.
+ * message may be passed directly, or read from the system clipboard in page
+ * context (message_from_clipboard) so secret-bearing payloads never transit
+ * tool parameters.
+ */
+export async function createWebhook({ symbol, price, message, message_from_clipboard, webhook_url, once_only = true, popup = true }) {
+  const value = Number(price);
+  if (!Number.isFinite(value)) throw new Error(`price must be a finite number, got: ${price}`);
+  if (!message && !message_from_clipboard) throw new Error('Provide message or set message_from_clipboard: true');
+
+  let msg = message;
+  if (message_from_clipboard) {
+    msg = await evaluateAsync(`navigator.clipboard.readText().catch(function(e) { return '__CLIP_ERR__' + e.message; })`);
+    if (typeof msg !== 'string' || msg.startsWith('__CLIP_ERR__') || !msg.trim()) {
+      throw new Error(`Clipboard read failed or empty: ${String(msg).replace('__CLIP_ERR__', '')}`);
+    }
+  }
+
+  const payload = {
+    conditions: [{
+      type: 'cross',
+      frequency: 'on_first_fire',
+      series: [{ type: 'barset' }, { type: 'value', value }],
+      resolution: '1',
+    }],
+    symbol: symbolSpec(symbol),
+    resolution: '1',
+    message: msg,
+    sound_file: null,
+    sound_duration: 0,
+    popup: !!popup,
+    auto_deactivate: !!once_only,
+    email: false,
+    sms_over_email: false,
+    mobile_push: false,
+    web_hook: webhook_url || null,
+    name: null,
+    expiration: null,
+    active: true,
+    ignore_warnings: true,
+  };
+
+  const resp = await restPost('create_alert', payload);
+  if (resp?.s !== 'ok') {
+    return { success: false, error: resp?.errmsg || 'create_alert returned an error', source: 'rest_api' };
+  }
+  return { success: true, source: 'rest_api', alert: summarize(resp.r) };
+}
+
+/** Change the trigger price of an existing alert: fetch raw → delete → recreate
+ *  with the new value. Returns the NEW alert (alert_id changes by design). */
+export async function modifyPrice({ alert_id, price }) {
+  const value = Number(price);
+  if (!Number.isFinite(value)) throw new Error(`price must be a finite number, got: ${price}`);
+
+  const raw = await evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/list_alerts', { credentials: 'include' })
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        var a = (d.r || []).find(function(x) { return String(x.alert_id) === ${safeString(String(alert_id))}; });
+        return a || null;
+      })
+      .catch(function(e) { return { __err: e.message }; })
+  `);
+  if (!raw) throw new Error(`Alert ${alert_id} not found`);
+  if (raw.__err) throw new Error(`list_alerts failed: ${raw.__err}`);
+  if (raw.type !== 'price') throw new Error(`Alert ${alert_id} is type '${raw.type}' — only price alerts supported`);
+
+  const cond = raw.condition || (raw.conditions && raw.conditions[0]);
+  const payload = {
+    conditions: [{
+      type: cond.type,
+      frequency: cond.frequency,
+      series: [{ type: 'barset' }, { type: 'value', value }],
+      resolution: cond.resolution || raw.resolution || '1',
+    }],
+    symbol: raw.symbol,
+    resolution: raw.resolution || '1',
+    message: raw.message,
+    sound_file: raw.sound_file || null,
+    sound_duration: raw.sound_duration || 0,
+    popup: !!raw.popup,
+    auto_deactivate: !!raw.auto_deactivate,
+    email: !!raw.email,
+    sms_over_email: !!raw.sms_over_email,
+    mobile_push: !!raw.mobile_push,
+    web_hook: raw.web_hook || null,
+    name: raw.name || null,
+    expiration: raw.expiration || null,
+    active: true,
+    ignore_warnings: true,
+  };
+
+  const created = await restPost('create_alert', payload);
+  if (created?.s !== 'ok') {
+    return { success: false, error: `recreate failed (${created?.errmsg || 'error'}) — original alert ${alert_id} left untouched`, source: 'rest_api' };
+  }
+  const del = await restPost('delete_alerts', { alert_ids: [Number(alert_id)] });
+  return {
+    success: true,
+    source: 'rest_api',
+    old_alert_id: Number(alert_id),
+    old_deleted: del?.s === 'ok',
+    alert: summarize(created.r),
+  };
+}
+
+/** Delete ONE alert by id (unlike deleteAlerts/delete_all which nukes everything). */
+export async function deleteOne({ alert_id }) {
+  const resp = await restPost('delete_alerts', { alert_ids: [Number(alert_id)] });
+  if (resp?.s !== 'ok') {
+    return { success: false, error: resp?.errmsg || 'delete_alerts returned an error', source: 'rest_api' };
+  }
+  const stillThere = await evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/list_alerts', { credentials: 'include' })
+      .then(function(r) { return r.json(); })
+      .then(function(d) { return (d.r || []).some(function(x) { return String(x.alert_id) === ${safeString(String(alert_id))}; }); })
+      .catch(function() { return null; })
+  `);
+  return { success: true, source: 'rest_api', alert_id: Number(alert_id), verified_gone: stillThere === false };
+}
+
 export async function deleteAlerts({ delete_all }) {
   if (delete_all) {
     const result = await evaluate(`

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -169,6 +169,9 @@ export async function createWebhook({ symbol, price, message, message_from_clipb
 
   let msg = message;
   if (message_from_clipboard) {
+    // clipboard.readText() throws "Document is not focused" unless the
+    // TradingView window is frontmost — bring it forward first
+    try { const c = await getClient(); await c.Page.bringToFront(); } catch {}
     msg = await evaluateAsync(`navigator.clipboard.readText().catch(function(e) { return '__CLIP_ERR__' + e.message; })`);
     if (typeof msg !== 'string' || msg.startsWith('__CLIP_ERR__') || !msg.trim()) {
       throw new Error(`Clipboard read failed or empty: ${String(msg).replace('__CLIP_ERR__', '')}`);

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -147,6 +147,7 @@ function summarize(raw) {
     alert_id: raw.alert_id,
     symbol: raw.symbol,
     trigger_value: valueSeries ? valueSeries.value : null,
+    condition_type: cond.type,
     frequency: cond.frequency,
     web_hook: raw.web_hook || null,
     once_only: !!raw.auto_deactivate,
@@ -162,10 +163,15 @@ function summarize(raw) {
  * context (message_from_clipboard) so secret-bearing payloads never transit
  * tool parameters.
  */
-export async function createWebhook({ symbol, price, message, message_from_clipboard, webhook_url, once_only = true, popup = true }) {
+export async function createWebhook({ symbol, price, message, message_from_clipboard, webhook_url, once_only = true, popup = true, direction = 'any' }) {
   const value = Number(price);
   if (!Number.isFinite(value)) throw new Error(`price must be a finite number, got: ${price}`);
   if (!message && !message_from_clipboard) throw new Error('Provide message or set message_from_clipboard: true');
+  // 'any' matches TV's direction-agnostic "Crossing" (backward compatible);
+  // 'up'/'down' map to TV's "Crossing Up"/"Crossing Down" condition types
+  const CROSS_TYPES = { any: 'cross', up: 'cross_up', down: 'cross_down' };
+  const condType = CROSS_TYPES[direction];
+  if (!condType) throw new Error(`direction must be 'up', 'down', or 'any', got: ${direction}`);
 
   let msg = message;
   if (message_from_clipboard) {
@@ -180,7 +186,7 @@ export async function createWebhook({ symbol, price, message, message_from_clipb
 
   const payload = {
     conditions: [{
-      type: 'cross',
+      type: condType,
       frequency: 'on_first_fire',
       series: [{ type: 'barset' }, { type: 'value', value }],
       resolution: '1',

--- a/src/server.js
+++ b/src/server.js
@@ -55,7 +55,7 @@ Screenshots: capture_screenshot → regions: "full", "chart", "strategy_tester"
 Replay: replay_start → replay_step → replay_trade → replay_status → replay_stop
 Batch: batch_run → run action across multiple symbols/timeframes
 Drawing: draw_shape → horizontal_line, trend_line, rectangle, text
-Alerts: alert_create, alert_list, alert_delete
+Alerts: alert_create_webhook (PREFERRED — one REST call: symbol, price, message or message_from_clipboard, webhook_url; returns committed trigger value), alert_modify_price, alert_delete_one, alert_list. Avoid alert_create (flaky DOM dialog) and alert_delete (deletes ALL).
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -20,6 +20,7 @@ export function registerAlertTools(server) {
     webhook_url: z.string().optional().describe('Webhook URL to POST the message to when the alert fires'),
     once_only: z.coerce.boolean().optional().describe('Trigger only once then deactivate (default true)'),
     popup: z.coerce.boolean().optional().describe('Show TradingView popup on fire (default true)'),
+    direction: z.enum(['up', 'down', 'any']).optional().describe('Cross direction: "up" (Crossing Up), "down" (Crossing Down), or "any" (Crossing, default). Use "up" for breakout/reclaim longs, "down" for breakdown alerts.'),
   }, async (args) => {
     try { return jsonResult(await core.createWebhook(args)); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -3,7 +3,7 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/alerts.js';
 
 export function registerAlertTools(server) {
-  server.tool('alert_create', 'Create a price alert via the TradingView alert dialog', {
+  server.tool('alert_create', 'DEPRECATED — drives the alert dialog via DOM and often fails to commit the price. Use alert_create_webhook instead.', {
     condition: z.string().describe('Alert condition (e.g., "crossing", "greater_than", "less_than")'),
     price: z.coerce.number().describe('Price level for the alert'),
     message: z.string().optional().describe('Alert message'),
@@ -12,12 +12,40 @@ export function registerAlertTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
+  server.tool('alert_create_webhook', 'Create a price-crossing alert (once-only, open-ended) with an optional webhook URL in ONE call via TradingView\'s alert REST API — no dialog, returns the post-write alert with its committed trigger value. Set message_from_clipboard: true to use the system clipboard as the message so secret-bearing payloads never appear in tool parameters.', {
+    symbol: z.string().describe('Exchange-prefixed symbol, e.g. "NASDAQ:LUNR" or "BATS:F" (US equities, USD)'),
+    price: z.coerce.number().describe('Trigger price (crossing)'),
+    message: z.string().optional().describe('Alert message body. Omit and set message_from_clipboard for secret payloads.'),
+    message_from_clipboard: z.coerce.boolean().optional().describe('Read the alert message from the system clipboard in page context (keeps webhook secrets out of tool params)'),
+    webhook_url: z.string().optional().describe('Webhook URL to POST the message to when the alert fires'),
+    once_only: z.coerce.boolean().optional().describe('Trigger only once then deactivate (default true)'),
+    popup: z.coerce.boolean().optional().describe('Show TradingView popup on fire (default true)'),
+  }, async (args) => {
+    try { return jsonResult(await core.createWebhook(args)); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('alert_modify_price', 'Change the trigger price of an existing price alert. Implemented as recreate-then-delete via the REST API (the returned alert has a NEW alert_id); message, webhook, and settings are preserved. On recreate failure the original alert is left untouched.', {
+    alert_id: z.coerce.number().describe('alert_id of the price alert to change (from alert_list)'),
+    price: z.coerce.number().describe('New trigger price'),
+  }, async ({ alert_id, price }) => {
+    try { return jsonResult(await core.modifyPrice({ alert_id, price })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('alert_delete_one', 'Delete a SINGLE alert by alert_id via the REST API, then verify it is gone. Safe alternative to alert_delete/delete_all.', {
+    alert_id: z.coerce.number().describe('alert_id to delete (from alert_list)'),
+  }, async ({ alert_id }) => {
+    try { return jsonResult(await core.deleteOne({ alert_id })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
   server.tool('alert_list', 'List active alerts', {}, async () => {
     try { return jsonResult(await core.list()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('alert_delete', 'Delete all alerts or open context menu for deletion', {
+  server.tool('alert_delete', 'DANGER: deletes ALL alerts (or opens the context menu). Prefer alert_delete_one for a single alert.', {
     delete_all: z.coerce.boolean().optional().describe('Delete all alerts'),
   }, async ({ delete_all }) => {
     try { return jsonResult(await core.deleteAlerts({ delete_all })); }


### PR DESCRIPTION
## What

Three new alert tools that talk to the pricealerts REST API from page context (via CDP), replacing the DOM-dialog automation for alert creation:

- **`alert_create_webhook`** — create a price-crossing alert (once-only, open-ended) with an optional webhook URL in one call. Returns the *post-write* alert object, so the committed trigger value is confirmed in the response. Supports `message_from_clipboard: true`, which reads the alert message from the system clipboard in page context — useful when the message carries a webhook secret that shouldn't transit MCP tool parameters (or session logs).
- **`alert_modify_price`** — change the trigger price of an existing price alert. Implemented as recreate-then-delete (the returned alert has a new `alert_id`); on recreate failure the original alert is left untouched.
- **`alert_delete_one`** — delete a single alert by `alert_id` and verify it's gone. Today's `alert_delete` only supports delete-all, which is dangerous when the panel holds live alerts.

The existing `alert_create` and `alert_delete` are kept for compatibility, with descriptions updated to steer usage (`alert_create`'s DOM dialog frequently fails to commit the typed price — the dialog *displays* the new value but saves the default).

## Why

Driving the alert dialog via DOM is fragile: price values silently revert when focus moves between dialog sections, the webhook URL field is inherited from the previously created alert (a fired alert can silently POST to the wrong endpoint), and there is no way to set the webhook URL programmatically at all. A REST round-trip removes the whole class of problems and returns server-confirmed state.

## Scope note

This follows the existing precedent in `core/alerts.js`: `list()` already calls `https://pricealerts.tradingview.com/list_alerts` via in-page `fetch` with the user's own session credentials. The new functions use the same channel — everything still goes through the locally running Desktop app via CDP, authenticated as the logged-in user; no credentials are handled or stored, and no market data is accessed.

## Implementation notes (discovered by capturing the app's own requests)

- Endpoint: `POST https://pricealerts.tradingview.com/create_alert?log_username=<user>` with body `JSON.stringify({ payload })` and **no Content-Type header** — an explicit `application/json` header triggers a CORS preflight that fails from page context, and sync XHR is blocked entirely.
- The payload uses a `conditions` **array** (not the `condition` object shape that `list_alerts` returns), plus `active: true` and `ignore_warnings: true`.
- `delete_alerts` takes `{ payload: { alert_ids: [...] } }`.
- The create response reports `active: false` momentarily; the alert shows `active: true` in `list_alerts` within seconds.
- `list_alerts` can serve stale values immediately after a write, which is why the tools trust the write response rather than a follow-up list.

## Testing

- `scripts/live-test-alert-rest.mjs` (included): live end-to-end create → modify → delete cycle against a running TradingView Desktop using throwaway `BATS:F` alerts; verifies the alert count is unchanged afterwards. Passing on Windows 11 + TradingView Desktop, July 2026.
- `tests/pine_analyze.test.js`: 16/16 pass. `test:cli`: 11/13 — the 2 failures are the Pine-compile tests, which require Pine editor state and fail on this machine before this change as well.
- Live-verified in real use: created webhook alerts fire into an AWS API Gateway endpoint correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
