### PR TITLE
Launch MSIX TradingView via COM activation as the primary path

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -47,20 +47,18 @@ Mac:
 
 Windows:
 
-TradingView for Windows now ships **only as an MSIX package** (Microsoft Store and tvd-packages.tradingview.com both install under `C:\Program Files\WindowsApps\`). Use the launch script — it resolves the install via `Get-AppxPackage`, which works without admin rights:
+TradingView for Windows now ships **only as an MSIX package** (Microsoft Store and tvd-packages.tradingview.com both install under `C:\Program Files\WindowsApps\`). The exe under `WindowsApps` cannot be started directly (**"Access is denied"**), and running a copy of the package outside its MSIX context crashes 3.3.0+ shortly after start with `bridge-not-loaded` (see `%APPDATA%\TradingView\logs`). The reliable method is **COM activation** (`IApplicationActivationManager`), which launches the app in its full package context and forwards `--remote-debugging-port` — no admin rights needed. Use the launch script, which does this automatically:
 
 ```bat
 scripts\launch_tv_debug.bat
 ```
 
-Or, preferred: let the `tv_launch` MCP tool do it — it auto-detects MSIX installs and, on Windows builds where launching from `WindowsApps` is blocked with **"Access is denied"**, automatically copies the package to `%LOCALAPPDATA%\tradingview-mcp\` (one-time, ~330MB) and launches from the copy. The copy keeps your login, layout, and chart state. If the fallback was used, the result includes `msix_local_copy: true`.
+Or, preferred: let the `tv_launch` MCP tool do it — it auto-detects MSIX installs and launches them via COM activation (the result then includes `msix_com_activation: true`). On the few builds where COM activation leaves the debug port unbound, it falls back to copying the package to `%LOCALAPPDATA%\tradingview-mcp\` (one-time, ~330MB) and launching from the copy (`msix_local_copy: true`) — a last resort only, since that copy crashes on 3.3.0+.
 
-Manual equivalent of that fallback, if you need it:
+Manual equivalent of the COM activation, if you need it:
 
 ```powershell
-$pkg = (Get-AppxPackage TradingView.Desktop).InstallLocation
-Copy-Item "$pkg\*" "$env:LOCALAPPDATA\tradingview-mcp\TradingView" -Recurse -Force
-& "$env:LOCALAPPDATA\tradingview-mcp\TradingView\TradingView.exe" --remote-debugging-port=9222
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\activate_msix.ps1 -Arguments "--remote-debugging-port=9222"
 ```
 
 Reading files out of `WindowsApps` by exact path is allowed even where executing them isn't. Do **not** try to change ACLs on `WindowsApps` with `icacls` — it fails and can break app servicing.
@@ -115,7 +113,8 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 | Problem | Solution |
 |---------|----------|
 | `cdp_connected: false` | Launch TradingView with `--remote-debugging-port=9222` |
-| Windows: "Access is denied" launching from `WindowsApps` | Use `tv_launch` (auto copy-fallback) or the manual copy snippet in Step 3 — never `icacls` on WindowsApps |
+| Windows: "Access is denied" launching from `WindowsApps` | Use `tv_launch` or `scripts\launch_tv_debug.bat` (COM activation) — never `icacls` on WindowsApps |
+| Windows: TradingView exits ~12s after launch, `bridge-not-loaded` in `%APPDATA%\TradingView\logs` | The app was launched from a copied package directory — relaunch via `tv_launch` / COM activation (Step 3) instead |
 | `ECONNREFUSED` | TradingView isn't running or port 9222 is blocked |
 | MCP server not showing in Claude Code | Check `~/.claude/.mcp.json` syntax, restart Claude Code |
 | `tv` command not found | Run `npm link` from the project directory |

--- a/scripts/activate_msix.ps1
+++ b/scripts/activate_msix.ps1
@@ -1,0 +1,88 @@
+# Launch an MSIX/Microsoft Store app with command-line arguments via COM
+# activation (IApplicationActivationManager).
+#
+# Why: TradingView.exe under C:\Program Files\WindowsApps cannot be started
+# directly (spawn fails with EPERM/"Access is denied"), and running a copy of
+# the package outside its MSIX context crashes 3.3.0+ with "bridge-not-loaded"
+# (~12s after start; see %APPDATA%\TradingView\logs). COM activation launches
+# the app full-trust inside its package context, forwards the arguments, and
+# CDP binds within ~2 seconds.
+#
+# Usage:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File activate_msix.ps1 `
+#     [-PackageName TradingView.Desktop] [-Arguments "--remote-debugging-port=9222"]
+#
+# Prints the launched process ID on success; exits non-zero on failure.
+
+param(
+    [string]$PackageName = 'TradingView.Desktop',
+    [string]$Arguments = '--remote-debugging-port=9222'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$pkg = Get-AppxPackage -Name $PackageName -ErrorAction SilentlyContinue
+if (-not $pkg) {
+    Write-Error "MSIX package '$PackageName' is not installed."
+    exit 1
+}
+
+# AUMID = PackageFamilyName + "!" + Application Id from AppxManifest.xml.
+# TradingView's manifest uses <Application Id="TradingView.Desktop">, so the
+# package name doubles as the fallback if the manifest can't be read.
+$appId = $PackageName
+try {
+    [xml]$manifest = Get-Content (Join-Path $pkg.InstallLocation 'AppxManifest.xml')
+    $firstApp = @($manifest.Package.Applications.Application) | Select-Object -First 1
+    if ($firstApp -and $firstApp.Id) { $appId = $firstApp.Id }
+} catch { }
+
+$aumid = "$($pkg.PackageFamilyName)!$appId"
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TvMcp
+{
+    public enum ActivateOptions
+    {
+        None = 0x0,
+        DesignMode = 0x1,
+        NoErrorUI = 0x2,
+        NoSplashScreen = 0x4
+    }
+
+    [ComImport, Guid("2e941141-7f97-4756-ba1d-9decde894a3d"),
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IApplicationActivationManager
+    {
+        IntPtr ActivateApplication([In] string appUserModelId, [In] string arguments,
+            [In] ActivateOptions options, [Out] out uint processId);
+        IntPtr ActivateForFile([In] string appUserModelId, [In] IntPtr itemArray,
+            [In] string verb, [Out] out uint processId);
+        IntPtr ActivateForProtocol([In] string appUserModelId, [In] IntPtr itemArray,
+            [Out] out uint processId);
+    }
+
+    [ComImport, Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+    public class ApplicationActivationManager : IApplicationActivationManager
+    {
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        public extern IntPtr ActivateApplication([In] string appUserModelId, [In] string arguments,
+            [In] ActivateOptions options, [Out] out uint processId);
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        public extern IntPtr ActivateForFile([In] string appUserModelId, [In] IntPtr itemArray,
+            [In] string verb, [Out] out uint processId);
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        public extern IntPtr ActivateForProtocol([In] string appUserModelId, [In] IntPtr itemArray,
+            [Out] out uint processId);
+    }
+}
+'@
+
+$manager = New-Object TvMcp.ApplicationActivationManager
+$procId = [uint32]0
+[void]$manager.ActivateApplication($aumid, $Arguments, [TvMcp.ActivateOptions]::None, [ref]$procId)
+$procId

--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -13,39 +13,43 @@ ping -n 3 127.0.0.1 >nul
 REM Auto-detect TradingView install location
 set "TV_EXE="
 
-REM Check common install locations
+REM Check classic (pre-MSIX) install locations first
 if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs.
-REM Get-AppxPackage resolves the install without elevation; enumerating
-REM %PROGRAMFILES%\WindowsApps with dir requires admin rights, so keep it as a fallback.
-if "%TV_EXE%"=="" (
-    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
-        if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
-    )
-)
-if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
-)
-if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
+if not "%TV_EXE%"=="" (
+    echo Found TradingView at: %TV_EXE%
+    echo Starting with --remote-debugging-port=%PORT%...
+    start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+    goto wait
 )
 
+REM MSIX / Microsoft Store installs: the exe under %PROGRAMFILES%\WindowsApps
+REM cannot be started directly ("Access is denied"), and running a copy of the
+REM package outside its MSIX context crashes 3.3.0+ with "bridge-not-loaded".
+REM Launch through COM activation (IApplicationActivationManager) instead —
+REM the debug argument is forwarded and the app runs in its full package context.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0activate_msix.ps1" -Arguments "--remote-debugging-port=%PORT%" >nul 2>&1
+if %errorlevel% equ 0 (
+    echo Launched MSIX package via COM activation.
+    goto wait
+)
+
+for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
 if "%TV_EXE%"=="" (
     echo Error: TradingView not found.
-    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps
+    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, MSIX packages
     echo.
     echo If installed elsewhere, run manually:
     echo   "C:\path\to\TradingView.exe" --remote-debugging-port=%PORT%
     exit /b 1
 )
-
 echo Found TradingView at: %TV_EXE%
 echo Starting with --remote-debugging-port=%PORT%...
 start "" "%TV_EXE%" --remote-debugging-port=%PORT%
 
+:wait
 echo Waiting for CDP to become available...
 ping -n 6 127.0.0.1 >nul
 
@@ -59,8 +63,9 @@ set /a TRIES+=1
 if %TRIES% geq 30 (
     echo.
     echo Error: TradingView is running but CDP never became available on port %PORT%.
-    echo Some Windows MSIX builds block the debug port. Use the tv_launch MCP tool,
-    echo which falls back to launching from a local copy of the package.
+    echo On some MSIX builds even COM activation leaves the debug port unbound.
+    echo Use the tv_launch MCP tool, which falls back to launching from a local
+    echo copy of the package as a last resort.
     exit /b 1
 )
 echo Still waiting...

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -5,6 +5,7 @@ import { getClient, getTargetInfo, evaluate, CDP_HOST, CDP_PORT } from '../conne
 import { existsSync, cpSync, rmSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { dirname, basename, join } from 'path';
+import { fileURLToPath } from 'url';
 
 // Best-effort git-pull update check: compare local HEAD to origin's default
 // branch on GitHub. Never throws — returns null on any failure (offline,
@@ -228,22 +229,17 @@ async function _probeCdp(cdpPort) {
 }
 
 function _spawnDetached(spawnFn, exe, args) {
-  const child = spawnFn(exe, args, { detached: true, stdio: 'ignore' });
-  child.unref();
-  return child;
-}
-
-// Resolves once with an error string if the process fails/exits within graceMs,
-// or with null if it survives that long.
-function _spawnFailedEarly(child, graceMs = 1500) {
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => { cleanup(); resolve(null); }, graceMs);
-    const onError = (e) => { cleanup(); resolve(e.code || e.message || 'spawn error'); };
-    const onExit = (code) => { cleanup(); resolve(`exited immediately (code ${code})`); };
-    const cleanup = () => { clearTimeout(timer); child.off?.('error', onError); child.off?.('exit', onExit); };
-    child.on('error', onError);
-    child.on('exit', onExit);
-  });
+  // spawn() can throw synchronously (e.g. EPERM for WindowsApps paths) as well
+  // as emit an async 'error'. Swallow both: an unhandled 'error' event would
+  // crash the server, and callers report failure via _waitForCdp timing out.
+  try {
+    const child = spawnFn(exe, args, { detached: true, stdio: 'ignore' });
+    child.on?.('error', () => {});
+    child.unref();
+    return child;
+  } catch {
+    return { pid: undefined };
+  }
 }
 
 async function _waitForCdp({ cdpPort, attempts, delay, probeCdp }) {
@@ -258,11 +254,31 @@ async function _waitForCdp({ cdpPort, attempts, delay, probeCdp }) {
 }
 
 /**
- * Some Windows builds block CDP for MSIX-packaged apps: direct spawn from
- * WindowsApps gets EACCES, and even COM activation passes the flag but the
- * debug port never binds (issues #42, #75, #128). Running the same files from
- * a plain directory outside WindowsApps works and keeps the user's session,
- * so copy the package into LOCALAPPDATA once per version and launch that.
+ * MSIX installs need their full package context: spawning TradingView.exe
+ * straight out of WindowsApps throws EPERM, and builds 3.3.0+ crash with
+ * "bridge-not-loaded" (~12s after start) when run from a plain directory.
+ * COM activation via IApplicationActivationManager launches the app
+ * full-trust inside its package context with the CDP flag forwarded, so it
+ * is the primary launch path for WindowsApps installs. Runs
+ * scripts/activate_msix.ps1; returns the launched PID (or undefined),
+ * throws if PowerShell/activation fails.
+ */
+function _activateMsixViaCom(cdpPort, { execSync }) {
+  const script = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'scripts', 'activate_msix.ps1');
+  const out = execSync(
+    `powershell -NoProfile -ExecutionPolicy Bypass -File "${script}" -Arguments "--remote-debugging-port=${cdpPort}"`,
+    { timeout: 30000, stdio: ['ignore', 'pipe', 'ignore'] }
+  ).toString().trim();
+  const pid = Number(out.split(/\r?\n/).pop());
+  return Number.isFinite(pid) && pid > 0 ? pid : undefined;
+}
+
+/**
+ * Last-resort fallback for MSIX installs where COM activation leaves the
+ * debug port unbound (seen on some builds: issues #42, #75, #128): copy the
+ * package into LOCALAPPDATA once per version and launch from the copy. The
+ * copy keeps the user's session. Known to crash with "bridge-not-loaded" on
+ * 3.3.0+, which is why COM activation is tried first.
  */
 function _copyMsixPackageLocal(tvPath, { cpSync, rmSync, readdirSync, existsSync }) {
   const srcDir = dirname(tvPath);
@@ -360,24 +376,33 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  let pid;
   let info = null;
   let usedLocalCopy = false;
+  let usedComActivation = false;
 
   if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
-    const earlyFailure = await _spawnFailedEarly(child);
-    if (!earlyFailure) {
+    // MSIX/Store install — COM activation is the primary path; direct spawn
+    // from WindowsApps always fails with EPERM (see _activateMsixViaCom).
+    try {
+      pid = _activateMsixViaCom(cdpPort, deps);
+      usedComActivation = true;
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
-    }
+    } catch { /* activation unavailable — fall through to the local copy */ }
     if (!info) {
-      // Direct WindowsApps launch was blocked or CDP never bound — fall back to
-      // a local copy of the package (see _copyMsixPackageLocal).
+      // COM activation failed or CDP never bound — last resort is a local
+      // copy of the package (see _copyMsixPackageLocal).
+      usedComActivation = false;
       const localExe = _copyMsixPackageLocal(tvPath, deps);
       await killExisting();
-      child = _spawnDetached(deps.spawn, localExe, cdpArgs);
+      const child = _spawnDetached(deps.spawn, localExe, cdpArgs);
       tvPath = localExe;
+      pid = child.pid;
       usedLocalCopy = true;
     }
+  } else {
+    const child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+    pid = child.pid;
   }
 
   if (!info) {
@@ -386,15 +411,17 @@ export async function launch({ port, kill_existing, _deps } = {}) {
 
   if (info) {
     return {
-      success: true, platform, binary: tvPath, pid: child.pid,
+      success: true, platform, binary: tvPath, pid,
       cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
+      ...(usedComActivation && { msix_com_activation: true }),
       ...(usedLocalCopy && { msix_local_copy: true }),
     };
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform, binary: tvPath, pid, cdp_port: cdpPort, cdp_ready: false,
+    ...(usedComActivation && { msix_com_activation: true }),
     ...(usedLocalCopy && { msix_local_copy: true }),
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -19,7 +19,7 @@ export function registerHealthTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux, including Windows MSIX/Store installs. If a Store install blocks the debug port, automatically relaunches from a local package copy (result then includes msix_local_copy: true; the first fallback launch copies ~330MB one time, so it can take a minute).', {
+  server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux, including Windows MSIX/Store installs. MSIX installs launch via COM activation so the debug flag reaches the packaged app (result includes msix_com_activation: true); if the debug port still never binds, falls back to relaunching from a local package copy (msix_local_copy: true; the first fallback launch copies ~330MB one time, so it can take a minute).', {
     port: z.coerce.number().optional().describe('CDP port (default 9222)'),
     kill_existing: z.coerce.boolean().optional().describe('Kill existing TradingView instances first (default true)'),
   }, async ({ port, kill_existing }) => {

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -1,16 +1,18 @@
 /**
  * Tests for launch() in src/core/health.js.
- * Covers Windows MSIX handling: direct WindowsApps spawn, local-copy fallback
- * when spawn fails or CDP never binds, copy reuse, and classic-path launches.
+ * Covers Windows MSIX handling: COM activation as the primary path, local-copy
+ * fallback when activation fails or CDP never binds, copy reuse, synchronous
+ * spawn throws, and classic-path launches.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { launch } from '../src/core/health.js';
 
-const MSIX_EXE = 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\\TradingView.exe';
-const LOCAL_COPY_EXE = `${process.env.LOCALAPPDATA || ''}\\tradingview-mcp\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\\TradingView.exe`;
-const CDP_VERSION = JSON.stringify({ Browser: 'Chrome/140', 'User-Agent': 'TVDesktop/3.1.0' });
+const MSIX_EXE = 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.3.0.8112_x64__n534cwy3pjxzj\\TradingView.exe';
+const LOCAL_COPY_EXE = `${process.env.LOCALAPPDATA || ''}\\tradingview-mcp\\TradingView.Desktop_3.3.0.8112_x64__n534cwy3pjxzj\\TradingView.exe`;
+const CDP_VERSION = JSON.stringify({ Browser: 'Chrome/140', 'User-Agent': 'TVDesktop/3.3.0' });
+const COM_PID = 4321;
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
 
@@ -25,12 +27,15 @@ function mockChild({ failWith } = {}) {
 /**
  * Build a _deps bundle simulating a win32 MSIX environment.
  * @param {object} opts
- *   spawnFailures — spawn paths (substring) that emit EACCES
+ *   comFails     — the COM activation PowerShell script exits non-zero
+ *   comBindsCdp  — probeCdp starts succeeding after COM activation
+ *   spawnFailures — spawn paths (substring) that emit an async EACCES error
+ *   spawnThrows  — spawn paths (substring) that throw EPERM synchronously
  *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
  *   copyExists   — local copy already present
  */
-function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } = {}) {
-  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
+function msixDeps({ comFails = false, comBindsCdp = false, spawnFailures = [], spawnThrows = [], cdpBindsFor = [], copyExists = false } = {}) {
+  const state = { spawned: [], copies: [], removed: [], killed: 0, comActivations: 0, cdpUp: false };
   const deps = {
     existsSync: (p) => {
       if (p === MSIX_EXE) return true;
@@ -38,21 +43,30 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
       return false;
     },
     execSync: (cmd) => {
+      if (cmd.includes('activate_msix.ps1')) {
+        state.comActivations++;
+        if (comFails) throw new Error('powershell exited with code 1');
+        if (comBindsCdp) state.cdpUp = true;
+        return `${COM_PID}\n`;
+      }
       if (cmd.includes('Get-AppxPackage')) {
-        return 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\n';
+        return 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.3.0.8112_x64__n534cwy3pjxzj\n';
       }
       if (cmd.includes('taskkill')) { state.killed++; return ''; }
       throw new Error(`unexpected execSync: ${cmd}`);
     },
     spawn: (exe) => {
       state.spawned.push(exe);
+      if (spawnThrows.some((s) => exe.includes(s))) {
+        throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
+      }
       const fail = spawnFailures.some((s) => exe.includes(s));
       if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
       return mockChild(fail ? { failWith: 'EACCES' } : {});
     },
     cpSync: (src, dst) => { state.copies.push({ src, dst }); },
     rmSync: (p) => { state.removed.push(p); },
-    readdirSync: () => ['TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj'],
+    readdirSync: () => ['TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj'],
     delay: async () => {},
     probeCdp: async () => (state.cdpUp ? CDP_VERSION : null),
   };
@@ -63,43 +77,47 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
 const onWindows = process.platform === 'win32';
 
 describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
-  it('direct WindowsApps spawn that binds CDP does not copy', async () => {
-    const { deps, state } = msixDeps({ cdpBindsFor: ['WindowsApps'] });
+  it('COM activation that binds CDP neither spawns nor copies', async () => {
+    const { deps, state } = msixDeps({ comBindsCdp: true });
     const result = await launch({ _deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.binary, MSIX_EXE);
+    assert.equal(result.msix_com_activation, true);
     assert.equal(result.msix_local_copy, undefined);
+    assert.equal(result.pid, COM_PID);
+    assert.equal(state.comActivations, 1);
+    assert.equal(state.spawned.length, 0);
     assert.equal(state.copies.length, 0);
     assert.equal(result.cdp_url, 'http://127.0.0.1:9222');
   });
 
-  it('EACCES on direct spawn falls back to local copy', async () => {
-    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+  it('COM activation failure falls back to local copy', async () => {
+    const { deps, state } = msixDeps({ comFails: true, cdpBindsFor: ['tradingview-mcp'] });
     const result = await launch({ _deps: deps });
     assert.equal(result.success, true);
+    assert.equal(result.msix_com_activation, undefined);
     assert.equal(result.msix_local_copy, true);
     assert.equal(result.binary, LOCAL_COPY_EXE);
     assert.equal(state.copies.length, 1);
     assert.match(state.copies[0].src, /WindowsApps/);
     // stale cached version of another release is cleaned up first
     assert.equal(state.removed.length, 1);
-    assert.match(state.removed[0], /3\.0\.0\.7652/);
-    // the CDP-less direct instance is killed before relaunching from the copy
+    assert.match(state.removed[0], /3\.1\.0\.7818/);
+    // any half-launched instance is killed before relaunching from the copy
     assert.ok(state.killed >= 2);
   });
 
-  it('CDP never binding on direct spawn falls back to local copy', async () => {
+  it('CDP never binding after COM activation falls back to local copy', async () => {
     const { deps, state } = msixDeps({ cdpBindsFor: ['tradingview-mcp'] });
     const result = await launch({ _deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.msix_local_copy, true);
-    assert.equal(state.spawned.length, 2);
-    assert.match(state.spawned[0], /WindowsApps/);
-    assert.match(state.spawned[1], /tradingview-mcp/);
+    assert.equal(state.comActivations, 1);
+    assert.deepEqual(state.spawned, [LOCAL_COPY_EXE]);
   });
 
   it('reuses an existing local copy without re-copying', async () => {
-    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'], copyExists: true });
+    const { deps, state } = msixDeps({ comFails: true, cdpBindsFor: ['tradingview-mcp'], copyExists: true });
     const result = await launch({ _deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.msix_local_copy, true);
@@ -114,27 +132,55 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.equal(result.msix_local_copy, true);
     assert.ok(result.warning);
   });
+
+  it('synchronous spawn throw on the fallback copy resolves instead of crashing', async () => {
+    const { deps, state } = msixDeps({ comFails: true, spawnThrows: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.cdp_ready, false);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(state.spawned.length, 1);
+  });
 });
 
 describe('launch() — classic install path', { skip: !onWindows }, () => {
-  it('launches classic LOCALAPPDATA install without MSIX logic', async () => {
+  function classicDeps({ spawnThrowsSync = false } = {}) {
     const classicExe = `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`;
     const state = { spawned: [], cdpUp: false };
     const deps = {
       existsSync: (p) => p === classicExe,
       execSync: (cmd) => { if (cmd.includes('taskkill')) return ''; throw new Error(`unexpected: ${cmd}`); },
-      spawn: (exe) => { state.spawned.push(exe); state.cdpUp = true; return mockChild(); },
+      spawn: (exe) => {
+        state.spawned.push(exe);
+        if (spawnThrowsSync) throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
+        state.cdpUp = true;
+        return mockChild();
+      },
       cpSync: () => { throw new Error('should not copy'); },
       rmSync: () => {},
       readdirSync: () => [],
       delay: async () => {},
       probeCdp: async () => (state.cdpUp ? CDP_VERSION : null),
     };
+    return { deps, state, classicExe };
+  }
+
+  it('launches classic LOCALAPPDATA install without MSIX logic', async () => {
+    const { deps, state, classicExe } = classicDeps();
     const result = await launch({ _deps: deps });
     assert.equal(result.success, true);
     assert.equal(result.binary, classicExe);
+    assert.equal(result.msix_com_activation, undefined);
     assert.equal(result.msix_local_copy, undefined);
     assert.deepEqual(state.spawned, [classicExe]);
+  });
+
+  it('synchronous spawn throw yields cdp_ready:false instead of throwing', async () => {
+    const { deps } = classicDeps({ spawnThrowsSync: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.cdp_ready, false);
+    assert.ok(result.warning);
   });
 
   it('throws a helpful error when TradingView is not found', async () => {


### PR DESCRIPTION
## Problem

`launch()` in `src/core/health.js` fails for MSIX/Microsoft Store installs of TradingView 3.3.0 on Windows:

1. Spawning `TradingView.exe` directly from `C:\Program Files\WindowsApps` throws **EPERM synchronously**, which bypassed the async-only early-failure handling (`_spawnFailedEarly` only listened for the `'error'` event), so the local-copy fallback was never reached.
2. The local-copy fallback itself crashes on 3.3.0 with **`bridge-not-loaded`** (`%APPDATA%\TradingView\logs`) ~12s after start — the app needs its full MSIX package context — even though CDP briefly binds.

## Fix

Use **COM activation** via `IApplicationActivationManager` (CLSID `45BA127D-10A8-46EA-8AB7-56EA9078943C`) as the primary launch path for WindowsApps installs. The `--remote-debugging-port` argument is forwarded into the full-trust packaged app, CDP binds in ~2s, and the app is stable. The AUMID is resolved dynamically: `PackageFamilyName` from `Get-AppxPackage` + the `Application Id` from `AppxManifest.xml`.

- New `scripts/activate_msix.ps1`: C# interop via `Add-Type`, prints the launched PID
- `launch()`: WindowsApps installs → COM activation first; the local-copy relaunch remains as last resort. Results report `msix_com_activation` / `msix_local_copy`
- `_spawnDetached`: catches synchronous spawn throws and swallows async `'error'` events so `launch()` degrades to `cdp_ready:false` instead of crashing; removes the now-unused `_spawnFailedEarly`
- `scripts/launch_tv_debug.bat`: MSIX installs go through `activate_msix.ps1` instead of `start`-ing the exe
- `SETUP_GUIDE.md`: documents COM activation as the method; adds a `bridge-not-loaded` troubleshooting row
- `tests/launch.test.js`: covers the COM-primary flow, both fallback triggers, copy reuse, and synchronous spawn throws

## Testing

- `node --test tests/launch.test.js`: 9/9 pass
- Verified live against Store build 3.3.0.7992: `msix_com_activation: true`, CDP responding on 9222, process still alive 15s+ after start (past the old crash window)
- The two `npm run test:unit` failures (`cli.test.js` pine compile, `sanitization.test.js` source audit) also fail on unmodified `main` on this machine — pre-existing/environmental

🤖 Generated with [Claude Code](https://claude.com/claude-code)
