### PR TITLE
chore: add project-scoped .mcp.json for tradingview server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "node",
+      "args": ["src/server.js"]
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a project-scoped `.mcp.json` that registers the local stdio MCP server (`node src/server.js`) under the name `tradingview`.

```json
{
  "mcpServers": {
    "tradingview": {
      "command": "node",
      "args": ["src/server.js"]
    }
  }
}
```

## Why

Without this, Claude Code (and other MCP clients that read project-scoped `.mcp.json`) don't auto-discover the server — `tv_*` tools never load, and the user has to register the server manually (`claude mcp add`) before `tv_health_check` and the other 78 tools become available. With the file present, the client offers to trust and load `tradingview` on launch.

## Reviewer notes

- Uses a relative `args` path (`src/server.js`), so it resolves against the project root regardless of machine — no absolute/user-specific paths committed.
- Client-agnostic: `.mcp.json` is the standard project-scoped MCP manifest; the trust prompt is client-side, so nothing runs automatically without user approval.
- No code changes; config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)