### PR TITLE
fix: launch TradingView from VS Code/Cursor extension hosts (strip ELECTRON_RUN_AS_NODE)

### DIFF
--- a/scripts/launch_tv_debug_mac.sh
+++ b/scripts/launch_tv_debug_mac.sh
@@ -4,6 +4,11 @@
 
 PORT="${1:-9222}"
 
+# VS Code / Cursor integrated terminals export ELECTRON_RUN_AS_NODE=1, which makes
+# TradingView (an Electron app) boot headless-as-Node with no debug port. Strip it so
+# this script also works when run from an editor-integrated shell, not just Terminal.
+unset ELECTRON_RUN_AS_NODE ELECTRON_NO_ATTACH_CONSOLE
+
 # Auto-detect TradingView install location
 APP=""
 LOCATIONS=(

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -228,7 +228,15 @@ async function _probeCdp(cdpPort) {
 }
 
 function _spawnDetached(spawnFn, exe, args) {
-  const child = spawnFn(exe, args, { detached: true, stdio: 'ignore' });
+  // VS Code / Cursor extension hosts export ELECTRON_RUN_AS_NODE=1 into every child
+  // process. TradingView Desktop is itself an Electron app, so inheriting that var
+  // makes it boot headless-as-Node: no window opens and --remote-debugging-port is
+  // ignored, so CDP never binds. Strip it (and its console companion) from the child
+  // env so the GUI launches normally no matter what spawned the MCP server.
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  delete env.ELECTRON_NO_ATTACH_CONSOLE;
+  const child = spawnFn(exe, args, { detached: true, stdio: 'ignore', env });
   child.unref();
   return child;
 }


### PR DESCRIPTION
## Problem

When the MCP server is spawned by the **VS Code / Cursor extension host** (rather than a plain terminal), `tv_launch` returns success with a PID but **the TradingView window never opens and CDP never binds** on the debug port — so every follow-up tool fails to connect.

## Root cause

VS Code / Cursor extension hosts export **`ELECTRON_RUN_AS_NODE=1`** into every child process they spawn. TradingView Desktop is itself an Electron app, so the inherited variable makes it **boot as plain Node.js** — no Chromium, no window, and `--remote-debugging-port` is ignored, so CDP never comes up. This is exactly why launching works from a normal Terminal (clean env) but silently fails inside the editor extension.

Confirmed on macOS: with the var present, `TradingView … --remote-debugging-port=9222` yields a PID but no listener on 9222; with it stripped, the app opens and `/json/version` reports `TradingView/… Electron/… TVDesktop/…` within ~4s.

## Fix

- `_spawnDetached` (`src/core/health.js`) spawns TradingView with a child env that has `ELECTRON_RUN_AS_NODE` and `ELECTRON_NO_ATTACH_CONSOLE` removed — covers both `tv_launch` spawn paths (normal + Windows MSIX local-copy).
- `scripts/launch_tv_debug_mac.sh` `unset`s the same vars so the shell path also works from an editor-integrated terminal.

No behavior change on Terminal/CLI or Claude Desktop (the vars aren't set there, so the delete is a no-op). All existing unit tests pass. The scrub is platform-agnostic, so it also helps Windows/Linux editor hosts that leak the same var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
