### PR TITLE
fix(wait): waitForChartReady always times out on TV Desktop 3.3.0 (10.6s per chart_set_symbol)

### DIFF
--- a/src/wait.js
+++ b/src/wait.js
@@ -17,19 +17,33 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
           || document.querySelector('[data-name="loading"]');
         var isLoading = spinner && spinner.offsetParent !== null;
 
-        // Try to get bar count from data window or chart
+        // Series load state + real bar count. The old '[class*="bar"]' DOM query matched
+        // toolbars/scrollbars, so it never reflected data loading at all.
+        // seriesLoading is the authoritative signal: chart.symbol() flips to the new symbol
+        // up to ~700ms BEFORE its data lands (measured), so the symbol alone cannot gate
+        // readiness — reading in that window returns the PREVIOUS symbol's bars.
+        var seriesLoading = false;
         var barCount = -1;
         try {
-          var bars = document.querySelectorAll('[class*="bar"]');
-          barCount = bars.length;
-        } catch {}
+          var ms = window.TradingViewApi._activeChartWidgetWV.value()
+            ._chartWidget.model().mainSeries();
+          var l = ms.isLoading;
+          seriesLoading = !!(typeof l === 'function' ? ms.isLoading() : l);
+          barCount = ms.bars().size();
+        } catch(e) {}
 
-        // Get current symbol from header
-        var symbolEl = document.querySelector('[data-name="legend-source-title"]')
-          || document.querySelector('[class*="title"] [class*="apply-common-tooltip"]');
-        var currentSymbol = symbolEl ? symbolEl.textContent.trim() : '';
+        // Get current symbol from the chart API (the header selectors are gone in TV 3.3.0
+        // and the fallback scrapes a description, so the match below could never pass)
+        var currentSymbol = '';
+        try {
+          currentSymbol = window.TradingViewApi._activeChartWidgetWV.value().symbol() || '';
+        } catch(e) {}
 
-        return { isLoading: !!isLoading, barCount: barCount, currentSymbol: currentSymbol };
+        return {
+          isLoading: !!isLoading || seriesLoading,
+          barCount: barCount,
+          currentSymbol: currentSymbol
+        };
       })()
     `);
 
@@ -67,7 +81,8 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
     await new Promise(r => setTimeout(r, POLL_INTERVAL));
   }
 
-  // Timeout — return true anyway, caller should verify
+  // Timeout — report NOT ready. Callers currently only echo this as `chart_ready`
+  // and proceed regardless, so a timeout does not abort the operation.
   return false;
 }
 


### PR DESCRIPTION
## Problem

`waitForChartReady` never returns ready on TradingView Desktop 3.3.0, so **every `chart_set_symbol` burns the full 10,000 ms `DEFAULT_TIMEOUT`** — including when setting the symbol the chart already shows.

Measured on TV Desktop 3.3.0 / Electron 38.2.2, setting the symbol already loaded (i.e. zero actual work): **10.66 / 10.67 / 10.68 s**.

`batch_run` pays this per iteration (`batch.js:34`) and `data.js` pays it on every temporary symbol switch (`:397`, `:446`). `setTimeframe` is unaffected because it passes `null` for the symbol — which is exactly why timeframe changes feel fast (~1.9 s) while symbol changes do not.

## Cause 1 — the symbol match can never pass

`currentSymbol` was scraped from `[data-name="legend-source-title"]`, which **no longer exists in 3.3.0**. The fallback selector returns a *description*, frequently from a different pane. Probed live on an **NQ** chart:

```json
{"isLoading": false,
 "currentSymbol": "YE-mini Dow Jones ($5) Futures",
 "containsTest": false}
```

`"YE-mini Dow Jones ($5) Futures".includes("CME_MINI:NQ1!")` is permanently false → `continue` → timeout.

Fixed by reading the symbol from the chart API — the pattern **`waitForRender` already uses further down this same file**.

## Cause 2 — the symbol alone is not a safe gate

Fixing only cause 1 is not enough, and introduces a data-correctness bug. `chart.symbol()` flips to the new symbol **up to ~700 ms before that symbol's data arrives**, so callers can read the *previous* symbol's bars. Sampled every 100 ms across a cold switch:

```
t100–t700   symbol=RTY1!  size=300  close=7503.5   <- the PREVIOUS symbol's bars
t800–t1100  symbol=RTY1!  size=0    close=null     <- series cleared
t1200+      symbol=RTY1!  size=300  close=2928.4   <- real data
```

`chart.symbol()` also echoes non-canonical input verbatim (setting `GLOBEX:NQ1!` returns `GLOBEX:NQ1!`), making the comparison near-tautological on its own.

The authoritative signal is **`mainSeries().isLoading()`** — true during the transition, false exactly when the new data lands:

```
t0          load=false  close=7503.5   (old symbol, settled)
t100–t200   load=true   close=7503.5   (loading; data still stale)
t300+       load=false  close=86.8     (new data arrived)
```

It is OR-ed into the existing spinner check.

## Also: `barCount` measured nothing

It counted `document.querySelectorAll('[class*="bar"]')`, which matches `toolbar`, `sidebar`, `scrollbar`, `widgetbar` — ~144 elements of UI chrome that never change during a data load. The stability test was therefore always trivially satisfied. It now reads `mainSeries().bars().size()`.

## Results

| | Before | After |
|---|---|---|
| `chart_set_symbol`, symbol already loaded | 10.66 s | **1.02 s** |
| `chart_set_symbol`, cold uncached symbol | 10.6 s | **1.23 s** |

Timing is **adaptive**, not merely faster: it returns quickly when data is already present and waits when it is not.

**Correctness verified on genuinely uncached symbols**, read immediately after switching — gold 4098.6, nat gas 2.792, heating oil 4.1936, copper 6.5075 — each its own price, never the previous symbol's.

⚠️ **If you verify this, use a COLD symbol.** Switching between symbols already loaded is warm-cache and does not exercise the race in cause 2 — that is precisely how a cause-1-only fix passed three tests while still being wrong.

## Notes

- Scope is `src/wait.js` only; no tool schemas or public behaviour change.
- The trailing `// Timeout — return true anyway` comment sat above `return false;` — updated to describe actual behaviour. No logic change; neither consumer (`chart.js:52`, `:64`) branches on it.
- Related open issues, though neither is this bug: #11 (MCP overhead / hangs) and #41 (CDP flag degrading drawing-heavy charts).
- One known limitation, deliberately not papered over: if those chart internals are ever renamed, the probe throws, `barCount` stays `-1`, and the wait degrades back to the 10 s timeout. I chose that over a permissive fallback, which would silently serve stale data — the worse failure. Happy to add an explicit fallback if you'd prefer.

Investigated and verified with Claude Code against a live TV Desktop 3.3.0 session.
