### PR TITLE
Fix Pine editor not opening on TradingView Desktop 3.3 (widget renamed to scripteditor)

### DIFF
--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -53,7 +53,8 @@ export async function ensurePineEditorOpen() {
       var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
       if (!bwb) return;
       if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab();
-      else if (typeof bwb.showWidget === 'function') bwb.showWidget('pine-editor');
+      // Widget renamed 'pine-editor' → 'scripteditor' in TV Desktop 3.3; unknown names no-op, so try both.
+      else if (typeof bwb.showWidget === 'function') { bwb.showWidget('scripteditor'); bwb.showWidget('pine-editor'); }
     })()
   `);
 

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -45,7 +45,9 @@ export async function openPanel({ panel, action }) {
         if (panel === 'strategy-tester') { var stratPanel = document.querySelector('[data-name="backtesting"]') || document.querySelector('[class*="strategyReport"]'); isOpen = isOpen && !!(stratPanel && stratPanel.offsetParent); }
         var performed = 'none';
         if (action === 'open' || (action === 'toggle' && !isOpen)) {
-          if (panel === 'pine-editor') { if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab(); else if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); }
+          // The editor widget was renamed 'pine-editor' → 'scripteditor' in TV Desktop 3.3;
+          // showWidget() with an unknown name is a silent no-op, so try both.
+          if (panel === 'pine-editor') { if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab(); else if (typeof bwb.showWidget === 'function') { bwb.showWidget('scripteditor'); bwb.showWidget(widgetName); } }
           else { if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); }
           performed = 'opened';
         } else if (action === 'close' || (action === 'toggle' && isOpen)) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -685,7 +685,7 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
         (function() {
           var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
           if (bwb && typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab();
-          else if (bwb && typeof bwb.showWidget === 'function') bwb.showWidget('pine-editor');
+          else if (bwb && typeof bwb.showWidget === 'function') { bwb.showWidget('scripteditor'); bwb.showWidget('pine-editor'); }
         })()
       `);
       for (let i = 0; i < 50; i++) {
@@ -1039,8 +1039,14 @@ val = array.get(a, 5)`;
       const bwb = await apiExists(BOTTOM_BAR);
       assert.ok(bwb, 'bottomWidgetBar exists');
 
-      // Open
-      await evaluate(`${BOTTOM_BAR}.showWidget('pine-editor')`);
+      // Open — widget renamed 'pine-editor' → 'scripteditor' in TV Desktop 3.3; unknown names no-op, so try both
+      await evaluate(`
+        (function() {
+          var bwb = ${BOTTOM_BAR};
+          if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab();
+          else { bwb.showWidget('scripteditor'); bwb.showWidget('pine-editor'); }
+        })()
+      `);
       await sleep(500);
       const isOpen = await evaluate(`!!document.querySelector('.monaco-editor.pine-editor-monaco')`);
 


### PR DESCRIPTION
## Problem

On TradingView Desktop 3.3, `ui_open_panel({ panel: 'pine-editor' })` reports `performed: "opened"` but the editor never opens.

The bottom-bar editor widget was renamed `pine-editor` -> `scripteditor`. `bottomWidgetBar.showWidget()` silently ignores an unknown name, so the fallback path is a no-op that still reports success.

Verified against a live TV Desktop 3.3.0 instance -- the widget registry now reads:

```
_widgetControllers: [paper_trading, backtesting, replay_trading, scripteditor]
```

`showWidget('pine-editor')` leaves the bar `minimized` with no Monaco in the DOM; `showWidget('scripteditor')` brings it to `normal` with `.monaco-editor.pine-editor-monaco` present.

## Fix

Call `showWidget()` with both names on the fallback path -- unknown names are harmless no-ops, so this works on old and new builds without version sniffing. `activateScriptEditorTab()` is still preferred first; it exists on every build tested.

Applied in the three places that open the editor:

- `src/core/ui.js` -- `openPanel()`
- `src/core/pine.js` -- `ensurePineEditorOpen()`
- `tests/e2e.test.js` -- `ensureEditor()` helper and the `ui_open_panel` test

The existing `hideWidget` -> `close()` -> `hide()` close fallback already on main is untouched; this is the matching gap on the open side.

## Testing

`ui_open_panel` e2e test fails on main against TV 3.3 and passes with this change:

```
> node --test --test-name-pattern="ui_open_panel" tests/e2e.test.js
  ui_open_panel -- open/close pine-editor (917ms)
  pass 1  fail 0
```

Unit suites: 89/91 pass. The 2 failures are pre-existing on main and unrelated -- `cli.test.js` pine-check tests exit `0xC0000409` from a libuv teardown assertion on Windows (`UV_HANDLE_CLOSING` in `src/win/async.c`), which reproduces on a clean checkout of main.

Environment: TradingView Desktop 3.3.0 (Electron 38.2.2 / Chrome 140), Windows 11.

---

Generated with [Claude Code](https://claude.com/claude-code)