### PR TITLE
feat: add symbol data tools (Forecast, Technicals, Financials, Key stats, Seasonals, News, Options)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-84 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+93 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 
@@ -32,6 +32,28 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 5. `data_get_pine_tables` → session stats, analytics tables
 6. `data_get_ohlcv` with `summary: true` → price action summary
 7. `capture_screenshot` → visual confirmation
+
+### "What do analysts / fundamentals / news say?" (symbol data panels)
+These read the sections of TradingView's symbol sidebar. They render to `<canvas>`, so they are
+read via TradingView's own data requests from page context — not DOM scraping. All default to the
+chart symbol; pass `symbol` (exchange-qualified, e.g. `"NASDAQ:AMZN"`) to read another instrument
+without touching the chart.
+
+- `data_get_key_stats` → market cap, next earnings date, volume, avg volume, dividend yield, P/E, EPS, beta
+- `data_get_technicals` → consensus gauges (Summary / Moving Averages / Oscillators) + raw indicator values; `timeframe` accepts 1, 5, 15, 30, 60, 120, 240, 1D, 1W, 1M
+- `data_get_forecast` → analyst price target low/average/high, upside %, consensus rating, buy/hold/sell counts
+- `data_get_financials` → revenue, net income, EPS, EBITDA, FCF, margins; `period: "annual"|"quarterly"`
+- `data_get_seasonals` → average return + win rate per calendar month (chart symbol only)
+- `data_get_news` → recent headlines with source, date, link
+- `data_get_options` → ATM implied-volatility term structure per expiry
+- `data_get_etf_profile` / `data_get_bond_info` → fund and bond specifics; error clearly on the wrong instrument type
+
+**Important:** the chart's display ticker is often the *feed* venue (`BATS:AMZN`), which the data
+service rejects. These tools resolve the listing venue (`NASDAQ:AMZN`) automatically — but if you
+pass `symbol` yourself, pass the listing venue.
+
+**Note:** `data_get_seasonals` briefly switches the chart to the 1M resolution and restores the
+original — it is the only symbol-data tool that touches chart state.
 
 ### "Change the chart"
 - `chart_set_symbol` → switch ticker (e.g., "AAPL", "ES1!", "NYMEX:CL1!")
@@ -109,6 +131,13 @@ These tools can return large payloads. Follow these rules to avoid context bloat
 | `data_get_ohlcv` (summary) | ~500 bytes |
 | `data_get_ohlcv` (100 bars) | ~8 KB |
 | `capture_screenshot` | ~300 bytes (returns file path, not image data) |
+| `data_get_key_stats` | ~600 bytes |
+| `data_get_technicals` | ~1 KB |
+| `data_get_forecast` | ~500 bytes |
+| `data_get_financials` | ~700 bytes per period (default 8) |
+| `data_get_seasonals` | ~2 KB |
+| `data_get_news` | ~300 bytes per headline (default 15) |
+| `data_get_options` | ~1 KB (default 10 expiries) |
 
 ## Tool Conventions
 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,12 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Set up a 4-chart grid" | `pane_set_layout` → `pane_set_symbol` for each pane |
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
+| "What do analysts think?" | `data_get_forecast` → `data_get_technicals` |
+| "Show me the fundamentals" | `data_get_key_stats` → `data_get_financials` |
+| "Any news on this?" | `data_get_news` |
+| "How does it trade in October?" | `data_get_seasonals` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (93 MCP tools)
 
 ### Chart Reading
 
@@ -238,6 +242,28 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `data_get_pine_boxes` | Read price zones / ranges as {high, low} pairs | ~1-2KB |
 
 **Always use `study_filter`** to target a specific indicator: `study_filter: "Profiler"`.
+
+### Symbol Data Panels
+
+The sections of TradingView's symbol sidebar — Forecast, Technicals, Financials, Key stats,
+Seasonals, News, Options. All default to the chart's current symbol; pass an exchange-qualified
+`symbol` (e.g. `"NASDAQ:AMZN"`) to read any other instrument without touching the chart.
+
+| Tool | When to use | Output size |
+|------|------------|-------------|
+| `data_get_key_stats` | Market cap, next earnings date, volume, dividend yield, P/E, beta | ~600B |
+| `data_get_technicals` | Consensus gauges (Summary / MAs / Oscillators) + raw indicator values, any timeframe | ~1KB |
+| `data_get_forecast` | Analyst price target low/avg/high, upside %, buy/hold/sell breakdown | ~500B |
+| `data_get_financials` | Revenue, net income, EPS, EBITDA, FCF and margins per period | ~700B per period |
+| `data_get_seasonals` | Average return and win rate per calendar month | ~2KB |
+| `data_get_news` | Recent headlines with source, date and link | ~300B per headline |
+| `data_get_options` | ATM implied-volatility term structure per expiry | ~1KB |
+| `data_get_etf_profile` | AUM, expense ratio, NAV (funds only) | ~300B |
+| `data_get_bond_info` | Yield, coupon, maturity (bonds only) | ~300B |
+
+> These sections render to `<canvas>` in TradingView's UI, so they are read by issuing
+> TradingView's own data requests from page context rather than by scraping the DOM.
+> `data_get_seasonals` briefly switches the chart to the 1M resolution and restores it.
 
 ### Chart Control
 
@@ -351,7 +377,7 @@ npm test
 Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
 ```
 
-- **Transport**: MCP over stdio (84 tools) + CLI (`tv` command, 30 commands with 66 subcommands)
+- **Transport**: MCP over stdio (93 tools) + CLI (`tv` command, 30 commands with 75 subcommands)
 - **Connection**: Chrome DevTools Protocol on localhost:9222
 - **Streaming**: Poll-and-diff loop with deduplication, JSONL output to stdout
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`

--- a/src/cli/commands/data.js
+++ b/src/cli/commands/data.js
@@ -23,8 +23,11 @@ register('values', {
   handler: () => core.getStudyValues(),
 });
 
+// Shared option for every symbol-data subcommand: omit to use the chart symbol.
+const SYMBOL_OPT = { type: 'string', short: 's', description: 'Exchange-qualified symbol (e.g. NASDAQ:AMZN); default = chart symbol' };
+
 register('data', {
-  description: 'Advanced data tools (lines, labels, tables, boxes, strategy, trades, equity, depth)',
+  description: 'Advanced data tools (lines, labels, tables, boxes, strategy, trades, equity, depth, symbol panels)',
   subcommands: new Map([
     ['lines', {
       description: 'Get Pine Script line.new() price levels',
@@ -83,6 +86,67 @@ register('data', {
         if (!positionals[0]) throw new Error('Entity ID required. Usage: tv data indicator eFu1Ot');
         return core.getIndicator({ entity_id: positionals[0] });
       },
+    }],
+    ['key-stats', {
+      description: 'Market cap, next earnings, volume, dividend yield, P/E',
+      options: { symbol: SYMBOL_OPT },
+      handler: (opts) => core.getKeyStats({ symbol: opts.symbol }),
+    }],
+    ['technicals', {
+      description: 'Technicals consensus gauges + indicator values',
+      options: {
+        symbol: SYMBOL_OPT,
+        timeframe: { type: 'string', short: 't', description: 'Timeframe: 1, 5, 15, 30, 60, 120, 240, 1D, 1W, 1M' },
+      },
+      handler: (opts) => core.getTechnicals({ symbol: opts.symbol, timeframe: opts.timeframe }),
+    }],
+    ['forecast', {
+      description: 'Analyst price targets, upside % and consensus rating',
+      options: { symbol: SYMBOL_OPT },
+      handler: (opts) => core.getForecast({ symbol: opts.symbol }),
+    }],
+    ['financials', {
+      description: 'Income statement history (revenue, net income, EPS, margins)',
+      options: {
+        symbol: SYMBOL_OPT,
+        period: { type: 'string', short: 'p', description: 'annual (default) or quarterly' },
+        limit: { type: 'string', short: 'n', description: 'Periods to return (default 8, max 32)' },
+      },
+      handler: (opts) => core.getFinancials({
+        symbol: opts.symbol, period: opts.period,
+        limit: opts.limit ? Number(opts.limit) : undefined,
+      }),
+    }],
+    ['seasonals', {
+      description: 'Average return and win rate per calendar month (chart symbol)',
+      options: { years: { type: 'string', short: 'y', description: 'Lookback in years (default 10, max 30)' } },
+      handler: (opts) => core.getSeasonals({ years: opts.years ? Number(opts.years) : undefined }),
+    }],
+    ['news', {
+      description: 'Recent news headlines',
+      options: {
+        symbol: SYMBOL_OPT,
+        limit: { type: 'string', short: 'n', description: 'Max headlines (default 15, max 50)' },
+      },
+      handler: (opts) => core.getNews({ symbol: opts.symbol, limit: opts.limit ? Number(opts.limit) : undefined }),
+    }],
+    ['options', {
+      description: 'ATM implied-volatility term structure',
+      options: {
+        symbol: SYMBOL_OPT,
+        max: { type: 'string', short: 'n', description: 'Max expiries (default 10, max 30)' },
+      },
+      handler: (opts) => core.getOptions({ symbol: opts.symbol, max_expirations: opts.max ? Number(opts.max) : undefined }),
+    }],
+    ['etf', {
+      description: 'ETF/fund profile (AUM, expense ratio, NAV)',
+      options: { symbol: SYMBOL_OPT },
+      handler: (opts) => core.getEtfProfile({ symbol: opts.symbol }),
+    }],
+    ['bond', {
+      description: 'Bond/yield info (yield, coupon, maturity)',
+      options: { symbol: SYMBOL_OPT },
+      handler: (opts) => core.getBondInfo({ symbol: opts.symbol }),
     }],
   ]),
 });

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -630,3 +630,540 @@ export async function getPineBoxes({ study_filter, verbose } = {}) {
   });
   return { success: true, study_count: studies.length, studies };
 }
+
+// ---------------------------------------------------------------------------
+// Symbol data panels — Forecast, Technicals, Financials, Key stats, Seasonals,
+// News, Options, ETF/Bond profiles.
+//
+// The chart's right sidebar renders every one of these sections into <canvas>,
+// so unlike Pine graphics there is nothing in the DOM worth scraping: the
+// panel's innerText yields only axis labels ("'21 '22 '23", "250.00 B") and
+// never a single underlying value. We therefore issue TradingView's own data
+// requests from page context via evaluateAsync() — same origin, same session
+// cookies, no new dependency. DOM scraping is kept only where it genuinely is
+// the better source: the Forecast consensus gauge encodes its rating as a CSS
+// needle angle that no endpoint returns.
+//
+// These endpoints are private to TradingView and unversioned. They can change
+// without notice, so every reader below degrades to an explicit error instead
+// of guessing at a shape it did not get.
+// ---------------------------------------------------------------------------
+
+// The chart's display ticker is the *feed* venue (e.g. "BATS:AMZN"), which
+// TradingView's data service does not recognise — it answers a bare `null`.
+// symbolInfo().pro_name carries the listing venue ("NASDAQ:AMZN"), which does.
+const SYMBOL_INFO_JS = `
+  (function() {
+    try {
+      var si = ${CHART_API}._chartWidget.model().mainSeries().symbolInfo();
+      if (!si) return null;
+      return {
+        pro_name: si.pro_name, name: si.name, full_name: si.full_name,
+        listed_exchange: si.listed_exchange, type: si.type,
+        currency: si.currency_code, description: si.description
+      };
+    } catch (e) { return null; }
+  })()
+`;
+
+async function resolveSymbol(symbol) {
+  if (symbol && String(symbol).trim()) {
+    return { pro_name: String(symbol).trim().toUpperCase(), from_chart: false };
+  }
+  const info = await evaluate(SYMBOL_INFO_JS);
+  if (!info || !info.pro_name) {
+    throw new Error('Could not read the chart symbol. Make sure a chart is loaded, or pass symbol explicitly (e.g. "NASDAQ:AMZN").');
+  }
+  return { ...info, from_chart: true };
+}
+
+/** Run one scanner field request from page context and return the raw record. */
+async function scannerFields(proSymbol, fields) {
+  const data = await evaluateAsync(`
+    (async function() {
+      try {
+        var url = 'https://scanner.tradingview.com/symbol?symbol=' + encodeURIComponent(${safeString(proSymbol)})
+          + '&fields=' + encodeURIComponent(${safeString(fields.join(','))}) + '&no_404=true';
+        var r = await fetch(url, { credentials: 'include' });
+        if (!r.ok) return { __error: 'TradingView data service returned HTTP ' + r.status };
+        var text = (await r.text()).trim();
+        if (!text || text === 'null') return { __error: '__unknown_symbol__' };
+        return JSON.parse(text);
+      } catch (e) { return { __error: String((e && e.message) || e) }; }
+    })()
+  `);
+  if (!data) throw new Error('No response from TradingView data service.');
+  if (data.__error === '__unknown_symbol__') {
+    throw new Error(`TradingView has no data record for "${proSymbol}". Use the exchange-qualified listing symbol (e.g. "NASDAQ:AMZN") — the chart's display ticker (e.g. "BATS:AMZN") is often a different venue and is not accepted.`);
+  }
+  if (data.__error) throw new Error(`TradingView data request failed: ${data.__error}`);
+  return data;
+}
+
+// Recommend.* is a -1..1 score; these are TradingView's own gauge buckets.
+function recommendLabel(v) {
+  if (v == null || !Number.isFinite(v)) return null;
+  if (v >= 0.5) return 'strong_buy';
+  if (v >= 0.1) return 'buy';
+  if (v >= -0.1) return 'neutral';
+  if (v >= -0.5) return 'sell';
+  return 'strong_sell';
+}
+
+// recommendation_mark is the *analyst* consensus on a 1..5 scale — note it
+// runs the opposite direction to Recommend.* (1 = strong buy, 5 = strong sell).
+function analystRatingLabel(mark) {
+  if (mark == null || !Number.isFinite(mark)) return null;
+  if (mark <= 1.5) return 'strong_buy';
+  if (mark <= 2.5) return 'buy';
+  if (mark <= 3.5) return 'neutral';
+  if (mark <= 4.5) return 'sell';
+  return 'strong_sell';
+}
+
+const isoDate = (unixSeconds) =>
+  (unixSeconds == null || !Number.isFinite(unixSeconds) ? null : new Date(unixSeconds * 1000).toISOString().slice(0, 10));
+
+const round2 = (v) => (v == null || !Number.isFinite(v) ? null : Math.round(v * 100) / 100);
+
+export async function getKeyStats({ symbol } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const d = await scannerFields(sym.pro_name, [
+    'description', 'type', 'currency', 'sector', 'industry', 'close', 'change',
+    'market_cap_basic', 'volume', 'average_volume_10d_calc', 'average_volume_30d_calc',
+    'earnings_release_next_date', 'earnings_per_share_forecast_next_fq',
+    'dividends_yield_current', 'price_earnings_ttm', 'earnings_per_share_diluted_ttm',
+    'beta_1_year', 'total_shares_outstanding', 'float_shares_outstanding',
+  ]);
+  return {
+    success: true,
+    symbol: sym.pro_name,
+    description: d.description ?? null,
+    instrument_type: d.type ?? null,
+    currency: d.currency ?? null,
+    sector: d.sector ?? null,
+    industry: d.industry ?? null,
+    price: d.close ?? null,
+    change_pct: round2(d.change),
+    market_cap: d.market_cap_basic ?? null,
+    volume: d.volume ?? null,
+    avg_volume_10d: Math.round(d.average_volume_10d_calc ?? 0) || null,
+    avg_volume_30d: Math.round(d.average_volume_30d_calc ?? 0) || null,
+    next_earnings_date: isoDate(d.earnings_release_next_date),
+    next_earnings_eps_estimate: d.earnings_per_share_forecast_next_fq ?? null,
+    dividend_yield_pct: d.dividends_yield_current ?? null,
+    pe_ratio_ttm: round2(d.price_earnings_ttm),
+    eps_ttm: d.earnings_per_share_diluted_ttm ?? null,
+    beta_1y: round2(d.beta_1_year),
+    shares_outstanding: d.total_shares_outstanding ?? null,
+    float_shares: d.float_shares_outstanding ?? null,
+  };
+}
+
+// Scanner timeframe suffixes. 1D is the unsuffixed default.
+const TECHNICAL_TIMEFRAMES = {
+  '1': '|1', '5': '|5', '15': '|15', '30': '|30', '60': '|60', '120': '|120', '240': '|240',
+  'D': '', '1D': '', 'W': '|1W', '1W': '|1W', 'M': '|1M', '1M': '|1M',
+};
+const OSCILLATOR_FIELDS = ['RSI', 'Stoch.K', 'Stoch.D', 'Stoch.RSI.K', 'Stoch.RSI.D', 'CCI20', 'ADX', 'AO', 'Mom', 'MACD.macd', 'MACD.signal', 'W.R', 'BBPower', 'UO'];
+const MA_FIELDS = ['EMA10', 'SMA10', 'EMA20', 'SMA20', 'EMA30', 'SMA30', 'EMA50', 'SMA50', 'EMA100', 'SMA100', 'EMA200', 'SMA200', 'Ichimoku.BLine', 'VWMA', 'HullMA9'];
+
+export async function getTechnicals({ symbol, timeframe } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const tfKey = String(timeframe || '1D').toUpperCase();
+  const suffix = TECHNICAL_TIMEFRAMES[tfKey];
+  if (suffix === undefined) {
+    throw new Error(`Unsupported timeframe "${timeframe}". Use one of: ${Object.keys(TECHNICAL_TIMEFRAMES).join(', ')}.`);
+  }
+  const scoped = ['Recommend.All', 'Recommend.MA', 'Recommend.Other', ...OSCILLATOR_FIELDS, ...MA_FIELDS];
+  const d = await scannerFields(sym.pro_name, [...scoped.map(f => f + suffix), 'close']);
+  const at = (f) => d[f + suffix] ?? null;
+
+  const gauge = (f) => ({ score: round2(at(f)), rating: recommendLabel(at(f)) });
+  const values = {};
+  for (const f of [...OSCILLATOR_FIELDS, ...MA_FIELDS]) values[f] = round2(at(f));
+
+  return {
+    success: true,
+    symbol: sym.pro_name,
+    timeframe: tfKey,
+    price: d.close ?? null,
+    summary: gauge('Recommend.All'),
+    moving_averages: gauge('Recommend.MA'),
+    oscillators: gauge('Recommend.Other'),
+    indicators: values,
+  };
+}
+
+export async function getForecast({ symbol } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const d = await scannerFields(sym.pro_name, [
+    'close', 'currency', 'price_target_1y', 'price_target_average', 'price_target_high',
+    'price_target_low', 'price_target_estimates_num', 'recommendation_mark',
+    'recommendation_total', 'recommendation_buy', 'recommendation_hold', 'recommendation_sell',
+  ]);
+  const price = d.close ?? null;
+  const target = d.price_target_average ?? d.price_target_1y ?? null;
+  const upside = (price && target) ? ((target - price) / price) * 100 : null;
+
+  // Best-effort DOM enrichment: the sidebar gauge exposes the consensus as a
+  // needle angle, which the data service does not return. Only meaningful when
+  // we are looking at the symbol the chart is actually showing.
+  let gaugeDegrees = null;
+  if (sym.from_chart) {
+    try {
+      gaugeDegrees = await evaluate(`
+        (function() {
+          try {
+            var nodes = document.querySelectorAll('.widgetbar-widget-detail [style*="recommendation-degrees"]');
+            for (var i = 0; i < nodes.length; i++) {
+              var m = (nodes[i].getAttribute('style') || '').match(/recommendation-degrees:\\s*([-\\d.]+)deg/);
+              if (m) return parseFloat(m[1]);
+            }
+            return null;
+          } catch (e) { return null; }
+        })()
+      `);
+    } catch { gaugeDegrees = null; }
+  }
+
+  if (target == null && d.recommendation_mark == null) {
+    throw new Error(`No analyst forecast is published for "${sym.pro_name}". TradingView only covers analyst estimates for stocks with research coverage.`);
+  }
+
+  return {
+    success: true,
+    symbol: sym.pro_name,
+    currency: d.currency ?? null,
+    price,
+    price_target: {
+      low: d.price_target_low ?? null,
+      average: round2(d.price_target_average ?? d.price_target_1y),
+      high: d.price_target_high ?? null,
+      estimates: d.price_target_estimates_num ?? null,
+    },
+    upside_pct: round2(upside),
+    consensus: {
+      rating: analystRatingLabel(d.recommendation_mark),
+      mark: round2(d.recommendation_mark),
+      analysts: d.recommendation_total ?? null,
+      buy: d.recommendation_buy ?? null,
+      hold: d.recommendation_hold ?? null,
+      sell: d.recommendation_sell ?? null,
+      ...(gaugeDegrees != null && { gauge_needle_degrees: gaugeDegrees }),
+    },
+  };
+}
+
+const FINANCIAL_METRICS = ['total_revenue', 'gross_profit', 'net_income', 'earnings_per_share_diluted', 'ebitda', 'free_cash_flow', 'total_debt', 'total_assets'];
+
+export async function getFinancials({ symbol, period, limit } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const p = String(period || 'annual').toLowerCase();
+  if (p !== 'annual' && p !== 'quarterly') throw new Error('period must be "annual" or "quarterly".');
+  const sfx = p === 'annual' ? '_fy_h' : '_fq_h';
+  const max = Math.min(limit || 8, 32);
+
+  const fields = FINANCIAL_METRICS.map(m => m + sfx);
+  fields.push('currency');
+  if (p === 'annual') fields.push('fiscal_period_fy_h');
+  const d = await scannerFields(sym.pro_name, fields);
+
+  const series = (m) => (Array.isArray(d[m + sfx]) ? d[m + sfx] : []);
+  const depth = Math.max(0, ...FINANCIAL_METRICS.map(m => series(m).length));
+  if (!depth) {
+    throw new Error(`No ${p} financial statements are published for "${sym.pro_name}". Indices, forex, crypto and most funds have no income statement.`);
+  }
+  const years = Array.isArray(d.fiscal_period_fy_h) ? d.fiscal_period_fy_h : null;
+
+  // Every series is newest-first, so index 0 is the most recent report.
+  const periods = [];
+  for (let i = 0; i < Math.min(depth, max); i++) {
+    const revenue = series('total_revenue')[i] ?? null;
+    const netIncome = series('net_income')[i] ?? null;
+    const grossProfit = series('gross_profit')[i] ?? null;
+    periods.push({
+      ...(p === 'annual' ? { fiscal_year: years?.[i] ?? null } : {}),
+      periods_ago: i,
+      revenue,
+      gross_profit: grossProfit,
+      net_income: netIncome,
+      eps_diluted: series('earnings_per_share_diluted')[i] ?? null,
+      ebitda: series('ebitda')[i] ?? null,
+      free_cash_flow: series('free_cash_flow')[i] ?? null,
+      total_debt: series('total_debt')[i] ?? null,
+      total_assets: series('total_assets')[i] ?? null,
+      gross_margin_pct: (revenue && grossProfit != null) ? round2((grossProfit / revenue) * 100) : null,
+      net_margin_pct: (revenue && netIncome != null) ? round2((netIncome / revenue) * 100) : null,
+    });
+  }
+
+  return {
+    success: true,
+    symbol: sym.pro_name,
+    period: p,
+    currency: d.currency ?? null,
+    period_count: periods.length,
+    periods,
+    ...(p === 'quarterly' && {
+      note: 'TradingView does not expose fiscal quarter labels through this feed; periods are ordered newest-first and identified by periods_ago (0 = most recently reported quarter).',
+    }),
+  };
+}
+
+const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+export async function getSeasonals({ years } = {}) {
+  const lookback = Math.min(Math.max(Number(years) || 10, 1), 30);
+  const info = await evaluate(SYMBOL_INFO_JS);
+
+  // TradingView renders seasonality to canvas and publishes no seasonality
+  // endpoint, so we derive it from monthly bars. That means briefly switching
+  // the chart to 1M and restoring the original resolution — the same
+  // switch-and-restore trade-off getQuote() already makes for symbols.
+  const data = await evaluateAsync(`
+    (async function() {
+      var chart = ${CHART_API};
+      var original = null;
+      try {
+        original = chart.resolution();
+        if (original !== '1M') chart.setResolution('1M', {});
+        var series = chart._chartWidget.model().mainSeries();
+        for (var attempt = 0; attempt < 40; attempt++) {
+          await new Promise(function(r) { setTimeout(r, 250); });
+          var bars = series.bars();
+          if (!bars || typeof bars.lastIndex !== 'function' || bars.size() < 3) continue;
+          var first = bars.firstIndex(), last = bars.lastIndex();
+          var prev = bars.valueAt(last - 1), curr = bars.valueAt(last);
+          if (!prev || !curr) continue;
+          // Guard against reading the pre-switch series: consecutive monthly
+          // bars are always more than 20 days apart, intraday/daily are not.
+          if ((curr[0] - prev[0]) < 20 * 86400) continue;
+          var rows = [];
+          for (var i = first; i <= last; i++) {
+            var v = bars.valueAt(i);
+            if (v && v[1] && v[4]) rows.push([v[0], v[1], v[4]]);
+          }
+          return { bars: rows };
+        }
+        return { error: 'Monthly bars did not load within 10s.' };
+      } catch (e) {
+        return { error: String((e && e.message) || e) };
+      } finally {
+        try { if (original && original !== '1M') chart.setResolution(original, {}); } catch (e2) {}
+      }
+    })()
+  `);
+
+  if (!data || data.error) {
+    throw new Error(`Could not build seasonality: ${data?.error || 'no monthly data returned'}.`);
+  }
+  const rows = data.bars || [];
+  if (rows.length < 12) {
+    throw new Error(`Not enough monthly history for "${info?.pro_name || 'this symbol'}" to compute seasonality (got ${rows.length} monthly bars, need at least 12).`);
+  }
+
+  const currentYear = new Date().getUTCFullYear();
+  const buckets = MONTH_NAMES.map(() => []);
+  let earliest = null, latest = null;
+  for (const [time, open, close] of rows) {
+    const dt = new Date(time * 1000);
+    const year = dt.getUTCFullYear();
+    if (currentYear - year >= lookback) continue;
+    const ret = ((close - open) / open) * 100;
+    if (!Number.isFinite(ret)) continue;
+    buckets[dt.getUTCMonth()].push({ year, ret });
+    if (earliest == null || year < earliest) earliest = year;
+    if (latest == null || year > latest) latest = year;
+  }
+
+  const months = buckets.map((samples, idx) => {
+    if (!samples.length) return { month: idx + 1, name: MONTH_NAMES[idx], samples: 0, avg_return_pct: null, win_rate_pct: null };
+    const avg = samples.reduce((a, s) => a + s.ret, 0) / samples.length;
+    const wins = samples.filter(s => s.ret > 0).length;
+    return {
+      month: idx + 1,
+      name: MONTH_NAMES[idx],
+      samples: samples.length,
+      avg_return_pct: round2(avg),
+      win_rate_pct: round2((wins / samples.length) * 100),
+      best_pct: round2(Math.max(...samples.map(s => s.ret))),
+      worst_pct: round2(Math.min(...samples.map(s => s.ret))),
+    };
+  });
+
+  const scored = months.filter(m => m.avg_return_pct != null);
+  const byReturn = [...scored].sort((a, b) => b.avg_return_pct - a.avg_return_pct);
+
+  return {
+    success: true,
+    symbol: info?.pro_name || null,
+    source: 'derived from monthly bars',
+    years_requested: lookback,
+    years_covered: earliest != null ? { from: earliest, to: latest } : null,
+    months,
+    best_month: byReturn[0] ? { name: byReturn[0].name, avg_return_pct: byReturn[0].avg_return_pct } : null,
+    worst_month: byReturn.length ? { name: byReturn[byReturn.length - 1].name, avg_return_pct: byReturn[byReturn.length - 1].avg_return_pct } : null,
+    note: 'Monthly return is measured open-to-close of each monthly bar. The chart resolution is switched to 1M and restored automatically.',
+  };
+}
+
+export async function getNews({ symbol, limit } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const max = Math.min(Number(limit) || 15, 50);
+  const data = await evaluateAsync(`
+    (async function() {
+      try {
+        var url = 'https://news-headlines.tradingview.com/v2/headlines?client=overview&lang=en&symbol='
+          + encodeURIComponent(${safeString(sym.pro_name)});
+        var r = await fetch(url, { credentials: 'include' });
+        if (!r.ok) return { __error: 'news service returned HTTP ' + r.status };
+        var j = await r.json();
+        return { items: (j && j.items) || [] };
+      } catch (e) { return { __error: String((e && e.message) || e) }; }
+    })()
+  `);
+  if (!data) throw new Error('No response from TradingView news service.');
+  if (data.__error) throw new Error(`TradingView news request failed: ${data.__error}`);
+
+  const items = (data.items || []).slice(0, max).map(it => ({
+    title: it.title ?? null,
+    source: it.source ?? it.provider ?? null,
+    published_at: isoDate(it.published),
+    // urgency 1 = breaking, 2 = regular story.
+    breaking: it.urgency === 1,
+    link: it.link || (it.storyPath ? `https://www.tradingview.com${it.storyPath}` : null),
+    related_symbols: Array.isArray(it.relatedSymbols) ? it.relatedSymbols.map(s => s.symbol).filter(Boolean) : [],
+  }));
+
+  return { success: true, symbol: sym.pro_name, count: items.length, headlines: items };
+}
+
+export async function getOptions({ symbol, max_expirations } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const maxExp = Math.min(Number(max_expirations) || 10, 30);
+
+  const data = await evaluateAsync(`
+    (async function() {
+      try {
+        var body = {
+          columns: ['expiration', 'strike', 'option-type', 'iv', 'delta'],
+          filter: [],
+          index_filters: [{ name: 'underlying_symbol', values: [${safeString(sym.pro_name)}] }],
+          range: [0, 4000],
+          sort: { sortBy: 'expiration', sortOrder: 'asc' }
+        };
+        // content-type text/plain keeps this a CORS "simple request"; the
+        // preflight triggered by application/json is rejected by this host.
+        var r = await fetch('https://scanner.tradingview.com/options/scan', {
+          method: 'POST', credentials: 'include',
+          headers: { 'content-type': 'text/plain' }, body: JSON.stringify(body)
+        });
+        if (!r.ok) return { __error: 'options service returned HTTP ' + r.status };
+        var j = await r.json();
+        var rows = (j && j.data) || [];
+        var byExpiry = {};
+        for (var i = 0; i < rows.length; i++) {
+          var d = rows[i].d;
+          if (!d || d[3] == null || d[4] == null) continue;
+          var key = d[0];
+          if (!byExpiry[key]) byExpiry[key] = [];
+          byExpiry[key].push({ strike: d[1], type: d[2], iv: d[3], delta: d[4] });
+        }
+        // Reduce in page context so we ship a term structure, not 2500 legs.
+        var out = [];
+        for (var expiry in byExpiry) {
+          var legs = byExpiry[expiry], nearest = {};
+          for (var n = 0; n < legs.length; n++) {
+            var leg = legs[n];
+            var offset = Math.abs(Math.abs(leg.delta) - 0.5);
+            if (!nearest[leg.type] || offset < nearest[leg.type].offset) {
+              nearest[leg.type] = { offset: offset, leg: leg };
+            }
+          }
+          var ivs = [], strikes = [];
+          for (var side in nearest) { ivs.push(nearest[side].leg.iv); strikes.push(nearest[side].leg.strike); }
+          if (!ivs.length) continue;
+          var sum = 0; for (var q = 0; q < ivs.length; q++) sum += ivs[q];
+          out.push({
+            expiration: Number(expiry),
+            atm_strike: strikes[0],
+            atm_iv: sum / ivs.length,
+            contracts: legs.length
+          });
+        }
+        out.sort(function(a, b) { return a.expiration - b.expiration; });
+        return { total_contracts: rows.length, expirations: out };
+      } catch (e) { return { __error: String((e && e.message) || e) }; }
+    })()
+  `);
+
+  if (!data) throw new Error('No response from TradingView options service.');
+  if (data.__error) throw new Error(`TradingView options request failed: ${data.__error}`);
+  if (!data.expirations || !data.expirations.length) {
+    throw new Error(`No listed options found for "${sym.pro_name}". Options data only exists for optionable US equities and ETFs.`);
+  }
+
+  const today = new Date();
+  const termStructure = data.expirations.slice(0, maxExp).map(e => {
+    const s = String(e.expiration);
+    const date = `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`;
+    const dte = Math.round((new Date(`${date}T00:00:00Z`) - today) / 86400000);
+    return { expiration: date, days_to_expiry: dte, atm_strike: e.atm_strike, atm_iv_pct: round2(e.atm_iv * 100), contracts: e.contracts };
+  });
+
+  return {
+    success: true,
+    symbol: sym.pro_name,
+    total_contracts: data.total_contracts,
+    expiration_count: data.expirations.length,
+    term_structure: termStructure,
+    note: 'ATM is the strike whose |delta| is closest to 0.50, averaged across calls and puts. IV spikes on the expiry that straddles an earnings date.',
+  };
+}
+
+export async function getEtfProfile({ symbol } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const d = await scannerFields(sym.pro_name, [
+    'description', 'type', 'typespecs', 'currency', 'close', 'change',
+    'aum', 'expense_ratio', 'nav', 'asset_class', 'focus', 'market_cap_basic', 'volume',
+  ]);
+  if (d.type !== 'fund') {
+    throw new Error(`"${sym.pro_name}" is not a fund/ETF (TradingView reports type "${d.type ?? 'unknown'}"). The ETF section only exists for funds — use data_get_key_stats for this instrument.`);
+  }
+  return {
+    success: true,
+    symbol: sym.pro_name,
+    description: d.description ?? null,
+    fund_type: Array.isArray(d.typespecs) ? d.typespecs.join(', ') : null,
+    currency: d.currency ?? null,
+    price: d.close ?? null,
+    change_pct: round2(d.change),
+    nav: d.nav ?? null,
+    aum: d.aum ?? null,
+    expense_ratio_pct: d.expense_ratio ?? null,
+    volume: d.volume ?? null,
+  };
+}
+
+export async function getBondInfo({ symbol } = {}) {
+  const sym = await resolveSymbol(symbol);
+  const d = await scannerFields(sym.pro_name, [
+    'description', 'type', 'typespecs', 'currency', 'close', 'change', 'coupon', 'maturity_date',
+  ]);
+  if (d.type !== 'bond') {
+    throw new Error(`"${sym.pro_name}" is not a bond (TradingView reports type "${d.type ?? 'unknown'}"). Try a yield symbol such as "TVC:US10Y".`);
+  }
+  const maturity = d.maturity_date != null ? String(d.maturity_date) : null;
+  return {
+    success: true,
+    symbol: sym.pro_name,
+    description: d.description ?? null,
+    bond_type: Array.isArray(d.typespecs) ? d.typespecs.join(', ') : null,
+    currency: d.currency ?? null,
+    yield_pct: d.close ?? null,
+    change_pct: round2(d.change),
+    coupon_pct: d.coupon ?? null,
+    maturity_date: maturity && maturity.length === 8 ? `${maturity.slice(0, 4)}-${maturity.slice(4, 6)}-${maturity.slice(6, 8)}` : null,
+  };
+}

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -83,4 +83,77 @@ export function registerDataTools(server) {
     try { return jsonResult(await core.getStudyValues()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
+
+  // --- Symbol data panels (Forecast, Technicals, Financials, ...) ------------
+  // Every tool below defaults to the chart's current symbol; pass an
+  // exchange-qualified symbol (e.g. "NASDAQ:AMZN") to read any other one
+  // without touching the chart.
+
+  server.tool('data_get_key_stats', 'Key stats for a symbol: market cap, next earnings date, volume, average volume, dividend yield, P/E, EPS, beta, shares outstanding.', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol (e.g. "NASDAQ:AMZN"). Omit for the current chart symbol.'),
+  }, async ({ symbol }) => {
+    try { return jsonResult(await core.getKeyStats({ symbol })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_technicals', 'Technicals consensus gauges (Strong buy…Strong sell) for Summary, Moving Averages and Oscillators, plus the underlying indicator values (RSI, Stoch, MACD, ADX, CCI, EMAs, SMAs).', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol. Omit for the current chart symbol.'),
+    timeframe: z.string().optional().describe('Timeframe for the gauges: 1, 5, 15, 30, 60, 120, 240, 1D (default), 1W, 1M'),
+  }, async ({ symbol, timeframe }) => {
+    try { return jsonResult(await core.getTechnicals({ symbol, timeframe })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_forecast', 'Analyst forecast: price target low/average/high, upside % vs current price, consensus rating and the analyst buy/hold/sell breakdown.', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol. Omit for the current chart symbol.'),
+  }, async ({ symbol }) => {
+    try { return jsonResult(await core.getForecast({ symbol })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_financials', 'Income statement history: revenue, gross profit, net income, diluted EPS, EBITDA, free cash flow, debt/assets and margins, per annual or quarterly period (newest first).', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol. Omit for the current chart symbol.'),
+    period: z.enum(['annual', 'quarterly']).optional().describe('Reporting period (default annual)'),
+    limit: z.coerce.number().optional().describe('How many periods to return (default 8, max 32)'),
+  }, async ({ symbol, period, limit }) => {
+    try { return jsonResult(await core.getFinancials({ symbol, period, limit })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_seasonals', 'Seasonality for the current chart symbol: average return, win rate, best and worst outcome per calendar month. Derived from monthly bars — briefly switches the chart to 1M and restores the original resolution.', {
+    years: z.coerce.number().optional().describe('Lookback window in years (default 10, max 30)'),
+  }, async ({ years }) => {
+    try { return jsonResult(await core.getSeasonals({ years })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_news', 'Recent news headlines for a symbol: title, source, publish date, breaking flag and article link.', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol. Omit for the current chart symbol.'),
+    limit: z.coerce.number().optional().describe('Max headlines to return (default 15, max 50)'),
+  }, async ({ symbol, limit }) => {
+    try { return jsonResult(await core.getNews({ symbol, limit })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_options', 'Options ATM implied-volatility term structure: per expiry, the ATM strike and ATM IV %. Only available for optionable US equities and ETFs.', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol. Omit for the current chart symbol.'),
+    max_expirations: z.coerce.number().optional().describe('How many expiries to return, nearest first (default 10, max 30)'),
+  }, async ({ symbol, max_expirations }) => {
+    try { return jsonResult(await core.getOptions({ symbol, max_expirations })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_etf_profile', 'ETF/fund profile: AUM, expense ratio, NAV, fund type. Returns an error for non-fund instruments.', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol (e.g. "AMEX:SPY"). Omit for the current chart symbol.'),
+  }, async ({ symbol }) => {
+    try { return jsonResult(await core.getEtfProfile({ symbol })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('data_get_bond_info', 'Bond/yield instrument info: current yield, coupon, maturity date. Returns an error for non-bond instruments.', {
+    symbol: z.string().optional().describe('Exchange-qualified symbol (e.g. "TVC:US10Y"). Omit for the current chart symbol.'),
+  }, async ({ symbol }) => {
+    try { return jsonResult(await core.getBondInfo({ symbol })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
 }


### PR DESCRIPTION
Closes #379

Adds nine read-only tools covering the symbol data panels in TradingView's right sidebar.

## New tools

| Tool | Returns |
|------|---------|
| `data_get_key_stats` | market cap, next earnings date, volume, avg volume, dividend yield, P/E, EPS, beta |
| `data_get_technicals` | consensus gauges (Summary / MAs / Oscillators) + 29 indicator values, any timeframe |
| `data_get_forecast` | price target low/avg/high, upside %, consensus rating, buy/hold/sell counts |
| `data_get_financials` | revenue, gross profit, net income, EPS, EBITDA, FCF, margins — annual or quarterly |
| `data_get_seasonals` | average return, win rate, best/worst per calendar month |
| `data_get_news` | headlines with source, date, breaking flag, link |
| `data_get_options` | ATM IV term structure per expiry |
| `data_get_etf_profile` | AUM, expense ratio, NAV |
| `data_get_bond_info` | yield, coupon, maturity |

All nine are also exposed on the CLI as `tv data <subcommand>`, keeping MCP/CLI parity.

## How the data is read — please read this bit

These sections render to `<canvas>`, so DOM scraping cannot reach the numbers: the panel's
`innerText` gives only axis labels (`'21 '22 '23`, `250.00 B`). Instead each reader issues
**TradingView's own data request from page context** via the existing `evaluateAsync()` bridge —
same origin, same session cookies, no new dependency and no credential handling.

DOM scraping is kept in exactly one place where it is genuinely the better source: the Forecast
consensus gauge encodes its rating as a CSS needle angle that no endpoint returns.

**This is more fragile than the chart-API tools.** These endpoints are private to TradingView and
unversioned, and they can change without notice. Every reader degrades to an explicit error rather
than guessing at a shape it did not get. Happy to gate this behind a flag or move it to its own
module if you'd rather keep `data.js` strictly chart-API.

Two details worth calling out:

- **Symbol resolution.** The chart's display ticker is the feed venue (`BATS:AMZN`), which the data
  service answers with a bare `null`. The tools resolve `symbolInfo().pro_name` (`NASDAQ:AMZN`)
  instead, and the error message says so when a caller passes the wrong form.
- **`data_get_seasonals` touches chart state.** TradingView publishes no seasonality endpoint, so
  seasonality is derived from monthly bars — which means briefly switching the chart to `1M` and
  restoring the original resolution (the same trade-off `getQuote()` already makes for symbols).
  It is the only symbol-data tool that does this, and it is documented on the tool description.

## Verification

Every tool was run live against TradingView Desktop (AMZN, MSFT, SPY, US10Y, BTCUSDT), including
the "not supported for this instrument" paths. Sanity checks: ATM strike 245 against a 246.26 spot,
and the IV term structure spiking to 61% on the expiry straddling the Jul 30 earnings date.

- `node --check` passes on all changed files
- `npm run test:unit` — 152/152 pass
- `npm run lint` — no new warnings (4 pre-existing, unchanged)
- No new dependency

Docs updated: tool count 84 → 93 in `README.md` / `CLAUDE.md`, plus a decision-tree entry and
output-size table rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113pg14Qw5fjWUs8Vvsp7nJ
