### PR TITLE
Fix TradingView CDP launch on Windows Store / MSIX installs

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -1,14 +1,18 @@
 @echo off
-REM Launch TradingView Desktop on Windows with Chrome DevTools Protocol enabled
+REM Launch TradingView Desktop on Windows with Chrome DevTools Protocol enabled.
 REM Usage: scripts\launch_tv_debug.bat [port]
+REM
+REM Self-contained MSIX handling: if TradingView is a Windows Store / MSIX install,
+REM a direct launch from WindowsApps is blocked (EPERM) or its debug port never
+REM binds. In that case this script copies the package once into
+REM %LOCALAPPDATA%\tradingview-mcp\<pkg> and launches CDP from that plain copy -
+REM the same fallback the tv_launch MCP tool performs (see src/core/health.js).
 
 set PORT=%1
 if "%PORT%"=="" set PORT=9222
 
 REM Kill existing TradingView instances
-REM (ping -n is used for waits throughout: timeout /t aborts when stdin is redirected)
-taskkill /F /IM TradingView.exe >nul 2>&1
-ping -n 3 127.0.0.1 >nul
+call :kill_tv
 
 REM Auto-detect TradingView install location
 set "TV_EXE="
@@ -43,32 +47,115 @@ if "%TV_EXE%"=="" (
 )
 
 echo Found TradingView at: %TV_EXE%
+
+REM Detect a WindowsApps (MSIX) install so we know a local-copy fallback is available.
+set "IS_MSIX="
+echo %TV_EXE% | find /i "\WindowsApps\" >nul && set "IS_MSIX=1"
+
+REM Resolve where a local copy would live (computed at top level so each SET is
+REM visible to the next line; harmless for non-MSIX installs, which never use it).
+for %%I in ("%TV_EXE%") do set "SRC_DIR=%%~dpI"
+if "%SRC_DIR:~-1%"=="\" set "SRC_DIR=%SRC_DIR:~0,-1%"
+for %%I in ("%SRC_DIR%") do set "PKG_NAME=%%~nxI"
+set "CACHE_ROOT=%LOCALAPPDATA%\tradingview-mcp"
+set "DST_DIR=%CACHE_ROOT%\%PKG_NAME%"
+set "DST_EXE=%DST_DIR%\TradingView.exe"
+
+REM Repeat launches: a valid local copy already exists, so skip the doomed
+REM direct WindowsApps attempt and launch straight from the copy.
+if defined IS_MSIX if exist "%DST_EXE%" (
+    echo Reusing existing local copy at %DST_DIR%
+    goto launch_copy
+)
+
+REM --- Attempt 1: launch directly --------------------------------------------
 echo Starting with --remote-debugging-port=%PORT%...
 start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+call :wait_cdp 15
+if "%CDP_OK%"=="1" goto ready
 
-echo Waiting for CDP to become available...
-ping -n 6 127.0.0.1 >nul
-
-REM Use 127.0.0.1 rather than localhost: on some machines localhost resolves to
-REM IPv6 ::1, which Electron's debug server does not listen on.
-set TRIES=0
-:check
-curl -s http://127.0.0.1:%PORT%/json/version >nul 2>&1
-if %errorlevel% equ 0 goto ready
-set /a TRIES+=1
-if %TRIES% geq 30 (
+if not defined IS_MSIX (
     echo.
     echo Error: TradingView is running but CDP never became available on port %PORT%.
-    echo Some Windows MSIX builds block the debug port. Use the tv_launch MCP tool,
-    echo which falls back to launching from a local copy of the package.
     exit /b 1
 )
-echo Still waiting...
-ping -n 3 127.0.0.1 >nul
-goto check
 
+REM --- Attempt 2: MSIX local-copy fallback -----------------------------------
+echo.
+echo Direct WindowsApps launch did not expose CDP ^(MSIX sandbox^).
+echo Falling back to a local copy outside WindowsApps...
+
+if not exist "%DST_EXE%" (
+    REM Remove stale copies of other TradingView versions first.
+    if exist "%CACHE_ROOT%" (
+        for /d %%D in ("%CACHE_ROOT%\TradingView.*") do (
+            if /i not "%%~nxD"=="%PKG_NAME%" rmdir /s /q "%%D"
+        )
+    )
+    echo Copying package ^(~330MB, one time^) to %DST_DIR% ...
+    robocopy "%SRC_DIR%" "%DST_DIR%" /E /NP /NFL /NDL /NJH /NJS >nul
+    REM robocopy exit codes 0-7 are success; 8+ indicate a real failure.
+    if errorlevel 8 (
+        echo Error: failed to copy package to %DST_DIR%.
+        exit /b 1
+    )
+) else (
+    echo Reusing existing local copy at %DST_DIR%
+)
+
+:launch_copy
+call :kill_tv
+echo Launching from local copy: %DST_EXE%
+start "" "%DST_EXE%" --remote-debugging-port=%PORT%
+call :wait_cdp 20
+if "%CDP_OK%"=="1" (
+    set "TV_EXE=%DST_EXE%"
+    goto ready
+)
+
+echo.
+echo Error: CDP never became available on port %PORT%, even from the local copy.
+echo If this persists, try the tv_launch MCP tool or launch manually:
+echo   "%DST_EXE%" --remote-debugging-port=%PORT%
+exit /b 1
+
+REM --- Success ---------------------------------------------------------------
 :ready
 echo.
 echo CDP ready at http://127.0.0.1:%PORT%
+echo Binary: %TV_EXE%
 curl -s http://127.0.0.1:%PORT%/json/version
 echo.
+exit /b 0
+
+REM --- Subroutines -----------------------------------------------------------
+
+REM Kill any running TradingView and give the OS a moment to release the port.
+REM (ping -n is used for waits throughout: timeout /t aborts when stdin is redirected)
+:kill_tv
+taskkill /F /IM TradingView.exe >nul 2>&1
+ping -n 3 127.0.0.1 >nul
+exit /b 0
+
+REM Poll the CDP version endpoint until it responds. %1 = max attempts.
+REM Sets CDP_OK=1 on success, 0 on timeout.
+REM Use 127.0.0.1 rather than localhost: on some machines localhost resolves to
+REM IPv6 ::1, which Electron's debug server does not listen on.
+:wait_cdp
+set CDP_OK=0
+set MAXTRIES=%1
+if "%MAXTRIES%"=="" set MAXTRIES=15
+echo Waiting for CDP to become available...
+ping -n 6 127.0.0.1 >nul
+set TRIES=0
+:wait_cdp_loop
+curl -s http://127.0.0.1:%PORT%/json/version >nul 2>&1
+if %errorlevel% equ 0 (
+    set CDP_OK=1
+    exit /b 0
+)
+set /a TRIES+=1
+if %TRIES% geq %MAXTRIES% exit /b 0
+echo Still waiting...
+ping -n 3 127.0.0.1 >nul
+goto wait_cdp_loop

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -360,18 +360,30 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  const isWindowsApps = platform === 'win32' && WINDOWS_APPS_RE.test(tvPath);
+  let child = null;
   let info = null;
   let usedLocalCopy = false;
 
-  if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
-    const earlyFailure = await _spawnFailedEarly(child);
-    if (!earlyFailure) {
-      info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+  // Spawning a WindowsApps execution alias can throw EPERM/EACCES *synchronously*
+  // (not just fail via the async 'error' event), so guard it and let the MSIX
+  // fallback below handle it. On other platforms preserve the original throw.
+  try {
+    child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  } catch (err) {
+    if (!isWindowsApps) throw err;
+  }
+
+  if (isWindowsApps) {
+    if (child) {
+      const earlyFailure = await _spawnFailedEarly(child);
+      if (!earlyFailure) {
+        info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+      }
     }
     if (!info) {
-      // Direct WindowsApps launch was blocked or CDP never bound — fall back to
-      // a local copy of the package (see _copyMsixPackageLocal).
+      // Direct WindowsApps launch was blocked (sync throw, early exit, or CDP
+      // never bound) — fall back to a local copy of the package (_copyMsixPackageLocal).
       const localExe = _copyMsixPackageLocal(tvPath, deps);
       await killExisting();
       child = _spawnDetached(deps.spawn, localExe, cdpArgs);

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -88,6 +88,28 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.ok(state.killed >= 2);
   });
 
+  it('synchronous EPERM throw on direct spawn falls back to local copy', async () => {
+    // Windows raises EPERM/EACCES *synchronously* for WindowsApps execution
+    // aliases, so spawn throws rather than emitting an async 'error' event.
+    const { deps, state } = msixDeps({ cdpBindsFor: ['tradingview-mcp'] });
+    const baseSpawn = deps.spawn;
+    deps.spawn = (exe, args, opts) => {
+      if (exe.includes('WindowsApps')) {
+        state.spawned.push(exe);
+        throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
+      }
+      return baseSpawn(exe, args, opts);
+    };
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.binary, LOCAL_COPY_EXE);
+    assert.equal(state.copies.length, 1);
+    assert.equal(state.spawned.length, 2);
+    assert.match(state.spawned[0], /WindowsApps/);
+    assert.match(state.spawned[1], /tradingview-mcp/);
+  });
+
   it('CDP never binding on direct spawn falls back to local copy', async () => {
     const { deps, state } = msixDeps({ cdpBindsFor: ['tradingview-mcp'] });
     const result = await launch({ _deps: deps });


### PR DESCRIPTION
## Summary

Fixes launching TradingView with CDP on **Windows Store / MSIX installs**, where TradingView lives under `%PROGRAMFILES%\WindowsApps\`. On these installs both `tv_launch` and `scripts/launch_tv_debug.bat` failed to expose the debug port, so no tools could connect.

Two independent fixes:

1. **`tv_launch` crash on MSIX (`src/core/health.js`)** — A direct `spawn()` of `TradingView.exe` from `WindowsApps` throws `EPERM`/`EACCES` **synchronously** (execution-alias restriction), not via the async `'error'` event. The existing local-copy fallback only handled a process that spawned and then died early, so the synchronous throw escaped `launch()` and crashed the tool instead of copying the package out and relaunching.

2. **`launch_tv_debug.bat` had no fallback at all** — it only attempted a direct launch and printed "CDP never became available" on MSIX, forcing users to the MCP tool. It now performs the same local-copy fallback standalone.

## Changes

### `src/core/health.js`
- Wrap the initial `spawn` in `try/catch`. On `WindowsApps` paths a synchronous throw now leaves `child = null` and drops into the existing `_copyMsixPackageLocal` fallback; on other platforms the error is rethrown (behavior unchanged).
- Guard the early-failure check with `if (child)` since `child` can now be `null`.

### `tests/launch.test.js`
- New regression test: simulates a **synchronous `EPERM` throw** from `spawn` and asserts the launch falls back to the local copy (copies once, relaunches from `%LOCALAPPDATA%\tradingview-mcp\<pkg>`).
- Full suite: **8/8 passing**.

### `scripts/launch_tv_debug.bat`
- Detects `\WindowsApps\` (MSIX) installs.
- Reuses an existing local copy (skips the doomed direct attempt) when present.
- On MSIX, if CDP never binds: cleans stale version copies, `robocopy`s the package once (~330MB), and relaunches CDP from the copy.
- CDP poll and process-kill refactored into `:wait_cdp` / `:kill_tv` subroutines.
- Kept **pure ASCII, no BOM** — `cmd.exe` reads `.bat` as ANSI, so non-ASCII bytes corrupt parsing.

## Testing

On a real Windows 10 MSIX install (`TradingView.Desktop 3.3.0`, Store build):

| Scenario | Result |
|---|---|
| `tv_launch` / `launch()` (previously crashed with `spawn EPERM`) | ✅ `success: true`, `msix_local_copy: true`, CDP ready |
| `launch_tv_debug.bat` — cold (direct fail → robocopy → launch) | ✅ CDP ready (~75s, one time) |
| `launch_tv_debug.bat` — warm (reuse local copy) | ✅ CDP ready (~10s) |
| `node --test tests/launch.test.js` | ✅ 8/8 pass |

Classic (non-MSIX) install paths and the "TradingView not found" error path are unchanged and still covered by existing tests.
