### PR TITLE
fix: make Pine script creation and saving reliable

### DIFF
--- a/src/cli/commands/pine.js
+++ b/src/cli/commands/pine.js
@@ -73,8 +73,8 @@ register('pine', {
       },
     }],
     ['save', {
-      description: 'Save the current Pine Script (Ctrl+S)',
-      handler: () => core.save(),
+      description: 'Save the current Pine Script; pass a name for the first save',
+      handler: (opts, positionals) => core.save({ name: positionals.join(' ') || undefined }),
     }],
     ['new', {
       description: 'Create a new blank Pine Script (indicator, strategy, library)',

--- a/src/core/batch.js
+++ b/src/core/batch.js
@@ -1,14 +1,8 @@
 /**
  * Core batch execution logic.
  */
-import { evaluate, evaluateAsync, getClient, getChartApi, getChartCollection, safeString } from '../connection.js';
+import { evaluate, evaluateAsync, getChartApi, getChartCollection, safeString } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
-import { writeFileSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const SCREENSHOT_DIR = join(dirname(dirname(__dirname)), 'screenshots');
 
 export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_count }) {
   const tfs = timeframes && timeframes.length > 0 ? timeframes : [null];
@@ -35,16 +29,7 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
         await new Promise(r => setTimeout(r, delay));
 
         let actionResult;
-        if (action === 'screenshot') {
-          mkdirSync(SCREENSHOT_DIR, { recursive: true });
-          const client = await getClient();
-          const { data } = await client.Page.captureScreenshot({ format: 'png' });
-          const ts = new Date().toISOString().replace(/[:.]/g, '-');
-          const fname = `batch_${symbol}_${tf || 'default'}_${ts}`.replace(/[\/\\]/g, '_') + '.png';
-          const filePath = join(SCREENSHOT_DIR, fname);
-          writeFileSync(filePath, Buffer.from(data, 'base64'));
-          actionResult = { file_path: filePath };
-        } else if (action === 'get_ohlcv' && apiPath) {
+        if (action === 'get_ohlcv' && apiPath) {
           const limit = Math.min(ohlcv_count || 100, 500);
           actionResult = await evaluateAsync(`
             new Promise(function(resolve, reject) {

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -60,14 +60,20 @@ const FIND_MONACO = `
  * Returns true if editor is accessible, false on timeout.
  */
 export async function ensurePineEditorOpen() {
-  const already = await evaluate(`
-    (function() {
-      var m = ${FIND_MONACO};
-      return m !== null;
-    })()
-  `);
-  if (already) return true;
+  async function waitForEditor(attempts, delay = 100) {
+    for (let i = 0; i < attempts; i++) {
+      const ready = await evaluate(`(function() { var m = ${FIND_MONACO}; return m !== null; })()`);
+      if (ready) return true;
+      await new Promise(r => setTimeout(r, delay));
+    }
+    return false;
+  }
 
+  if (await waitForEditor(1, 0)) return true;
+
+  // Prefer TradingView's internal panel API, but give the editor time to mount
+  // before falling back to UI input. Some Desktop builds expose these methods
+  // while silently ignoring them for the right-side Pine panel.
   await evaluate(`
     (function() {
       var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
@@ -76,21 +82,44 @@ export async function ensurePineEditorOpen() {
       else if (typeof bwb.showWidget === 'function') bwb.showWidget('pine-editor');
     })()
   `);
+  if (await waitForEditor(10)) return true;
 
-  await evaluate(`
+  const panelState = await evaluate(`
     (function() {
-      var btn = document.querySelector('[aria-label="Pine"]')
-        || document.querySelector('[data-name="pine-dialog-button"]');
-      if (btn) btn.click();
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var sideTitle = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+      var editorContainer = Array.from(document.querySelectorAll('.monaco-editor.pine-editor-monaco')).find(visible);
+      if (sideTitle || editorContainer) return { panelVisible: true, button: null };
+
+      var buttons = Array.from(document.querySelectorAll('[aria-label="Pine"], [data-name="pine-dialog-button"]'));
+      var button = buttons.find(visible);
+      if (!button) return { panelVisible: false, button: null };
+      var rect = button.getBoundingClientRect();
+      return {
+        panelVisible: false,
+        button: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+      };
     })()
   `);
 
-  for (let i = 0; i < 50; i++) {
-    await new Promise(r => setTimeout(r, 200));
-    const ready = await evaluate(`(function() { return ${FIND_MONACO} !== null; })()`);
-    if (ready) return true;
-  }
-  return false;
+  // If the panel is already visible, clicking its toolbar button would close it.
+  // Allow a slower Monaco mount before deciding that it is unavailable.
+  if (panelState?.panelVisible) return waitForEditor(40, 200);
+  if (!panelState?.button) return false;
+
+  // TradingView Desktop ignores HTMLElement.click() for this toolbar button in
+  // some builds. Dispatch real CDP mouse input, matching an actual user click.
+  const c = await getClient();
+  const { x, y } = panelState.button;
+  await c.Input.dispatchMouseEvent({ type: 'mouseMoved', x, y });
+  await c.Input.dispatchMouseEvent({ type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1 });
+  await c.Input.dispatchMouseEvent({ type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1 });
+
+  return waitForEditor(50, 200);
 }
 
 // ── Pure / offline functions ──
@@ -967,7 +996,12 @@ export async function newScript({ type }) {
   const label = labels[type];
   if (!label) throw new Error(`Unsupported Pine script type: ${type}`);
 
-  // Never destroy an unsaved editor buffer while establishing a new script identity.
+  const currentSource = await getSource();
+  const previousName = await getCurrentScriptName();
+
+  // Never destroy meaningful unsaved user content while establishing a new
+  // script identity. TradingView marks a blank Untitled buffer as dirty too;
+  // replacing that empty recovery buffer is safe and must remain possible.
   await openCurrentScriptMenu();
   await new Promise(r => setTimeout(r, 200));
   const dirtyState = await evaluate(`
@@ -986,11 +1020,10 @@ export async function newScript({ type }) {
     })()
   `);
   await dismissOpenMenu();
-  if (dirtyState?.known && dirtyState.dirty) {
+  if (dirtyState?.known && dirtyState.dirty && currentSource.source.trim() !== '') {
     throw new Error('The current Pine editor has unsaved changes. Save them before creating a new script.');
   }
 
-  const previousName = await getCurrentScriptName();
   const placement = await ensureSidePineEditorForCreate();
 
   const titleOpened = await evaluate(`

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -8,30 +8,50 @@ import { evaluate, evaluateAsync, getClient } from '../connection.js';
 // ── Monaco finder (injected into TV page) ──
 const FIND_MONACO = `
   (function findMonacoEditor() {
-    var container = document.querySelector('.monaco-editor.pine-editor-monaco');
-    if (!container) return null;
-    var el = container;
-    var fiberKey;
-    for (var i = 0; i < 20; i++) {
-      if (!el) break;
-      fiberKey = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); });
-      if (fiberKey) break;
-      el = el.parentElement;
-    }
-    if (!fiberKey) return null;
-    var current = el[fiberKey];
-    for (var d = 0; d < 15; d++) {
-      if (!current) break;
-      if (current.memoizedProps && current.memoizedProps.value && current.memoizedProps.value.monacoEnv) {
-        var env = current.memoizedProps.value.monacoEnv;
-        if (env.editor && typeof env.editor.getEditors === 'function') {
-          var editors = env.editor.getEditors();
-          if (editors.length > 0) return { editor: editors[0], env: env };
-        }
+    var containers = Array.from(document.querySelectorAll('.monaco-editor.pine-editor-monaco'));
+    if (containers.length === 0) return null;
+    containers.sort(function(a, b) {
+      var ar = a.getBoundingClientRect();
+      var br = b.getBoundingClientRect();
+      var av = a.isConnected && ar.width > 0 && ar.height > 0 ? 1 : 0;
+      var bv = b.isConnected && br.width > 0 && br.height > 0 ? 1 : 0;
+      return bv - av;
+    });
+
+    var fallback = null;
+    for (var c = 0; c < containers.length; c++) {
+      var el = containers[c];
+      var fiberKey = null;
+      for (var i = 0; i < 20; i++) {
+        if (!el) break;
+        fiberKey = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); });
+        if (fiberKey) break;
+        el = el.parentElement;
       }
-      current = current.return;
+      if (!fiberKey) continue;
+      var current = el[fiberKey];
+      for (var d = 0; d < 15; d++) {
+        if (!current) break;
+        if (current.memoizedProps && current.memoizedProps.value && current.memoizedProps.value.monacoEnv) {
+          var env = current.memoizedProps.value.monacoEnv;
+          if (env.editor && typeof env.editor.getEditors === 'function') {
+            var editors = env.editor.getEditors();
+            for (var e = 0; e < editors.length; e++) {
+              var editor = editors[e];
+              var node = editor && typeof editor.getDomNode === 'function' ? editor.getDomNode() : null;
+              var rect = node ? node.getBoundingClientRect() : null;
+              if (node && node.isConnected && rect.width > 0 && rect.height > 0) {
+                if (typeof editor.hasTextFocus === 'function' && editor.hasTextFocus()) return { editor: editor, env: env };
+                if (!fallback) fallback = { editor: editor, env: env };
+              }
+            }
+            if (!fallback && editors.length > 0) fallback = { editor: editors[0], env: env };
+          }
+        }
+        current = current.return;
+      }
     }
-    return null;
+    return fallback;
   })()
 `;
 
@@ -267,18 +287,52 @@ export async function setSource({ source }) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
-  const escaped = JSON.stringify(source);
-  const set = await evaluate(`
+  const escaped = JSON.stringify(source.replace(/\r\n/g, '\n'));
+  const result = await evaluate(`
     (function() {
       var m = ${FIND_MONACO};
-      if (!m) return false;
-      m.editor.setValue(${escaped});
-      return true;
+      if (!m) return { success: false, error: 'Monaco editor not found' };
+      var model = m.editor.getModel();
+      if (!model) return { success: false, error: 'Monaco model not found' };
+      var before = model.getValue();
+      var beforeVersion = model.getAlternativeVersionId();
+      var requestedSource = ${escaped};
+      var modelEol = typeof model.getEOL === 'function' ? model.getEOL() : '\\n';
+      var nextSource = modelEol === '\\n' ? requestedSource : requestedSource.replace(/\\n/g, modelEol);
+      m.editor.pushUndoStop();
+      var applied = m.editor.executeEdits('tradingview-mcp', [{
+        range: model.getFullModelRange(),
+        text: nextSource,
+        forceMoveMarkers: true
+      }]);
+      m.editor.pushUndoStop();
+      var after = model.getValue();
+      var afterVersion = model.getAlternativeVersionId();
+      if (typeof m.editor.focus === 'function') m.editor.focus();
+      return {
+        success: applied !== false && after === nextSource,
+        changed: before !== after,
+        before_version: beforeVersion,
+        after_version: afterVersion,
+        eol: modelEol === '\\r\\n' ? 'CRLF' : 'LF',
+        line_count: after.split('\\n').length,
+        char_count: after.length,
+        error: after === nextSource ? null : 'Editor contents do not match requested source'
+      };
     })()
   `);
 
-  if (!set) throw new Error('Monaco found but setValue() failed.');
-  return { success: true, lines_set: source.split('\n').length };
+  if (!result?.success) throw new Error(result?.error || 'Monaco executeEdits() failed.');
+  return {
+    success: true,
+    lines_set: result.line_count,
+    chars_set: result.char_count,
+    changed: result.changed,
+    before_version: result.before_version,
+    after_version: result.after_version,
+    eol: result.eol,
+    method: 'monaco_executeEdits',
+  };
 }
 
 export async function compile() {
@@ -344,36 +398,298 @@ export async function getErrors() {
   };
 }
 
-export async function save() {
-  const editorReady = await ensurePineEditorOpen();
-  if (!editorReady) throw new Error('Could not open Pine Editor.');
-
-  const c = await getClient();
-  await c.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 2, key: 's', code: 'KeyS', windowsVirtualKeyCode: 83 });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 's', code: 'KeyS' });
-  await new Promise(r => setTimeout(r, 800));
-
-  // Handle "Save Script" name dialog that appears for new/unsaved scripts
-  const dialogHandled = await evaluate(`
+async function getCurrentScriptName() {
+  return evaluate(`
     (function() {
-      var saveBtn = null;
-      var btns = document.querySelectorAll('button');
-      for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (text === 'Save' && btns[i].offsetParent !== null) {
-          // Check if it's in a dialog (not the Pine Editor save button)
-          var parent = btns[i].closest('[class*="dialog"], [class*="modal"], [class*="popup"], [role="dialog"]');
-          if (parent) { saveBtn = btns[i]; break; }
-        }
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
       }
-      if (saveBtn) { saveBtn.click(); return true; }
-      return false;
+      var sideTitle = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+      if (sideTitle) return (sideTitle.textContent || '').trim() || null;
+
+      var tab = Array.from(document.querySelectorAll('button[data-qa-id="scripteditor"]')).find(visible);
+      if (!tab) {
+        tab = Array.from(document.querySelectorAll('button[aria-label="Close Pine Editor"]')).find(function(el) {
+          return visible(el) && !el.closest('[class*="fakeTabs"]');
+        });
+      }
+      return tab ? ((tab.textContent || '').trim() || null) : null;
+    })()
+  `);
+}
+
+async function openCurrentScriptMenu() {
+  const result = await evaluate(`
+    (function() {
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var alreadyOpen = Array.from(document.querySelectorAll('[role="menuitem"][aria-label="Save script"]')).find(visible);
+      if (alreadyOpen) return { success: true, already_open: true };
+
+      var sideTitle = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+      if (sideTitle) {
+        sideTitle.click();
+        return { success: true, location: 'right', name: (sideTitle.textContent || '').trim() };
+      }
+
+      var tab = Array.from(document.querySelectorAll('button[data-qa-id="scripteditor"]')).find(visible);
+      if (!tab) {
+        tab = Array.from(document.querySelectorAll('button[aria-label="Close Pine Editor"]')).find(function(el) {
+          return visible(el) && !el.closest('[class*="fakeTabs"]');
+        });
+      }
+      if (!tab) return { success: false, error: 'Visible Pine Editor tab was not found' };
+
+      // The Strategy Tester and Pine Editor menus can share the same Y coordinate.
+      // Resolve the trigger from the Pine tab's own container instead of sorting all
+      // context-menu buttons by vertical distance.
+      var tabContainer = tab.parentElement;
+      var menuButton = tabContainer && tabContainer.querySelector(
+        'button[data-qa-id="tab-menu-trigger"], button[title="Open context menu"]'
+      );
+      if (!menuButton || !visible(menuButton)) {
+        return { success: false, error: 'Pine Editor context-menu button was not found' };
+      }
+      menuButton.click();
+      return { success: true, location: 'bottom', name: (tab.textContent || '').trim() };
     })()
   `);
 
-  if (dialogHandled) await new Promise(r => setTimeout(r, 500));
+  if (!result?.success) throw new Error(result?.error || 'Could not open the Pine Editor script menu.');
+  return result;
+}
 
-  return { success: true, action: dialogHandled ? 'saved_with_dialog' : 'Ctrl+S_dispatched' };
+async function submitInitialSaveDialog(name) {
+  const escapedName = JSON.stringify(name || '');
+  for (let attempt = 0; attempt < 15; attempt++) {
+    const result = await evaluate(`
+      (function() {
+        function visible(el) {
+          if (!el || !el.isConnected) return false;
+          var rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        }
+        var dialogs = Array.from(document.querySelectorAll('[role="dialog"]')).filter(visible);
+        var dialog = dialogs.find(function(el) {
+          var text = (el.textContent || '').trim();
+          return /save script/i.test(text) && !!el.querySelector('input');
+        });
+        if (!dialog) return { found: false };
+
+        var requestedName = ${escapedName};
+        if (!requestedName) {
+          var cancel = Array.from(dialog.querySelectorAll('button')).find(function(button) {
+            return /^cancel$/i.test((button.textContent || '').trim());
+          });
+          if (cancel) cancel.click();
+          return { found: true, submitted: false, error: 'A name is required when saving a new script' };
+        }
+
+        var input = dialog.querySelector('input');
+        if (!input) return { found: true, submitted: false, error: 'Save script name input was not found' };
+        input.focus();
+        var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value');
+        if (setter && setter.set) setter.set.call(input, requestedName);
+        else input.value = requestedName;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        var saveButton = Array.from(dialog.querySelectorAll('button')).find(function(button) {
+          return /^save$/i.test((button.textContent || '').trim());
+        });
+        if (!saveButton) return { found: true, submitted: false, error: 'Save dialog submit button was not found' };
+        if (saveButton.disabled || saveButton.getAttribute('aria-disabled') === 'true') {
+          return { found: true, submitted: false, error: 'Save dialog submit button is disabled' };
+        }
+        saveButton.click();
+        return { found: true, submitted: true };
+      })()
+    `);
+    if (result?.found) return result;
+    await new Promise(r => setTimeout(r, 100));
+  }
+  return { found: false, submitted: false };
+}
+
+export async function save({ name } = {}) {
+  const editorReady = await ensurePineEditorOpen();
+  if (!editorReady) throw new Error('Could not open Pine Editor.');
+
+  const editor = await getSource();
+  const currentName = await getCurrentScriptName();
+  let currentSaved = null;
+  if (currentName) {
+    try { currentSaved = await getSavedSource({ name: currentName }); } catch { /* new/unsaved script */ }
+  }
+
+  const requestedName = (name || '').trim();
+  if (currentSaved && requestedName) {
+    const target = requestedName.toLowerCase();
+    const aliases = [currentSaved.name, currentSaved.title].filter(Boolean).map(value => value.toLowerCase());
+    if (!aliases.includes(target)) {
+      throw new Error(
+        `The editor is attached to saved script "${currentSaved.name}", not "${requestedName}". `
+        + 'pine_save does not rename or create a copy of an existing script.'
+      );
+    }
+  }
+
+  const verificationName = requestedName || currentSaved?.name || (currentName || '').trim();
+  if (!verificationName || (!currentSaved && !requestedName)) {
+    throw new Error('A script name is required for the first save. Pass name explicitly to pine_save.');
+  }
+
+  await openCurrentScriptMenu();
+  await new Promise(r => setTimeout(r, 250));
+
+  const saveAction = await evaluate(`
+    (function() {
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var items = Array.from(document.querySelectorAll('[role="menuitem"][aria-label="Save script"]')).filter(visible);
+      if (items.length === 0) {
+        items = Array.from(document.querySelectorAll('[role="menuitem"]')).filter(function(el) {
+          return visible(el) && /^save script(?:\s|$)/i.test((el.textContent || '').trim());
+        });
+      }
+      if (items.length === 0) return { success: false, error: 'Save script menu item was not found' };
+      var item = items[0];
+      var disabled = item.getAttribute('aria-disabled') === 'true'
+        || item.hasAttribute('disabled')
+        || item.getAttribute('data-disabled') === 'true';
+      if (disabled) return { success: false, disabled: true, error: 'Save script menu item is disabled' };
+      item.click();
+      return { success: true, disabled: false };
+    })()
+  `);
+
+  if (!saveAction?.success) {
+    if (saveAction?.disabled) {
+      const saved = await getSavedSource({ name: verificationName });
+      if (saved.source.replace(/\r\n/g, '\n') === editor.source.replace(/\r\n/g, '\n')) {
+        return {
+          success: true,
+          action: 'already_persisted',
+          name: saved.name,
+          script_id: saved.script_id,
+          version: saved.version,
+          verified: true,
+        };
+      }
+      throw new Error(`Save script is disabled and the saved server source for "${verificationName}" does not match the editor. The editor change was not registered as dirty.`);
+    }
+    throw new Error(saveAction?.error || 'Could not activate Save script.');
+  }
+
+  const dialog = await submitInitialSaveDialog(requestedName);
+  if (dialog.found && !dialog.submitted) throw new Error(dialog.error || 'Could not submit the initial Save script dialog.');
+
+  const deadline = Date.now() + 10000;
+  let lastSaved = null;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+    try {
+      lastSaved = await getSavedSource({ name: verificationName });
+      if (lastSaved.source.replace(/\r\n/g, '\n') === editor.source.replace(/\r\n/g, '\n')) {
+        return {
+          success: true,
+          action: dialog.found ? 'created_and_saved_via_dialog' : 'saved_via_script_menu',
+          name: lastSaved.name,
+          script_id: lastSaved.script_id,
+          version: lastSaved.version,
+          modified: lastSaved.modified,
+          verified: true,
+        };
+      }
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  const detail = lastError?.message
+    ? ` Last verification error: ${lastError.message}`
+    : lastSaved
+      ? ' The server still returns different source code.'
+      : '';
+  throw new Error(`TradingView did not persist the current editor source for "${verificationName}" within 10 seconds.${detail}`);
+}
+
+export async function getSavedSource({ name }) {
+  if (!name || !name.trim()) throw new Error('Script name is required. Spaces and full-width parentheses are supported.');
+  const escapedName = JSON.stringify(name.trim().toLowerCase());
+
+  const result = await evaluateAsync(`
+    (function() {
+      var target = ${escapedName};
+      function responseJson(response, label) {
+        if (!response.ok) throw new Error(label + ' returned HTTP ' + response.status);
+        return response.json();
+      }
+      return fetch('https://pine-facade.tradingview.com/pine-facade/list/?filter=saved', { credentials: 'include' })
+        .then(function(r) { return responseJson(r, 'Script list'); })
+        .then(function(scripts) {
+          if (!Array.isArray(scripts)) return { error: 'pine-facade returned unexpected script-list data' };
+          var exact = scripts.filter(function(script) {
+            var scriptName = (script.scriptName || '').toLowerCase();
+            var scriptTitle = (script.scriptTitle || '').toLowerCase();
+            return scriptName === target || scriptTitle === target;
+          });
+          var matches = exact.length > 0 ? exact : scripts.filter(function(script) {
+            var scriptName = (script.scriptName || '').toLowerCase();
+            var scriptTitle = (script.scriptTitle || '').toLowerCase();
+            return scriptName.indexOf(target) !== -1 || scriptTitle.indexOf(target) !== -1;
+          });
+          if (matches.length === 0) return { error: 'Script "' + target + '" not found. Use pine_list_scripts to see available scripts.' };
+          if (matches.length > 1 && exact.length === 0) {
+            return { error: 'Script name "' + target + '" is ambiguous. Pass the full exact name.' };
+          }
+          var match = matches[0];
+          var id = match.scriptIdPart;
+          var version = match.version || 1;
+          if (!id) return { error: 'Matched script has no scriptIdPart' };
+          return fetch('https://pine-facade.tradingview.com/pine-facade/get/' + encodeURIComponent(id) + '/' + encodeURIComponent(version), { credentials: 'include' })
+            .then(function(r2) { return responseJson(r2, 'Script source'); })
+            .then(function(data) {
+              var source = typeof data.source === 'string' ? data.source : '';
+              if (!source) return { error: 'Script source is empty', name: match.scriptName || match.scriptTitle };
+              return {
+                success: true,
+                name: match.scriptName || match.scriptTitle || 'Untitled',
+                title: match.scriptTitle || null,
+                id: id,
+                version: version,
+                modified: match.modified || null,
+                source: source
+              };
+            });
+        })
+        .catch(function(error) { return { error: error.message }; });
+    })()
+  `);
+
+  if (result?.error) throw new Error(result.error);
+  if (!result?.success || typeof result.source !== 'string') throw new Error('pine-facade returned an invalid saved-source response.');
+  return {
+    success: true,
+    name: result.name,
+    title: result.title,
+    script_id: result.id,
+    version: result.version,
+    modified: result.modified,
+    source: result.source,
+    line_count: result.source.split('\n').length,
+    char_count: result.source.length,
+    origin: 'pine_facade',
+  };
 }
 
 export async function getConsole() {
@@ -505,87 +821,269 @@ export async function smartCompile() {
   };
 }
 
+async function dismissOpenMenu() {
+  const c = await getClient();
+  await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+}
+
+async function ensureSidePineEditorForCreate() {
+  const initial = await evaluate(`
+    (function() {
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var title = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+      return { side_open: !!title };
+    })()
+  `);
+  if (initial?.side_open) return { moved: false };
+
+  await openCurrentScriptMenu();
+  await new Promise(r => setTimeout(r, 200));
+  const moved = await evaluate(`
+    (function() {
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var item = Array.from(document.querySelectorAll('[role="menuitem"]')).find(function(el) {
+        return visible(el) && /^move script to right$/i.test((el.getAttribute('aria-label') || el.textContent || '').trim());
+      });
+      if (!item) return { success: false, error: 'Move script to right menu item was not found' };
+      item.click();
+      return { success: true };
+    })()
+  `);
+  if (!moved?.success) throw new Error(moved?.error || 'Could not move Pine Editor to the side panel.');
+
+  let pineButtonClicked = false;
+  for (let attempt = 0; attempt < 30; attempt++) {
+    await new Promise(r => setTimeout(r, 100));
+    const state = await evaluate(`
+      (function() {
+        function visible(el) {
+          if (!el || !el.isConnected) return false;
+          var rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        }
+        var title = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+        if (title) return { ready: true };
+        var pineButton = Array.from(document.querySelectorAll('button[data-name="pine-dialog-button"], button[aria-label="Pine"]')).find(visible);
+        return { ready: false, can_open: !!pineButton };
+      })()
+    `);
+    if (state?.ready) return { moved: true };
+    if (!pineButtonClicked && state?.can_open) {
+      await evaluate(`
+        (function() {
+          function visible(el) {
+            if (!el || !el.isConnected) return false;
+            var rect = el.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+          }
+          var button = Array.from(document.querySelectorAll('button[data-name="pine-dialog-button"], button[aria-label="Pine"]')).find(visible);
+          if (button) button.click();
+        })()
+      `);
+      pineButtonClicked = true;
+    }
+  }
+  throw new Error('Pine Editor side panel did not become available.');
+}
+
+async function restorePineEditorToBottom() {
+  const opened = await evaluate(`
+    (function() {
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var title = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+      if (!title) return { success: false };
+      if (title.getAttribute('aria-expanded') !== 'true') title.click();
+      return { success: true };
+    })()
+  `);
+  if (!opened?.success) return false;
+
+  for (let attempt = 0; attempt < 15; attempt++) {
+    await new Promise(r => setTimeout(r, 100));
+    const result = await evaluate(`
+      (function() {
+        function visible(el) {
+          if (!el || !el.isConnected) return false;
+          var rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        }
+        var item = Array.from(document.querySelectorAll('[role="menuitem"]')).find(function(el) {
+          return visible(el) && /^move script to bottom$/i.test((el.getAttribute('aria-label') || el.textContent || '').trim());
+        });
+        if (!item) return { found: false };
+        item.click();
+        return { found: true };
+      })()
+    `);
+    if (result?.found) {
+      // A synthetic click only proves that the menu item received the event. Wait
+      // for TradingView to remount the editor in the bottom panel before claiming
+      // success; some layouts currently ignore the move command.
+      for (let verifyAttempt = 0; verifyAttempt < 30; verifyAttempt++) {
+        await new Promise(r => setTimeout(r, 100));
+        const state = await evaluate(`
+          (function() {
+            function visible(el) {
+              if (!el || !el.isConnected) return false;
+              var rect = el.getBoundingClientRect();
+              return rect.width > 0 && rect.height > 0;
+            }
+            var sideTitle = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+            var bottomTab = Array.from(document.querySelectorAll('button[data-qa-id="scripteditor"]')).find(visible);
+            return {
+              restored: !!bottomTab || !sideTitle,
+              bottom_tab_visible: !!bottomTab,
+              side_title_visible: !!sideTitle
+            };
+          })()
+        `);
+        if (state?.restored) return true;
+      }
+      return false;
+    }
+  }
+  return false;
+}
+
 export async function newScript({ type }) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
-  const typeMap = { indicator: 'indicator', strategy: 'strategy', library: 'library' };
-  const templates = {
-    indicator: '//@version=6\nindicator("My script")\nplot(close)',
-    strategy: '//@version=6\nstrategy("My strategy", overlay=true)\n',
-    library: '//@version=6\n// @description TODO: add library description here\nlibrary("MyLibrary")\n',
-  };
+  const labels = { indicator: 'Indicator', strategy: 'Strategy', library: 'Library' };
+  const declarations = { indicator: /\bindicator\s*\(/, strategy: /\bstrategy\s*\(/, library: /\blibrary\s*\(/ };
+  const label = labels[type];
+  if (!label) throw new Error(`Unsupported Pine script type: ${type}`);
 
-  const template = templates[type] || templates.indicator;
-
-  // Simply set the source to a new template — this is the most reliable approach
-  const escaped = JSON.stringify(template);
-  const set = await evaluate(`
+  // Never destroy an unsaved editor buffer while establishing a new script identity.
+  await openCurrentScriptMenu();
+  await new Promise(r => setTimeout(r, 200));
+  const dirtyState = await evaluate(`
     (function() {
-      var m = ${FIND_MONACO};
-      if (!m) return false;
-      m.editor.setValue(${escaped});
-      return true;
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var saveItem = Array.from(document.querySelectorAll('[role="menuitem"][aria-label="Save script"]')).find(visible);
+      if (!saveItem) return { known: false };
+      var disabled = saveItem.getAttribute('aria-disabled') === 'true'
+        || saveItem.hasAttribute('disabled')
+        || saveItem.getAttribute('data-disabled') === 'true';
+      return { known: true, dirty: !disabled };
     })()
   `);
+  await dismissOpenMenu();
+  if (dirtyState?.known && dirtyState.dirty) {
+    throw new Error('The current Pine editor has unsaved changes. Save them before creating a new script.');
+  }
 
-  if (!set) throw new Error('Monaco editor not found. Ensure Pine Editor is open.');
+  const previousName = await getCurrentScriptName();
+  const placement = await ensureSidePineEditorForCreate();
 
-  return { success: true, type, action: 'new_script_created', template: typeMap[type] };
+  const titleOpened = await evaluate(`
+    (function() {
+      function visible(el) {
+        if (!el || !el.isConnected) return false;
+        var rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+      var title = Array.from(document.querySelectorAll('[data-qa-id="pine-script-title-button"]')).find(visible);
+      if (!title) return { success: false, error: 'Pine script title button was not found' };
+      if (title.getAttribute('aria-expanded') !== 'true') title.click();
+      return { success: true };
+    })()
+  `);
+  if (!titleOpened?.success) throw new Error(titleOpened?.error || 'Could not open the Pine script menu.');
+
+  let typeClicked = false;
+  for (let attempt = 0; attempt < 25 && !typeClicked; attempt++) {
+    await new Promise(r => setTimeout(r, 100));
+    const result = await evaluate(`
+      (function() {
+        function visible(el) {
+          if (!el || !el.isConnected) return false;
+          var rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        }
+        var createItem = Array.from(document.querySelectorAll('[role="menuitem"]')).find(function(el) {
+          return visible(el) && /^create new$/i.test((el.textContent || '').trim());
+        });
+        if (!createItem) return { ready: false, stage: 'create_new_missing' };
+        ['pointerenter', 'mouseenter', 'mouseover'].forEach(function(eventName) {
+          createItem.dispatchEvent(new MouseEvent(eventName, { bubbles: true, view: window }));
+        });
+        var typeItem = Array.from(document.querySelectorAll('[role="menuitem"]')).find(function(el) {
+          return visible(el) && (el.getAttribute('aria-label') || '').trim() === ${JSON.stringify(label)};
+        });
+        if (!typeItem) return { ready: false, stage: 'type_submenu_missing' };
+        typeItem.click();
+        return { ready: true };
+      })()
+    `);
+    typeClicked = !!result?.ready;
+  }
+  if (!typeClicked) throw new Error(`Could not activate Create new → ${label}.`);
+
+  let source = null;
+  let currentName = null;
+  for (let attempt = 0; attempt < 40; attempt++) {
+    await new Promise(r => setTimeout(r, 100));
+    try {
+      const current = await getSource();
+      if (declarations[type].test(current.source)) {
+        source = current;
+        currentName = await getCurrentScriptName();
+        break;
+      }
+    } catch { /* editor is remounting */ }
+  }
+  if (!source) throw new Error(`TradingView did not create a new ${type} editor.`);
+
+  let restoredToBottom = null;
+  if (placement.moved) restoredToBottom = await restorePineEditorToBottom();
+
+  return {
+    success: true,
+    type,
+    action: 'new_tradingview_script_created',
+    identity_created: true,
+    previous_name: previousName,
+    name: currentName,
+    line_count: source.line_count,
+    changed: true,
+    restored_to_bottom: restoredToBottom,
+    warning: 'The new script is not persisted until pine_save is called with a name.',
+  };
 }
 
 export async function openScript({ name }) {
-  const editorReady = await ensurePineEditorOpen();
-  if (!editorReady) throw new Error('Could not open Pine Editor.');
-
-  const escapedName = JSON.stringify(name.toLowerCase());
-
-  const result = await evaluateAsync(`
-    (function() {
-      var target = ${escapedName};
-      return fetch('https://pine-facade.tradingview.com/pine-facade/list/?filter=saved', { credentials: 'include' })
-        .then(function(r) { return r.json(); })
-        .then(function(scripts) {
-          if (!Array.isArray(scripts)) return {error: 'pine-facade returned unexpected data'};
-          var match = null;
-          for (var i = 0; i < scripts.length; i++) {
-            var sn = (scripts[i].scriptName || '').toLowerCase();
-            var st = (scripts[i].scriptTitle || '').toLowerCase();
-            if (sn === target || st === target) { match = scripts[i]; break; }
-          }
-          if (!match) {
-            for (var j = 0; j < scripts.length; j++) {
-              var sn2 = (scripts[j].scriptName || '').toLowerCase();
-              var st2 = (scripts[j].scriptTitle || '').toLowerCase();
-              if (sn2.indexOf(target) !== -1 || st2.indexOf(target) !== -1) { match = scripts[j]; break; }
-            }
-          }
-          if (!match) return {error: 'Script "' + target + '" not found. Use pine_list_scripts to see available scripts.'};
-
-          var id = match.scriptIdPart;
-          var ver = match.version || 1;
-          return fetch('https://pine-facade.tradingview.com/pine-facade/get/' + id + '/' + ver, { credentials: 'include' })
-            .then(function(r2) { return r2.json(); })
-            .then(function(data) {
-              var source = data.source || '';
-              if (!source) return {error: 'Script source is empty', name: match.scriptName || match.scriptTitle};
-              var m = ${FIND_MONACO};
-              if (m) {
-                m.editor.setValue(source);
-                return {success: true, name: match.scriptName || match.scriptTitle, id: id, lines: source.split('\\n').length};
-              }
-              return {error: 'Monaco editor not found to inject source', name: match.scriptName || match.scriptTitle};
-            });
-        })
-        .catch(function(e) { return {error: e.message}; });
-    })()
-  `);
-
-  if (result?.error) {
-    throw new Error(result.error);
-  }
-
-  return { success: true, name: result.name, script_id: result.id, lines: result.lines, source: 'internal_api', opened: true };
+  const saved = await getSavedSource({ name });
+  const set = await setSource({ source: saved.source });
+  return {
+    success: true,
+    name: saved.name,
+    script_id: saved.script_id,
+    version: saved.version,
+    lines: saved.line_count,
+    origin: saved.origin,
+    injected: true,
+    destructive: true,
+    changed: set.changed,
+    warning: 'pine_open injects saved source into the current editor; it does not switch script identity. Do not use it to verify a save.',
+  };
 }
 
 export async function listScripts() {

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,6 @@ import { registerHealthTools } from './tools/health.js';
 import { registerChartTools } from './tools/chart.js';
 import { registerPineTools } from './tools/pine.js';
 import { registerDataTools } from './tools/data.js';
-import { registerCaptureTools } from './tools/capture.js';
 import { registerDrawingTools } from './tools/drawing.js';
 import { registerAlertTools } from './tools/alerts.js';
 import { registerBatchTools } from './tools/batch.js';
@@ -22,7 +21,7 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 84 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — structured tools for reading and controlling a live TradingView Desktop chart.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 
@@ -47,11 +46,13 @@ Changing the chart:
 - indicator_set_inputs → change indicator settings (length, source, etc.)
 
 Pine Script development:
-- pine_set_source → inject code, pine_smart_compile → compile + check errors
+- pine_set_source → inject code with Monaco edit events, pine_smart_compile → compile + check errors
 - pine_get_errors → read errors, pine_get_console → read log output
+- pine_save → save through the enabled Pine context-menu command and verify server persistence
+- pine_get_saved_source → non-destructively read the saved server source for verification
+- WARNING: pine_open overwrites the current editor and does not switch script identity; never use it to verify a save
 - WARNING: pine_get_source can return 200KB+ for complex scripts — avoid unless editing
 
-Screenshots: capture_screenshot → regions: "full", "chart", "strategy_tester"
 Replay: replay_start → replay_step → replay_trade → replay_status → replay_stop
 Batch: batch_run → run action across multiple symbols/timeframes
 Drawing: draw_shape → horizontal_line, trend_line, rectangle, text
@@ -64,7 +65,8 @@ CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv
 - ALWAYS use study_filter on pine tools when you know which indicator you want
 - NEVER use verbose=true unless user specifically asks for raw data
-- Prefer capture_screenshot for visual context over pulling large datasets
+- Use structured TradingView tools for all operations
+- Screenshots and image recognition are disabled; if a structured tool fails, report the error instead of attempting visual inspection
 - Call chart_get_state ONCE at start, reuse entity IDs`,
   }
 );
@@ -74,7 +76,6 @@ registerHealthTools(server);
 registerChartTools(server);
 registerPineTools(server);
 registerDataTools(server);
-registerCaptureTools(server);
 registerDrawingTools(server);
 registerAlertTools(server);
 registerBatchTools(server);

--- a/src/tools/batch.js
+++ b/src/tools/batch.js
@@ -6,7 +6,7 @@ export function registerBatchTools(server) {
   server.tool('batch_run', 'Run an action across multiple symbols and/or timeframes', {
     symbols: z.array(z.string()).describe('Array of symbols to iterate (e.g., ["BTCUSD", "ETHUSD", "AAPL"])'),
     timeframes: z.array(z.string()).optional().describe('Array of timeframes (e.g., ["D", "60", "15"])'),
-    action: z.string().describe('Action to run: screenshot, get_ohlcv, get_strategy_results'),
+    action: z.enum(['get_ohlcv', 'get_strategy_results']).describe('Action to run: get_ohlcv or get_strategy_results'),
     delay_ms: z.coerce.number().optional().describe('Delay between iterations in ms (default 2000)'),
     ohlcv_count: z.coerce.number().optional().describe('Bar count for get_ohlcv action (default 100)'),
   }, async ({ symbols, timeframes, action, delay_ms, ohlcv_count }) => {

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -25,8 +25,10 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_save', 'Save the current Pine Script (Ctrl+S)', {}, async () => {
-    try { return jsonResult(await core.save()); }
+  server.tool('pine_save', 'Save the current Pine Script and verify the persisted server source. For a new script, fills and submits TradingView’s initial naming dialog.', {
+    name: z.string().optional().describe('Script name. Required on the first save; optional for an existing saved script when its name can be read from the editor.'),
+  }, async ({ name }) => {
+    try { return jsonResult(await core.save({ name })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
@@ -40,18 +42,25 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_new', 'Create a new blank Pine Script', {
+  server.tool('pine_new', 'Create a genuine new TradingView Pine script identity using Create new. Refuses to discard unsaved editor changes.', {
     type: z.enum(['indicator', 'strategy', 'library']).describe('Type of script to create'),
   }, async ({ type }) => {
     try { return jsonResult(await core.newScript({ type })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_open', 'Open a saved Pine Script by name', {
+  server.tool('pine_open', 'Destructively inject a saved Pine Script source into the current editor. This does not switch script identity and must not be used to verify saving.', {
     name: z.string().describe('Name of the saved script to open (case-insensitive match)'),
   }, async ({ name }) => {
     try { return jsonResult(await core.openScript({ name })); }
     catch (err) { return jsonResult({ success: false, source: 'internal_api', error: err.message }, true); }
+  });
+
+  server.tool('pine_get_saved_source', 'Read a saved Pine Script source from TradingView without changing the editor. Use this to verify persistence after pine_save.', {
+    name: z.string().describe('Saved script name (case-insensitive; full exact name recommended)'),
+  }, async ({ name }) => {
+    try { return jsonResult(await core.getSavedSource({ name })); }
+    catch (err) { return jsonResult({ success: false, origin: 'pine_facade', error: err.message }, true); }
   });
 
   server.tool('pine_list_scripts', 'List saved Pine Scripts', {}, async () => {

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -348,6 +348,30 @@ describe('Pine editor persistence safety', () => {
   const pineCore = readFileSync(new URL('../src/core/pine.js', import.meta.url), 'utf8');
   const pineTools = readFileSync(new URL('../src/tools/pine.js', import.meta.url), 'utf8');
 
+  it('opens a closed Pine panel with real CDP mouse input instead of HTMLElement.click()', () => {
+    const ensureBody = pineCore.slice(
+      pineCore.indexOf('export async function ensurePineEditorOpen'),
+      pineCore.indexOf('// ── Pure / offline functions')
+    );
+    assert.ok(ensureBody.includes('var m = ${FIND_MONACO}; return m !== null;'));
+    assert.ok(ensureBody.includes('await getClient()'));
+    assert.ok(ensureBody.includes("Input.dispatchMouseEvent({ type: 'mouseMoved'"));
+    assert.ok(ensureBody.includes("Input.dispatchMouseEvent({ type: 'mousePressed'"));
+    assert.ok(ensureBody.includes("Input.dispatchMouseEvent({ type: 'mouseReleased'"));
+    assert.ok(ensureBody.includes('panelState?.panelVisible'));
+    assert.ok(!ensureBody.includes('btn.click()'));
+  });
+
+  it('allows replacing a blank dirty buffer but protects non-empty unsaved Pine source', () => {
+    const newBody = pineCore.slice(
+      pineCore.indexOf('export async function newScript'),
+      pineCore.indexOf('export async function openScript')
+    );
+    assert.ok(newBody.includes('const currentSource = await getSource()'));
+    assert.ok(newBody.includes("dirtyState.dirty && currentSource.source.trim() !== ''"));
+    assert.ok(newBody.includes('The current Pine editor has unsaved changes'));
+  });
+
   it('writes through Monaco executeEdits so TradingView receives a dirty edit event', () => {
     const setSourceBody = pineCore.slice(
       pineCore.indexOf('export async function setSource'),

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -323,8 +323,114 @@ describe('path traversal prevention', () => {
     assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"));
   });
 
-  it('batch.js strips path separators from filename', () => {
-    const source = readFileSync(new URL('../src/core/batch.js', import.meta.url), 'utf8');
-    assert.ok(source.includes(".replace(/[\\/\\\\]/g, '_')"));
+});
+
+// ── Screenshot tools are not exposed ─────────────────────────────────────
+
+describe('screenshot tools disabled', () => {
+  it('server does not register capture_screenshot', () => {
+    const source = readFileSync(new URL('../src/server.js', import.meta.url), 'utf8');
+    assert.ok(!source.includes('registerCaptureTools(server)'));
+  });
+
+  it('batch_run does not accept the screenshot action', () => {
+    const toolSource = readFileSync(new URL('../src/tools/batch.js', import.meta.url), 'utf8');
+    const coreSource = readFileSync(new URL('../src/core/batch.js', import.meta.url), 'utf8');
+    assert.ok(!toolSource.includes("'screenshot'"));
+    assert.ok(!coreSource.includes("action === 'screenshot'"));
+    assert.ok(!coreSource.includes('Page.captureScreenshot'));
+  });
+});
+
+// ── Pine editor persistence safety ───────────────────────────────────────
+
+describe('Pine editor persistence safety', () => {
+  const pineCore = readFileSync(new URL('../src/core/pine.js', import.meta.url), 'utf8');
+  const pineTools = readFileSync(new URL('../src/tools/pine.js', import.meta.url), 'utf8');
+
+  it('writes through Monaco executeEdits so TradingView receives a dirty edit event', () => {
+    const setSourceBody = pineCore.slice(
+      pineCore.indexOf('export async function setSource'),
+      pineCore.indexOf('export async function compile')
+    );
+    assert.ok(setSourceBody.includes("executeEdits('tradingview-mcp'"));
+    assert.ok(!setSourceBody.includes('.setValue('));
+    assert.ok(setSourceBody.includes('after === nextSource'));
+    assert.ok(setSourceBody.includes("model.getEOL"));
+    assert.ok(setSourceBody.includes("requestedSource.replace(/\\\\n/g, modelEol)"));
+  });
+
+  it('rejects a disabled Save script menu item instead of reporting click success', () => {
+    const saveBody = pineCore.slice(
+      pineCore.indexOf('export async function save'),
+      pineCore.indexOf('export async function getSavedSource')
+    );
+    assert.ok(saveBody.includes("getAttribute('aria-disabled') === 'true'"));
+    assert.ok(saveBody.includes('Save script is disabled'));
+    assert.ok(saveBody.includes('does not match the editor'));
+    assert.ok(!saveBody.includes('Ctrl+S_dispatched'));
+  });
+
+
+  it('opens the Pine tab menu from its own container, not by Y-coordinate proximity', () => {
+    const menuBody = pineCore.slice(
+      pineCore.indexOf('async function openCurrentScriptMenu'),
+      pineCore.indexOf('async function submitInitialSaveDialog')
+    );
+    assert.ok(menuBody.includes('button[data-qa-id=\"scripteditor\"]'));
+    assert.ok(menuBody.includes('tab.parentElement'));
+    assert.ok(menuBody.includes('tabContainer.querySelector'));
+    assert.ok(!menuBody.includes('candidates.sort'));
+  });
+
+  it('fills and submits the first-save naming dialog', () => {
+    const dialogBody = pineCore.slice(
+      pineCore.indexOf('async function submitInitialSaveDialog'),
+      pineCore.indexOf('export async function save')
+    );
+    assert.ok(dialogBody.includes('window.HTMLInputElement.prototype'));
+    assert.ok(dialogBody.includes("new Event('input', { bubbles: true })"));
+    assert.ok(dialogBody.includes("/^save$/i"));
+    assert.ok(dialogBody.includes('saveButton.click()'));
+  });
+
+  it('verifies that moving the Pine editor back to the bottom actually completed', () => {
+    const restoreBody = pineCore.slice(
+      pineCore.indexOf('async function restorePineEditorToBottom'),
+      pineCore.indexOf('export async function newScript')
+    );
+    assert.ok(restoreBody.includes('bottom_tab_visible'));
+    assert.ok(restoreBody.includes('side_title_visible'));
+    assert.ok(restoreBody.includes('if (state?.restored) return true'));
+    assert.ok(!restoreBody.includes('if (result?.found) return true'));
+  });
+
+  it('creates a genuine TradingView script identity instead of replacing the model text', () => {
+    const newBody = pineCore.slice(
+      pineCore.indexOf('export async function newScript'),
+      pineCore.indexOf('export async function openScript')
+    );
+    assert.ok(newBody.includes("action: 'new_tradingview_script_created'"));
+    assert.ok(newBody.includes('identity_created: true'));
+    assert.ok(newBody.includes('Create new'));
+    assert.ok(!newBody.includes('setSource({ source: template })'));
+    assert.ok(pineTools.includes('Create a genuine new TradingView Pine script identity'));
+  });
+
+  it('exposes non-destructive saved-source verification', () => {
+    const savedReaderBody = pineCore.slice(
+      pineCore.indexOf('export async function getSavedSource'),
+      pineCore.indexOf('export async function getConsole')
+    );
+    assert.ok(savedReaderBody.includes('pine-facade/list/?filter=saved'));
+    assert.ok(savedReaderBody.includes('pine-facade/get/'));
+    assert.ok(!savedReaderBody.includes('.setValue('));
+    assert.ok(!savedReaderBody.includes('.executeEdits('));
+    assert.ok(pineTools.includes("server.tool('pine_get_saved_source'"));
+  });
+
+  it('documents pine_open as destructive and unsuitable for save verification', () => {
+    assert.ok(pineTools.includes('does not switch script identity'));
+    assert.ok(pineTools.includes('must not be used to verify saving'));
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes several reliability and safety issues in the Pine Script workflow, including script creation, editor updates, first-time saving, persistence verification, and script identity handling.

It also disables screenshot-related MCP operations so that the server exposes only structured TradingView interfaces.

## Problems addressed

### 1. `pine_new` did not create a real TradingView script

Previously, `pine_new` only replaced the current Monaco editor source with a template.

This caused several problems:

- no new TradingView script identity was created
- the editor could remain attached to the previously opened saved script
- a later save could overwrite the wrong script
- the result looked like a newly created script even though only the editor text had changed

### 2. `pine_save` could open the wrong context menu

The previous implementation selected a context-menu trigger based on vertical position.

The Pine Editor and Strategy Tester tabs can appear at the same Y coordinate, so the implementation could accidentally open the Strategy Tester menu instead of the Pine Editor menu.

### 3. First-time save dialogs were not handled

Saving a new TradingView script opens a `Save script` dialog that requires a script name.

Previously, the `name` argument was only used for verification. It was not entered into the dialog, so first-time saves could time out even when a name was supplied.

### 4. Save success did not guarantee persistence

Dispatching a keyboard shortcut or clicking a Save control does not prove that TradingView persisted the current editor source.

The previous implementation could report success without verifying the saved server-side source.

### 5. Monaco updates were not always registered as dirty changes

Directly calling `model.setValue()` could update the visible source without reliably registering the edit in TradingView's editor state.

This could leave the Save command disabled even though the displayed source had changed.

### 6. A closed Pine Editor could not be reopened reliably

`ensurePineEditorOpen()` attempted to activate the internal bottom-widget API and then called `HTMLElement.click()` on the Pine toolbar button.

In current TradingView Desktop builds, the Pine button can ignore synthetic DOM clicks. The internal bottom-widget methods can also exist while doing nothing for the right-side Pine panel. This caused structured Pine operations to fail with `Could not open Pine Editor.` even though the input and MCP configuration were valid.

A related recovery issue occurred when TradingView marked a blank `Untitled script` as dirty: `pine_new` refused to replace the empty buffer, leaving no structured way to recover.

## Pine Script changes

### Genuine script creation

`pine_new` now uses TradingView's real UI workflow:

```text
Create new → Indicator / Strategy / Library
```

This creates a genuine TradingView script identity instead of replacing the source of the currently attached script.

Additional safeguards:

- refuses to create a new script when the current editor contains non-empty unsaved content
- allows a blank or whitespace-only dirty `Untitled script` buffer to be replaced for recovery
- waits for the Monaco editor to remount
- verifies that the generated source contains the requested declaration: `indicator(...)`, `strategy(...)`, or `library(...)`
- temporarily moves the Pine Editor to the right-side panel when required by the TradingView UI
- attempts to restore the editor to the bottom afterward
- verifies the actual editor placement instead of treating a menu-item click as successful
- returns `restored_to_bottom: false` if TradingView ignores the move operation

### Reliable Pine Editor opening

`ensurePineEditorOpen()` now uses a staged opening sequence:

1. checks whether a usable Pine Monaco editor is already available
2. tries TradingView's internal bottom-widget API
3. waits briefly for Monaco to mount before taking another action
4. checks whether the Pine side panel is already visible to avoid toggling it closed
5. resolves the visible Pine toolbar button's center coordinates
6. dispatches real CDP `mouseMoved`, `mousePressed`, and `mouseReleased` events
7. polls until Monaco is accessible

The previous synthetic `HTMLElement.click()` fallback has been removed. This matches the real input path that TradingView Desktop accepts in the affected panel state.

### Safer Monaco source updates

`pine_set_source` now updates the Monaco model through `executeEdits()` instead of `setValue()`.

The implementation now:

- selects the connected and visible Pine Monaco editor
- prefers the editor that currently has text focus
- normalizes line endings to the model's configured EOL format
- uses a full-model edit so TradingView receives an editor change event
- verifies the resulting model source
- reports whether the operation actually changed the source

This makes TradingView more likely to correctly mark the script as modified and enable the Save command.

### Reliable Pine Editor menu selection

The Pine context-menu trigger is now resolved from the Pine Editor tab's own DOM container.

It no longer searches all context-menu buttons and selects one based on Y-coordinate proximity. This avoids opening the Strategy Tester menu when both tabs are aligned at the same vertical position.

### First-time save support

`pine_save` now accepts an optional script name:

```json
{
  "name": "My Strategy"
}
```

The name is required when saving a new script for the first time.

When TradingView displays the first-save dialog, the implementation now:

1. locates the visible `Save script` dialog
2. finds its script-name input
3. updates the input using the native `HTMLInputElement.value` setter
4. dispatches `input` and `change` events
5. verifies that the Save button is enabled
6. submits the dialog

The CLI supports the same workflow:

```bash
tv pine save "My Strategy"
```

### Existing-script save protection

For an existing saved script, `pine_save` checks the currently attached script identity before saving.

If a different name is supplied, the operation is rejected instead of silently renaming, copying, or overwriting another script. `pine_save` is intentionally not treated as a rename or “save as” operation.

### Server-side persistence verification

After saving, the implementation reads the saved script through TradingView's Pine facade and compares its normalized source with the current editor source.

A save is only reported as successful when the server-side source matches the editor.

Possible successful actions include:

- `already_persisted`
- `saved_via_script_menu`
- `created_and_saved_via_dialog`

If the Save command is disabled, the operation only returns `already_persisted` when the saved server source already matches the editor. If the sources differ, the operation returns an error instead of reporting false success.

### New `pine_get_saved_source` tool

This PR adds `pine_get_saved_source`, which reads a saved Pine Script from TradingView without modifying the current editor.

It returns information including:

- saved script name and title
- script ID and version
- modification time
- source and line count

This provides a non-destructive way to verify persistence after `pine_save`.

### Clarified `pine_open` behavior

`pine_open` does not switch the TradingView script identity. It downloads a saved source and injects it into the current editor, which is a destructive operation.

Its description and return value now explicitly warn that it:

- overwrites the current editor source
- does not attach the editor to the selected saved script
- must not be used to verify that a save succeeded

## Screenshot tools disabled

This PR disables screenshot and image-recognition operations from the MCP server's structured tool surface.

### `capture_screenshot`

`registerCaptureTools()` is no longer registered by the MCP server. As a result, `capture_screenshot` is no longer exposed as an available MCP tool.

The capture implementation file is not deleted, but the server no longer advertises or registers the tool.

### Batch screenshot action

The screenshot action has also been removed from `batch_run`.

Previously accepted actions included:

```text
screenshot
get_ohlcv
get_strategy_results
```

The allowed actions are now restricted to:

```text
get_ohlcv
get_strategy_results
```

The tool schema now uses an enum so unsupported action names are rejected during argument validation. The batch screenshot implementation and its filesystem-writing dependencies were removed from `src/core/batch.js`.

### Server guidance

The MCP server instructions now explicitly state that:

- operations should use structured TradingView tools
- screenshots and image recognition are disabled
- a structured-tool failure should be reported directly instead of falling back to visual inspection

This prevents agents from claiming that a screenshot fallback was performed when no supported structured screenshot interface is available.

## Tool and CLI changes

### `pine_save`

Before:

```text
pine_save()
```

Now:

```text
pine_save({ name?: string })
```

The name is required for the first save and optional when the current saved script identity can be determined.

### CLI save command

Both forms are now supported:

```bash
tv pine save
tv pine save "My New Script"
```

### `pine_new`

The tool description now clarifies that it creates a genuine TradingView script identity and refuses to discard unsaved changes.

### `batch_run`

The action argument is now validated as:

```text
get_ohlcv | get_strategy_results
```

The previous `screenshot` action is no longer available.

## Safety behavior

The updated workflow avoids the following unsafe outcomes:

- overwriting a saved script while pretending to create a new one
- saving through the Strategy Tester context menu
- reporting save success before server persistence
- accepting a first-save name without entering it into the dialog
- silently using a supplied name to rename or copy an existing script
- treating a Monaco source replacement as a registered TradingView edit
- using `pine_open` as proof that a script was saved
- reporting that the editor was restored to the bottom when only the menu item was clicked

## Tests

The regression coverage checks that:

- a closed Pine panel uses real CDP mouse input instead of `HTMLElement.click()`
- an already visible Pine panel is not toggled closed
- blank dirty buffers can be replaced while non-empty unsaved source remains protected
- Monaco updates use `executeEdits()` instead of `setValue()`
- line endings are normalized using the Monaco model EOL
- the resulting editor source is verified
- disabled Save commands do not report false success
- the Pine Editor menu is resolved from its own tab container
- the first-save dialog is filled and submitted
- `pine_new` uses the real `Create new` workflow
- `pine_new` no longer creates a template through `setSource()`
- editor placement restoration is verified
- saved-source verification is non-destructive
- `pine_open` is documented as destructive
- screenshot tools are not registered
- `batch_run` no longer accepts `screenshot`

Test results:

```text
npm run test:unit
163 tests passed
0 tests failed
```

Additional checks:

```text
node --check src/core/pine.js
git diff --check
npm run lint
```

ESLint reports 0 errors. Four existing unrelated warnings remain in `src/core/data.js`, `src/core/pane.js`, and `src/tools/watchlist.js`.

## Live TradingView verification

The updated local implementation was connected to a live TradingView Desktop session.

### Closed Pine Editor recovery

The Pine side panel was closed through its visible `Close` control and verified as hidden. Calling the updated local `ensurePineEditorOpen()` then reopened it through CDP mouse input and made Monaco accessible in approximately 6.1 seconds.

The follow-up source read returned the current blank buffer successfully:

```json
{
  "success": true,
  "source": "",
  "line_count": 1,
  "char_count": 0
}
```

### Blank and non-empty dirty-buffer behavior

From the blank dirty `Untitled script`, `pine_new({ type: "indicator" })` successfully created a genuine unsaved Indicator identity. No cloud save was performed.

A subsequent attempt to create a Strategy while the generated Indicator source was non-empty was rejected with the existing unsaved-changes error, and the source remained unchanged.

### Existing saved script

Saving the existing script returned:

```json
{
  "success": true,
  "action": "already_persisted",
  "name": "五线 EMA（可配置）",
  "script_id": "USER;e4e6a0fc7089424d956b556fea157f0f",
  "version": "4.0",
  "verified": true
}
```

### New Strategy identity

Creating a Strategy returned:

```json
{
  "success": true,
  "type": "strategy",
  "action": "new_tradingview_script_created",
  "identity_created": true,
  "previous_name": "五线 EMA（可配置）",
  "name": "Untitled script",
  "changed": true
}
```

The TradingView editor switched from the existing saved script to a genuine new `Untitled script` Strategy identity.

The temporary Strategy was not saved to the TradingView account, avoiding the creation of test scripts in the user's cloud script list.

## Compatibility notes

This PR intentionally changes the public MCP surface:

- `capture_screenshot` is no longer registered
- `batch_run(action: "screenshot")` is no longer supported
- first-time `pine_save` calls must provide a script name
- `pine_new` rejects non-empty unsaved content but allows recovery from a blank dirty buffer
- `pine_open` remains available but is explicitly documented as destructive source injection

