### PR TITLE
Fix source-audit test crash on Windows

### DIFF
--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Summary

`tests/sanitization.test.js` crashes on Windows before running any of its source-audit assertions.

The `source audit` suite builds a directory path with `new URL('../src/core/', import.meta.url).pathname`. On Windows, `.pathname` keeps the leading slash from the `file://` URL (e.g. `/C:/Users/.../src/core/`). Passing that straight to `fs.readdirSync` resolves against the current drive first, producing a doubled drive prefix (`C:\C:\Users\...`) and throwing `ENOENT`.

Fix: use `fileURLToPath()` instead of `.pathname`, which is the standard cross-platform way to turn a `file://` URL into a filesystem path.

## Test plan

- [x] `node --test tests/sanitization.test.js` — 68/68 passing (was crashing before this fix)
- [x] `npm run lint` — no new warnings/errors introduced