### PR TITLE
docs: fix tool count in CLAUDE.md (81 -> 78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-81 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+78 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md` stated 81 tools; every other reference to the tool count (`README.md`, `RESEARCH.md`, and the server's own runtime `instructions` string in `src/server.js`) says 78.
- Fixes the stray digit so `CLAUDE.md` matches the rest of the docs and the actual shipped code.

## Test plan
- Docs-only change, no behavior affected.
- Verified via `grep` that 78 is the count used everywhere else in the repo.