### PR TITLE
fix: resolve CORE_DIR with fileURLToPath instead of URL.pathname

### DIFF
--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Summary
- `tests/sanitization.test.js` built `CORE_DIR` with `new URL(...).pathname`, which on Windows keeps a leading slash before the drive letter (e.g. `/C:/Users/...`). Passing that straight into `readdirSync` fails to resolve the directory correctly on Windows.
- The rest of the codebase already works around this using `fileURLToPath` (`src/core/update.js`, `src/core/batch.js`, `src/core/capture.js`), so this applies the same fix — it was the only remaining spot using `.pathname` directly as a filesystem path.

## Test plan
Ran on Windows 10:
- `npm run lint` — 0 errors (same 4 pre-existing warnings, unrelated to this change)
- `npm run test:unit` — before: the entire "source audit — no unsafe interpolation patterns" suite failed to even enumerate (`ENOENT: ... scandir 'C:\C:\Users\...\src\core\'`). After: that suite runs fully (34 additional tests now execute and pass). Overall unit suite went from 123 pass / 2 fail (125 total) to 157 pass / 2 fail (159 total) — the 2 remaining failures are pre-existing and unrelated (`cli.test.js` child-process exit code issue on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)