### PR TITLE
Document Windows MSIX launch + Access-Denied fallback in SETUP_GUIDE

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -46,6 +46,26 @@ Mac:
 ```
 
 Windows:
+
+TradingView for Windows now ships **only as an MSIX package** (Microsoft Store and tvd-packages.tradingview.com both install under `C:\Program Files\WindowsApps\`). Use the launch script — it resolves the install via `Get-AppxPackage`, which works without admin rights:
+
+```bat
+scripts\launch_tv_debug.bat
+```
+
+Or, preferred: let the `tv_launch` MCP tool do it — it auto-detects MSIX installs and, on Windows builds where launching from `WindowsApps` is blocked with **"Access is denied"**, automatically copies the package to `%LOCALAPPDATA%\tradingview-mcp\` (one-time, ~330MB) and launches from the copy. The copy keeps your login, layout, and chart state. If the fallback was used, the result includes `msix_local_copy: true`.
+
+Manual equivalent of that fallback, if you need it:
+
+```powershell
+$pkg = (Get-AppxPackage TradingView.Desktop).InstallLocation
+Copy-Item "$pkg\*" "$env:LOCALAPPDATA\tradingview-mcp\TradingView" -Recurse -Force
+& "$env:LOCALAPPDATA\tradingview-mcp\TradingView\TradingView.exe" --remote-debugging-port=9222
+```
+
+Reading files out of `WindowsApps` by exact path is allowed even where executing them isn't. Do **not** try to change ACLs on `WindowsApps` with `icacls` — it fails and can break app servicing.
+
+Legacy (pre-MSIX) installs:
 ```bash
 %LOCALAPPDATA%\TradingView\TradingView.exe --remote-debugging-port=9222
 ```
@@ -95,6 +115,7 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 | Problem | Solution |
 |---------|----------|
 | `cdp_connected: false` | Launch TradingView with `--remote-debugging-port=9222` |
+| Windows: "Access is denied" launching from `WindowsApps` | Use `tv_launch` (auto copy-fallback) or the manual copy snippet in Step 3 — never `icacls` on WindowsApps |
 | `ECONNREFUSED` | TradingView isn't running or port 9222 is blocked |
 | MCP server not showing in Claude Code | Check `~/.claude/.mcp.json` syntax, restart Claude Code |
 | `tv` command not found | Run `npm link` from the project directory |


### PR DESCRIPTION
Docs gap surfaced by discussion #331 — the Windows section pointed at the legacy non-MSIX path. Now documents the launch script, tv_launch's automatic copy-fallback, the manual Copy-Item workaround, and warns against icacls on WindowsApps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)