### PR TITLE
Fix launch() to surface synchronous spawn errors and add CLI bin entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -323,12 +323,21 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  let child = null;
   let info = null;
   let usedLocalCopy = false;
 
-  if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
-    const earlyFailure = await _spawnFailedEarly(child);
+  const isMsix = platform === 'win32' && WINDOWS_APPS_RE.test(tvPath);
+  let spawnError = null;
+  try {
+    child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  } catch (e) {
+    spawnError = e.code || e.message || 'spawn error';
+  }
+
+  if (isMsix) {
+    // Check for early failure from either a synchronous spawn error or a quick exit/error event.
+    const earlyFailure = spawnError || (child ? await _spawnFailedEarly(child) : 'no child');
     if (!earlyFailure) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }
@@ -341,6 +350,8 @@ export async function launch({ port, kill_existing, _deps } = {}) {
       tvPath = localExe;
       usedLocalCopy = true;
     }
+  } else if (spawnError) {
+    throw new Error(`Failed to launch TradingView: ${spawnError}`);
   }
 
   if (!info) {


### PR DESCRIPTION
## What changed

- `launch()` in `src/core/health.js` now wraps the initial `_spawnDetached` call in try/catch. Previously, a synchronous spawn error (e.g. `ENOENT` for a bad path) thrown before the async early-failure check would crash `launch()` outside the MSIX fallback path instead of being handled gracefully.
- For MSIX installs, a synchronous spawn error is now treated the same as an early async failure, triggering the local-copy CDP fallback (from #316/`e2ef51e`).
- For classic (non-MSIX) installs, a synchronous spawn error is now surfaced as a clear `Error("Failed to launch TradingView: ...")` instead of an uncaught exception.
- `package-lock.json` updated to register the `tv` bin entry, matching `package.json` (lockfile was out of sync).

## Why

Builds on the MSIX CDP fallback work in `e2ef51e` (fixes #42, #75, #99, #122, #128, #203, #23, #14). That change assumed `_spawnDetached` only fails asynchronously (late binding failure or early exit event), but on some machines the spawn itself throws synchronously before any event fires, which bypassed the fallback/error-surfacing logic entirely.

## Reviewer notes

- No new tests added in this pass; existing `tests/launch.test.js` coverage (direct launch, EACCES fallback, no-bind fallback, copy reuse, classic installs) still applies since the try/catch preserves existing control flow when spawn succeeds synchronously.
- `package-lock.json` diff is mechanical (adding the `bin` field to match `package.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)