### PR TITLE
Add MSIX-aware launch script that preserves package identity

### DIFF
--- a/scripts/launch_tv_debug_msix.ps1
+++ b/scripts/launch_tv_debug_msix.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    Launch TradingView Desktop (MSIX/Store install) with Chrome DevTools Protocol enabled.
+
+.DESCRIPTION
+    On modern Windows, TradingView ships as an MSIX package installed under
+    C:\Program Files\WindowsApps. Two common approaches FAIL on such builds:
+      * Running the exe directly from WindowsApps  -> "Access is denied"
+      * Copying the package elsewhere and running it -> exits with 0x80000003
+        (STATUS_BREAKPOINT) because the loose copy has no MSIX package identity.
+
+    The reliable method is Invoke-CommandInDesktopPackage, which launches the real
+    packaged exe WITH its package identity AND forwards command-line arguments.
+
+.PARAMETER Port
+    CDP port to expose. Default 9222.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File scripts\launch_tv_debug_msix.ps1
+    powershell -ExecutionPolicy Bypass -File scripts\launch_tv_debug_msix.ps1 -Port 9333
+#>
+param(
+    [int]$Port = 9222
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Resolve the installed MSIX package (no admin required) ---
+$pkg = Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue
+if (-not $pkg) {
+    Write-Error "TradingView.Desktop MSIX package not found. Is TradingView Desktop installed?"
+    exit 1
+}
+
+$pfn = $pkg.PackageFamilyName
+$manifest = Get-AppxPackageManifest $pkg
+$app = $manifest.Package.Applications.Application | Select-Object -First 1
+$appId = $app.Id
+$exe = Join-Path $pkg.InstallLocation $app.Executable
+
+Write-Host "Package : $pfn"
+Write-Host "AppId   : $appId"
+Write-Host "Exe     : $exe"
+Write-Host "Port    : $Port"
+
+# --- If CDP is already up, don't relaunch ---
+try {
+    $existing = Invoke-RestMethod -Uri "http://127.0.0.1:$Port/json/version" -TimeoutSec 2 -ErrorAction Stop
+    Write-Host "CDP already available on port $Port ($($existing.Browser)). Nothing to do."
+    exit 0
+} catch { }
+
+# --- Launch with package identity + forwarded debug-port flag ---
+Write-Host "Launching TradingView with --remote-debugging-port=$Port ..."
+Invoke-CommandInDesktopPackage -PackageFamilyName $pfn -AppId $appId `
+    -Command $exe -Args "--remote-debugging-port=$Port"
+
+# --- Poll until the CDP endpoint responds ---
+$ready = $false
+for ($i = 0; $i -lt 20; $i++) {
+    try {
+        $v = Invoke-RestMethod -Uri "http://127.0.0.1:$Port/json/version" -TimeoutSec 3 -ErrorAction Stop
+        Write-Host ""
+        Write-Host "CDP ready at http://127.0.0.1:$Port"
+        Write-Host "  Browser: $($v.Browser)"
+        Write-Host "  WS: $($v.webSocketDebuggerUrl)"
+        $ready = $true
+        break
+    } catch {
+        Start-Sleep -Seconds 3
+    }
+}
+
+if (-not $ready) {
+    Write-Error "TradingView launched but CDP never became available on port $Port after ~60s."
+    exit 1
+}


### PR DESCRIPTION
## Problem

On current Windows builds, TradingView Desktop ships **only as an MSIX package** (installed under `C:\Program Files\WindowsApps\`). Both existing launch paths fail on such installs:

- **`scripts/launch_tv_debug.bat`** resolves the exe inside `WindowsApps` and runs it directly → **`Access is denied`** (Windows blocks direct execution of packaged binaries).
- **The `SETUP_GUIDE.md` copy-to-`%LOCALAPPDATA%` fallback** → the loose copy exits immediately with **`0x80000003` (STATUS_BREAKPOINT)** because it has no MSIX **package identity**. The `tv_launch` copy-fallback relies on this working, so it fails the same way.

Reproduced on `TradingView.Desktop 3.3.0.7992` / Electron 38, Windows 10 19045. The package also declares **no App Execution Alias**, so there's no alias to launch through either.

## Fix

Add `scripts/launch_tv_debug_msix.ps1`, which launches via **`Invoke-CommandInDesktopPackage`** — the supported mechanism that runs the *real* packaged exe **with full package identity** while still **forwarding `--remote-debugging-port`**. This is the only approach that produced a live CDP endpoint on the affected build.

The script:
- Resolves `PackageFamilyName`, `AppId`, and the exe path at runtime via `Get-AppxPackage` / the package manifest, so it survives version updates (no hardcoded `3.3.0.7992` path).
- Skips relaunch if CDP is already listening on the port.
- Polls `http://127.0.0.1:<port>/json/version` after launch and prints the WebSocket debugger URL, or errors out after ~60s.
- Takes an optional `-Port` parameter (default `9222`).

## Verification

```
> powershell -ExecutionPolicy Bypass -File scripts\launch_tv_debug_msix.ps1
Package : TradingView.Desktop_n534cwy3pjxzj
AppId   : TradingView.Desktop
Exe     : C:\Program Files\WindowsApps\TradingView.Desktop_3.3.0.7992_x64__n534cwy3pjxzj\TradingView.exe
Port    : 9222
CDP ready at http://127.0.0.1:9222
  Browser: Chrome/140.0.7339.133
```

`GET /json/version` confirmed reachable; the MCP server connected over CDP afterward.

## Notes

This is purely additive — it does not touch `launch_tv_debug.bat`. A natural follow-up (not included here) would be to have `tv_launch` prefer `Invoke-CommandInDesktopPackage` on MSIX installs, and to update `SETUP_GUIDE.md` Step 3 to note that the loose-copy fallback fails on builds that enforce package identity.
