### PR TITLE
Expose --wait-for-render on the screenshot CLI command

### DIFF
--- a/src/cli/commands/capture.js
+++ b/src/cli/commands/capture.js
@@ -6,9 +6,11 @@ register('screenshot', {
   options: {
     region: { type: 'string', short: 'r', description: 'Region: full, chart, strategy_tester' },
     output: { type: 'string', short: 'o', description: 'Custom filename (without .png)' },
+    'wait-for-render': { type: 'boolean', short: 'w', description: 'Wait for the chart canvas to stabilize before capturing. Use after setting symbol or timeframe to avoid stale frames.' },
   },
   handler: (opts) => core.captureScreenshot({
     region: opts.region,
     filename: opts.output,
+    waitForRender: opts['wait-for-render'],
   }),
 });


### PR DESCRIPTION
## Problem

`wait_for_render` (#144, e7932e7) is wired to the `capture_screenshot` MCP tool but **not to the CLI**. `src/cli/commands/capture.js` only forwards `region` and `output`:

```js
handler: (opts) => core.captureScreenshot({
  region: opts.region,
  filename: opts.output,
}),
```

So shell harnesses driving `tv screenshot` after `tv timeframe` / `tv symbol` can't reach it, and keep capturing stale frames. The core already supports it (`captureScreenshot({ ..., waitForRender })`) — only the CLI wiring is missing.

## Change

Adds `-w` / `--wait-for-render`, passing through to the existing core option. Two lines. No behaviour change unless the flag is set.

## Why a byte-size guard isn't a substitute

We'd worked around this with a "retry until the PNG exceeds 8KB" loop, assuming a bad frame is a blank one. It isn't sufficient — there are two distinct failure modes:

| | Size | Caught by size check? |
|---|---|---|
| **Blank/loading** frame | ~1KB | yes |
| **Stale** frame (previous timeframe's content) | **~282KB** | **no** |

Measured on XAUUSD: a capture immediately after a timeframe switch returned a full-size **282,103-byte** frame — indistinguishable from a good one by size, but showing the wrong timeframe. `--wait-for-render` is the only guard for that case. For anything doing vision analysis on the capture, a silently stale frame is worse than a blank one: it produces a confident wrong answer instead of an obvious failure.

## Testing

- `npm run lint` — clean (the 4 pre-existing warnings in `data.js`/`pane.js`/`watchlist.js` are untouched)
- `npm run test:unit` — **152 pass, 0 fail**
- Verified live against TradingView Desktop on Linux/XWayland: `tv screenshot --wait-for-render` returns `waited_for_render: true` and a correct post-switch frame; without it, the same sequence yields a full-size stale frame.