### PR TITLE
Fix MSIX package lookup to match non-Desktop-suffixed package IDs

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -318,7 +318,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'*TradingView*\' -ErrorAction SilentlyContinue).InstallLocation"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;


### PR DESCRIPTION
`Get-AppxPackage -Name 'TradingView.Desktop'` misses installs published under a different package ID (e.g. `31178TradingViewInc.TradingView`), which some Microsoft Store / tvd-packages installs use. This widens the lookup to a wildcard match (`*TradingView*`) so it finds the app regardless of the publisher's exact package name.

Tested locally on Windows 11 against a `31178TradingViewInc.TradingView_3.3.0.0` install — `tv launch` now succeeds where it previously failed with "TradingView not found on win32."