### PR TITLE
docs: fix stale tool count (78 -> 84) in README and SETUP_GUIDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (84 MCP tools)
 
 ### Chart Reading
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -125,5 +125,5 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 ## What to Read Next
 
 - `CLAUDE.md` — Decision tree for which tool to use when (auto-loaded by Claude Code)
-- `README.md` — Full tool reference (78 MCP tools, 30 CLI commands)
+- `README.md` — Full tool reference (84 MCP tools, 30 CLI commands)
 - `RESEARCH.md` — Research context and open questions


### PR DESCRIPTION
## Summary
- `README.md` and `SETUP_GUIDE.md` still said "78 MCP tools" in two places, while `CLAUDE.md` and another line in `README.md` (transport section) already say 84 — and counting `server.tool(...)` registrations in `src/tools/*.js` confirms 84 is the correct current count.
- Updated both stale references to 84 for consistency.

## Test plan
- [x] Verified tool count via `grep -c "server.tool(" src/tools/*.js` → 84
- [x] Docs-only change, no code/behavior affected