### PR TITLE
Fix MSIX package detection in launch_tv_debug.bat

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -22,7 +22,7 @@ REM Check MSIX / Windows Store installs.
 REM Get-AppxPackage resolves the install without elevation; enumerating
 REM %PROGRAMFILES%\WindowsApps with dir requires admin rights, so keep it as a fallback.
 if "%TV_EXE%"=="" (
-    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
+    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage | Where-Object { $_.Name -like '*TradingView*' } | Select-Object -First 1).InstallLocation" 2^>nul`) do (
         if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
     )
 )

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -318,7 +318,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage | Where-Object { $_.Name -like \'*TradingView*\' } | Select-Object -First 1).InstallLocation"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;


### PR DESCRIPTION
## Summary
- `launch_tv_debug.bat` looked up the TradingView MSIX package with `Get-AppxPackage -Name 'TradingView.Desktop'`, but the actual installed package name is publisher-prefixed (e.g. `31178TradingViewInc.TradingView`), so the exact-name filter never matched.
- This caused the script to report "TradingView not found" even when TradingView was installed via MSIX/Microsoft Store, and to skip straight past the MSIX detection branch.
- Changed the filter to match any `Get-AppxPackage` entry whose `Name` contains "TradingView" instead of an exact string match.

## Test plan
- [x] Ran `scripts\launch_tv_debug.bat` on a Windows machine with TradingView installed via MSIX (package name `31178TradingViewInc.TradingView`) — script now finds the install, launches TradingView with `--remote-debugging-port=9222`, and confirms CDP is ready.
