### PR TITLE
feat(update): self-disable after successful tv_update

### DIFF
--- a/src/core/update.js
+++ b/src/core/update.js
@@ -17,11 +17,12 @@ function _resolve(deps) {
     execSync: deps?.execSync || _execSync,
     existsSync: deps?.existsSync || _existsSync,
     repoRoot: deps?.repoRoot || REPO_ROOT,
+    exit: deps?.exit || ((code) => setTimeout(() => process.exit(code), 500)),
   };
 }
 
 export async function update({ _deps } = {}) {
-  const { execSync, existsSync, repoRoot } = _resolve(_deps);
+  const { execSync, existsSync, repoRoot, exit } = _resolve(_deps);
   const git = (args, timeout = 15000) =>
     execSync(`git ${args}`, { cwd: repoRoot, timeout, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
 
@@ -90,7 +91,7 @@ export async function update({ _deps } = {}) {
     }
   }
 
-  return {
+  const result = {
     success: true,
     updated: true,
     from_commit: before.slice(0, 8),
@@ -98,7 +99,10 @@ export async function update({ _deps } = {}) {
     commits_pulled: behind,
     deps_installed: depsInstalled,
     ...(depsWarning && { warning: depsWarning }),
-    restart_required: true,
-    note: 'Update applied. Restart the MCP server (reconnect it in your client) to load the new code — the running process still has the old version.',
+    self_disabling: true,
+    note: 'Update applied. This MCP server process is shutting down now — your client will restart it automatically to load the new code.',
   };
+
+  exit(0);
+  return result;
 }

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -27,7 +27,7 @@ export function registerHealthTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('tv_update', 'Update this MCP server to the latest version: git fast-forward of origin/main + npm ci when dependencies changed. Safe by design — refuses on non-git installs, dirty working trees, non-main branches, or diverged history. After a successful update the MCP server must be restarted to load the new code.', {}, async () => {
+  server.tool('tv_update', 'Update this MCP server to the latest version: git fast-forward of origin/main + npm ci when dependencies changed. Safe by design — refuses on non-git installs, dirty working trees, non-main branches, or diverged history. On success the server exits immediately so your MCP client restarts it with the new code.', {}, async () => {
     try { return jsonResult(await update({})); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });

--- a/tests/update.test.js
+++ b/tests/update.test.js
@@ -15,10 +15,11 @@ const NEW = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
  * @param {object} opts — branch, dirty, remoteSha, ahead, behind, lockChanged
  */
 function gitDeps({ branch = 'main', dirty = '', remoteSha = OLD, ahead = 0, behind = 0, lockChanged = false, npmFails = false } = {}) {
-  const state = { merged: false, npmCi: 0, cmds: [] };
+  const state = { merged: false, npmCi: 0, cmds: [], exited: false };
   const deps = {
     existsSync: () => true,
     repoRoot: 'C:/fake/repo',
+    exit: () => { state.exited = true; },
     execSync: (cmd) => {
       state.cmds.push(cmd);
       if (cmd.includes('rev-parse --abbrev-ref')) return branch;
@@ -40,6 +41,7 @@ function gitDeps({ branch = 'main', dirty = '', remoteSha = OLD, ahead = 0, behi
   };
   return { deps, state };
 }
+
 
 describe('update() — guards', () => {
   it('refuses non-git installs with a clone hint', async () => {
@@ -105,7 +107,8 @@ describe('update() — update paths', () => {
     assert.equal(r.to_commit, NEW.slice(0, 8));
     assert.equal(r.deps_installed, false);
     assert.equal(state.npmCi, 0);
-    assert.equal(r.restart_required, true);
+    assert.equal(r.self_disabling, true);
+    assert.ok(state.exited, 'exit() called after successful update');
   });
 
   it('runs npm ci when the lockfile changed', async () => {


### PR DESCRIPTION
After a successful git fast-forward, schedule process.exit(0) with a 500 ms delay so the response is flushed to the MCP client before the server stops. The client then restarts the process automatically, loading the new code without any manual intervention.

- Replace restart_required flag with self_disabling: true
- Inject exit via _deps so tests can mock it without killing the runner
- Update tv_update tool description to reflect the new behaviour
- Add exit mock + assertion to update.test.js