### PR TITLE
Bump package.json version to 2.0.0 to match server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradingview-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradingview-mcp",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradingview-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "MCP bridge for TradingView Desktop via Chrome DevTools Protocol",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## What changed

Updated the `version` field in `package.json` (and both project-version entries in `package-lock.json`) from `1.0.0` to `2.0.0`.

## Why

An automated repo health check flagged that `package.json` declares `1.0.0` while `src/server.js` declares `2.0.0` in its `McpServer` info. Git history shows the mismatch originated in 7034759 ("Add MCP server instructions for LLM tool selection + update license"), whose commit message explicitly states "Version bumped to 2.0.0" — but only `src/server.js` was updated, leaving `package.json` stale at its initial-commit value. This aligns the manifest with the intended version.

## Notes for reviewers

- Bumped via `npm version 2.0.0 --no-git-tag-version`, so the lockfile stays consistent. The three dependency entries in the lockfile that coincidentally read `1.0.0` are untouched.
- No behavioral impact: nothing in the codebase reads the package.json version (the `tv_update` self-updater in `src/core/update.js` does not compare version numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)