### PR TITLE
fix(launch): detect MSIX TradingView by wildcard, not exact package name

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -317,8 +317,11 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (!tvPath && platform === 'win32') {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
+    // The package Name is publisher-prefixed (e.g. `31178TradingViewInc.TradingView`),
+    // not the bare `TradingView.Desktop`, so match on a `*TradingView*` wildcard and pick
+    // the first install whose folder actually contains TradingView.exe.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const ps = 'powershell -NoProfile -Command "Get-AppxPackage *TradingView* | ForEach-Object { $_.InstallLocation } | Where-Object { $_ -and (Test-Path (Join-Path $_ \'TradingView.exe\')) } | Select-Object -First 1"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;


### PR DESCRIPTION
## Problem

On Windows, `tv launch` (and the `tv_launch` MCP tool) fail with **"TradingView not found on win32"** even when TradingView Desktop is installed as an MSIX/Store package.

The MSIX detection in `src/core/health.js` queries:

```powershell
(Get-AppxPackage -Name 'TradingView.Desktop').InstallLocation
```

But the installed package name is **publisher-prefixed** — e.g. `31178TradingViewInc.TradingView` — so the exact `-Name 'TradingView.Desktop'` match returns nothing. Detection then falls through to the legacy install paths (`%LOCALAPPDATA%\TradingView`, `%PROGRAMFILES%\TradingView`, …), none of which exist for a Store install, and throws.

Real install observed:
```
C:\Program Files\WindowsApps\31178TradingViewInc.TradingView_3.3.0.0_x64__q4jpyh43s5mv6
```

## Fix

Match on a `*TradingView*` wildcard and select the first install whose folder actually contains `TradingView.exe`:

```powershell
Get-AppxPackage *TradingView* | ForEach-Object { $_.InstallLocation } |
  Where-Object { $_ -and (Test-Path (Join-Path $_ 'TradingView.exe')) } |
  Select-Object -First 1
```

The `Test-Path` guard avoids picking up an unrelated `*TradingView*` package that has no launcher. The existing WindowsApps → `%LOCALAPPDATA%` local-copy fallback (for the "Access is denied" case) is unchanged.

## Verification

- Resolves the real MSIX install via the exact `execSync` code path (v3.3.0.0).
- `tests/launch.test.js` → **7/7 pass** (the mock keys on the `Get-AppxPackage` substring, so it stays compatible).
- ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)