### PR TITLE
Complete DI refactor for remaining drawing.js functions

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,9 +44,10 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
-  const apiPath = await _getChartApi();
-  const shapes = await _evaluate(`
+export async function listDrawings(_deps) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  const shapes = await evaluate(`
     (function() {
       var api = ${apiPath};
       var all = api.getAllShapes();
@@ -56,9 +57,10 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
-  const apiPath = await _getChartApi();
-  const result = await _evaluate(`
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  const result = await evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -85,9 +87,10 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
-  const apiPath = await _getChartApi();
-  const result = await _evaluate(`
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  const result = await evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -106,8 +109,9 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
-  const apiPath = await _getChartApi();
-  await _evaluate(`${apiPath}.removeAllShapes()`);
+export async function clearAll(_deps) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };
 }


### PR DESCRIPTION
## Summary

`drawShape` already resolves its dependencies through `_resolve(_deps)`, but the other four exported functions in `src/core/drawing.js` still call the module-level `_evaluate` / `_getChartApi` imports directly. That makes them the only functions in the module that can't be unit tested without a live CDP connection.

This applies the existing `_resolve(_deps)` pattern to the remaining four:

- `listDrawings`
- `getProperties`
- `removeOne`
- `clearAll`

## Behavior

No functional change. `_resolve()` falls back to the real `connection.js` implementations when no deps are passed, and every current caller passes none:

- `src/tools/drawing.js` — `core.listDrawings()`, `core.clearAll()`, `core.removeOne({ entity_id })`, `core.getProperties({ entity_id })`
- `src/cli/commands/drawing.js` — same call shapes

`listDrawings` and `clearAll` take deps as a positional arg (they have no other parameters); `getProperties` and `removeOne` take `_deps` in their existing options object. This matches how `drawShape` already does it.

## Testing

`node --test` across the offline suites — 152 passing, 0 failing. This includes `tests/sanitization.test.js`, which audits `drawing.js` for unsafe interpolation and still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)