### PR TITLE
feat: export box text field in getPineBoxes verbose output

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -620,7 +620,7 @@ export async function getPineBoxes({ study_filter, verbose } = {}) {
       const v = item.raw;
       const high = v.y1 != null && v.y2 != null ? roundPrice(Math.max(v.y1, v.y2)) : null;
       const low = v.y1 != null && v.y2 != null ? roundPrice(Math.min(v.y1, v.y2)) : null;
-      if (verbose) allBoxes.push({ id: item.id, high, low, x1: v.x1, x2: v.x2, borderColor: v.c, bgColor: v.bc });
+      if (verbose) allBoxes.push({ id: item.id, high, low, x1: v.x1, x2: v.x2, borderColor: v.c, bgColor: v.bc, text: v.t || '' });
       if (high != null && low != null) { const key = high + ':' + low; if (!seen[key]) { zones.push({ high, low }); seen[key] = true; } }
     }
     zones.sort((a, b) => b.high - a.high);


### PR DESCRIPTION
## Summary

One-line change to `getPineBoxes`: include each box's `text` label (the raw primitive's `t` field) in verbose output, as `text: v.t || ''`.

Pine boxes created with `box.new(..., text=...)` carry a label, but the verbose output currently drops it — only coordinates and colors come through. Indicators that stamp meaningful labels on their boxes (e.g. multi-timeframe zone indicators tagging each box `5m`/`15m`/`1h`) are unreadable through the MCP without this: the only workaround is fragile color-decoding heuristics.

## Behavior

- `verbose: true`: each box entry gains a `text` field (`''` when the box has no label).
- Default (non-verbose) `zones` output: unchanged.

We've been running this patch locally for a while (it predates #335) — upstreaming it so syncs stop dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)