### PR TITLE
Fix three CLI bugs: tab new false success, scroll ReferenceError, ui eval promise handling

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,7 +115,8 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
-export async function getVisibleRange() {
+export async function getVisibleRange({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -157,7 +158,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
@@ -196,7 +198,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,17 +2,23 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
+import CDP from 'chrome-remote-interface';
 import { getClient, evaluate } from '../connection.js';
 
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
 
+async function listPageTargets() {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  return targets.filter(t => t.type === 'page');
+}
+
 /**
  * List all open chart tabs (CDP page targets).
  */
 export async function list() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
+  const targets = await listPageTargets();
 
   const tabs = targets
     .filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
@@ -28,30 +34,49 @@ export async function list() {
 }
 
 /**
- * Open a new chart tab via keyboard shortcut (Ctrl+T / Cmd+T).
+ * Open a new tab by clicking the tab bar's "+" button in the window host page.
+ * Synthetic Cmd+T via CDP does NOT work — Electron menu accelerators live in the
+ * main process and never see renderer-level Input.dispatchKeyEvent.
  */
 export async function newTab() {
-  const c = await getClient();
+  const before = await listPageTargets();
+  const host = before.find(t => /app\/window\/index\.html/.test(t.url));
+  if (!host) throw new Error('TradingView window host target not found. Is TradingView Desktop running with --remote-debugging-port?');
 
-  // Electron/TradingView Desktop uses Ctrl+T for new tab on macOS too
-  // But some versions use Cmd+T
-  const isMac = process.platform === 'darwin';
-  const mod = isMac ? 4 : 2; // 4 = meta (Cmd), 2 = ctrl
+  const c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: host.id });
+  try {
+    await c.Runtime.enable();
+    const r = await c.Runtime.evaluate({
+      expression: `(function(){var b=document.querySelector('.create-new-tab-button');if(!b)return false;b.click();return true;})()`,
+      returnByValue: true,
+    });
+    if (r.exceptionDetails || !r.result?.value) {
+      throw new Error('create-new-tab-button not found in TradingView window host');
+    }
+  } finally {
+    await c.close().catch(() => {});
+  }
 
-  await c.Input.dispatchKeyEvent({
-    type: 'keyDown',
-    modifiers: mod,
-    key: 't',
-    code: 'KeyT',
-    windowsVirtualKeyCode: 84,
-  });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 't', code: 'KeyT' });
-
-  await new Promise(r => setTimeout(r, 2000));
-
-  // Verify a new tab appeared
-  const state = await list();
-  return { success: true, action: 'new_tab_opened', ...state };
+  // Only report success once the new target is verifiably present
+  const beforeIds = new Set(before.map(t => t.id));
+  for (let i = 0; i < 10; i++) {
+    await new Promise(r => setTimeout(r, 500));
+    const now = await listPageTargets();
+    const added = now.find(t => !beforeIds.has(t.id) && /app\/new-tab\/|tradingview\.com\/chart/i.test(t.url));
+    if (added) {
+      const state = await list();
+      return {
+        success: true,
+        action: 'new_tab_opened',
+        new_target: { id: added.id, url: added.url },
+        note: /app\/new-tab\//.test(added.url)
+          ? 'New tab opened on the start screen — it becomes a chart tab once a chart is selected.'
+          : undefined,
+        ...state,
+      };
+    }
+  }
+  throw new Error('New tab did not appear within 5s of clicking the tab bar "+" button');
 }
 
 /**

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -288,6 +288,7 @@ export async function findElement({ query, strategy }) {
 }
 
 export async function uiEvaluate({ expression }) {
-  const result = await evaluate(expression);
+  // awaitPromise so async expressions return their resolved value, not {}
+  const result = await evaluateAsync(expression);
   return { success: true, result };
 }

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -7,7 +7,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeString, requireFinite } from '../src/connection.js';
-import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
+import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange, scrollToDate, getVisibleRange, symbolInfo } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
@@ -285,6 +285,33 @@ describe('drawing.js — sanitized evaluate calls', () => {
 });
 
 // ── Source-level audit ───────────────────────────────────────────────────
+
+describe('chart.js — DI regression (all evaluate calls must resolve via _deps)', () => {
+  // Regression: the DI refactor renamed the module import to _evaluate, but
+  // scrollToDate/getVisibleRange/symbolInfo still referenced bare `evaluate`
+  // → ReferenceError "evaluate is not defined" at call time.
+  it('scrollToDate uses injected evaluate', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const r = await scrollToDate({ date: '2026-05-15', _deps });
+    assert.equal(r.success, true);
+    assert.ok(evaluate.calls.some(c => c.includes('zoomToBarsRange')), 'injected evaluate was called');
+  });
+
+  it('getVisibleRange uses injected evaluate', async () => {
+    const calls = [];
+    const evaluate = async (expr) => { calls.push(expr); return { visible_range: { from: 1, to: 2 }, bars_range: { from: 0, to: 10 } }; };
+    const r = await getVisibleRange({ _deps: { evaluate } });
+    assert.equal(r.success, true);
+    assert.equal(calls.length, 1, 'injected evaluate was called');
+  });
+
+  it('symbolInfo uses injected evaluate', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const r = await symbolInfo({ _deps });
+    assert.equal(r.success, true);
+    assert.ok(evaluate.calls.length > 0, 'injected evaluate was called');
+  });
+});
 
 describe('source audit — no unsafe interpolation patterns', () => {
   const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;


### PR DESCRIPTION
Fixes three CLI bugs, each reproduced against a live TradingView Desktop instance (macOS, CDP on 9222) before fixing, and re-verified live after — not just covered by the new unit tests.

## 1. `tv tab new` reports success without creating a tab

**Repro (before):** `tv tab new` → `{ "success": true, "action": "new_tab_opened", "tab_count": 2, ... }` with the tab count unchanged and no tab created.

Two root causes:
- It dispatched Cmd+T via `Input.dispatchKeyEvent`, but Electron menu accelerators live in the **main process** and never see renderer-level synthetic CDP input — so no tab was ever created.
- The "verify" step listed tabs but never compared counts before reporting success.

**Fix:** click the real `.create-new-tab-button` in the window-host page (`app/window/index.html`), then poll `/json/list` until the new target verifiably appears (5s timeout → error). The new tab lands on the desktop start screen (`app/new-tab/index.html`) — same as clicking the + button by hand — and the response notes it becomes a chart tab once a chart is selected.

## 2. `tv scroll` throws `evaluate is not defined`

**Repro (before):** `tv scroll 2026-05-15` → `{ "success": false, "error": "evaluate is not defined" }`

The DI refactor (f23eb1b) renamed the module-level import in `src/core/chart.js` to `_evaluate`, with each function resolving deps via `_resolve(_deps)` — but missed three call sites: `scrollToDate`, `getVisibleRange`, and `symbolInfo`. So `tv range` and `tv info` were silently broken too, not just `scroll`. All three now use the same `_resolve(_deps)` pattern as their siblings, and a DI regression test block is added so a missed function fails the unit suite.

## 3. `tv ui eval` doesn't await promises

**Repro (before):** `tv ui eval "Promise.resolve(42)"` → `{ "success": true, "result": {} }`

`Runtime.evaluate` defaults to `awaitPromise: false`, so async expressions serialized to a pending promise (`{}`) instead of their resolved value. Switched `uiEvaluate` to `evaluateAsync` (`awaitPromise: true`), which returns non-promise values unchanged — synchronous expressions are unaffected (`"1+1"` → `2`, verified).

---

**Verification:** all three original commands re-run live after the fixes (tab created and detected; scroll/range/info working; promise eval returns `42`). Unit suite: 98/98 passing including the new regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
