### PR TITLE
Add Claude Code launch config for the MCP server

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,10 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+          {
+                  "name": "tradingview-mcp",
+                  "runtimeExecutable": "npm",
+                  "runtimeArgs": ["start"]
+          }
+    ]
+}


### PR DESCRIPTION
## What
Adds a `.claude/launch.json` so Claude Code's `preview_start` tool can launch the MCP server (`node src/server.js`) directly, without having to rediscover the entry point each session.

## Why
This project's server runs over stdio rather than HTTP, so there's no meaningful `port` to declare — the config only sets `runtimeExecutable`/`runtimeArgs`.

## Notes for reviewers
- No source changes, dev-tooling config only.
- - Not a browser-previewable server, so `preview_start` won't render a page for it, but it does start/stop the process and surface logs.