### PR TITLE
fix(pine): FIND_MONACO prefers visible Monaco container over stale hidden one

### DIFF
--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -6,30 +6,45 @@
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
 // ── Monaco finder (injected into TV page) ──
+// TV can leave a stale hidden .pine-editor-monaco container in the DOM after
+// the editor is re-docked; the stale one has no React fiber on any ancestor,
+// so visible containers (offsetParent !== null) must be tried first.
 const FIND_MONACO = `
   (function findMonacoEditor() {
-    var container = document.querySelector('.monaco-editor.pine-editor-monaco');
-    if (!container) return null;
-    var el = container;
-    var fiberKey;
-    for (var i = 0; i < 20; i++) {
-      if (!el) break;
-      fiberKey = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); });
-      if (fiberKey) break;
-      el = el.parentElement;
-    }
-    if (!fiberKey) return null;
-    var current = el[fiberKey];
-    for (var d = 0; d < 15; d++) {
-      if (!current) break;
-      if (current.memoizedProps && current.memoizedProps.value && current.memoizedProps.value.monacoEnv) {
-        var env = current.memoizedProps.value.monacoEnv;
-        if (env.editor && typeof env.editor.getEditors === 'function') {
-          var editors = env.editor.getEditors();
-          if (editors.length > 0) return { editor: editors[0], env: env };
-        }
+    var all = document.querySelectorAll('.monaco-editor.pine-editor-monaco');
+    if (all.length === 0) return null;
+    var containers = [];
+    var i;
+    for (i = 0; i < all.length; i++) { if (all[i].offsetParent !== null) containers.push(all[i]); }
+    for (i = 0; i < all.length; i++) { if (all[i].offsetParent === null) containers.push(all[i]); }
+    for (var c = 0; c < containers.length; c++) {
+      var el = containers[c];
+      var fiberKey;
+      for (var j = 0; j < 20; j++) {
+        if (!el) break;
+        fiberKey = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); });
+        if (fiberKey) break;
+        el = el.parentElement;
       }
-      current = current.return;
+      if (!fiberKey) continue;
+      var current = el[fiberKey];
+      for (var d = 0; d < 15; d++) {
+        if (!current) break;
+        if (current.memoizedProps && current.memoizedProps.value && current.memoizedProps.value.monacoEnv) {
+          var env = current.memoizedProps.value.monacoEnv;
+          if (env.editor && typeof env.editor.getEditors === 'function') {
+            var editors = env.editor.getEditors();
+            var editor = null;
+            for (var e = 0; e < editors.length; e++) {
+              var dom = editors[e].getDomNode && editors[e].getDomNode();
+              if (dom && dom.offsetParent !== null) { editor = editors[e]; break; }
+            }
+            if (!editor && editors.length > 0) editor = editors[0];
+            if (editor) return { editor: editor, env: env };
+          }
+        }
+        current = current.return;
+      }
     }
     return null;
   })()


### PR DESCRIPTION
## Problem

TradingView Desktop can leave a **stale hidden** `.monaco-editor.pine-editor-monaco` container in the DOM after the Pine editor is re-docked. The stale container:

- matches `document.querySelector(...)` **first** (document order), and
- has **no React fiber on any ancestor**,

so `FIND_MONACO` walked the dead container, found no fiber, and returned `null`. Every `pine_*` MCP tool (and `tv pine ...` CLI command) then failed with `"Could not open Pine Editor"` — even while the editor was open and visible on screen.

## Fix

`FIND_MONACO` in `src/core/pine.js` now:

1. Iterates `querySelectorAll('.monaco-editor.pine-editor-monaco')` with **visible containers first** (`offsetParent !== null`), keeping hidden ones as a fallback so `ensurePineEditorOpen`'s poll still resolves while the panel is opening.
2. **Skips** containers whose ancestor chain has no `__reactFiber$` key instead of giving up entirely (this was the actual failure mode).
3. When walking `monacoEnv`'s editors, prefers the instance whose `getDomNode().offsetParent !== null`, falling back to `editors[0]`.

The return shape `{ editor, env }` is unchanged, so all 9 interpolation sites work as before. Logic ported from a proven CDP workaround script used during a live deploy, which this change supersedes.

## Verification (against a live TradingView instance)

- DOM census confirmed the bug scenario present: a stale container (hidden, no fiber) **and** a visible container coexisting, stale one first in document order.
- Instrumented probe: visible container resolves fiber at ancestor depth 1, `monacoEnv` at fiber depth 11, 3 editor instances (1 visible) — all within walk limits.
- `tv pine get`: read the open 464-line / 25,213-char script successfully with the stale container still in the DOM.
- `pine set` round-trip: wrote the identical source back and re-read it — byte-identical.
- Offline unit tests: 27 pass; the 2 failures (`pine check` server compile) fail identically on unmodified HEAD and are unrelated.

## Notes for reviewers

- A separate pre-existing issue was observed during verification: with the panel fully closed, `ensurePineEditorOpen`'s 10s poll window can expire while Monaco cold-mounts. Not addressed here to keep this change focused.
- The injected snippet stays ES5-style to match the surrounding injected code conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)