### PR TITLE
fix: run update-check git commands with explicit repo cwd

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -5,6 +5,10 @@ import { getClient, getTargetInfo, evaluate, CDP_HOST, CDP_PORT } from '../conne
 import { existsSync, cpSync, rmSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { dirname, basename, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// src/core/health.js -> repo root, independent of process.cwd()
+const REPO_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 
 // Best-effort git-pull update check: compare local HEAD to origin's default
 // branch on GitHub. Never throws — returns null on any failure (offline,
@@ -14,8 +18,8 @@ async function checkForUpdate() {
   if (_updateCache && (Date.now() - _updateCache.at) < 3600_000) return _updateCache.value;
   let value = null;
   try {
-    const localSha = execSync('git rev-parse HEAD', { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
-    const remoteUrl = execSync('git config --get remote.origin.url', { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    const localSha = execSync('git rev-parse HEAD', { cwd: REPO_ROOT, timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    const remoteUrl = execSync('git config --get remote.origin.url', { cwd: REPO_ROOT, timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
     const m = remoteUrl.match(/github\.com[:/](.+?)(?:\.git)?$/);
     if (localSha && m) {
       const repo = m[1];


### PR DESCRIPTION
## Summary
- \`checkForUpdate()\` in \`src/core/health.js\` shelled out to \`git\` without passing an explicit \`cwd\`, so it inherited the Node process's current working directory instead of the MCP server's own repo directory.
- When the server is launched from a different working directory (e.g. via an MCP client config that starts the process elsewhere), \`tv_health_check\` reported the wrong \`local_commit\`, which could make \`update_available\` incorrect and confuse \`tv_update\`.
- Fix: run the update-check git commands with the server's own repo path as \`cwd\` explicitly.

## Test plan
- [x] Ran \`tv_health_check\` and \`tv_update\` against a checkout launched from an unrelated working directory; \`local_commit\` now reflects the server's actual repo state.
- [x] \`tv_update\` still correctly refuses to fast-forward when the local branch has commits not on \`origin/main\` (verified against a repo with an unpushed local commit).