### PR TITLE
fix: correct AppX package name lookup for TradingView MSIX install

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -318,7 +318,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'*TradingView*\' -ErrorAction SilentlyContinue).InstallLocation"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;


### PR DESCRIPTION
## Summary
- `tv_launch`'s MSIX discovery searched `Get-AppxPackage -Name 'TradingView.Desktop'`, which doesn't match the actual Store package name (publisher-prefixed, e.g. `31178TradingViewInc.TradingView`), so the lookup silently failed and TradingView was never found on Windows Store installs.
- Switched the lookup to a wildcard match (`'*TradingView*'`) so it resolves correctly regardless of publisher prefix.

## Test plan
- [x] Verified `Get-AppxPackage -Name '*TradingView*'` resolves the correct `InstallLocation` on a machine with the Store install.
- [x] Confirmed `tv_launch` finds and launches TradingView from the MSIX path with the fix applied.