### PR TITLE
Fix tv_launch and launch scripts for Windows Store (MSIX) installs

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -12,6 +12,7 @@ ping -n 3 127.0.0.1 >nul
 
 REM Auto-detect TradingView install location
 set "TV_EXE="
+set "TV_AUMID="
 
 REM Check common install locations
 if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%\TradingView\TradingView.exe"
@@ -22,12 +23,15 @@ REM Check MSIX / Windows Store installs.
 REM Get-AppxPackage resolves the install without elevation; enumerating
 REM %PROGRAMFILES%\WindowsApps with dir requires admin rights, so keep it as a fallback.
 if "%TV_EXE%"=="" (
-    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
+    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "Get-AppxPackage | Where-Object { $_.Name -like '*TradingView*' -or $_.PackageFullName -like '*TradingView*' } | Select-Object -First 1 -ExpandProperty InstallLocation" 2^>nul`) do (
         if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
+    )
+    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "$pkg = Get-AppxPackage | Where-Object { $_.Name -like '*TradingView*' -or $_.PackageFullName -like '*TradingView*' } | Select-Object -First 1; if ($pkg) { $manifest = [xml](Get-Content (Join-Path $pkg.InstallLocation 'AppxManifest.xml')); $pkg.PackageFamilyName + '!' + $manifest.Package.Applications.Application.Id }" 2^>nul`) do (
+        set "TV_AUMID=%%i"
     )
 )
 if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\*TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
 )
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
@@ -42,9 +46,15 @@ if "%TV_EXE%"=="" (
     exit /b 1
 )
 
-echo Found TradingView at: %TV_EXE%
-echo Starting with --remote-debugging-port=%PORT%...
-start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+if not "%TV_AUMID%"=="" (
+    echo Found TradingView AppX: %TV_AUMID%
+    echo Starting with --remote-debugging-port=%PORT%...
+    powershell -NoProfile -Command "Start-Process -FilePath 'shell:AppsFolder\%TV_AUMID%' -ArgumentList '--remote-debugging-port=%PORT%'" >nul 2>&1
+) else (
+    echo Found TradingView at: %TV_EXE%
+    echo Starting with --remote-debugging-port=%PORT%...
+    start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+)
 
 echo Waiting for CDP to become available...
 ping -n 6 127.0.0.1 >nul

--- a/scripts/launch_tv_debug.vbs
+++ b/scripts/launch_tv_debug.vbs
@@ -1,6 +1,13 @@
 Set oShell = CreateObject("WScript.Shell")
-Set oEnv = oShell.Environment("Process")
-oEnv("ELECTRON_EXTRA_LAUNCH_ARGS") = "--remote-debugging-port=9222"
-oShell.Run "explorer.exe shell:AppsFolder\TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop", 1, False
+
+Set oExec = oShell.Exec("powershell -NoProfile -Command ""$pkg = Get-AppxPackage | Where-Object { $_.Name -like '*TradingView*' -or $_.PackageFullName -like '*TradingView*' } | Select-Object -First 1; if ($pkg) { $manifest = [xml](Get-Content (Join-Path $pkg.InstallLocation 'AppxManifest.xml')); $pkg.PackageFamilyName + '!' + $manifest.Package.Applications.Application.Id }""")
+appId = Trim(oExec.StdOut.ReadAll)
+
+If appId = "" Then
+  WScript.Echo "TradingView AppX package not found"
+  WScript.Quit 1
+End If
+
+oShell.Run "powershell -NoProfile -Command ""Start-Process -FilePath 'shell:AppsFolder\" & appId & "' -ArgumentList '--remote-debugging-port=9222'""", 1, False
 WScript.Sleep 1000
-WScript.Echo "Launched"
+WScript.Echo "Launched " & appId

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -233,6 +233,18 @@ function _spawnDetached(spawnFn, exe, args) {
   return child;
 }
 
+function _activateWindowsStoreApp(appId, cdpPort, deps) {
+  const safeAppId = appId.replace(/'/g, "''");
+  const ps = `powershell -NoProfile -Command "Start-Process -FilePath 'shell:AppsFolder\\${safeAppId}' -ArgumentList '--remote-debugging-port=${cdpPort}'"`;
+  try {
+    deps.execSync(ps, { timeout: 5000 });
+  } catch {
+    // Some Store activations return a non-zero PowerShell status even after
+    // TradingView starts. The CDP probe below is the source of truth.
+  }
+  return { pid: undefined };
+}
+
 // Resolves once with an error string if the process fails/exits within graceMs,
 // or with null if it survives that long.
 function _spawnFailedEarly(child, graceMs = 1500) {
@@ -273,7 +285,7 @@ function _copyMsixPackageLocal(tvPath, { cpSync, rmSync, readdirSync, existsSync
   if (!existsSync(dstExe)) {
     try {
       for (const entry of readdirSync(cacheRoot)) {
-        if (entry !== pkgName && /^TradingView\./i.test(entry)) {
+        if (entry !== pkgName && /TradingView/i.test(entry)) {
           rmSync(join(cacheRoot, entry), { recursive: true, force: true });
         }
       }
@@ -309,6 +321,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   };
 
   let tvPath = null;
+  let windowsStoreAppId = null;
   const candidates = pathMap[platform] || pathMap.linux;
   for (const p of candidates) {
     if (p && deps.existsSync(p)) { tvPath = p; break; }
@@ -318,8 +331,10 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
-      const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
+      const ps = 'powershell -NoProfile -Command "$pkg = Get-AppxPackage | Where-Object { $_.Name -like \'*TradingView*\' -or $_.PackageFullName -like \'*TradingView*\' } | Select-Object -First 1; if ($pkg) { $manifest = [xml](Get-Content (Join-Path $pkg.InstallLocation \'AppxManifest.xml\')); Write-Output $pkg.InstallLocation; Write-Output ($pkg.PackageFamilyName + \'!\' + $manifest.Package.Applications.Application.Id) }"';
+      const lines = deps.execSync(ps, { timeout: 5000 }).toString().trim().split(/\r?\n/).filter(Boolean);
+      const installDir = lines[0];
+      windowsStoreAppId = lines[1] || null;
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;
         if (deps.existsSync(candidate)) tvPath = candidate;
@@ -351,7 +366,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
 
   const killExisting = async () => {
     try {
-      if (platform === 'win32') deps.execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
+      if (platform === 'win32') deps.execSync('taskkill /F /IM TradingView.exe >nul 2>nul', { timeout: 5000 });
       else deps.execSync('pkill -f TradingView', { timeout: 5000 });
       await deps.delay(1500);
     } catch { /* may not be running */ }
@@ -369,11 +384,17 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     if (!earlyFailure) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }
+    if (!info && windowsStoreAppId) {
+      if (killFirst) await killExisting();
+      child = _activateWindowsStoreApp(windowsStoreAppId, cdpPort, deps);
+      tvPath = `shell:AppsFolder\\${windowsStoreAppId}`;
+      info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+    }
     if (!info) {
       // Direct WindowsApps launch was blocked or CDP never bound — fall back to
       // a local copy of the package (see _copyMsixPackageLocal).
       const localExe = _copyMsixPackageLocal(tvPath, deps);
-      await killExisting();
+      if (killFirst) await killExisting();
       child = _spawnDetached(deps.spawn, localExe, cdpArgs);
       tvPath = localExe;
       usedLocalCopy = true;


### PR DESCRIPTION
## Problem

On Windows Store (MSIX) installs, `tv_launch` and the launch scripts fail in two ways:

1. Package detection looks for the exact AppX name `TradingView.Desktop`, but Store installs don't always carry that name — detection returns nothing and the tool reports TV as not installed.
2. Even when the exe inside `WindowsApps` is found, spawning it directly can be blocked by package ACLs, or the process starts without binding the CDP port. The existing fallback (copying ~330 MB of the package to a local cache) works but is slow and loses package identity.

## Fix

- `src/core/health.js`: match any `*TradingView*` AppX package and resolve its AUMID (`PackageFamilyName!ApplicationId`) from `AppxManifest.xml`. When the direct spawn fails or CDP never binds, try **`shell:AppsFolder` AUMID activation** with `--remote-debugging-port` before falling back to the local package copy. Activation preserves package identity and is near-instant. Also: honor `kill_existing=false` on the fallback paths (previously the local-copy fallback killed TV unconditionally), and suppress `taskkill` console noise.
- `scripts/launch_tv_debug.bat`: same broader package matching + AUMID activation path.
- `scripts/launch_tv_debug.vbs`: resolve the AUMID dynamically instead of the hardcoded `TradingView.Desktop_n534cwy3pjxzj` family name, which breaks on other machines.

## Verification

Daily-driven for weeks on Windows 11 Home (26220) with the Microsoft Store MSIX install of TradingView Desktop:

- `tv_launch` via MCP: package detected, AUMID activation starts TV with CDP bound on :9222 (`tv_health_check` → `cdp_connected: true, api_available: true`).
- `launch_tv_debug.bat` / `.vbs` both launch with the debug port from cold start.
- `kill_existing=false` no longer kills a running instance when the fallback path engages.

`npm run lint`: 0 errors (4 warnings, all pre-existing on main). `npm run test:unit`: 123/125 pass — the 2 failures are pre-existing on clean main in this Windows environment (one is the `0xC0000409` CLI exit crash addressed by #246, the other a doubled-drive-letter path in `sanitization.test.js`'s source-audit scandir).

## Related PRs

- #350 fixes the `.bat` detection one-liner only; this PR includes that plus the activation path and the `tv_launch` (health.js) fix.
- #346 adds a separate new MSIX launch script; this PR instead fixes the existing scripts/tool path. Happy to rebase if either merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
