### PR TITLE
docs: reconcile tool count to 84 across all docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-81 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+84 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ npm test
 Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
 ```
 
-- **Transport**: MCP over stdio (78 tools) + CLI (`tv` command, 30 commands with 66 subcommands)
+- **Transport**: MCP over stdio (84 tools) + CLI (`tv` command, 30 commands with 66 subcommands)
 - **Connection**: Chrome DevTools Protocol on localhost:9222
 - **Streaming**: Poll-and-diff loop with deduplication, JSONL output to stdout
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -22,7 +22,7 @@ How does an agent reason about data that may be stale by the time it responds? W
 
 ### 3. Tool Granularity
 
-Should an agent have one `read_chart` tool or 78 granular tools? This project chose granularity — separate tools for quote, OHLCV, indicator values, pine lines, pine labels, pine tables, pine boxes, etc.
+Should an agent have one `read_chart` tool or 84 granular tools? This project chose granularity — separate tools for quote, OHLCV, indicator values, pine lines, pine labels, pine tables, pine boxes, etc.
 
 The tradeoff: granular tools give the agent precise control and small payloads, but require the agent to know which tool to call (solved via `CLAUDE.md` decision trees and MCP server instructions). A single coarse tool would be simpler but would waste context on unneeded data.
 
@@ -54,7 +54,7 @@ The most impactful design decision was making all tools return compact output by
 
 ### Tool Count Does Not Confuse the Agent
 
-78 tools seems excessive, but with clear MCP server instructions and a `CLAUDE.md` decision tree, Claude consistently selects the right tools. The key is descriptive tool names and the instruction block — not reducing tool count.
+84 tools seems excessive, but with clear MCP server instructions and a `CLAUDE.md` decision tree, Claude consistently selects the right tools. The key is descriptive tool names and the instruction block — not reducing tool count.
 
 ### Pine Script Development is the Strongest Use Case
 

--- a/src/server.js
+++ b/src/server.js
@@ -22,7 +22,7 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 78 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — 84 tools for reading and controlling a live TradingView Desktop chart.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 


### PR DESCRIPTION
## What

The registered MCP tool count had drifted across the docs and the server's own instructions header:

| Location | Said | Actual |
|----------|------|--------|
| `CLAUDE.md` | 81 | **84** |
| `README.md` | 78 | **84** |
| `RESEARCH.md` (×2) | 78 | **84** |
| `src/server.js` (MCP instructions header) | 78 | **84** |

## Verification

```
grep -c "server.tool(" src/tools/*.js   # sums to 84
```

Docs-only change — no code behavior affected. The `src/server.js` edit is inside the `instructions` string literal (agent-facing guidance), not logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)