### PR TITLE
fix: correct MSIX package name filter in tv_launch detection

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -318,7 +318,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'*TradingView*\' -ErrorAction SilentlyContinue).InstallLocation"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;


### PR DESCRIPTION
## Summary
- \`tv_launch\`'s MSIX detection queried \`Get-AppxPackage -Name 'TradingView.Desktop'\`, which never matches the actual installed package name (\`31178TradingViewInc.TradingView\`), so Store/MSIX installs always fell through to the "not found" error instead of using the existing local-copy fallback.
- Widened the filter to \`-Name '*TradingView*'\` so the lookup succeeds and the existing fallback logic (copy package to a writable folder, relaunch with the CDP flag) actually triggers.

## Test plan
- [x] \`node --test tests/launch.test.js\` — all 7 tests pass
- [x] Verified manually on a real MSIX/Store install of TradingView on Windows: \`tv_launch\` now finds the package via \`Get-AppxPackage\`, falls back to a local copy, and CDP connects successfully (\`tv_health_check\` returns \`cdp_connected: true\`)