### PR TITLE
test: add unit coverage for jsonResult() response formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/format.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/format.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -1,0 +1,43 @@
+/**
+ * Tests for the shared MCP response formatter (src/tools/_format.js).
+ * jsonResult() is used by every tool file, so its output shape and the
+ * conditional isError flag are worth pinning down.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { jsonResult } from '../src/tools/_format.js';
+
+describe('jsonResult', () => {
+  it('wraps an object in the MCP content shape with pretty-printed JSON', () => {
+    const result = jsonResult({ success: true, value: 42 });
+    assert.deepEqual(result.content, [
+      { type: 'text', text: JSON.stringify({ success: true, value: 42 }, null, 2) },
+    ]);
+  });
+
+  it('round-trips the payload through the text field', () => {
+    const payload = { a: 1, nested: { b: [2, 3], c: 'x' } };
+    const result = jsonResult(payload);
+    assert.deepEqual(JSON.parse(result.content[0].text), payload);
+  });
+
+  it('pretty-prints with 2-space indentation', () => {
+    const result = jsonResult({ a: 1 });
+    assert.ok(result.content[0].text.includes('\n  "a": 1'));
+  });
+
+  it('omits isError when not an error (default)', () => {
+    const result = jsonResult({ ok: true });
+    assert.ok(!('isError' in result), 'isError should be absent by default');
+  });
+
+  it('omits isError when isError is explicitly false', () => {
+    const result = jsonResult({ ok: true }, false);
+    assert.ok(!('isError' in result), 'isError should be absent when false');
+  });
+
+  it('sets isError: true when flagged as an error', () => {
+    const result = jsonResult({ error: 'boom' }, true);
+    assert.equal(result.isError, true);
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for `jsonResult()` in `src/tools/_format.js` — the shared helper that builds the MCP response envelope used by every tool file. It previously had no test coverage.

New file `tests/format.test.js` (6 tests) covers:
- the `content: [{ type: 'text', text }]` shape
- JSON round-trip of the payload through the `text` field
- 2-space pretty-printing
- the conditional `isError` flag: absent by default and when `false`, `true` when flagged

`package.json` is updated to register the file in the `test:unit` and `test:all` scripts so CI runs it.

## Why

`jsonResult()` is used everywhere, so pinning down its output shape and the `...(isError && { isError: true })` conditional guards against accidental regressions in the response envelope. This is additive and test-only — no product code is touched.

## Verification

```
$ node --test tests/format.test.js
# tests 6
# pass 6
# fail 0

$ npm run lint
# unchanged (4 pre-existing warnings, none introduced here)
```

Scope: fits "Bug fixes and test coverage" / "Documentation improvements" in CONTRIBUTING; single focused change.
