### PR TITLE
docs: fix stale 78-tool count to 84

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (84 MCP tools)
 
 ### Chart Reading
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -125,5 +125,5 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 ## What to Read Next
 
 - `CLAUDE.md` — Decision tree for which tool to use when (auto-loaded by Claude Code)
-- `README.md` — Full tool reference (78 MCP tools, 30 CLI commands)
+- `README.md` — Full tool reference (84 MCP tools, 30 CLI commands)
 - `RESEARCH.md` — Research context and open questions


### PR DESCRIPTION
## Summary
- README.md's "Tool Reference" section heading said 78 MCP tools, while the README's own Transport line and CLAUDE.md already say 84.
- SETUP_GUIDE.md had the same stale 78 figure.
- Verified the actual count by counting registered tools in `src/tools/*.js` — it's 84.

## Test plan
- Docs-only change, no code affected.
- Confirmed both files now consistently read "84 MCP tools".

🤖 Generated with [Claude Code](https://claude.com/claude-code)