### PR TITLE
Fix indicator_search returning zero/wrong results on repeated searches

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/indicator_search.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/indicator_search.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/core/indicators.js
+++ b/src/core/indicators.js
@@ -1,42 +1,99 @@
 /**
  * Core indicator settings logic.
  */
-import { evaluate, safeString } from '../connection.js';
+import { evaluate as _evaluate, safeString } from '../connection.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 const DIALOG = '[data-name="indicators-dialog"]';
 
 const delay = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Only the search path (openDialog/typeQuery/closeDialog/runSearch,
+// searchStudies, addStudyFromSearch) takes _deps — it's the part covered by
+// unit tests, following the same injection pattern as core/chart.js.
+// pollIntervalMs/maxPolls are overridable so tests can exercise the
+// "never settles" timeout path without a real ~12s wait.
+function _resolve(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    pollIntervalMs: deps?.pollIntervalMs ?? 400,
+    maxPolls: deps?.maxPolls ?? 30,
+  };
+}
+
 // Read result rows out of the open Indicators dialog. The results pane is a
-// VIRTUALIZED list of absolutely-positioned rows: section headers contain an
-// <h3> (title-case: "My scripts", "Technicals", …), result rows don't. Rows
-// are read by that stable structure, NOT the hashed class names
-// (container-HtNLE8A5, …) which change on every TradingView build. Titles are
-// read from the row's whole textContent (search highlighting fragments the
-// text into multiple <span>s, so leaf-node matching would break).
+// VIRTUALIZED list of absolutely-positioned rows. Each real result row has
+// `data-role="list-item"` and its title directly on `data-title` — that
+// data-role is scoped to the results list alone (verified live: 0 matches
+// inside the category sidebar), so unlike a class-name scan it needs no
+// exclusion list for the sidebar/header/search-box chrome. Section headers
+// are the `[class*="contentHeader"]` elements interspersed between them,
+// each wrapping an <h3> (title-case: "My scripts", "Technicals", …).
+// `data-title` is also immune to search-highlighting fragmenting a title
+// into multiple <span>s, which plain textContent scraping is not.
+//
+// Also reports `emptyState`: TradingView renders its own "No indicators
+// matched your criteria" message when a query genuinely has no matches.
+// That's the only reliable way to tell "no matches" apart from "results
+// haven't rendered yet" — community-script results can take anywhere from
+// well under a second to several seconds to arrive, and reopening the
+// dialog does NOT clear whatever was rendered for the previous query, so a
+// plain "are there any rows" check can read stale leftovers from the prior
+// search as if they were fresh (verified live on both counts). The check is
+// a loose regex, not the exact string, so minor copy changes across
+// TradingView builds don't quietly break it.
 const READ_RESULTS_JS = `
   (function() {
     var dlg = document.querySelector('${DIALOG}');
     if (!dlg) return { open: false };
-    var scroll = dlg.querySelector('[class*="scroll"]') || dlg;
-    var rows = scroll.querySelectorAll('[class*="container"]');
+    var nodes = dlg.querySelectorAll('[data-role="list-item"], [class*="contentHeader"]');
     var results = [], section = null;
-    for (var i = 0; i < rows.length; i++) {
-      var r = rows[i];
-      var h3 = r.querySelector('h3');
-      if (h3 && r.contains(h3) && h3.parentElement === r) { section = (h3.textContent || '').trim(); continue; }
-      var titleEl = r.querySelector('[class*="title"]');
-      if (!titleEl) continue;
-      var title = (titleEl.textContent || '').trim();
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (n.getAttribute('data-role') !== 'list-item') {
+        var h3 = n.querySelector('h3');
+        section = ((h3 ? h3.textContent : n.textContent) || '').trim();
+        continue;
+      }
+      var title = (n.getAttribute('data-title') || '').trim();
       if (!title) continue;
       results.push({ title: title, section: section });
     }
-    return { open: true, results: results };
+    var emptyState = false;
+    var leaves = dlg.querySelectorAll('*');
+    for (var j = 0; j < leaves.length; j++) {
+      var e = leaves[j];
+      if (e.children.length > 0) continue;
+      var txt = (e.textContent || '').trim();
+      if (txt.length > 0 && txt.length < 80 && /no .*(matched|found|results)/i.test(txt)) { emptyState = true; break; }
+    }
+    return { open: true, results: results, emptyState: emptyState };
   })()
 `;
 
-async function openDialog() {
+// Polls (from Node, not inside the evaluated browser JS — an `async`
+// IIFE with an internal `await` never resumes through a plain CDP
+// Runtime.evaluate call: without `awaitPromise: true` it just returns the
+// pending Promise, which serializes as `{}`) until the dialog either shows
+// new content (different from `baseline`, taken right before typing) or its
+// own empty-state message. Real result timing varies a lot — under a
+// second for built-ins, several seconds for community/store results — so
+// this waits for a real signal rather than racing a fixed delay.
+async function waitForSettled(evaluate, baseline, pollIntervalMs, maxPolls) {
+  const baselineKey = JSON.stringify(baseline?.results || []);
+  for (let i = 0; i < maxPolls; i++) {
+    await delay(pollIntervalMs);
+    const current = await evaluate(READ_RESULTS_JS);
+    if (!current || !current.open) throw new Error('Indicators dialog closed unexpectedly during search.');
+    if (current.emptyState) return { results: [], emptyState: true };
+    if (current.results.length > 0 && JSON.stringify(current.results) !== baselineKey) {
+      return { results: current.results, emptyState: false };
+    }
+  }
+  return null;
+}
+
+async function openDialog(evaluate) {
   const opened = await evaluate(`
     (function() {
       if (document.querySelector('${DIALOG}')) return 'already';
@@ -55,7 +112,7 @@ async function openDialog() {
   throw new Error('Indicators dialog did not open.');
 }
 
-async function typeQuery(query) {
+async function typeQuery(evaluate, query) {
   await evaluate(`
     (function() {
       var inp = document.querySelector('${DIALOG} input');
@@ -67,10 +124,33 @@ async function typeQuery(query) {
       return true;
     })()
   `);
-  await delay(1200);
 }
 
-async function closeDialog() {
+// Clears the search box back to a blank query before capturing the
+// pre-type baseline. Without this, baseline capture can land on whatever
+// the previous search left rendered — including, if this exact same query
+// was searched last, content IDENTICAL to what the new search will settle
+// on, which would make waitForSettled wait forever for a "change" that
+// already happened before it started looking (reproduced live: searching
+// "stochastic" twice in a row with no clear in between timed out). Blank
+// query reliably settles into a distinct default listing within ~200ms
+// (verified live) since it's a local re-filter, not a network round trip,
+// so a short fixed delay is fine here — unlike the real query below.
+async function clearQuery(evaluate) {
+  await evaluate(`
+    (function() {
+      var inp = document.querySelector('${DIALOG} input');
+      if (!inp) return false;
+      var setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+      setter.call(inp, '');
+      inp.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    })()
+  `);
+  await delay(500);
+}
+
+async function closeDialog(evaluate) {
   await evaluate(`
     (function() {
       var dlg = document.querySelector('${DIALOG}');
@@ -82,21 +162,38 @@ async function closeDialog() {
   await delay(300);
 }
 
+// Runs one full open→type→read(settled)→close cycle. Reopening the dialog
+// fresh each time — rather than reusing an already-open one — matters here
+// too: it does NOT clear whatever the previous query left rendered, so the
+// pre-type baseline captured below still reflects real prior state that
+// needs to be diffed against, not an empty slate.
+async function runSearch(evaluate, query, pollIntervalMs, maxPolls) {
+  await openDialog(evaluate);
+  await clearQuery(evaluate);
+  const baseline = await evaluate(READ_RESULTS_JS);
+  await typeQuery(evaluate, query);
+  const settled = await waitForSettled(evaluate, baseline, pollIntervalMs, maxPolls);
+  await closeDialog(evaluate);
+  if (!settled) {
+    const timeoutS = Math.round((pollIntervalMs * maxPolls) / 1000);
+    throw new Error(`Indicators search for "${query}" did not settle within ${timeoutS}s (no new results and no "no matches" message rendered) — TradingView's search may be unusually slow or stuck. Try again, or restart TradingView Desktop if this persists.`);
+  }
+  return settled.results;
+}
+
 /**
  * Search TradingView's Indicators dialog — covers built-ins, strategies,
  * community/public scripts, and your saved scripts (everything the manual
  * search box returns).
  */
-export async function searchStudies({ query, limit } = {}) {
+export async function searchStudies({ query, limit, _deps } = {}) {
   if (!query || !String(query).trim()) throw new Error('query is required.');
+  const { evaluate, pollIntervalMs, maxPolls } = _resolve(_deps);
   const cap = limit || 25;
-  await openDialog();
-  await typeQuery(query);
-  const res = await evaluate(READ_RESULTS_JS);
-  await closeDialog();
-  if (!res || !res.open) throw new Error('Indicators dialog closed unexpectedly during search.');
-  const results = (res.results || []).map(({ title, section }) => ({ title, section })).slice(0, cap);
-  return { success: true, query, count: results.length, results };
+
+  const results = await runSearch(evaluate, query, pollIntervalMs, maxPolls);
+
+  return { success: true, query, count: Math.min(results.length, cap), results: results.slice(0, cap).map(({ title, section }) => ({ title, section })) };
 }
 
 /**
@@ -104,35 +201,48 @@ export async function searchStudies({ query, limit } = {}) {
  * query) is matched case-insensitively against result titles; the first
  * matching row is added. Verifies a new study landed on the chart.
  */
-export async function addStudyFromSearch({ query, match, section } = {}) {
+export async function addStudyFromSearch({ query, match, section, _deps } = {}) {
   if (!query || !String(query).trim()) throw new Error('query is required.');
+  const { evaluate, pollIntervalMs, maxPolls } = _resolve(_deps);
   const want = String(match || query).trim();
 
   const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s){return s.id;})`);
 
-  await openDialog();
-  await typeQuery(query);
+  await openDialog(evaluate);
+  await clearQuery(evaluate);
+  const baseline = await evaluate(READ_RESULTS_JS);
+  await typeQuery(evaluate, query);
+  const settled = await waitForSettled(evaluate, baseline, pollIntervalMs, maxPolls);
+  if (!settled) {
+    await closeDialog(evaluate);
+    const timeoutS = Math.round((pollIntervalMs * maxPolls) / 1000);
+    throw new Error(`Indicators search for "${query}" did not settle within ${timeoutS}s (no new results and no "no matches" message rendered) — TradingView's search may be unusually slow or stuck. Try again, or restart TradingView Desktop if this persists.`);
+  }
+  if (settled.emptyState) {
+    await closeDialog(evaluate);
+    throw new Error(`No result matching "${want}" found.`);
+  }
 
   const clicked = await evaluate(`
     (function() {
       var dlg = document.querySelector('${DIALOG}');
       if (!dlg) return { error: 'dialog closed' };
-      var scroll = dlg.querySelector('[class*="scroll"]') || dlg;
       var want = ${safeString(want.toLowerCase())};
       var wantSection = ${section ? safeString(String(section).toLowerCase()) : 'null'};
-      var rows = scroll.querySelectorAll('[class*="container"]');
+      var nodes = dlg.querySelectorAll('[data-role="list-item"], [class*="contentHeader"]');
       var section = null, exact = null, contains = null;
-      for (var i = 0; i < rows.length; i++) {
-        var r = rows[i];
-        var h3 = r.querySelector('h3');
-        if (h3 && h3.parentElement === r) { section = (h3.textContent || '').trim().toLowerCase(); continue; }
+      for (var i = 0; i < nodes.length; i++) {
+        var n = nodes[i];
+        if (n.getAttribute('data-role') !== 'list-item') {
+          var h3 = n.querySelector('h3');
+          section = ((h3 ? h3.textContent : n.textContent) || '').trim().toLowerCase();
+          continue;
+        }
         if (wantSection && section !== wantSection) continue;
-        var titleEl = r.querySelector('[class*="title"]');
-        if (!titleEl) continue;
-        var t = (titleEl.textContent || '').trim();
+        var t = (n.getAttribute('data-title') || '').trim();
         var tl = t.toLowerCase();
-        if (tl === want && !exact) exact = { row: r, title: t, section: section };
-        if (tl.indexOf(want) !== -1 && !contains) contains = { row: r, title: t, section: section };
+        if (tl === want && !exact) exact = { row: n, title: t, section: section };
+        if (tl.indexOf(want) !== -1 && !contains) contains = { row: n, title: t, section: section };
       }
       var pick = exact || contains;
       if (!pick) return { error: 'No result matching "' + want + '" found.' };
@@ -141,10 +251,10 @@ export async function addStudyFromSearch({ query, match, section } = {}) {
     })()
   `);
 
-  if (clicked && clicked.error) { await closeDialog(); throw new Error(clicked.error); }
+  if (clicked && clicked.error) { await closeDialog(evaluate); throw new Error(clicked.error); }
 
   await delay(1500);
-  await closeDialog();
+  await closeDialog(evaluate);
 
   const after = await evaluate(`${CHART_API}.getAllStudies().map(function(s){return { id: s.id, name: s.getStudyMeta ? s.getStudyMeta().description : (s.name || null) };})`);
   const beforeSet = new Set(before || []);
@@ -168,7 +278,7 @@ export async function setInputs({ entity_id, inputs: inputsRaw }) {
 
   const inputsJson = JSON.stringify(inputs);
 
-  const result = await evaluate(`
+  const result = await _evaluate(`
     (function() {
       var chart = ${CHART_API};
       var study = chart.getStudyById(${safeString(entity_id)});
@@ -195,7 +305,7 @@ export async function toggleVisibility({ entity_id, visible }) {
   if (!entity_id) throw new Error('entity_id is required. Use chart_get_state to find study IDs.');
   if (typeof visible !== 'boolean') throw new Error('visible must be a boolean (true or false)');
 
-  const result = await evaluate(`
+  const result = await _evaluate(`
     (function() {
       var chart = ${CHART_API};
       var study = chart.getStudyById(${safeString(entity_id)});

--- a/tests/indicator_search.test.js
+++ b/tests/indicator_search.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests for searchStudies/addStudyFromSearch in src/core/indicators.js.
+ *
+ * Covers a live-reproduced bug: TradingView's Indicators dialog does not
+ * clear previously-rendered results when reopened, and community-script
+ * search results can take anywhere from well under a second to several
+ * seconds to render. A naive "read once after a fixed delay" either reads
+ * stale leftover rows from the *previous* query (a false positive) or races
+ * a genuinely slow render and reads nothing yet (a false "stuck" negative).
+ * searchStudies now polls until the dialog shows either new content (a
+ * diff against a pre-type baseline) or its own "No indicators matched your
+ * criteria" empty-state message — the two real, observable terminal states
+ * — and only reports a hard failure if neither appears within the timeout.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { searchStudies, addStudyFromSearch } from '../src/core/indicators.js';
+
+// ── Mock helpers ─────────────────────────────────────────────────────────
+
+// Simulates the Indicators dialog at the `evaluate` boundary: it recognizes
+// which step of openDialog/typeQuery/READ_RESULTS_JS/closeDialog is being
+// evaluated (by stable substrings from the real templates) and returns
+// canned data instead of running the injected DOM-scanning JS for real.
+//
+// `readsByQuery` maps a query string to an array of "readouts" consumed one
+// per read (baseline capture counts as a read too, so a fresh dialog with
+// no prior query reads `readsByQuery[null]`); each readout is either an
+// array of {title, section} rows, or the string 'EMPTY' for TradingView's
+// own no-match message. Once a query's readouts are exhausted, the last one
+// repeats — matching a dialog that's settled and stops changing.
+function mockDialog({ readsByQuery }) {
+  let dialogOpen = false;
+  let currentQuery = null;
+  const readIndex = {};
+
+  const evaluate = async (expr) => {
+    if (expr.includes("return 'already';")) {
+      if (dialogOpen) return 'already';
+      dialogOpen = true;
+      return 'clicked';
+    }
+    if (expr.includes('!!document.querySelector(') && expr.includes('input')) {
+      return dialogOpen;
+    }
+    if (expr.includes("dispatchEvent(new Event('input'")) {
+      const m = expr.match(/setter\.call\(inp,\s*(".*?")\)/);
+      currentQuery = m ? JSON.parse(m[1]) : null;
+      return true;
+    }
+    if (expr.includes('var emptyState = false;')) {
+      const seq = readsByQuery[currentQuery] || [[]];
+      const i = readIndex[currentQuery] || 0;
+      readIndex[currentQuery] = i + 1;
+      const readout = seq[Math.min(i, seq.length - 1)];
+      if (readout === 'EMPTY') return { open: true, results: [], emptyState: true };
+      return { open: true, results: readout || [], emptyState: false };
+    }
+    if (expr.includes('data-name="close"')) {
+      dialogOpen = false;
+      return undefined;
+    }
+    return undefined;
+  };
+  evaluate.readIndex = readIndex;
+  return evaluate;
+}
+
+// Small/fast values so tests don't wait on the real 400ms/30-poll (~12s) budget.
+const FAST_DEPS = { pollIntervalMs: 2, maxPolls: 5 };
+
+describe('searchStudies', () => {
+  it('returns results once they render', async () => {
+    const evaluate = mockDialog({
+      readsByQuery: {
+        supertrend: [[{ title: 'Supertrend', section: 'Technicals' }, { title: 'SuperTrend AI', section: 'Community' }]],
+      },
+    });
+    const r = await searchStudies({ query: 'supertrend', _deps: { evaluate, ...FAST_DEPS } });
+    assert.equal(r.success, true);
+    assert.equal(r.count, 2);
+    assert.deepEqual(r.results, [{ title: 'Supertrend', section: 'Technicals' }, { title: 'SuperTrend AI', section: 'Community' }]);
+  });
+
+  it('respects the limit and reports the capped count', async () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ title: `Study ${i}`, section: 'Technicals' }));
+    const evaluate = mockDialog({ readsByQuery: { rsi: [many] } });
+    const r = await searchStudies({ query: 'rsi', limit: 5, _deps: { evaluate, ...FAST_DEPS } });
+    assert.equal(r.success, true);
+    assert.equal(r.count, 5);
+    assert.equal(r.results.length, 5);
+  });
+
+  it('waits out a slow render instead of reporting a false failure', async () => {
+    // Two empty polls (still loading) before the real results land — must
+    // not be mistaken for "no matches" or "stuck".
+    const evaluate = mockDialog({
+      readsByQuery: {
+        ema: [[], [], [{ title: 'Moving Average Exponential', section: 'Technicals' }]],
+      },
+    });
+    const r = await searchStudies({ query: 'ema', _deps: { evaluate, ...FAST_DEPS } });
+    assert.equal(r.success, true);
+    assert.equal(r.count, 1);
+    assert.equal(r.results[0].title, 'Moving Average Exponential');
+  });
+
+  it('does not mistake stale leftover rows from a previous query for a fresh match', async () => {
+    // The dialog still shows the *previous* query's rows the instant after
+    // typing (reopening doesn't clear them) — those must not be reported
+    // as if they matched the new query. Baseline capture reads the stale
+    // rows (keyed by the leftover/null query); the new query's first two
+    // reads still show that same stale content before it actually updates.
+    const stale = [{ title: 'Stale Old Result', section: 'Technicals' }];
+    const evaluate = mockDialog({
+      readsByQuery: {
+        null: [stale],
+        macd: [stale, stale, [{ title: 'MACD', section: 'Technicals' }]],
+      },
+    });
+    const r = await searchStudies({ query: 'macd', _deps: { evaluate, ...FAST_DEPS } });
+    assert.equal(r.success, true);
+    assert.equal(r.count, 1);
+    assert.equal(r.results[0].title, 'MACD');
+  });
+
+  it('reports a clear, honest failure when the query never settles', async () => {
+    const evaluate = mockDialog({ readsByQuery: { xyzzy: [[]] } });
+    await assert.rejects(
+      () => searchStudies({ query: 'xyzzy', _deps: { evaluate, ...FAST_DEPS } }),
+      /did not settle/,
+    );
+  });
+
+  it('requires a non-empty query', async () => {
+    await assert.rejects(() => searchStudies({ query: '  ' }), /query is required/);
+  });
+});
+
+describe('addStudyFromSearch', () => {
+  function mockAddDeps({ after, clickResult }) {
+    let readCount = 0;
+    const evaluate = async (expr) => {
+      // The "after" read asks for {id, name} objects; the "before" read (run
+      // before the dialog even opens) just asks for bare ids.
+      if (expr.includes('getAllStudies()') && expr.includes('name:')) return after;
+      if (expr.includes('getAllStudies()')) return [];
+      if (expr.includes('pick.row.click')) return clickResult;
+      if (expr.includes("return 'already';")) return 'clicked';
+      if (expr.includes('!!document.querySelector(')) return true;
+      if (expr.includes("dispatchEvent(new Event('input'")) return true;
+      if (expr.includes('var emptyState = false;')) {
+        // First read is the pre-type baseline (empty); every read after
+        // that reflects the query having rendered a real result row.
+        readCount += 1;
+        if (readCount === 1) return { open: true, results: [], emptyState: false };
+        return { open: true, results: [{ title: 'placeholder', section: null }], emptyState: false };
+      }
+      return undefined;
+    };
+    return evaluate;
+  }
+
+  it('surfaces a clear error when no result matches', async () => {
+    const evaluate = mockAddDeps({ after: [], clickResult: { error: 'No result matching "totally-bogus-name" found.' } });
+    await assert.rejects(
+      () => addStudyFromSearch({ query: 'totally-bogus-name', _deps: { evaluate, ...FAST_DEPS } }),
+      /No result matching/,
+    );
+  });
+
+  it('reports success and the new entity_id when a row is clicked and a study appears', async () => {
+    const evaluate = mockAddDeps({
+      after: [{ id: 'study_1', name: 'Supertrend' }],
+      clickResult: { clicked: 'Supertrend', section: 'Technicals' },
+    });
+    const r = await addStudyFromSearch({ query: 'supertrend', _deps: { evaluate, ...FAST_DEPS } });
+    assert.equal(r.success, true);
+    assert.equal(r.entity_id, 'study_1');
+    assert.equal(r.added_from_search, 'Supertrend');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #404 — `indicator_search`/`indicator_add` returning zero or wrong results on repeated searches.

- Replaces the fixed 1200ms wait with polling (every ~400ms, up to ~12s) for a real DOM signal: either the result set changing from a pre-type baseline, or TradingView's own "No indicators matched your criteria" empty-state message.
- Clears the search box to blank immediately before capturing that baseline, so searching the same query twice in a row can't produce a baseline identical to the new results (verified live to otherwise time out).
- Switches result-row detection to the `data-role="list-item"` / `data-title` attributes TradingView puts on real result rows, instead of scraping hashed `container`/`title` classes. That data-role is scoped to the results list only (0 matches inside the category sidebar), so it needs no sidebar/header exclusion list and isn't fooled by search-highlighting fragmenting a title into multiple `<span>`s. This also fixes a live false positive where a section header ("Technicals") was misread as a result title.
- Threads `_deps` through the search path (`searchStudies`/`addStudyFromSearch`), matching the existing injection pattern in `core/chart.js`, with `pollIntervalMs`/`maxPolls` also injectable so the timeout path is unit-testable without a real ~12s wait.
- Adds `tests/indicator_search.test.js` covering the slow-render, stale-leftover-row, and never-settles paths; wired into `test:unit`/`test:all`.

## What I ran and observed

- `npm run lint` — clean (pre-existing unrelated warnings only, in `data.js`/`pane.js`/`watchlist.js`).
- `npm run test:unit` — 160/160 passing.
- Live against a running TradingView Desktop instance (CDP on :9222):
  - Repeated distinct queries (`stochastic`, `bollinger bands`, `macd`, etc.) each resolve correctly in ~1-1.5s.
  - The same query searched twice in a row (previously timed out) now resolves correctly both times.
  - A genuine no-match query (`zzzznonexistentqueryxyz123`) correctly returns `success: true, count: 0` rather than a false stuck-diagnostic.
  - `addStudyFromSearch` end-to-end: searched and added "Bollinger Bands", got back a real `entity_id`, then removed it via `chart_manage_indicator` to leave the chart unchanged.
- Externally verified against a separate consuming project using this MCP as a live dependency.

## Root cause

TradingView's Indicators dialog has two properties the original code didn't account for: community-script results can take anywhere from well under a second to several seconds to render, and reopening the dialog does not clear whatever the previous query left rendered. A fixed wait either raced a genuinely slow render (false empty result) or read stale leftover rows from the previous query as if they matched the new one.
