### PR TITLE
Fix MSIX package detection and add AppsFolder-shortcut launch fallback

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -21,13 +21,15 @@ if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMF
 REM Check MSIX / Windows Store installs.
 REM Get-AppxPackage resolves the install without elevation; enumerating
 REM %PROGRAMFILES%\WindowsApps with dir requires admin rights, so keep it as a fallback.
+REM Match by Name substring, not exact: 'TradingView.Desktop' is the manifest AppId, not the
+REM package Name (e.g. the retail listing installs as '31178TradingViewInc.TradingView').
 if "%TV_EXE%"=="" (
-    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
+    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage ^| Where-Object { $_.Name -like '*TradingView*' } ^| Select-Object -First 1).InstallLocation" 2^>nul`) do (
         if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
     )
 )
 if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\*TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
 )
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
@@ -59,8 +61,9 @@ set /a TRIES+=1
 if %TRIES% geq 30 (
     echo.
     echo Error: TradingView is running but CDP never became available on port %PORT%.
-    echo Some Windows MSIX builds block the debug port. Use the tv_launch MCP tool,
-    echo which falls back to launching from a local copy of the package.
+    echo Some Windows MSIX builds block the debug port even from a local copy. Use the
+    echo tv_launch MCP tool ^(or `tv launch`^), which also falls back to activating the
+    echo package through a shell:AppsFolder shortcut.
     exit /b 1
 )
 echo Still waiting...

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -283,6 +283,47 @@ function _copyMsixPackageLocal(tvPath, { cpSync, rmSync, readdirSync, existsSync
   return dstExe;
 }
 
+/**
+ * Resolves the AUMID (PackageFamilyName!AppId) of the installed TradingView
+ * package, for use with shell:AppsFolder activation. Returns null on any
+ * failure — this is a best-effort last resort, never the primary path.
+ */
+function _resolveAumid(deps) {
+  try {
+    const ps = 'powershell -NoProfile -Command "' +
+      '$p = Get-AppxPackage | Where-Object { $_.Name -like \'*TradingView*\' } | Select-Object -First 1; ' +
+      'if ($p) { $a = (Get-AppxPackageManifest $p).Package.Applications.Application; ' +
+      'if ($a -is [System.Array]) { $a = $a[0] }; ' +
+      'Write-Output ($p.PackageFamilyName + \'!\' + $a.Id) }"';
+    const out = deps.execSync(ps, { timeout: 5000 }).toString().trim().split('\n').pop().trim();
+    return out.includes('!') ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Some Desktop Bridge builds verify package identity at startup and silently
+ * exit (no CDP, exit code 9) when launched from anywhere but a proper
+ * activation — even from a byte-identical local copy outside WindowsApps.
+ * A bare `explorer.exe shell:AppsFolder\<aumid>` launch drops arguments, but
+ * a .lnk shortcut targeting that same shell path still forwards its
+ * Arguments string through to a Desktop Bridge app's command line, so we
+ * build one on the fly and launch that instead.
+ */
+function _launchViaAppsFolderShortcut(aumid, cdpArgs, deps) {
+  const lnkPath = join(process.env.TEMP || process.env.TMP || '.', 'tradingview-mcp-launch.lnk');
+  const argString = cdpArgs.join(' ');
+  const ps = 'powershell -NoProfile -Command "' +
+    '$s = New-Object -ComObject WScript.Shell; ' +
+    `$sc = $s.CreateShortcut('${lnkPath}'); ` +
+    `$sc.TargetPath = 'shell:AppsFolder\\${aumid}'; ` +
+    `$sc.Arguments = '${argString}'; ` +
+    '$sc.Save(); ' +
+    `Start-Process '${lnkPath}'"`;
+  deps.execSync(ps, { timeout: 8000 });
+}
+
 export async function launch({ port, kill_existing, _deps } = {}) {
   const deps = _resolveLaunchDeps(_deps);
   const cdpPort = port || CDP_PORT;
@@ -317,8 +358,10 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (!tvPath && platform === 'win32') {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
+    // Match by Name substring, not exact: 'TradingView.Desktop' is the manifest AppId, not the
+    // package Name (e.g. the retail listing installs as '31178TradingViewInc.TradingView').
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage | Where-Object { $_.Name -like \'*TradingView*\' } | Select-Object -First 1).InstallLocation"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;
@@ -363,12 +406,14 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
   let info = null;
   let usedLocalCopy = false;
+  let usedAppsFolderShortcut = false;
 
   if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
     const earlyFailure = await _spawnFailedEarly(child);
     if (!earlyFailure) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }
+
     if (!info) {
       // Direct WindowsApps launch was blocked or CDP never bound — fall back to
       // a local copy of the package (see _copyMsixPackageLocal).
@@ -377,25 +422,46 @@ export async function launch({ port, kill_existing, _deps } = {}) {
       child = _spawnDetached(deps.spawn, localExe, cdpArgs);
       tvPath = localExe;
       usedLocalCopy = true;
+      info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }
-  }
 
-  if (!info) {
+    if (!info) {
+      // The local copy didn't bind CDP either — fall back to proper package
+      // activation via a shell:AppsFolder shortcut (see _launchViaAppsFolderShortcut).
+      const aumid = _resolveAumid(deps);
+      if (aumid) {
+        await killExisting();
+        try {
+          _launchViaAppsFolderShortcut(aumid, cdpArgs, deps);
+          usedAppsFolderShortcut = true;
+          info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+        } catch { /* leave info null; fall through to the not-ready response below */ }
+      }
+    }
+  } else {
     info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
   }
 
+  // A shortcut launch is fire-and-forget through PowerShell/explorer — there's no
+  // child process handle for the actual TradingView instance it spawns.
+  const pid = usedAppsFolderShortcut ? undefined : child.pid;
+  const extraFlags = {
+    ...(usedLocalCopy && { msix_local_copy: true }),
+    ...(usedAppsFolderShortcut && { msix_apps_folder_shortcut: true }),
+  };
+
   if (info) {
     return {
-      success: true, platform, binary: tvPath, pid: child.pid,
+      success: true, platform, binary: tvPath, pid,
       cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
-      ...(usedLocalCopy && { msix_local_copy: true }),
+      ...extraFlags,
     };
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
-    ...(usedLocalCopy && { msix_local_copy: true }),
+    success: true, platform, binary: tvPath, pid, cdp_port: cdpPort, cdp_ready: false,
+    ...extraFlags,
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };
 }

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -28,9 +28,11 @@ function mockChild({ failWith } = {}) {
  *   spawnFailures — spawn paths (substring) that emit EACCES
  *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
  *   copyExists   — local copy already present
+ *   shortcutBinds — CDP starts succeeding once the AppsFolder shortcut is launched
+ *   noAumid      — simulate Get-AppxPackageManifest failing to resolve an AUMID
  */
-function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } = {}) {
-  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
+function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false, shortcutBinds = false, noAumid = false } = {}) {
+  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false, shortcutLaunched: false };
   const deps = {
     existsSync: (p) => {
       if (p === MSIX_EXE) return true;
@@ -38,8 +40,17 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
       return false;
     },
     execSync: (cmd) => {
+      if (cmd.includes('Get-AppxPackageManifest')) {
+        if (noAumid) return '\n';
+        return 'TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop\n';
+      }
       if (cmd.includes('Get-AppxPackage')) {
         return 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\n';
+      }
+      if (cmd.includes('WScript.Shell')) {
+        state.shortcutLaunched = true;
+        if (shortcutBinds) state.cdpUp = true;
+        return '';
       }
       if (cmd.includes('taskkill')) { state.killed++; return ''; }
       throw new Error(`unexpected execSync: ${cmd}`);
@@ -113,6 +124,27 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.equal(result.cdp_ready, false);
     assert.equal(result.msix_local_copy, true);
     assert.ok(result.warning);
+  });
+
+  it('falls back to an AppsFolder shortcut when the local copy also fails to bind CDP', async () => {
+    const { deps, state } = msixDeps({ shortcutBinds: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.msix_apps_folder_shortcut, true);
+    assert.equal(result.pid, undefined);
+    assert.equal(result.cdp_url, 'http://127.0.0.1:9222');
+    assert.equal(state.shortcutLaunched, true);
+  });
+
+  it('skips the AppsFolder shortcut when no AUMID can be resolved', async () => {
+    const { deps, state } = msixDeps({ noAumid: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.cdp_ready, false);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.msix_apps_folder_shortcut, undefined);
+    assert.equal(state.shortcutLaunched, false);
   });
 });
 


### PR DESCRIPTION
﻿## Summary
- `Get-AppxPackage -Name 'TradingView.Desktop'` never matched, since `TradingView.Desktop` is the manifest AppId, not the package `Name` (e.g. the retail Store listing installs as `31178TradingViewInc.TradingView`). Switched to a `Name -like '*TradingView*'` match in both `scripts/launch_tv_debug.bat` and `health.js`'s `launch()`.
- Some Desktop Bridge builds verify package identity at startup and silently exit (code 9, no CDP) when launched outside proper activation -- even from a byte-identical local copy outside `WindowsApps`. Added a third fallback tier that resolves the package AUMID and activates it through a `shell:AppsFolder` shortcut, which still forwards the debug-port argument (unlike a bare AppsFolder launch).

## Test plan
- [x] `node --test tests/launch.test.js` -- 9/9 passing (7 existing + 2 new covering the shortcut fallback tier)
- [x] Verified end-to-end on a real Windows machine with the retail MSIX build (`31178TradingViewInc.TradingView`), starting cold with no cached local copy: direct WindowsApps launch fails, local-copy fallback fails, AppsFolder-shortcut fallback succeeds and CDP binds on port 9222.

Generated with Claude Code
