### PR TITLE
fix(drawing): resolve evaluate/getChartApi in listDrawings, getProperties, removeOne, clearAll

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };


### PR DESCRIPTION
## Problem

Four of the five exported functions in `src/core/drawing.js` throw at runtime:

```
ReferenceError: getChartApi is not defined
```

Affected tools: `draw_list`, `draw_get_properties`, `draw_remove_one`, `draw_clear`.

## Root cause

The module imports its dependencies under underscore-prefixed aliases so they can be overridden for testing:

```js
import { evaluate as _evaluate, getChartApi as _getChartApi, ... } from '../connection.js';

function _resolve(deps) {
  return { evaluate: deps?.evaluate || _evaluate, getChartApi: deps?.getChartApi || _getChartApi };
}
```

`drawShape` resolves them correctly:

```js
const { evaluate, getChartApi } = _resolve(_deps);   // ✅
```

But `listDrawings`, `getProperties`, `removeOne` and `clearAll` reference the bare names directly:

```js
const apiPath = await getChartApi();                  // ❌ not in module scope
```

Since only `_evaluate` and `_getChartApi` exist in module scope, every call throws before reaching the CDP layer.

This appears to have been introduced in f23eb1b ("Add DI and full test coverage for chart.js and drawing.js"), where the dependency-injection pattern was added to `drawShape` and the imports were renamed, but the four other functions were not updated.

## Fix

Each affected function now calls `_resolve(_deps)` first and accepts an optional `_deps` parameter, mirroring `drawShape`.

Call signatures are preserved — `listDrawings()` and `clearAll()` remain callable with no argument, which is how both `src/tools/drawing.js` and `src/cli/commands/drawing.js` invoke them:

```js
export async function listDrawings({ _deps } = {}) {
  const { evaluate, getChartApi } = _resolve(_deps);
  ...
}
```

8 insertions, 4 deletions, single file.

## Verification

- `node --check src/core/drawing.js` passes
- `npm run test:unit` — 29 passed, 0 failed
- `draw_list` verified against a live TradingView Desktop session: returned `getChartApi is not defined` before the change, returns the shape list after

## Note

The existing test coverage added alongside the DI refactor exercises `drawShape` but not the four other exported functions, which is why this went unnoticed. Adding coverage for them would prevent a recurrence, but I kept this PR limited to the fix itself.
