### PR TITLE
fix(macos): launch via `open --args` so launchd owns the process

### DIFF
--- a/scripts/launch_tv_debug_mac.sh
+++ b/scripts/launch_tv_debug_mac.sh
@@ -4,54 +4,67 @@
 
 PORT="${1:-9222}"
 
-# Auto-detect TradingView install location
-APP=""
+# Auto-detect TradingView install location. `open -a` needs the .app bundle,
+# not the inner Mach-O binary.
+BUNDLE=""
 LOCATIONS=(
-  "/Applications/TradingView.app/Contents/MacOS/TradingView"
-  "$HOME/Applications/TradingView.app/Contents/MacOS/TradingView"
+  "/Applications/TradingView.app"
+  "$HOME/Applications/TradingView.app"
 )
 
 for loc in "${LOCATIONS[@]}"; do
-  if [ -f "$loc" ]; then
-    APP="$loc"
+  if [ -d "$loc" ]; then
+    BUNDLE="$loc"
     break
   fi
 done
 
 # Fallback: search with mdfind (Spotlight)
-if [ -z "$APP" ]; then
-  APP=$(mdfind "kMDItemCFBundleIdentifier == 'com.niceincontact.TradingView'" 2>/dev/null | head -1)
-  if [ -n "$APP" ]; then
-    APP="$APP/Contents/MacOS/TradingView"
-  fi
+if [ -z "$BUNDLE" ]; then
+  BUNDLE=$(mdfind "kMDItemCFBundleIdentifier == 'com.niceincontact.TradingView'" 2>/dev/null | head -1)
 fi
 
 # Fallback: find any TradingView.app
-if [ -z "$APP" ] || [ ! -f "$APP" ]; then
-  APP=$(find /Applications "$HOME/Applications" -name "TradingView.app" -maxdepth 2 2>/dev/null | head -1)
-  if [ -n "$APP" ]; then
-    APP="$APP/Contents/MacOS/TradingView"
-  fi
+if [ -z "$BUNDLE" ] || [ ! -d "$BUNDLE" ]; then
+  BUNDLE=$(find /Applications "$HOME/Applications" -name "TradingView.app" -maxdepth 2 2>/dev/null | head -1)
 fi
 
-if [ -z "$APP" ] || [ ! -f "$APP" ]; then
+if [ -z "$BUNDLE" ] || [ ! -d "$BUNDLE" ]; then
   echo "Error: TradingView not found."
   echo "Checked: /Applications/TradingView.app, ~/Applications/TradingView.app"
   echo ""
   echo "If installed elsewhere, run manually:"
-  echo "  /path/to/TradingView.app/Contents/MacOS/TradingView --remote-debugging-port=$PORT"
+  echo "  open -a /path/to/TradingView.app --args --remote-debugging-port=$PORT"
   exit 1
 fi
 
-# Kill any existing TradingView
-pkill -f "TradingView" 2>/dev/null
-sleep 1
+BIN="$BUNDLE/Contents/MacOS/TradingView"
 
-echo "Found TradingView at: $APP"
+# Quit any running instance: `open --args` only forwards arguments when the app
+# is not already running. Match $BIN rather than the bare name — `pkill -f TradingView`
+# also matches unrelated processes that merely mention it.
+osascript -e 'quit app "TradingView"' 2>/dev/null
+for _ in $(seq 1 10); do
+  pgrep -f "$BIN" > /dev/null 2>&1 || break
+  sleep 1
+done
+if pgrep -f "$BIN" > /dev/null 2>&1; then
+  pkill -f "$BIN" 2>/dev/null
+  sleep 2
+fi
+
+echo "Found TradingView at: $BUNDLE"
 echo "Launching with --remote-debugging-port=$PORT ..."
-"$APP" --remote-debugging-port=$PORT &
-TV_PID=$!
-echo "PID: $TV_PID"
+
+# Launch via `open` so launchd owns the process (PPID 1). Launching $BIN directly
+# makes it a child of the calling shell; under a degraded GUI session — e.g. an
+# editor extension host — CDP answers but the renderer never finishes booting:
+# the chart sits on a spinner and api_available stays false indefinitely.
+#
+# ELECTRON_RUN_AS_NODE is exported by some editor extension hosts. When set, the
+# Electron stub runs as a plain Node interpreter and rejects the flag with
+# "bad option: --remote-debugging-port=$PORT".
+env -u ELECTRON_RUN_AS_NODE open -a "$BUNDLE" --args --remote-debugging-port="$PORT"
 
 # Wait for CDP to be ready
 echo "Waiting for CDP..."


### PR DESCRIPTION
## Problem

`scripts/launch_tv_debug_mac.sh` fails to produce a usable chart when run from an editor-integrated terminal (VS Code, Cursor). Two independent causes, both environmental — neither is a bug in the server code itself.

### 1. `ELECTRON_RUN_AS_NODE` breaks the launch outright

VS Code and Cursor export `ELECTRON_RUN_AS_NODE=1` in their extension host environment. Any shell spawned from there inherits it. With it set, the TradingView Electron stub runs as a plain Node interpreter, which rejects the flag:

```
/Applications/TradingView.app/Contents/MacOS/TradingView: bad option: --remote-debugging-port=9222
```

The message format is Node's, not Chromium's — Chromium silently ignores unknown flags. Reproduce with:

```bash
ELECTRON_RUN_AS_NODE=1 ./scripts/launch_tv_debug_mac.sh
```

### 2. Shell parentage leaves the renderer unable to boot

Unsetting the variable alone is not enough. `"$APP" --remote-debugging-port=$PORT &` makes TradingView a child of the calling shell. Under a degraded GUI session the app starts and **CDP answers on the port**, but the renderer never finishes initialising:

| Check | Value |
|---|---|
| `document.readyState` | `complete` |
| `document.body.innerText.length` | `0` |
| `window.TradingViewApi` | `undefined` |
| `api_available` | `false` after 13 min |
| Native modal dialog | none |
| `Runtime.evaluate` | responds at first, then hangs |

The chart sits on a spinner indefinitely. This is easy to misdiagnose as a slow layout load or an auth problem, because `tv_health_check` reports the CDP connection as healthy.

## Fix

Launch through `open -a "$BUNDLE" --args`, which hands the launch to launchd (`PPID 1`) — the same context the Dock and Finder use — and unset `ELECTRON_RUN_AS_NODE` first.

Two supporting changes this requires or enables:

- Detection now resolves the **`.app` bundle** rather than the inner Mach-O binary, since `open -a` needs the bundle.
- The pre-launch kill is scoped to the bundle binary. A bare `pkill -f "TradingView"` also matches unrelated processes whose command line merely mentions the name — including the user's own shell commands.

`open --args` only forwards arguments when the app is not already running, so the existing quit-first behaviour is preserved (now via a graceful `osascript quit`, falling back to `pkill`).

## Verification

macOS 15 (darwin 24.6.0), TradingView Desktop 3.1.0 / Electron 38.2.2, Node 24, run **with `ELECTRON_RUN_AS_NODE=1` present** — the failing case:

```
$ bash scripts/launch_tv_debug_mac.sh 9222
Found TradingView at: /Applications/TradingView.app
Launching with --remote-debugging-port=9222 ...
Waiting for CDP...
CDP ready at http://localhost:9222

$ ps -o ppid -p $(pgrep -f "TradingView.app/Contents/MacOS")
   1

$ node src/cli/index.js status
"cdp_connected": true, "api_available": true, "chart_symbol": "OANDA:XAUUSD"
```

CDP ready in ~1s and `api_available: true` on the first poll, against an indefinite spinner before.

## Not covered — `launch_tv_debug_linux.sh`

That script has the same `"$APP" --remote-debugging-port=$PORT &` line, so cause **1** very likely affects it too (`ELECTRON_RUN_AS_NODE` is an Electron mechanism, not a macOS one, and VS Code exports it on every platform). Cause 2 does not apply — launchd is Apple-specific.

I have left it untouched because I have no Linux machine to test on, and I would rather not put unverified code in front of you. If you can confirm it, the fix there is just prefixing the launch with `env -u ELECTRON_RUN_AS_NODE`. Happy to add it to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)