### PR TITLE
fix: bound every CDP call with a timeout so a frozen TradingView can't hang MCP sessions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default [
         setInterval: 'readonly', clearInterval: 'readonly', console: 'readonly',
         process: 'readonly', Buffer: 'readonly', URL: 'readonly',
         URLSearchParams: 'readonly', WebSocket: 'readonly', AbortController: 'readonly',
+        AbortSignal: 'readonly',
         TextEncoder: 'readonly', TextDecoder: 'readonly', global: 'readonly',
         __dirname: 'readonly', structuredClone: 'readonly',
       },

--- a/src/connection.js
+++ b/src/connection.js
@@ -7,8 +7,31 @@ let targetInfo = null;
 // resolves to ::1 first, and Electron's --remote-debugging-port only listens on IPv4.
 export const CDP_HOST = process.env.TV_CDP_HOST || process.env.CDP_HOST || '127.0.0.1';
 export const CDP_PORT = Number(process.env.TV_CDP_PORT || process.env.CDP_PORT) || 9222;
-const MAX_RETRIES = 5;
+// 3 retries, not 5: every attempt is now individually bounded (see timeouts
+// below), and callers should get a clear failure in seconds, not ~a minute.
+const MAX_RETRIES = 3;
 const BASE_DELAY = 500;
+
+// Hard deadlines on every CDP interaction. TradingView's debug port keeps
+// answering HTTP even when its renderers have crashed or been frozen by
+// macOS, so an unbounded Runtime.evaluate can block forever and wedge the
+// whole MCP session. Nothing in this file may await a CDP promise bare.
+const EVAL_TIMEOUT = 15000;
+const CONNECT_TIMEOUT = 5000;
+const PROBE_TIMEOUT = 2500;
+const HTTP_TIMEOUT = 3000;
+
+export function withTimeout(promise, ms, label) {
+  let timer;
+  const deadline = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(
+      `${label} timed out after ${ms}ms — TradingView is not responding. ` +
+      `Its renderer may have crashed or been suspended by macOS; ` +
+      `restart TradingView Desktop (tv_launch) and retry.`
+    )), ms);
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
+}
 
 // Known direct API paths discovered via live probing (see PROBE_RESULTS.md)
 const KNOWN_PATHS = {
@@ -54,9 +77,13 @@ export async function getClient() {
   if (client) {
     try {
       // Quick liveness check
-      await client.Runtime.evaluate({ expression: '1', returnByValue: true });
+      await withTimeout(
+        client.Runtime.evaluate({ expression: '1', returnByValue: true }),
+        PROBE_TIMEOUT, 'Liveness check'
+      );
       return client;
     } catch {
+      try { await client.close(); } catch {}
       client = null;
       targetInfo = null;
     }
@@ -68,21 +95,44 @@ export async function connect(targetId = null) {
   let lastError;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const target = targetId ? await findTargetById(targetId) : await findChartTarget();
-      if (!target) {
+      const candidates = targetId
+        ? [await findTargetById(targetId)].filter(Boolean)
+        : await findChartTargets();
+      if (candidates.length === 0) {
         throw new Error(targetId
           ? `CDP target ${targetId} not found — is the tab still open?`
           : 'No TradingView chart target found. Is TradingView open with a chart?');
       }
-      targetInfo = target;
-      client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
-
-      // Enable required domains
-      await client.Runtime.enable();
-      await client.Page.enable();
-      await client.DOM.enable();
-
-      return client;
+      // Attach to the first candidate whose renderer actually answers.
+      // A crashed/frozen renderer still shows up in /json/list, so a URL
+      // match alone is not proof the page can execute anything.
+      for (const target of candidates) {
+        let c = null;
+        try {
+          c = await withTimeout(
+            CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id }),
+            CONNECT_TIMEOUT, 'CDP attach'
+          );
+          await withTimeout(
+            c.Runtime.evaluate({ expression: '1', returnByValue: true }),
+            PROBE_TIMEOUT, 'Renderer probe'
+          );
+          await withTimeout(
+            Promise.all([c.Runtime.enable(), c.Page.enable(), c.DOM.enable()]),
+            CONNECT_TIMEOUT, 'CDP domain enable'
+          );
+          targetInfo = target;
+          client = c;
+          return client;
+        } catch (err) {
+          lastError = err;
+          if (c) { try { await c.close(); } catch {} }
+        }
+      }
+      throw new Error(
+        `Found ${candidates.length} TradingView target(s) but none responded — ` +
+        `renderers appear crashed or suspended. ${lastError?.message ?? ''}`
+      );
     } catch (err) {
       lastError = err;
       const delay = Math.min(BASE_DELAY * Math.pow(2, attempt), 30000);
@@ -107,17 +157,24 @@ export async function reconnectTo(targetId) {
   return connect(targetId);
 }
 
-async function findChartTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+async function findChartTargets() {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`,
+    { signal: AbortSignal.timeout(HTTP_TIMEOUT) });
   const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
-    || null;
+  // Only real chart pages qualify. The old fallback (/tradingview/i) also
+  // matched the app's own file:// shell pages (…/TradingView.app/…), which
+  // never expose window.TradingViewApi — require the tradingview.com host.
+  const isPage = t => t.type === 'page' || t.type === 'webview';
+  return [
+    ...targets.filter(t => isPage(t) && /tradingview\.com\/chart/i.test(t.url)),
+    ...targets.filter(t => isPage(t) && /https?:\/\/[^/]*tradingview\.com/i.test(t.url)
+      && !/tradingview\.com\/chart/i.test(t.url)),
+  ];
 }
 
 async function findTargetById(id) {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`,
+    { signal: AbortSignal.timeout(HTTP_TIMEOUT) });
   const targets = await resp.json();
   return targets.find(t => t.id === id) || null;
 }
@@ -131,12 +188,28 @@ export async function getTargetInfo() {
 
 export async function evaluate(expression, opts = {}) {
   const c = await getClient();
-  const result = await c.Runtime.evaluate({
-    expression,
-    returnByValue: true,
-    awaitPromise: opts.awaitPromise ?? false,
-    ...opts,
-  });
+  const { timeoutMs, ...cdpOpts } = opts;
+  let result;
+  try {
+    result = await withTimeout(
+      c.Runtime.evaluate({
+        expression,
+        returnByValue: true,
+        awaitPromise: cdpOpts.awaitPromise ?? false,
+        ...cdpOpts,
+      }),
+      timeoutMs ?? EVAL_TIMEOUT, 'Runtime.evaluate'
+    );
+  } catch (err) {
+    // Drop the cached client on timeout so the next call re-probes targets
+    // instead of piling more calls onto a dead renderer.
+    if (/timed out/.test(err.message)) {
+      try { await c.close(); } catch {}
+      client = null;
+      targetInfo = null;
+    }
+    throw err;
+  }
   if (result.exceptionDetails) {
     const msg = result.exceptionDetails.exception?.description
       || result.exceptionDetails.text

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -3,7 +3,7 @@
  */
 import { getClient, getTargetInfo, evaluate, CDP_HOST, CDP_PORT } from '../connection.js';
 import { existsSync, cpSync, rmSync, readdirSync } from 'fs';
-import { execSync, spawn } from 'child_process';
+import { execSync, execFileSync, spawn } from 'child_process';
 import { dirname, basename, join } from 'path';
 
 // Best-effort git-pull update check: compare local HEAD to origin's default
@@ -205,6 +205,7 @@ function _resolveLaunchDeps(deps) {
   return {
     spawn: deps?.spawn || spawn,
     execSync: deps?.execSync || execSync,
+    execFileSync: deps?.execFileSync || execFileSync,
     existsSync: deps?.existsSync || existsSync,
     cpSync: deps?.cpSync || cpSync,
     rmSync: deps?.rmSync || rmSync,
@@ -360,7 +361,20 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  let child;
+  if (platform === 'darwin' && tvPath.includes('.app/')) {
+    // Launch through `open` so launchd starts the app at normal foreground
+    // QoS. A direct spawn() inherits this process's priority — when the MCP
+    // runs under a background scheduler (launchd agent, cron), TradingView
+    // comes up App-Napped (ps state SN) and macOS throttles and eventually
+    // evicts its renderers. The CDP port keeps answering HTTP in that state
+    // while every Runtime.evaluate hangs.
+    const appPath = tvPath.replace(/\/Contents\/MacOS\/.*$/, '');
+    deps.execFileSync('open', ['-a', appPath, '--args', ...cdpArgs], { timeout: 15000 });
+    child = { pid: null };
+  } else {
+    child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  }
   let info = null;
   let usedLocalCopy = false;
 

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -16,7 +16,7 @@ import { getClient, reconnectTo, CDP_HOST, CDP_PORT } from '../connection.js';
  * List all open chart tabs (CDP page targets).
  */
 export async function list() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`, { signal: AbortSignal.timeout(3000) });
   const targets = await resp.json();
 
   // Chart tabs plus new-tab landing pages (layout picker), so every tab in the
@@ -41,7 +41,7 @@ export async function list() {
  * is the one whose DOM actually contains `.tabs-container .tab`.
  */
 async function withShell(fn) {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`, { signal: AbortSignal.timeout(3000) });
   const targets = await resp.json();
   const candidates = targets.filter(t => t.type === 'page' && /\/window\/index\.html/i.test(t.url || ''));
 
@@ -85,7 +85,7 @@ async function isTargetVisible(targetId) {
 
 /** Find an open new-tab landing page target (shows the layout picker). */
 async function findLandingTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`, { signal: AbortSignal.timeout(3000) });
   const targets = await resp.json();
   return targets.find(t => t.type === 'page' && t.title === 'New tab') || null;
 }
@@ -147,7 +147,7 @@ export async function newTab({ layout, name } = {}) {
   if (!landing) throw new Error('New tab opened but its landing page target was not found.');
 
   // Snapshot existing chart targets so we can spot the one the pick creates.
-  const beforeResp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const beforeResp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`, { signal: AbortSignal.timeout(3000) });
   const chartIdsBefore = new Set(
     (await beforeResp.json())
       .filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
@@ -226,7 +226,7 @@ export async function newTab({ layout, name } = {}) {
   let chartTarget = null;
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 500));
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`, { signal: AbortSignal.timeout(3000) });
     const targets = await resp.json();
     chartTarget = targets.find(x =>
       x.type === 'page' && /tradingview\.com\/chart/i.test(x.url) && !chartIdsBefore.has(x.id)


### PR DESCRIPTION
## Problem

When TradingView Desktop's renderer processes crash or get suspended (e.g. macOS App Nap / background-QoS eviction), the CDP debug port on :9222 **keeps answering HTTP** — `/json/version` and `/json/list` still respond — but every `Runtime.evaluate` against its page targets blocks forever. Since nothing in `connection.js` had a deadline, one tool call in that state hung the MCP server indefinitely and wedged the whole client session with it. We hit this in production: an app launched by a background scheduler ran for days, macOS evicted all its renderers, and every session that touched a `tv_*` tool froze until manually killed.

Two contributing bugs made it worse:

1. **Target selection matched dead shell pages.** The fallback regex `/tradingview/i` also matched the app's own `file://…/TradingView.app/…` windows (new-tab screen, tooltip, drag-service). Those never expose `window.TradingViewApi`, and on a broken app they're exactly the targets that hang.
2. **On macOS, `launch()` spawned the binary directly**, so TradingView inherited the MCP process's QoS. When the MCP runs under a background scheduler (launchd agent, cron), the app comes up App-Napped (`ps` state `SN`) and macOS throttles and eventually evicts its renderers — recreating the zombie state on every automated launch.

## Fix

- `connection.js`: new `withTimeout()` helper; every CDP interaction is bounded (attach 5s, renderer probe 2.5s, domain enable 5s, evaluate 15s — overridable per call via `opts.timeoutMs`, liveness check 2.5s, `/json/list` fetches 3s via `AbortSignal.timeout`). Timeout errors say what happened and suggest `tv_launch`.
- On evaluate timeout the cached client is dropped, so the next call re-probes targets instead of piling onto a dead renderer.
- `connect()` now collects candidate targets (real `tradingview.com` URLs only, chart pages first) and attaches to the first one whose renderer **actually answers a probe** — a URL match alone is not proof the page can execute anything.
- `MAX_RETRIES` 5 → 3: each attempt is now individually bounded, and callers should get a clear failure in seconds.
- `core/health.js`: on macOS, launch via `open -a … --args --remote-debugging-port=…` (through the injectable deps bundle, so tests can stub it) so TradingView always starts at normal foreground QoS regardless of the caller's priority.
- `core/tab.js`: `AbortSignal.timeout(3000)` on the remaining `/json/list` fetches.
- `eslint.config.mjs`: add `AbortSignal` to globals.

## Testing

- `npm run test:unit`: 152/152 pass; `npm run lint`: 0 errors.
- Live-verified on macOS against Desktop 3.2.0: healthy chart connects in ~40ms and reads symbol/study data; with a deliberately created zombie (renderers killed, main process + CDP port alive) every tool now fails in ~3s with an actionable error instead of hanging forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)