### PR TITLE
docs: document draw_get_properties in README tool reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | Tool | What it does |
 |------|-------------|
 | `draw_shape` | Draw horizontal_line, trend_line, rectangle, text |
-| `draw_list` / `draw_remove_one` / `draw_clear` | Manage drawings |
+| `draw_list` / `draw_get_properties` / `draw_remove_one` / `draw_clear` | List, inspect, and manage drawings |
 | `alert_create` / `alert_list` / `alert_delete` | Manage price alerts |
 | `capture_screenshot` | Screenshot (regions: full, chart, strategy_tester) |
 | `batch_run` | Run action across multiple symbols/timeframes |


### PR DESCRIPTION
## Summary
- `draw_get_properties` is registered in `src/tools/drawing.js` (get properties/points of a drawing by `entity_id`) but was missing from the README's "Drawing, Alerts, UI Automation" tool reference table.
- Adds it alongside the other `draw_*` tools.

## Test plan
- Docs-only change, no code touched.
- Verified the tool exists and its description by reading `src/tools/drawing.js` directly.
