### PR TITLE
Fix chart_manage_indicator add for TradingView Desktop 3.2.0

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -85,22 +85,42 @@ export async function setType({ chart_type, _deps }) {
 }
 
 export async function manageIndicator({ action, indicator, entity_id, inputs: inputsRaw, _deps }) {
-  const { evaluate } = _resolve(_deps);
+  const { evaluate, evaluateAsync } = _resolve(_deps);
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;
 
   if (action === 'add') {
-    const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
-    const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
-    await evaluate(`
+    // TradingView Desktop's chart.createStudy(name, ...) is broken on TV 3.2.0 (Electron 38):
+    // its name→metainfo lookup rejects with "unknown" even for exact descriptions. Instead we
+    // resolve the study's internal id from the metainfo repository ourselves and drive the
+    // model's study inserter directly, which is verified working live. The whole flow runs
+    // in-page as a single awaited promise so real errors surface instead of being swallowed.
+    const result = await evaluateAsync(`
       (function() {
         var chart = ${CHART_API};
-        chart.createStudy(${safeString(indicator)}, false, false, ${JSON.stringify(inputArr)});
+        var repo = chart.studyMetaIntoRepository();
+        var all = repo.getInternalMetaInfoArray();
+        var wanted = ${safeString(indicator)}.toLowerCase();
+        var meta = all.find(function(m) { return (m.description || '').toLowerCase() === wanted; });
+        if (!meta) {
+          return Promise.resolve({ error: 'Indicator not found: ' + ${safeString(indicator)} +
+            '. Use the full description (e.g. "Moving Average", "Relative Strength Index").' });
+        }
+        var inserter = chart._chartWidget.model().createStudyInserter({ type: 'java', studyId: meta.id }, []);
+        if (inserter.setForceOverlay) inserter.setForceOverlay(!!meta.is_price_study);
+        var inputs = ${JSON.stringify(inputs || {})};
+        return inserter.insert(function() {
+          return Promise.resolve({ inputs: inputs, parentSources: [] });
+        }).then(function(study) {
+          return { entity_id: study && study.id ? study.id() : null, study_id: meta.id };
+        }, function(e) {
+          return { error: 'Study insert failed: ' + (e && e.message ? e.message : String(e)) };
+        });
       })()
     `);
-    await new Promise(r => setTimeout(r, 1500));
-    const after = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
-    const newIds = (after || []).filter(id => !(before || []).includes(id));
-    return { success: newIds.length > 0, action: 'add', indicator, entity_id: newIds[0] || null, new_study_count: newIds.length };
+    if (!result || result.error) {
+      throw new Error(result?.error || 'Unknown error adding indicator');
+    }
+    return { success: true, action: 'add', indicator, entity_id: result.entity_id, study_id: result.study_id };
   } else if (action === 'remove') {
     if (!entity_id) throw new Error('entity_id required for remove action. Use chart_get_state to find study IDs.');
     await evaluate(`

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -181,20 +181,36 @@ describe('chart.js — sanitized evaluate calls', () => {
     }
   });
 
-  it('manageIndicator add uses safeString for indicator name', async () => {
-    const { _deps, evaluate } = mockDeps();
-    evaluate.calls.length = 0;
-    // First evaluate call is getAllStudies (before), then createStudy, then getAllStudies (after)
-    const evalFn = async (expr) => {
-      evaluate.calls.push(expr);
-      if (expr.includes('getAllStudies')) return ['id1'];
-      return undefined;
-    };
-    _deps.evaluate = evalFn;
-    await manageIndicator({ action: 'add', indicator: "Relative Strength Index", _deps });
-    const createCall = evaluate.calls.find(c => c.includes('createStudy'));
-    assert.ok(createCall, 'createStudy called');
-    assert.ok(createCall.includes('"Relative Strength Index"'), 'indicator name via safeString');
+  it('manageIndicator add resolves study via inserter and uses safeString for name', async () => {
+    const calls = [];
+    const evaluateAsync = async (expr) => { calls.push(expr); return { entity_id: 'new1', study_id: 'RSI@tv-basicstudies' }; };
+    const _deps = { evaluate: mockEval(), evaluateAsync, waitForChartReady: async () => true };
+    const r = await manageIndicator({ action: 'add', indicator: "Relative Strength Index", _deps });
+    const addCall = calls.find(c => c.includes('createStudyInserter'));
+    assert.ok(addCall, 'study inserter used');
+    assert.ok(addCall.includes('"Relative Strength Index"'), 'indicator name via safeString');
+    assert.ok(addCall.includes('studyMetaIntoRepository'), 'metainfo repository used for id lookup');
+    assert.equal(r.success, true);
+    assert.equal(r.entity_id, 'new1');
+  });
+
+  it('manageIndicator add passes inputs as a plain object, not {id,value} array', async () => {
+    const calls = [];
+    const evaluateAsync = async (expr) => { calls.push(expr); return { entity_id: 'new1' }; };
+    const _deps = { evaluate: mockEval(), evaluateAsync };
+    await manageIndicator({ action: 'add', indicator: 'Moving Average', inputs: { length: 200 }, _deps });
+    const addCall = calls.find(c => c.includes('createStudyInserter'));
+    assert.ok(addCall.includes('{"length":200}'), 'inputs serialized as keyed object');
+    assert.ok(!addCall.includes('"id"'), 'no {id,value} array form');
+  });
+
+  it('manageIndicator add surfaces a real error instead of silent success:false', async () => {
+    const evaluateAsync = async () => ({ error: 'Indicator not found: Bogus' });
+    const _deps = { evaluate: mockEval(), evaluateAsync };
+    await assert.rejects(
+      () => manageIndicator({ action: 'add', indicator: 'Bogus', _deps }),
+      /Indicator not found: Bogus/,
+    );
   });
 
   it('manageIndicator remove uses safeString for entity_id', async () => {


### PR DESCRIPTION
## Problem

The `chart_manage_indicator` tool's `add` action is broken against TradingView Desktop 3.2.0 (Electron 38):

- `chart.createStudy(name, false, false, inputArr)` always rejects with `"unknown"` — the name→metainfo lookup inside TV's `createStudy` fails even for exact descriptions like `"Moving Average"`.
- Inputs were passed as an array of `{id, value}` objects, which `createStudy` doesn't accept (it expects a plain object keyed by input id).
- The promise was never awaited, so the rejection was silently swallowed and the tool returned `success:false` with no reason (based on a before/after study-count diff).

## Fix

The `add` path in `src/core/chart.js` now:

1. Resolves the study's internal id from `chart.studyMetaIntoRepository().getInternalMetaInfoArray()` by case-insensitive match on `description` (e.g. `"Moving Average"` → `MASimple@tv-basicstudies`, `"Relative Strength Index"` → `RSI@tv-basicstudies`).
2. Drives the model's inserter directly: `model().createStudyInserter({type:'java', studyId}, [])` + `inserter.insert(...)`, passing **inputs as a plain keyed object** (e.g. `{"length": 200}`).
3. Sets `setForceOverlay(!!meta.is_price_study)` so price studies (MA) overlay the main pane and oscillators (RSI) get their own pane.
4. Runs the whole flow as a single awaited in-page promise and **throws the real error** (including a clear not-found message listing the expected name format) instead of returning `success:false` with no reason.

The returned payload now includes both the created `entity_id` (from the resolved study's `.id()`) and the internal `study_id`.

## Verification

Live against TradingView Desktop 3.2.0 / Electron 38.2.2 via CDP (`--remote-debugging-port=9222`):

- `add "Moving Average"` with `{"length": 200}` → `success:true`, entity id returned, and the `length` input confirmed applied as `200` on the created study.
- `add "Relative Strength Index"` → `success:true`, inserted into its own pane.
- Unknown name → throws `Indicator not found: ... Use the full description (e.g. "Moving Average", "Relative Strength Index").`

Test suites:

- `npm test` (live e2e): 79 tests, 77 pass. The 2 failures (`ui_open_panel`: `bottomWidgetBar.hideWidget is not a function`; `replay_stop`: "Replay is not started") are pre-existing TV 3.2.0 API drift unrelated to this change.
- `tests/sanitization.test.js`: 68/68 — the old createStudy-based test is replaced with three covering the inserter path (safeString on the name + metainfo lookup), inputs serialized as a keyed object (not `{id,value}` array), and error surfacing.
- `tests/pine_analyze.test.js` + `tests/cli.test.js`: 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)