### PR TITLE
Honor explicitly owned TradingView CDP targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/connection.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/connection.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/connection.js
+++ b/src/connection.js
@@ -6,7 +6,11 @@ let targetInfo = null;
 // Default is 127.0.0.1, not localhost: on some Windows machines localhost
 // resolves to ::1 first, and Electron's --remote-debugging-port only listens on IPv4.
 export const CDP_HOST = process.env.TV_CDP_HOST || process.env.CDP_HOST || '127.0.0.1';
-export const CDP_PORT = Number(process.env.TV_CDP_PORT || process.env.CDP_PORT) || 9222;
+export function resolveCdpPort(env = process.env) {
+  const value = Number(env.TV_CDP_PORT || env.CDP_PORT || env.TRADINGVIEW_CDP_PORT);
+  return Number.isInteger(value) && value > 0 && value <= 65_535 ? value : 9222;
+}
+export const CDP_PORT = resolveCdpPort();
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 
@@ -64,14 +68,19 @@ export async function getClient() {
   return connect();
 }
 
+export function resolveConnectionTargetId(targetId = null, env = process.env) {
+  return targetId?.trim() || env.TRADINGVIEW_MCP_TARGET_ID?.trim() || null;
+}
+
 export async function connect(targetId = null) {
+  const resolvedTargetId = resolveConnectionTargetId(targetId);
   let lastError;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const target = targetId ? await findTargetById(targetId) : await findChartTarget();
+      const target = await findChartTarget(resolvedTargetId);
       if (!target) {
-        throw new Error(targetId
-          ? `CDP target ${targetId} not found — is the tab still open?`
+        throw new Error(resolvedTargetId
+          ? `CDP target ${resolvedTargetId} not found — is the tab still open?`
           : 'No TradingView chart target found. Is TradingView open with a chart?');
       }
       targetInfo = target;
@@ -107,19 +116,18 @@ export async function reconnectTo(targetId) {
   return connect(targetId);
 }
 
-async function findChartTarget() {
+async function findChartTarget(targetId = null) {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
+  return selectChartTarget(targets, targetId);
+}
+
+export function selectChartTarget(targets, targetId = null) {
+  if (targetId) return targets.find(t => t.id === targetId) || null;
   // Prefer targets with tradingview.com/chart in the URL
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
     || null;
-}
-
-async function findTargetById(id) {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
-  return targets.find(t => t.id === id) || null;
 }
 
 export async function getTargetInfo() {

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveCdpPort, resolveConnectionTargetId, selectChartTarget } from '../src/connection.js';
+
+describe('selectChartTarget', () => {
+  it('selects the explicitly owned CDP target instead of the first TradingView tab', () => {
+    const targets = [
+      { id: 'existing-iren', type: 'page', url: 'https://www.tradingview.com/chart/?symbol=IREN' },
+      { id: 'owned-abbv', type: 'page', url: 'https://www.tradingview.com/chart/?symbol=ABBV' },
+    ];
+
+    assert.equal(selectChartTarget(targets, 'owned-abbv')?.id, 'owned-abbv');
+  });
+});
+
+describe('resolveConnectionTargetId', () => {
+  it('uses the Ticker Alpha owned-target environment binding by default', () => {
+    assert.equal(
+      resolveConnectionTargetId(null, { TRADINGVIEW_MCP_TARGET_ID: 'owned-abbv' }),
+      'owned-abbv',
+    );
+  });
+});
+
+describe('resolveCdpPort', () => {
+  it('accepts the Ticker Alpha TradingView CDP port variable', () => {
+    assert.equal(resolveCdpPort({ TRADINGVIEW_CDP_PORT: '9224' }), 9224);
+  });
+});


### PR DESCRIPTION
## Summary

- honor `TRADINGVIEW_MCP_TARGET_ID` when a CLI process opens its CDP connection
- select the explicitly owned chart tab instead of the first TradingView tab returned by Chrome
- accept Ticker Alpha's `TRADINGVIEW_CDP_PORT` compatibility variable and cover both behaviors with unit tests

## Root cause

Ticker Alpha opens a dedicated CDP chart target and passes its ID to every TradingView MCP CLI command. The MCP connection layer ignored that environment binding and selected the first TradingView chart target. With an existing chart tab ahead of the newly opened target, Ticker Alpha's owned-target attestation failed closed.

## Validation

- `npm run test:unit` — 155 passed, 0 failed
- `npm run lint` — 0 errors; 4 pre-existing warnings
- production canary reproduced the failure before this fix: the owned ABBV target differed from the first existing IREN target
- full live E2E remains pending because this workstation has no TradingView CDP session on port 9222; the PR is intentionally draft until it is installed and canaried on the Mac Mini
