### PR TITLE
Strip Pine source blob from data_get_study_values inputs

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -524,19 +524,26 @@ export async function getStudyValues() {
           // (e.g. two EMAs with different lengths) are distinguishable (#143).
           var id = null;
           try { id = s.id ? s.id() : null; } catch(e) {}
-          // Pine studies stash their obfuscated source in inputs().text — multi-KB
-          // per study, and it says nothing about how the study is configured. Drop
-          // it and the internal flags, and unwrap the {v,f,t} envelope so the
-          // inputs stay readable while still distinguishing instances (#143).
+          // A Pine study's inputs() carries its identity alongside its configuration:
+          // the obfuscated source (text, multi-KB), the script id and version, the
+          // feature list and the internal calc flags. None of it says how the study
+          // is configured, and pineId is identical across every instance of a script
+          // — so it cannot help tell instances apart either (#143). Drop that set,
+          // keep the in_* values that do, and unwrap the {v,f,t} envelope.
+          var META = ['text', 'pineId', 'pineVersion', 'pineFeatures', '__fast_calc', '__profile'];
           var inputs = null;
           try {
             var ip = s.inputs ? s.inputs() : null;
             if (ip) {
               var lean = {};
               for (var k in ip) {
-                if (k === 'text' || k === 'pineFeatures' || k === '__fast_calc' || k === '__profile') continue;
+                if (META.indexOf(k) !== -1) continue;
                 var iv = ip[k];
-                lean[k] = (iv && typeof iv === 'object' && 'v' in iv) ? iv.v : iv;
+                var val = (iv && typeof iv === 'object' && 'v' in iv) ? iv.v : iv;
+                // Safety net for unknown blobs: getIndicator() drops strings over
+                // 500 chars (src/core/data.js:203) — same threshold here.
+                if (typeof val === 'string' && val.length > 500) continue;
+                lean[k] = val;
               }
               if (Object.keys(lean).length) inputs = lean;
             }

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -524,8 +524,23 @@ export async function getStudyValues() {
           // (e.g. two EMAs with different lengths) are distinguishable (#143).
           var id = null;
           try { id = s.id ? s.id() : null; } catch(e) {}
+          // Pine studies stash their obfuscated source in inputs().text — multi-KB
+          // per study, and it says nothing about how the study is configured. Drop
+          // it and the internal flags, and unwrap the {v,f,t} envelope so the
+          // inputs stay readable while still distinguishing instances (#143).
           var inputs = null;
-          try { var ip = s.inputs ? s.inputs() : null; if (ip && Object.keys(ip).length) inputs = ip; } catch(e) {}
+          try {
+            var ip = s.inputs ? s.inputs() : null;
+            if (ip) {
+              var lean = {};
+              for (var k in ip) {
+                if (k === 'text' || k === 'pineFeatures' || k === '__fast_calc' || k === '__profile') continue;
+                var iv = ip[k];
+                lean[k] = (iv && typeof iv === 'object' && 'v' in iv) ? iv.v : iv;
+              }
+              if (Object.keys(lean).length) inputs = lean;
+            }
+          } catch(e) {}
           if (Object.keys(values).length > 0) results.push({ id: id, name: name, inputs: inputs, values: values });
         } catch(e) {}
       }


### PR DESCRIPTION
## Problem

`data_get_study_values` returns each study's full `inputs()` object. For Pine studies that carries the script's **identity** alongside its configuration: the obfuscated source (`text`, multi-KB), `pineId`, `pineVersion`, `pineFeatures`, and the internal `__fast_calc` / `__profile` flags. None of it describes how the study is configured.

This matters because the tool's output goes straight into an LLM context window. On a chart carrying several Pine toolkits, the blob crowds out the values the call was made for.

## What this does

Drops the six identity/metadata keys, unwraps the `{v, f, t}` envelope so the remaining inputs stay readable, and caps string values at 500 chars as a safety net for unknown blobs.

`pineId` deserves a note, because it is the one that looks useful and isn't: it is **identical across every instance of the same script**, so it cannot help tell instances apart. What does that — and what #143 asked for — is `in_0..in_N`, which stay.

The 500-char cap is the same threshold `getIndicator()` uses in this file (`src/core/data.js:203`). The name list alone would let a Pine script with a long text input slip through; the cap alone would keep the small boolean flags. Both are needed, which is why this doesn't simply reuse `getIndicator()`'s filter — that one operates on the array from `getInputValues()`, an API the data-source objects reached here don't expose.

## Verification

Live against TradingView Desktop 3.3.0 (Electron 38.2.2, CDP 9222), macOS.

`JSON.stringify` length of the `inputs` payload for the same chart state:

| | chars |
|---|---|
| raw | 1373 |
| name filter only | 143 |
| **this PR** | **74** |

The Pine study itself went 1352 → 53. A non-Pine data source on the same chart is untouched at 21 chars, confirming the filter doesn't reach past Pine metadata.

Values themselves are unchanged. Verified across a custom Pine study (4 configured inputs, all preserved: `{in_0: true, in_1: 163.988, in_2: true, in_3: 162.2}`), built-in RSI and built-in MACD — all returned complete and identical before and after.

`npm run lint` clean and `npm run test:unit` 152/152 on the branch.

## Note on tests

No unit test added: the changed code is page-context JS inside the `evaluate()` template string, so it is only reachable through a live CDP session, and extracting it into a Node-testable function would mean restructuring well beyond this fix. Happy to add one if you would like it covered a particular way.
