### PR TITLE
Fix tv_launch failing when ELECTRON_RUN_AS_NODE is set

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -228,7 +228,13 @@ async function _probeCdp(cdpPort) {
 }
 
 function _spawnDetached(spawnFn, exe, args) {
-  const child = spawnFn(exe, args, { detached: true, stdio: 'ignore' });
+  // Strip ELECTRON_RUN_AS_NODE from the child env: when it is set, the Electron
+  // binary (TradingView) runs as plain Node — no Chromium, no window, no CDP —
+  // and rejects Chromium switches like --remote-debugging-port as a "bad option",
+  // so the debug port never binds. Inherited from some shells/host environments.
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  const child = spawnFn(exe, args, { detached: true, stdio: 'ignore', env });
   child.unref();
   return child;
 }
@@ -390,6 +396,22 @@ export async function launch({ port, kill_existing, _deps } = {}) {
       cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
       ...(usedLocalCopy && { msix_local_copy: true }),
+    };
+  }
+
+  // CDP never came up. If the process already exited, this is a hard launch
+  // failure (bad flag, crash, wrong binary) — not a slow load — so report it
+  // honestly instead of a misleading success:true.
+  if (typeof child.exitCode === 'number' || child.signalCode) {
+    const reason = child.signalCode
+      ? `was killed by ${child.signalCode}`
+      : `exited immediately (code ${child.exitCode})`;
+    return {
+      success: false, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort,
+      ...(usedLocalCopy && { msix_local_copy: true }),
+      error: `TradingView ${reason} without binding CDP on port ${cdpPort}. `
+        + 'If ELECTRON_RUN_AS_NODE is set in your environment, unset it and retry '
+        + '(it forces the app to run as headless Node and rejects the debug flag).',
     };
   }
 


### PR DESCRIPTION
## Problem

When `ELECTRON_RUN_AS_NODE` is set in the host environment (common in some shells, CI runners, and agent/editor runtimes), `tv_launch` silently fails: TradingView launches but no CDP port binds, and every downstream tool fails with `CDP connection failed after 5 attempts: fetch failed`.

**Root cause:** `ELECTRON_RUN_AS_NODE=1` forces the Electron binary to run as plain Node — no Chromium, no window, no CDP. The `spawn` call in `launch()` inherits the parent env, so the child TradingView runs headless-as-Node and rejects Chromium switches like `--remote-debugging-port` as a `bad option`. The debug port never binds.

Compounding it, `tv_launch` returned `success: true` even when the spawned process died immediately, masking the failure.

## Fix

1. **Strip `ELECTRON_RUN_AS_NODE` from the child env** in `_spawnDetached` before spawning, so TradingView always launches as a real Electron/Chromium app with CDP.
2. **Report `success: false` on immediate exit** — when the process exits without binding CDP (bad flag, crash, wrong binary), return an honest failure with a diagnostic error instead of a misleading success. Guarded on `typeof exitCode === 'number'` so a still-loading child keeps the existing "still loading" warning path.

## Verification

- `launch()` now binds CDP on macOS with `ELECTRON_RUN_AS_NODE=1` set in the environment (verified against TradingView Desktop 3.3.0 / Electron 38.2.2) — reconnected in ~2s.
- Immediate-exit path returns `success: false` with a diagnostic error pointing at the env var.
- All 141 unit tests pass; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)