### PR TITLE
Ignore local .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.mcp.json
 screenshots/
 scripts/current.pine
 temp_*


### PR DESCRIPTION
Prevents accidentally committing machine-specific absolute paths from local project-level MCP server config.