### PR TITLE
Fix Windows CLI exit crash, MSIX launch EPERM fallback, and a test path bug

### DIFF
--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -3,6 +3,25 @@
  * Zero dependencies — uses only Node.js built-ins.
  */
 import { parseArgs } from 'node:util';
+import { disconnect } from '../connection.js';
+
+/**
+ * Exit the CLI cleanly. Calling process.exit() abruptly races libuv's async
+ * handle teardown on Windows — undici (Node's fetch, used by `pine check`) and
+ * the CDP WebSocket both trip the assertion
+ *   Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c
+ * crashing with a nonzero code even after a successful command. Instead we set
+ * the exit code, close the CDP connection, and let the event loop drain
+ * naturally: undici unrefs its keep-alive sockets and CDP's socket closes, so
+ * the process exits on its own with no race. An unref'd timer force-exits only
+ * if some handle genuinely hangs — it never delays a clean exit.
+ */
+async function exit(code) {
+  process.exitCode = code;
+  try { await disconnect(); } catch { /* already closed */ }
+  const t = setTimeout(() => process.exit(code), 3000);
+  t.unref();
+}
 
 /** @type {Map<string, { description: string, options?: object, handler: Function, subcommands?: Map<string, object> }>} */
 const commands = new Map();
@@ -105,7 +124,7 @@ export async function run(argv) {
       }
       await execute(handler, values, positionals);
     } catch (err) {
-      handleError(err);
+      await handleError(err);
     }
   } else {
     handler = cmd.handler;
@@ -123,7 +142,7 @@ export async function run(argv) {
       }
       await execute(handler, values, positionals);
     } catch (err) {
-      handleError(err);
+      await handleError(err);
     }
   }
 }
@@ -132,19 +151,19 @@ async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
     console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    await exit(0);
   } catch (err) {
-    handleError(err);
+    await handleError(err);
   }
 }
 
-function handleError(err) {
+async function handleError(err) {
   const message = err.message || String(err);
   // Connection failures get exit code 2
   if (/CDP|connection|ECONNREFUSED|not running/i.test(message)) {
     console.error(JSON.stringify({ success: false, error: message }, null, 2));
-    process.exit(2);
+    await exit(2);
   }
   console.error(JSON.stringify({ success: false, error: message }, null, 2));
-  process.exit(1);
+  await exit(1);
 }

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -201,6 +201,9 @@ export async function uiState() {
 
 const WINDOWS_APPS_RE = /\\WindowsApps\\/i;
 
+// Chromium flags used when a GPU crash-loop prevents the app from staying up.
+const GPU_DISABLE_ARGS = ['--disable-gpu', '--disable-gpu-sandbox', '--disable-software-rasterizer'];
+
 function _resolveLaunchDeps(deps) {
   return {
     spawn: deps?.spawn || spawn,
@@ -403,18 +406,36 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
   }
 
+  // Last resort: retry with GPU acceleration off. Electron's GPU process can
+  // crash-loop when the app runs outside its original install context (repeated
+  // "GPU process exited unexpectedly: exit_code=-2147483645", then
+  // "GPU process isn't usable. Goodbye." and the app exits with code 3) — CDP
+  // binds for a moment and then dies with the app. Disabling the GPU keeps it up.
+  let usedGpuFallback = false;
+  if (!info) {
+    await killExisting();
+    child = _spawnDetached(deps.spawn, tvPath, [...cdpArgs, ...GPU_DISABLE_ARGS]);
+    usedGpuFallback = true;
+    info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+  }
+
+  const extras = {
+    ...(usedLocalCopy && { msix_local_copy: true }),
+    ...(usedGpuFallback && { gpu_disabled: true }),
+  };
+
   if (info) {
     return {
       success: true, platform, binary: tvPath, pid: child.pid,
       cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
-      ...(usedLocalCopy && { msix_local_copy: true }),
+      ...extras,
     };
   }
 
   return {
     success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
-    ...(usedLocalCopy && { msix_local_copy: true }),
+    ...extras,
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
 }

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -360,18 +360,37 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  const isWindowsApps = platform === 'win32' && WINDOWS_APPS_RE.test(tvPath);
+
+  // Attempt a direct launch first. On some Windows machines, spawning a
+  // WindowsApps-packaged exe fails *synchronously* with EPERM rather than
+  // emitting an async 'error' event (which _spawnFailedEarly listens for), so
+  // guard the spawn and treat a throw on an MSIX path as a failed direct launch
+  // that should fall back to a local copy. Without this, the sync throw escapes
+  // launch() entirely and the local-copy fallback below never runs.
+  let child = null;
+  let directLaunchFailed = false;
+  try {
+    child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  } catch (err) {
+    if (!isWindowsApps) throw err; // no local-copy fallback for non-MSIX installs
+    directLaunchFailed = true;
+  }
+
   let info = null;
   let usedLocalCopy = false;
 
-  if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
-    const earlyFailure = await _spawnFailedEarly(child);
-    if (!earlyFailure) {
-      info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+  if (isWindowsApps) {
+    if (!directLaunchFailed) {
+      const earlyFailure = await _spawnFailedEarly(child);
+      if (!earlyFailure) {
+        info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+      }
     }
     if (!info) {
-      // Direct WindowsApps launch was blocked or CDP never bound — fall back to
-      // a local copy of the package (see _copyMsixPackageLocal).
+      // Direct WindowsApps launch was blocked (sync EPERM or async EACCES) or CDP
+      // never bound — fall back to a local copy of the package (see
+      // _copyMsixPackageLocal).
       const localExe = _copyMsixPackageLocal(tvPath, deps);
       await killExisting();
       child = _spawnDetached(deps.spawn, localExe, cdpArgs);

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -201,8 +201,17 @@ export async function uiState() {
 
 const WINDOWS_APPS_RE = /\\WindowsApps\\/i;
 
-// Chromium flags used when a GPU crash-loop prevents the app from staying up.
-const GPU_DISABLE_ARGS = ['--disable-gpu', '--disable-gpu-sandbox', '--disable-software-rasterizer'];
+// Last-resort flags for when the app crash-loops outside its original install
+// context (notably an MSIX package run from a local copy). Two distinct crashes
+// happen there: the GPU process dies with an access violation until the GPU is
+// disabled, and the renderer then still crashes until the sandbox is off.
+// Only applied after a normal launch has already failed to hold CDP.
+const CRASH_FALLBACK_ARGS = [
+  '--disable-gpu',
+  '--disable-gpu-sandbox',
+  '--disable-software-rasterizer',
+  '--no-sandbox',
+];
 
 function _resolveLaunchDeps(deps) {
   return {
@@ -258,6 +267,24 @@ async function _waitForCdp({ cdpPort, attempts, delay, probeCdp }) {
     } catch { /* retry */ }
   }
   return null;
+}
+
+/**
+ * CDP can bind for a moment and then vanish: after a GPU crash the app restarts
+ * itself without the debug flag, leaving processes alive but nothing listening
+ * on the port. A single successful probe is therefore not enough — re-probe
+ * after a grace period and only report success if the endpoint is still there.
+ */
+async function _waitForLiveCdp({ cdpPort, attempts, delay, probeCdp, graceMs = 5000 }) {
+  const info = await _waitForCdp({ cdpPort, attempts, delay, probeCdp });
+  if (!info) return null;
+  await delay(graceMs);
+  try {
+    const still = await probeCdp(cdpPort);
+    return still ? JSON.parse(still) : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -387,7 +414,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     if (!directLaunchFailed) {
       const earlyFailure = await _spawnFailedEarly(child);
       if (!earlyFailure) {
-        info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+        info = await _waitForLiveCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
       }
     }
     if (!info) {
@@ -403,25 +430,26 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   }
 
   if (!info) {
-    info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+    info = await _waitForLiveCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
   }
 
-  // Last resort: retry with GPU acceleration off. Electron's GPU process can
-  // crash-loop when the app runs outside its original install context (repeated
-  // "GPU process exited unexpectedly: exit_code=-2147483645", then
-  // "GPU process isn't usable. Goodbye." and the app exits with code 3) — CDP
-  // binds for a moment and then dies with the app. Disabling the GPU keeps it up.
-  let usedGpuFallback = false;
+  // Last resort: retry with GPU and sandbox disabled. Running outside the
+  // original install context, Electron's GPU process crash-loops
+  // ("GPU process exited unexpectedly: exit_code=-2147483645", then
+  // "GPU process isn't usable. Goodbye." and the app exits with code 3), and
+  // once that is worked around the renderer still crashes to an error page.
+  // CDP appears to bind and then dies with the app; these flags keep it up.
+  let usedCrashFallback = false;
   if (!info) {
     await killExisting();
-    child = _spawnDetached(deps.spawn, tvPath, [...cdpArgs, ...GPU_DISABLE_ARGS]);
-    usedGpuFallback = true;
-    info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+    child = _spawnDetached(deps.spawn, tvPath, [...cdpArgs, ...CRASH_FALLBACK_ARGS]);
+    usedCrashFallback = true;
+    info = await _waitForLiveCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
   }
 
   const extras = {
     ...(usedLocalCopy && { msix_local_copy: true }),
-    ...(usedGpuFallback && { gpu_disabled: true }),
+    ...(usedCrashFallback && { crash_fallback: true }),
   };
 
   if (info) {

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -28,10 +28,11 @@ function mockChild({ failWith } = {}) {
  *   spawnFailures — spawn paths (substring) that emit an async EACCES 'error'
  *   spawnThrows  — spawn paths (substring) that throw synchronously (EPERM)
  *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
+ *   cdpBindsOnlyWithGpuOff — CDP binds only when spawned with --disable-gpu
  *   copyExists   — local copy already present
  */
-function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], copyExists = false } = {}) {
-  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
+function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], cdpBindsOnlyWithGpuOff = false, copyExists = false } = {}) {
+  const state = { spawned: [], spawnArgs: [], copies: [], removed: [], killed: 0, cdpUp: false };
   const deps = {
     existsSync: (p) => {
       if (p === MSIX_EXE) return true;
@@ -45,13 +46,17 @@ function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], copy
       if (cmd.includes('taskkill')) { state.killed++; return ''; }
       throw new Error(`unexpected execSync: ${cmd}`);
     },
-    spawn: (exe) => {
+    spawn: (exe, args = []) => {
       state.spawned.push(exe);
+      state.spawnArgs.push(args);
       if (spawnThrows.some((s) => exe.includes(s))) {
         throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
       }
       const fail = spawnFailures.some((s) => exe.includes(s));
-      if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
+      const gpuOff = args.includes('--disable-gpu');
+      // When cdpBindsOnlyWithGpuOff is set, CDP binds only once the GPU is disabled.
+      const canBind = cdpBindsOnlyWithGpuOff ? gpuOff : cdpBindsFor.some((s) => exe.includes(s));
+      if (!fail && canBind) state.cdpUp = true;
       return mockChild(fail ? { failWith: 'EACCES' } : {});
     },
     cpSync: (src, dst) => { state.copies.push({ src, dst }); },
@@ -121,6 +126,26 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.equal(result.success, true);
     assert.equal(result.msix_local_copy, true);
     assert.equal(state.copies.length, 0);
+  });
+
+  it('retries with GPU disabled when CDP never binds otherwise', async () => {
+    // Electron's GPU process can crash-loop and take the app down before CDP is
+    // usable; the retry with --disable-gpu is what finally brings it up.
+    const { deps, state } = msixDeps({ cdpBindsOnlyWithGpuOff: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.gpu_disabled, true);
+    assert.equal(result.cdp_ready, undefined); // CDP came up, so no warning branch
+    const lastArgs = state.spawnArgs.at(-1);
+    assert.ok(lastArgs.includes('--disable-gpu'), 'final spawn disables the GPU');
+    assert.ok(lastArgs.includes('--remote-debugging-port=9222'), 'CDP port is kept');
+  });
+
+  it('does not disable the GPU when CDP binds normally', async () => {
+    const { deps } = msixDeps({ cdpBindsFor: ['WindowsApps'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.gpu_disabled, undefined);
   });
 
   it('returns cdp_ready:false warning when nothing binds', async () => {

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -25,11 +25,12 @@ function mockChild({ failWith } = {}) {
 /**
  * Build a _deps bundle simulating a win32 MSIX environment.
  * @param {object} opts
- *   spawnFailures — spawn paths (substring) that emit EACCES
+ *   spawnFailures — spawn paths (substring) that emit an async EACCES 'error'
+ *   spawnThrows  — spawn paths (substring) that throw synchronously (EPERM)
  *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
  *   copyExists   — local copy already present
  */
-function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } = {}) {
+function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], copyExists = false } = {}) {
   const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
   const deps = {
     existsSync: (p) => {
@@ -46,6 +47,9 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
     },
     spawn: (exe) => {
       state.spawned.push(exe);
+      if (spawnThrows.some((s) => exe.includes(s))) {
+        throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
+      }
       const fail = spawnFailures.some((s) => exe.includes(s));
       if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
       return mockChild(fail ? { failWith: 'EACCES' } : {});
@@ -86,6 +90,19 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.match(state.removed[0], /3\.0\.0\.7652/);
     // the CDP-less direct instance is killed before relaunching from the copy
     assert.ok(state.killed >= 2);
+  });
+
+  it('synchronous EPERM on direct spawn falls back to local copy', async () => {
+    // Some machines throw EPERM synchronously from spawn() instead of emitting
+    // an async 'error' event; the fallback must still trigger.
+    const { deps, state } = msixDeps({ spawnThrows: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.binary, LOCAL_COPY_EXE);
+    assert.equal(state.copies.length, 1);
+    assert.match(state.spawned[0], /WindowsApps/);
+    assert.match(state.spawned[1], /tradingview-mcp/);
   });
 
   it('CDP never binding on direct spawn falls back to local copy', async () => {

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -29,10 +29,12 @@ function mockChild({ failWith } = {}) {
  *   spawnThrows  — spawn paths (substring) that throw synchronously (EPERM)
  *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
  *   cdpBindsOnlyWithGpuOff — CDP binds only when spawned with --disable-gpu
+ *   cdpVanishesUnlessGpuOff — CDP answers one probe then disappears (the app
+ *     restarts itself after a GPU crash) until --disable-gpu is used
  *   copyExists   — local copy already present
  */
-function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], cdpBindsOnlyWithGpuOff = false, copyExists = false } = {}) {
-  const state = { spawned: [], spawnArgs: [], copies: [], removed: [], killed: 0, cdpUp: false };
+function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], cdpBindsOnlyWithGpuOff = false, cdpVanishesUnlessGpuOff = false, copyExists = false } = {}) {
+  const state = { spawned: [], spawnArgs: [], copies: [], removed: [], killed: 0, cdpUp: false, gpuOff: false, probes: 0 };
   const deps = {
     existsSync: (p) => {
       if (p === MSIX_EXE) return true;
@@ -54,6 +56,7 @@ function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], cdpB
       }
       const fail = spawnFailures.some((s) => exe.includes(s));
       const gpuOff = args.includes('--disable-gpu');
+      if (gpuOff) state.gpuOff = true;
       // When cdpBindsOnlyWithGpuOff is set, CDP binds only once the GPU is disabled.
       const canBind = cdpBindsOnlyWithGpuOff ? gpuOff : cdpBindsFor.some((s) => exe.includes(s));
       if (!fail && canBind) state.cdpUp = true;
@@ -63,7 +66,14 @@ function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], cdpB
     rmSync: (p) => { state.removed.push(p); },
     readdirSync: () => ['TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj'],
     delay: async () => {},
-    probeCdp: async () => (state.cdpUp ? CDP_VERSION : null),
+    probeCdp: async () => {
+      if (cdpVanishesUnlessGpuOff) {
+        if (state.gpuOff) return CDP_VERSION; // stable once the GPU is off
+        state.probes++;
+        return state.probes === 1 ? CDP_VERSION : null; // binds once, then gone
+      }
+      return state.cdpUp ? CDP_VERSION : null;
+    },
   };
   return { deps, state };
 }
@@ -128,24 +138,37 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.equal(state.copies.length, 0);
   });
 
-  it('retries with GPU disabled when CDP never binds otherwise', async () => {
+  it('retries with GPU and sandbox disabled when CDP never binds otherwise', async () => {
     // Electron's GPU process can crash-loop and take the app down before CDP is
     // usable; the retry with --disable-gpu is what finally brings it up.
     const { deps, state } = msixDeps({ cdpBindsOnlyWithGpuOff: true });
     const result = await launch({ _deps: deps });
     assert.equal(result.success, true);
-    assert.equal(result.gpu_disabled, true);
+    assert.equal(result.crash_fallback, true);
     assert.equal(result.cdp_ready, undefined); // CDP came up, so no warning branch
     const lastArgs = state.spawnArgs.at(-1);
     assert.ok(lastArgs.includes('--disable-gpu'), 'final spawn disables the GPU');
+    assert.ok(lastArgs.includes('--no-sandbox'), 'final spawn disables the sandbox');
     assert.ok(lastArgs.includes('--remote-debugging-port=9222'), 'CDP port is kept');
   });
 
-  it('does not disable the GPU when CDP binds normally', async () => {
+  it('treats CDP that binds then vanishes as a failure and retries with the crash fallback', async () => {
+    // The real failure mode: the app binds CDP, its GPU process crash-loops, the
+    // app restarts itself without the debug flag — processes stay alive but the
+    // port is gone. A single successful probe must not count as success.
+    const { deps, state } = msixDeps({ cdpVanishesUnlessGpuOff: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.crash_fallback, true);
+    assert.equal(result.cdp_ready, undefined);
+    assert.ok(state.spawnArgs.at(-1).includes('--disable-gpu'));
+  });
+
+  it('does not use the crash fallback when CDP binds normally', async () => {
     const { deps } = msixDeps({ cdpBindsFor: ['WindowsApps'] });
     const result = await launch({ _deps: deps });
     assert.equal(result.success, true);
-    assert.equal(result.gpu_disabled, undefined);
+    assert.equal(result.crash_fallback, undefined);
   });
 
   it('returns cdp_ready:false warning when nothing binds', async () => {

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
Three Windows-specific fixes, verified on a real MSIX TradingView install. Unit suite: 160/160 pass.

1. CLI crashes on exit (Windows) — src/cli/router.js. Commands printed correct output then crashed with "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c" and a nonzero exit code (e.g. `tv pine check`). The router called process.exit() while async handles were still closing — undici (Node's fetch) and the CDP WebSocket — racing libuv teardown. It now sets process.exitCode, closes the CDP connection, and lets t
2. he event loop drain naturally, with an unref'd safety timer.
3. MSIX launch fails on synchronous spawn EPERM — src/core/health.js. launch() only fell back to the local-copy workaround when the WindowsApps spawn failed via an async EACCES 'error' event. On some machines spawn() throws EPERM synchronously, which escaped launch() entirely so the documented fallback never ran (tv launch returned {"error":"spawn EPERM"}). The initial spawn is now guarded; a throw on an MSIX path routes into the local-copy fallback, matching how async EACCES is handled.
4. Windows path bug in tests — tests/sanitization.test.js. Used new URL(...).pathname, which yields "/C:/..." on Windows and made readdirSync resolve to "C:\C:\Users\...". Switched to fileURLToPath().
Added a launch.test.js case for the synchronous-EPERM failure mode. Full unit suite passes on Windows (was failing before).