### PR TITLE
Fix FIND_MONACO targeting stale/wrong Monaco editor instance

### DIFF
--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -8,7 +8,14 @@ import { evaluate, evaluateAsync, getClient } from '../connection.js';
 // ── Monaco finder (injected into TV page) ──
 const FIND_MONACO = `
   (function findMonacoEditor() {
-    var container = document.querySelector('.monaco-editor.pine-editor-monaco');
+    // Panel close/reopen can leave a stale invisible container behind —
+    // prefer the visible instance (offsetParent set) over DOM order.
+    var candidates = document.querySelectorAll('.monaco-editor.pine-editor-monaco');
+    var container = null;
+    for (var ci = 0; ci < candidates.length; ci++) {
+      if (candidates[ci].offsetParent !== null) { container = candidates[ci]; break; }
+    }
+    if (!container) container = candidates[0] || null;
     if (!container) return null;
     var el = container;
     var fiberKey;
@@ -26,7 +33,18 @@ const FIND_MONACO = `
         var env = current.memoizedProps.value.monacoEnv;
         if (env.editor && typeof env.editor.getEditors === 'function') {
           var editors = env.editor.getEditors();
-          if (editors.length > 0) return { editor: editors[0], env: env };
+          // getEditors() lists every mounted editor oldest-first; with
+          // multiple tabs (or a stale hidden instance) editors[0] is NOT
+          // the active one. Prefer focused, then visible, then first.
+          var pick = null;
+          for (var e = 0; e < editors.length; e++) {
+            var node = editors[e].getDomNode && editors[e].getDomNode();
+            var vis = !!(node && node.offsetParent !== null);
+            if (typeof editors[e].hasTextFocus === 'function' && editors[e].hasTextFocus()) { pick = editors[e]; break; }
+            if (vis && !pick) pick = editors[e];
+          }
+          if (!pick && editors.length > 0) pick = editors[0];
+          if (pick) return { editor: pick, env: env };
         }
       }
       current = current.return;


### PR DESCRIPTION
Two related bugs made every pine tool (`pine_get_source` / `pine_set_source` / `pine_smart_compile` / `pine_new`) silently read and write the wrong Monaco editor:

1. **Stale container**: closing and reopening the Pine Editor panel leaves an invisible `.monaco-editor.pine-editor-monaco` container in the DOM. `querySelector` matched it first, and the React-fiber walk from it then failed outright — all pine tools errored with `Could not open Pine Editor` even when the editor was visibly open.

2. **Wrong editor index**: once `monacoEnv` was found, `FIND_MONACO` returned `getEditors()[0]` — the *oldest* mounted editor. With multiple editor tabs open, reads and writes went to a hidden background editor while the visible tab showed different code: `pine_set_source` reported success but the displayed buffer never changed, and `pine_smart_compile` compiled/saved a different tab than intended (a data-loss hazard for whichever script that tab held).

`FIND_MONACO` now prefers the visible container over DOM order, and picks the focused editor first, then a visible one, falling back to `editors[0]`.

Found and verified live against TradingView Desktop 3.3.0 (Electron 38.2.2): repro'd both failure modes with two editor tabs open, confirmed reads/writes/compile target the active tab after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)