### PR TITLE
feat: Add deterministic TradingView alert sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,14 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `draw_clear` → remove all
 
 ### "Manage alerts"
-- `alert_create` → set price alert (condition: "crossing", "greater_than", "less_than")
-- `alert_list` → view active alerts
+- `alert_create` → create an exact symbol/timeframe price or named live Pine alert; pass every field and use `dry_run` first
+- `alerts_sync` → idempotently diff/apply a complete approved plan; preserves unrelated alerts and replaces only approved IDs
+- `alert_list` → view normalized definitions for existing alerts
 - `alert_delete` → remove alerts
+
+Indicator alerts require an already-open pane with the exact canonical symbol,
+timeframe, live indicator title, and named `alertcondition()`. Alert tools do not
+switch or focus panes and never substitute a price condition.
 
 ### "Navigate the UI"
 - `ui_open_panel` → open/close pine-editor, strategy-tester, watchlist, alerts, trading

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Gives your AI assistant eyes and hands on your own chart:
 - **Chart navigation** — change symbols, timeframes, zoom to dates, add/remove indicators
 - **Visual analysis** — read your chart's indicator values, price levels, and annotations
 - **Draw on charts** — trend lines, horizontal lines, rectangles, text annotations
-- **Manage alerts** — create, list, and delete price alerts
+- **Manage alerts** — create and idempotently sync exact price or named Pine-indicator alerts
 - **Replay practice** — step through historical bars, practice entries/exits
 - **Screenshots** — capture chart state for AI visual analysis
 - **Multi-pane layouts** — set up 2x2, 3x1, etc. grids with different symbols per pane
@@ -170,7 +170,7 @@ tv quote / ohlcv / values
 tv data lines/labels/tables/boxes/strategy/trades/equity/depth/indicator
 tv pine get/set/compile/analyze/check/save/new/open/list/errors/console
 tv draw shape/list/get/remove/clear
-tv alert list/create/delete
+tv alert list/create/delete/sync
 tv watchlist get/add
 tv indicator add/remove/toggle/set/get
 tv layout list/switch
@@ -181,6 +181,26 @@ tv stream quote/bars/values/lines/labels/tables/all
 tv ui click/keyboard/hover/scroll/find/eval/type/panel/fullscreen/mouse
 tv screenshot / discover / ui-state / range / scroll
 ```
+
+### Deterministic Alert Sync
+
+Validate a complete approved alert plan without changing TradingView:
+
+```bash
+tv alert sync --file ./daily_alerts/2030-01-02.alerts.json --dry-run
+```
+
+Each alert requires an exchange-qualified `symbol`, explicit `timeframe`,
+`kind`, exact condition, frequency, offset-bearing ISO-8601 expiration, and
+deterministic message. Price alerts also require a positive `price`. Indicator
+alerts require the exact title of a live indicator and one of its named Pine
+`alertcondition()` conditions.
+
+`alerts_sync` lists existing alerts once, preserves unrelated alerts, avoids
+duplicates, and replaces only conflicting IDs named in `replace_alert_ids`.
+Pine metadata is read from an already-open pane with the exact canonical symbol
+and timeframe; the alert resolver never focuses or changes a chart pane. Run a
+dry-run before applying a plan.
 
 ## Streaming
 
@@ -303,7 +323,8 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 |------|-------------|
 | `draw_shape` | Draw horizontal_line, trend_line, rectangle, text |
 | `draw_list` / `draw_remove_one` / `draw_clear` | Manage drawings |
-| `alert_create` / `alert_list` / `alert_delete` | Manage price alerts |
+| `alert_create` / `alert_list` / `alert_delete` | Create/list/delete exact price or named Pine alerts |
+| `alerts_sync` | Idempotently diff/apply a complete alert plan while preserving unrelated alerts |
 | `capture_screenshot` | Screenshot (regions: full, chart, strategy_tester) |
 | `batch_run` | Run action across multiple symbols/timeframes |
 | `watchlist_get` / `watchlist_add` | Read/modify watchlist |

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/alerts.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/alerts.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/cli/commands/alerts.js
+++ b/src/cli/commands/alerts.js
@@ -1,25 +1,63 @@
 import { register } from '../router.js';
 import * as core from '../../core/alerts.js';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
 register('alert', {
-  description: 'Alert tools (list, create, delete)',
+  description: 'Alert tools (list, create, delete, sync)',
   subcommands: new Map([
     ['list', {
-      description: 'List active alerts',
+      description: 'List normalized TradingView alerts',
       handler: () => core.list(),
     }],
     ['create', {
-      description: 'Create a price alert',
+      description: 'Create an exact price or live Pine-indicator alert',
       options: {
-        price: { type: 'string', short: 'p', description: 'Price level' },
-        condition: { type: 'string', short: 'c', description: 'Condition: crossing, greater_than, less_than' },
-        message: { type: 'string', short: 'm', description: 'Alert message' },
+        symbol: { type: 'string', short: 's', description: 'Exchange-qualified symbol (required)' },
+        timeframe: { type: 'string', short: 't', description: 'Exact TradingView timeframe (required)' },
+        kind: { type: 'string', short: 'k', description: 'price or indicator (required)' },
+        condition: { type: 'string', short: 'c', description: 'Price condition or exact Pine condition name' },
+        price: { type: 'string', short: 'p', description: 'Positive level for price alerts' },
+        indicator: { type: 'string', short: 'i', description: 'Exact live indicator title' },
+        frequency: { type: 'string', description: 'once, once_per_bar, or once_per_bar_close' },
+        expiration: { type: 'string', short: 'e', description: 'ISO-8601 timestamp with offset' },
+        message: { type: 'string', short: 'm', description: 'Exact deterministic alert message' },
+        'dry-run': { type: 'boolean', description: 'Validate without creating an alert' },
       },
       handler: (opts) => core.create({
-        price: Number(opts.price),
-        condition: opts.condition || 'crossing',
+        symbol: opts.symbol,
+        timeframe: opts.timeframe,
+        kind: opts.kind,
+        condition: opts.condition,
+        price: opts.price === undefined ? undefined : Number(opts.price),
+        indicator: opts.indicator,
+        frequency: opts.frequency,
+        expiration: opts.expiration,
         message: opts.message,
+        dry_run: !!opts['dry-run'],
       }),
+    }],
+    ['sync', {
+      description: 'Idempotently synchronize a complete alert plan from JSON',
+      options: {
+        file: { type: 'string', short: 'f', description: 'Alert-plan JSON file (required)' },
+        'dry-run': { type: 'boolean', description: 'Return the diff without creating or deleting alerts' },
+      },
+      handler: async (opts) => {
+        if (!opts.file) throw new Error('File required. Usage: tv alert sync --file <alerts.json> --dry-run');
+        const filePath = resolve(opts.file);
+        let plan;
+        try {
+          plan = JSON.parse(await readFile(filePath, 'utf8'));
+        } catch (err) {
+          throw new Error(`Could not read alert plan ${filePath}: ${err.message}`);
+        }
+        return core.syncAlerts({
+          alerts: plan.alerts,
+          replace_alert_ids: plan.replace_alert_ids || [],
+          dry_run: !!opts['dry-run'] || plan.dry_run === true,
+        });
+      },
     }],
     ['delete', {
       description: 'Delete alerts',

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,128 +1,807 @@
 /**
- * Core alert logic.
+ * Deterministic TradingView alert creation and synchronization.
  *
- * Alerts are created / listed / deleted through TradingView's pricealerts REST API
- * (https://pricealerts.tradingview.com) using the desktop app's authenticated session.
- * Requests are sent as text/plain so the browser does not issue a CORS preflight that
- * the endpoint rejects. The create/delete bodies must be wrapped in a `payload` object.
+ * Alert mutations use TradingView's authenticated pricealerts REST endpoint.
+ * Pine alertcondition metadata is resolved read-only from studies that are
+ * already live on an exact symbol/timeframe pane; no pane focus or chart state
+ * changes are required.
  */
-import { evaluate, evaluateAsync, safeString, requireFinite } from '../connection.js';
+import { evaluate, evaluateAsync, safeString } from '../connection.js';
 
-// Map the tool's friendly condition names to TradingView's alert condition types.
-const CONDITION_TYPE_MAP = {
-  crossing: 'cross', cross: 'cross',
-  greater_than: 'greater', greater: 'greater', above: 'greater', '>': 'greater',
-  less_than: 'less', less: 'less', below: 'less', '<': 'less',
+const PRICE_CONDITIONS = new Set(['crossing', 'greater_than', 'less_than']);
+const FREQUENCIES = new Set(['once', 'once_per_bar', 'once_per_bar_close']);
+const CONDITION_TO_INTERNAL = {
+  crossing: 'cross',
+  greater_than: 'greater',
+  less_than: 'less',
 };
+const CONDITION_FROM_INTERNAL = {
+  cross: 'crossing',
+  greater: 'greater_than',
+  less: 'less_than',
+};
+const FREQUENCY_TO_INTERNAL = {
+  once: 'on_first_fire',
+  once_per_bar: 'on_each_fire',
+  once_per_bar_close: 'on_bar_close',
+};
+const FREQUENCY_FROM_INTERNAL = Object.fromEntries(
+  Object.entries(FREQUENCY_TO_INTERNAL).map(([external, internal]) => [internal, external]),
+);
 
-export async function create({ condition, price, message }) {
-  const p = requireFinite(price, 'price');
-  const condType = CONDITION_TYPE_MAP[String(condition || 'crossing').trim().toLowerCase()] || 'cross';
+class AlertCapabilityError extends Error {
+  constructor(stage, code, message, details = {}) {
+    super(message);
+    this.name = 'AlertCapabilityError';
+    this.stage = stage;
+    this.code = code;
+    this.details = details;
+  }
+}
 
+function errorResult(err, extra = {}) {
+  const error = {
+    stage: err?.stage || 'unexpected',
+    code: err?.code || 'unexpected_error',
+    message: err?.message || String(err),
+    ...(err?.details || {}),
+  };
+  return { success: false, stage: error.stage, error, ...extra };
+}
+
+function nowValue(deps) {
+  const value = typeof deps?.now === 'function' ? deps.now() : deps?.now;
+  return value == null ? Date.now() : Number(value);
+}
+
+function requireString(value, field) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new AlertCapabilityError('validation', `invalid_${field}`, `${field} is required`);
+  }
+  return value.trim();
+}
+
+function canonicalExpiration(value, now = Date.now()) {
+  const text = requireString(value, 'expiration');
+  if (!/(?:Z|[+-]\d{2}:\d{2})$/i.test(text)) {
+    throw new AlertCapabilityError(
+      'validation',
+      'invalid_expiration',
+      'expiration must be an ISO-8601 timestamp with Z or an explicit UTC offset',
+    );
+  }
+  const timestamp = Date.parse(text);
+  if (!Number.isFinite(timestamp)) {
+    throw new AlertCapabilityError('validation', 'invalid_expiration', 'expiration is not a valid timestamp');
+  }
+  if (timestamp <= now) {
+    throw new AlertCapabilityError('validation', 'expired_expiration', 'expiration must be in the future');
+  }
+  return new Date(timestamp).toISOString();
+}
+
+/** Validate and normalize the exact public alert contract. */
+export function validateAlertDefinition(input, options = {}) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new AlertCapabilityError('validation', 'invalid_definition', 'alert definition must be an object');
+  }
+
+  const symbol = requireString(input.symbol, 'symbol').toUpperCase();
+  if (!/^[A-Z0-9._-]+:[A-Z0-9._!\-/]+$/.test(symbol)) {
+    throw new AlertCapabilityError(
+      'validation',
+      'invalid_symbol',
+      'symbol must be exchange-qualified (for example NASDAQ:NVDA)',
+    );
+  }
+  const timeframe = requireString(input.timeframe, 'timeframe');
+  if (/\s/.test(timeframe)) {
+    throw new AlertCapabilityError('validation', 'invalid_timeframe', 'timeframe must not contain whitespace');
+  }
+  const kind = requireString(input.kind, 'kind').toLowerCase();
+  if (kind !== 'price' && kind !== 'indicator') {
+    throw new AlertCapabilityError('validation', 'invalid_kind', 'kind must be "price" or "indicator"');
+  }
+  const condition = requireString(input.condition, 'condition');
+  const frequency = requireString(input.frequency, 'frequency').toLowerCase();
+  if (!FREQUENCIES.has(frequency)) {
+    throw new AlertCapabilityError(
+      'validation',
+      'invalid_frequency',
+      'frequency must be once, once_per_bar, or once_per_bar_close',
+    );
+  }
+  const expiration = canonicalExpiration(input.expiration, options.now ?? Date.now());
+  const message = requireString(input.message, 'message');
+
+  const normalized = { symbol, timeframe, kind, condition, frequency, expiration, message };
+  if (kind === 'price') {
+    if (!PRICE_CONDITIONS.has(condition)) {
+      throw new AlertCapabilityError(
+        'validation',
+        'invalid_price_condition',
+        'price condition must be crossing, greater_than, or less_than',
+      );
+    }
+    const price = Number(input.price);
+    if (!Number.isFinite(price) || price <= 0) {
+      throw new AlertCapabilityError('validation', 'invalid_price', 'price alerts require a positive finite price');
+    }
+    if (input.indicator != null) {
+      throw new AlertCapabilityError('validation', 'unexpected_indicator', 'price alerts must not include indicator');
+    }
+    normalized.price = price;
+  } else {
+    normalized.indicator = requireString(input.indicator, 'indicator');
+    if (input.price != null) {
+      throw new AlertCapabilityError('validation', 'unexpected_price', 'indicator alerts must not include price');
+    }
+  }
+  return normalized;
+}
+
+function parseSymbol(value) {
+  if (!value) return '';
+  if (typeof value === 'object') return String(value.symbol || '').toUpperCase();
+  const text = String(value);
+  try {
+    const parsed = JSON.parse(text.replace(/^=/, ''));
+    return String(parsed.symbol || text).toUpperCase();
+  } catch {
+    return text.toUpperCase();
+  }
+}
+
+function presentationStudy(raw, series) {
+  const studies = raw?.presentation_data?.studies || {};
+  const entries = Object.entries(studies);
+  const pineId = String(series?.pine_id || '');
+  const exact = entries.find(([key]) => pineId && key.includes(pineId));
+  return exact?.[1] || (entries.length === 1 ? entries[0][1] : null);
+}
+
+/** Convert a raw list_alerts item into the exact public definition shape. */
+export function normalizeListedAlert(raw) {
+  const conditionData = raw?.condition || raw?.conditions?.[0] || {};
+  const series = Array.isArray(conditionData.series) ? conditionData.series : [];
+  const studySeries = series.find(item => item?.type === 'study');
+  const valueSeries = series.find(item => item?.type === 'value');
+  const kind = raw?.type === 'indicator' || conditionData.type === 'alert_cond' ? 'indicator' : 'price';
+  const base = {
+    alert_id: raw?.alert_id,
+    symbol: parseSymbol(raw?.pro_symbol || raw?.symbol),
+    timeframe: String(raw?.resolution || conditionData.resolution || ''),
+    kind,
+    frequency: FREQUENCY_FROM_INTERNAL[conditionData.frequency] || conditionData.frequency || null,
+    expiration: raw?.expiration ? new Date(raw.expiration).toISOString() : null,
+    message: raw?.message ?? '',
+    active: raw?.active !== false,
+    created: raw?.create_time || null,
+    last_fired: raw?.last_fire_time || null,
+  };
+
+  if (kind === 'price') {
+    base.condition = CONDITION_FROM_INTERNAL[conditionData.type] || conditionData.type || null;
+    base.price = Number(valueSeries?.value);
+  } else {
+    const study = presentationStudy(raw, studySeries);
+    const conditionMeta = study?.alert_conditions?.[conditionData.alert_cond_id];
+    base.condition = conditionMeta?.title || null;
+    base.indicator = study?.description || study?.short_description || null;
+  }
+  return base;
+}
+
+async function fetchRawAlerts() {
+  return evaluateAsync(`
+    fetch('https://pricealerts.tradingview.com/list_alerts', { credentials: 'include' })
+      .then(function(response) { return response.json(); })
+      .then(function(data) {
+        if (data.s !== 'ok' || !Array.isArray(data.r)) {
+          return { success: false, error: data.errmsg || 'Unexpected list_alerts response' };
+        }
+        return { success: true, alerts: data.r };
+      })
+      .catch(function(error) { return { success: false, error: error.message }; })
+  `);
+}
+
+async function postCreateAlert(payload) {
+  const serialized = JSON.stringify(payload);
   return evaluate(`
     (function() {
       try {
-        var ms = window.TradingViewApi._activeChartWidgetWV.value()._chartWidget.model().mainSeries();
-        var sym = (ms.proSymbol && ms.proSymbol()) || (ms.symbol && ms.symbol());
-        if (!sym) return { success: false, error: 'Could not read current chart symbol from TradingView' };
-        var price = ${JSON.stringify(p)};
-        var condType = ${safeString(condType)};
-        var msg = ${safeString(message || '')};
-        if (!msg) {
-          var verb = condType === 'greater' ? 'above' : (condType === 'less' ? 'below' : 'crossing');
-          msg = sym.split(':').pop() + ' ' + verb + ' ' + price;
-        }
-        var cond = { type: condType, frequency: 'on_first_fire', series: [{ type: 'barset' }, { type: 'value', value: price }], resolution: '1' };
-        var payload = {
-          conditions: [cond],
-          symbol: '={"symbol":"' + sym + '"}',
-          resolution: '1',
-          message: msg,
-          sound_file: 'alert/fired', sound_duration: 0,
-          popup: true, auto_deactivate: true,
-          email: false, sms_over_email: false, mobile_push: true,
-          web_hook: null, name: null,
-          expiration: new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString(),
-          active: true, ignore_warnings: true
-        };
-        var x = new XMLHttpRequest();
-        x.open('POST', 'https://pricealerts.tradingview.com/create_alert', false);
-        x.withCredentials = true;
-        x.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
-        x.send(JSON.stringify({ payload: payload }));
+        var payload = JSON.parse(${safeString(serialized)});
+        var request = new XMLHttpRequest();
+        request.open('POST', 'https://pricealerts.tradingview.com/create_alert', false);
+        request.withCredentials = true;
+        request.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
+        request.send(JSON.stringify({ payload: payload }));
         var data = {};
-        try { data = JSON.parse(x.responseText); } catch (e) {}
+        try { data = JSON.parse(request.responseText); } catch (e) {}
         if (data.s === 'ok') {
-          return { success: true, source: 'internal_api', symbol: sym, price: price, condition: condType, message: msg, alert_id: (data.r && data.r.alert_id) || null };
+          return { success: true, alert_id: data.r && data.r.alert_id, status: request.status };
         }
-        return { success: false, source: 'internal_api', error: (data.err && data.err.code) || data.errmsg || ('HTTP ' + x.status), response: (x.responseText || '').slice(0, 200) };
-      } catch (e) {
-        return { success: false, source: 'internal_api', error: e.message };
+        return {
+          success: false,
+          status: request.status,
+          error: (data.err && data.err.code) || data.errmsg || ('HTTP ' + request.status),
+          response: (request.responseText || '').slice(0, 500)
+        };
+      } catch (error) {
+        return { success: false, error: error.message };
       }
     })()
   `);
 }
 
-export async function list() {
-  // Use pricealerts REST API — returns structured data with alert_id, symbol, price, conditions
-  const result = await evaluateAsync(`
-    fetch('https://pricealerts.tradingview.com/list_alerts', { credentials: 'include' })
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
-        if (data.s !== 'ok' || !Array.isArray(data.r)) return { alerts: [], error: data.errmsg || 'Unexpected response' };
-        return {
-          alerts: data.r.map(function(a) {
-            var sym = '';
-            try { sym = JSON.parse(a.symbol.replace(/^=/, '')).symbol || a.symbol; } catch(e) { sym = a.symbol; }
-            return {
-              alert_id: a.alert_id,
-              symbol: sym,
-              type: a.type,
-              message: a.message,
-              active: a.active,
-              condition: a.condition,
-              resolution: a.resolution,
-              created: a.create_time,
-              last_fired: a.last_fire_time,
-              expiration: a.expiration,
-            };
-          })
-        };
-      })
-      .catch(function(e) { return { alerts: [], error: e.message }; })
-  `);
-  return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
-}
-
-export async function deleteAlerts({ delete_all, alert_ids, alert_id } = {}) {
-  // Resolve the set of alert ids to delete.
-  let ids = [];
-  if (Array.isArray(alert_ids)) ids = ids.concat(alert_ids);
-  if (alert_id != null) ids.push(alert_id);
-  if (delete_all) {
-    const listed = await list();
-    ids = (listed.alerts || []).map((a) => a.alert_id);
-  }
-  ids = ids.filter((x) => x != null);
-  if (!ids.length) {
-    return { success: false, source: 'internal_api', error: delete_all ? 'No alerts to delete.' : 'Provide delete_all: true or an alert_id to delete.' };
-  }
-
-  const result = await evaluate(`
+async function postDeleteAlerts(ids) {
+  return evaluate(`
     (function() {
       try {
-        var x = new XMLHttpRequest();
-        x.open('POST', 'https://pricealerts.tradingview.com/delete_alerts', false);
-        x.withCredentials = true;
-        x.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
-        x.send(JSON.stringify({ payload: { alert_ids: ${JSON.stringify(ids)} } }));
-        var data = {}; try { data = JSON.parse(x.responseText); } catch (e) {}
-        return { ok: data.s === 'ok', status: x.status, response: (x.responseText || '').slice(0, 200) };
-      } catch (e) { return { ok: false, error: e.message }; }
+        var request = new XMLHttpRequest();
+        request.open('POST', 'https://pricealerts.tradingview.com/delete_alerts', false);
+        request.withCredentials = true;
+        request.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
+        request.send(JSON.stringify({ payload: { alert_ids: ${JSON.stringify(ids)} } }));
+        var data = {};
+        try { data = JSON.parse(request.responseText); } catch (e) {}
+        if (data.s === 'ok') return { success: true, alert_ids: ${JSON.stringify(ids)} };
+        return {
+          success: false,
+          error: (data.err && data.err.code) || data.errmsg || ('HTTP ' + request.status),
+          response: (request.responseText || '').slice(0, 500)
+        };
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
     })()
   `);
-  if (result && result.ok) {
-    return { success: true, source: 'internal_api', deleted_count: ids.length, alert_ids: ids };
+}
+
+/** Resolve an exact live Pine study and alertcondition without changing panes. */
+export async function resolveLiveIndicator(definition) {
+  const result = await evaluate(`
+    (function() {
+      var requestedSymbol = ${safeString(definition.symbol)};
+      var requestedTimeframe = ${safeString(definition.timeframe)};
+      var requestedIndicator = ${safeString(definition.indicator)};
+      var requestedCondition = ${safeString(definition.condition)};
+      var collection = window.TradingViewApi && window.TradingViewApi._chartWidgetCollection;
+      var panes = collection && collection.getAll ? collection.getAll() : [];
+      var matchingPanes = [], indicatorCandidates = [], matches = [];
+
+      for (var i = 0; i < panes.length; i++) {
+        try {
+          var model = panes[i].model();
+          var mainSeries = model.mainSeries();
+          var symbol = (mainSeries.proSymbol && mainSeries.proSymbol()) || mainSeries.symbol();
+          var timeframe = String(mainSeries.interval());
+          var paneInfo = { pane_index: i, symbol: symbol, timeframe: timeframe, indicators: [] };
+          var sources = model.model().dataSources();
+          for (var j = 0; j < sources.length; j++) {
+            var source = sources[j], meta = null;
+            try { meta = source.metaInfo && source.metaInfo(); } catch (e) {}
+            if (!meta || !meta.description) continue;
+            var plots = Array.isArray(meta.plots) ? meta.plots : [];
+            var alertPlots = plots.filter(function(plot) { return plot.type === 'alertcondition'; });
+            if (!alertPlots.length) continue;
+            var conditionNames = alertPlots.map(function(plot) {
+              return { id: plot.id, title: meta.styles && meta.styles[plot.id] && meta.styles[plot.id].title };
+            }).filter(function(item) { return !!item.title; });
+            paneInfo.indicators.push({ title: meta.description, conditions: conditionNames.map(function(item) { return item.title; }) });
+            if (meta.description !== requestedIndicator) continue;
+            indicatorCandidates.push({ pane_index: i, symbol: symbol, timeframe: timeframe, conditions: conditionNames.map(function(item) { return item.title; }) });
+            if (symbol !== requestedSymbol || timeframe !== requestedTimeframe) continue;
+            var conditionMatches = conditionNames.filter(function(item) { return item.title === requestedCondition; });
+            if (conditionMatches.length !== 1) continue;
+
+            var state = {};
+            try { state = source.properties().state(); } catch (e) {}
+            var inputs = Object.assign({}, state.inputs || {});
+            delete inputs.text;
+            delete inputs.pineId;
+            delete inputs.pineVersion;
+            var offsets = {};
+            plots.forEach(function(plot) { if (plot.type !== 'alertcondition') offsets[plot.id] = 0; });
+            matches.push({
+              pane_index: i,
+              symbol: symbol,
+              timeframe: timeframe,
+              indicator: meta.description,
+              condition: requestedCondition,
+              alert_condition_id: conditionMatches[0].id,
+              series: {
+                type: 'study',
+                study: 'Script@tv-scripting-' + meta.version,
+                pine_id: meta.scriptIdPart,
+                pine_version: meta.pine && meta.pine.version,
+                inputs: inputs,
+                offsets_by_plot: offsets
+              }
+            });
+          }
+          if (symbol === requestedSymbol && timeframe === requestedTimeframe) matchingPanes.push(paneInfo);
+        } catch (e) {}
+      }
+      return { matches: matches, matching_panes: matchingPanes, indicator_candidates: indicatorCandidates };
+    })()
+  `);
+
+  if (result?.matches?.length === 1) return result.matches[0];
+  if (result?.matches?.length > 1) {
+    throw new AlertCapabilityError(
+      'indicator_resolution',
+      'ambiguous_indicator',
+      'More than one live study exactly matches the requested indicator condition',
+      { matches: result.matches.map(item => ({ pane_index: item.pane_index })) },
+    );
   }
-  return { success: false, source: 'internal_api', alert_ids: ids, error: (result && (result.error || result.response)) || 'delete failed' };
+  if (!result?.matching_panes?.length) {
+    throw new AlertCapabilityError(
+      'indicator_resolution',
+      'exact_pane_not_found',
+      'Indicator alerts require an already-open pane with the exact canonical symbol and timeframe',
+      { indicator_candidates: result?.indicator_candidates || [] },
+    );
+  }
+  const exactIndicator = (result.indicator_candidates || []).filter(item => (
+    item.symbol === definition.symbol && item.timeframe === definition.timeframe
+  ));
+  if (!exactIndicator.length) {
+    throw new AlertCapabilityError(
+      'indicator_resolution',
+      'indicator_not_found',
+      'The exact live indicator title is not present on the requested symbol/timeframe pane',
+      { available_indicators: result.matching_panes.flatMap(item => item.indicators || []) },
+    );
+  }
+  throw new AlertCapabilityError(
+    'indicator_resolution',
+    'condition_not_found',
+    'The exact Pine alertcondition() name is not present on the requested live indicator',
+    { available_conditions: [...new Set(exactIndicator.flatMap(item => item.conditions || []))] },
+  );
+}
+
+/** Build the exact payload understood by TradingView's structured alert API. */
+export function buildAlertPayload(definition, indicatorResolution = null) {
+  const internalFrequency = FREQUENCY_TO_INTERNAL[definition.frequency];
+  let condition;
+  if (definition.kind === 'price') {
+    condition = {
+      type: CONDITION_TO_INTERNAL[definition.condition],
+      frequency: internalFrequency,
+      series: [{ type: 'barset' }, { type: 'value', value: definition.price }],
+      resolution: definition.timeframe,
+    };
+  } else {
+    if (!indicatorResolution?.series || !indicatorResolution?.alert_condition_id) {
+      throw new AlertCapabilityError(
+        'indicator_resolution',
+        'indicator_metadata_unavailable',
+        'Exact live Pine alertcondition metadata is unavailable',
+      );
+    }
+    condition = {
+      type: 'alert_cond',
+      frequency: internalFrequency,
+      series: [indicatorResolution.series],
+      alert_cond_id: indicatorResolution.alert_condition_id,
+      cross_interval: false,
+      resolution: definition.timeframe,
+    };
+  }
+
+  return {
+    conditions: [condition],
+    symbol: `=${JSON.stringify({ symbol: definition.symbol })}`,
+    resolution: definition.timeframe,
+    message: definition.message,
+    sound_file: 'alert/fired',
+    sound_duration: 0,
+    popup: true,
+    auto_deactivate: true,
+    email: false,
+    sms_over_email: false,
+    mobile_push: true,
+    web_hook: null,
+    name: null,
+    expiration: definition.expiration,
+    active: true,
+    ignore_warnings: false,
+  };
+}
+
+function resolveDeps(deps = {}) {
+  return {
+    fetchRawAlerts: deps.fetchRawAlerts || fetchRawAlerts,
+    createRaw: deps.createRaw || postCreateAlert,
+    deleteRaw: deps.deleteRaw || postDeleteAlerts,
+    resolveIndicator: deps.resolveIndicator || resolveLiveIndicator,
+    listAlerts: deps.listAlerts,
+    now: nowValue(deps),
+  };
+}
+
+export async function list({ _deps } = {}) {
+  const deps = resolveDeps(_deps);
+  try {
+    const result = await deps.fetchRawAlerts();
+    if (!result?.success) {
+      throw new AlertCapabilityError('list', 'list_failed', result?.error || 'Could not list alerts');
+    }
+    const alerts = (result.alerts || []).map(normalizeListedAlert);
+    return { success: true, alert_count: alerts.length, source: 'internal_api', alerts };
+  } catch (err) {
+    return errorResult(err, { source: 'internal_api', alerts: [], alert_count: 0 });
+  }
+}
+
+async function createValidated(definition, deps, indicatorResolution) {
+  const payload = buildAlertPayload(definition, indicatorResolution);
+  const result = await deps.createRaw(payload);
+  if (!result?.success || result.alert_id == null) {
+    throw new AlertCapabilityError(
+      'create',
+      'create_failed',
+      result?.error || 'TradingView did not return an alert ID',
+      { response: result?.response, status: result?.status },
+    );
+  }
+  return { alert_id: result.alert_id, payload };
+}
+
+export async function create(args = {}) {
+  const deps = resolveDeps(args._deps);
+  try {
+    const definition = validateAlertDefinition(args, { now: deps.now });
+    const indicatorResolution = definition.kind === 'indicator'
+      ? await deps.resolveIndicator(definition)
+      : null;
+    if (args.dry_run === true) {
+      return {
+        success: true,
+        action: 'dry_run',
+        dry_run: true,
+        definition,
+        chart_state_changed: false,
+        ...(indicatorResolution && {
+          resolved_indicator: {
+            pane_index: indicatorResolution.pane_index,
+            alert_condition_id: indicatorResolution.alert_condition_id,
+          },
+        }),
+      };
+    }
+    const created = await createValidated(definition, deps, indicatorResolution);
+    return {
+      success: true,
+      action: 'created',
+      source: 'internal_api',
+      alert_id: created.alert_id,
+      definition,
+      chart_state_changed: false,
+    };
+  } catch (err) {
+    return errorResult(err, { chart_state_changed: false });
+  }
+}
+
+function definitionFromExisting(alert) {
+  const definition = {
+    symbol: alert.symbol,
+    timeframe: alert.timeframe,
+    kind: alert.kind,
+    condition: alert.condition,
+    frequency: alert.frequency,
+    expiration: alert.expiration,
+    message: alert.message,
+  };
+  if (alert.kind === 'price') definition.price = alert.price;
+  if (alert.kind === 'indicator') definition.indicator = alert.indicator;
+  return definition;
+}
+
+function sameInstant(left, right) {
+  return Number.isFinite(Date.parse(left)) && Date.parse(left) === Date.parse(right);
+}
+
+function exactDefinition(left, right) {
+  return left.symbol === right.symbol
+    && left.timeframe === right.timeframe
+    && left.kind === right.kind
+    && left.condition === right.condition
+    && left.frequency === right.frequency
+    && sameInstant(left.expiration, right.expiration)
+    && left.message === right.message
+    && (left.kind !== 'price' || left.price === right.price)
+    && (left.kind !== 'indicator' || left.indicator === right.indicator);
+}
+
+function sameAlertIdentity(left, right) {
+  if (left.symbol !== right.symbol || left.timeframe !== right.timeframe || left.kind !== right.kind) return false;
+  if (left.kind === 'price') return left.condition === right.condition && left.price === right.price;
+  return left.indicator === right.indicator && left.condition === right.condition;
+}
+
+function definitionKey(definition) {
+  return JSON.stringify([
+    definition.symbol,
+    definition.timeframe,
+    definition.kind,
+    definition.condition,
+    definition.price ?? null,
+    definition.indicator ?? null,
+    definition.frequency,
+    Date.parse(definition.expiration),
+    definition.message,
+  ]);
+}
+
+/** Pure classification helper used by alerts_sync and focused tests. */
+export function classifyAlertPlan(definitions, existingAlerts, replaceAlertIds = []) {
+  const replaceIds = new Set(replaceAlertIds.map(String));
+  const unchanged = [], missing = [], conflict = [], replace = [];
+  const referencedIds = new Set();
+
+  definitions.forEach((definition, index) => {
+    const exact = existingAlerts.filter(alert => alert.active !== false && exactDefinition(definition, definitionFromExisting(alert)));
+    if (exact.length) {
+      exact.forEach(alert => referencedIds.add(String(alert.alert_id)));
+      unchanged.push({ index, definition, alert_ids: exact.map(alert => alert.alert_id) });
+      return;
+    }
+    const related = existingAlerts.filter(alert => sameAlertIdentity(definition, definitionFromExisting(alert)));
+    if (!related.length) {
+      missing.push({ index, definition });
+      return;
+    }
+    related.forEach(alert => referencedIds.add(String(alert.alert_id)));
+    const approved = related.filter(alert => replaceIds.has(String(alert.alert_id)));
+    const item = {
+      index,
+      definition,
+      existing: related.map(alert => ({ alert_id: alert.alert_id, active: alert.active, definition: definitionFromExisting(alert) })),
+    };
+    if (approved.length === related.length) {
+      replace.push({ ...item, replace_alert_ids: approved.map(alert => alert.alert_id) });
+    } else {
+      conflict.push({ ...item, approved_replace_alert_ids: approved.map(alert => alert.alert_id) });
+    }
+  });
+
+  const allReferenced = new Set([...referencedIds]);
+  const unrelated = existingAlerts.filter(alert => !allReferenced.has(String(alert.alert_id)));
+  const claimedReplacementIds = new Set([
+    ...replace.flatMap(item => item.replace_alert_ids.map(String)),
+    ...conflict.flatMap(item => item.approved_replace_alert_ids.map(String)),
+  ]);
+  const unclaimed_replace_alert_ids = replaceAlertIds.filter(id => !claimedReplacementIds.has(String(id)));
+  return { unchanged, missing, conflict, replace, unrelated, unclaimed_replace_alert_ids };
+}
+
+function validatePlan(alerts, now) {
+  if (!Array.isArray(alerts)) {
+    throw new AlertCapabilityError('plan_validation', 'invalid_alerts', 'alerts must be an array');
+  }
+  const definitions = [];
+  const failures = [];
+  alerts.forEach((alert, index) => {
+    try {
+      definitions.push(validateAlertDefinition(alert, { now }));
+    } catch (err) {
+      failures.push({ index, error: { stage: err.stage, code: err.code, message: err.message, ...(err.details || {}) } });
+    }
+  });
+  if (failures.length) {
+    throw new AlertCapabilityError(
+      'plan_validation',
+      'invalid_plan',
+      'The alert plan contains invalid definitions; no mutations were made',
+      { failed: failures },
+    );
+  }
+  const seen = new Map();
+  const duplicates = [];
+  definitions.forEach((definition, index) => {
+    const key = definitionKey(definition);
+    if (seen.has(key)) duplicates.push({ first_index: seen.get(key), duplicate_index: index });
+    else seen.set(key, index);
+  });
+  if (duplicates.length) {
+    throw new AlertCapabilityError(
+      'plan_validation',
+      'duplicate_plan_definitions',
+      'The alert plan contains duplicate definitions; no mutations were made',
+      { duplicates },
+    );
+  }
+  return definitions;
+}
+
+async function getExistingAlerts(deps) {
+  if (deps.listAlerts) return deps.listAlerts();
+  const raw = await deps.fetchRawAlerts();
+  if (!raw?.success) {
+    throw new AlertCapabilityError('list', 'list_failed', raw?.error || 'Could not list existing alerts');
+  }
+  return { success: true, alerts: (raw.alerts || []).map(normalizeListedAlert) };
+}
+
+export async function syncAlerts({ alerts, replace_alert_ids = [], dry_run = false, _deps } = {}) {
+  const deps = resolveDeps(_deps);
+  let definitions;
+  try {
+    definitions = validatePlan(alerts, deps.now);
+    if (!Array.isArray(replace_alert_ids) || replace_alert_ids.some(id => !Number.isSafeInteger(Number(id)) || Number(id) <= 0)) {
+      throw new AlertCapabilityError(
+        'plan_validation',
+        'invalid_replace_alert_ids',
+        'replace_alert_ids must contain positive integer alert IDs',
+      );
+    }
+    replace_alert_ids = [...new Set(replace_alert_ids.map(Number))];
+
+    const listed = await getExistingAlerts(deps);
+    if (!listed?.success) throw new AlertCapabilityError('list', 'list_failed', listed?.error || 'Could not list existing alerts');
+    const existing = listed.alerts || [];
+    const diff = classifyAlertPlan(definitions, existing, replace_alert_ids);
+    if (diff.unclaimed_replace_alert_ids.length) {
+      throw new AlertCapabilityError(
+        'plan_validation',
+        'unrelated_replace_ids',
+        'Every replace_alert_id must identify a conflicting alert in this exact plan',
+        { replace_alert_ids: diff.unclaimed_replace_alert_ids },
+      );
+    }
+
+    const replacementClaims = new Map();
+    for (const item of diff.replace) {
+      for (const id of item.replace_alert_ids) {
+        const key = String(id);
+        if (!replacementClaims.has(key)) replacementClaims.set(key, []);
+        replacementClaims.get(key).push(item.index);
+      }
+    }
+    const duplicateReplacementClaims = [...replacementClaims.entries()]
+      .filter(([, indexes]) => indexes.length > 1)
+      .map(([alert_id, indexes]) => ({ alert_id: Number(alert_id), indexes }));
+    if (duplicateReplacementClaims.length) {
+      throw new AlertCapabilityError(
+        'plan_validation',
+        'ambiguous_replace_ids',
+        'A replace_alert_id cannot be claimed by more than one planned alert',
+        { claims: duplicateReplacementClaims },
+      );
+    }
+
+    // Resolve every Pine definition before the first mutation, including in a
+    // dry-run. Unsupported entries are reported per item, while the diff
+    // remains complete and no fallback condition is ever substituted.
+    const actionable = [...diff.missing, ...diff.replace];
+    const resolutions = new Map();
+    const failed = [];
+    for (const item of actionable) {
+      if (item.definition.kind !== 'indicator') continue;
+      try {
+        resolutions.set(item.index, await deps.resolveIndicator(item.definition));
+      } catch (err) {
+        failed.push({ index: item.index, definition: item.definition, stage: err.stage || 'indicator_resolution', error: err.message });
+      }
+    }
+
+    if (dry_run === true) {
+      return {
+        success: failed.length === 0,
+        action: 'dry_run',
+        dry_run: true,
+        unchanged: diff.unchanged,
+        missing: diff.missing,
+        conflicts: diff.conflict,
+        replace: diff.replace,
+        failed,
+        unrelated_preserved: diff.unrelated.map(alert => alert.alert_id),
+        mutation_count: 0,
+      };
+    }
+
+    const failedIndexes = new Set(failed.map(item => item.index));
+    const created = [];
+    const replaced = [];
+    for (const item of diff.missing) {
+      if (failedIndexes.has(item.index)) continue;
+      try {
+        const result = await createValidated(item.definition, deps, resolutions.get(item.index));
+        created.push({ alert_id: result.alert_id, definition: item.definition });
+      } catch (err) {
+        failed.push({ index: item.index, definition: item.definition, stage: err.stage || 'create', error: err.message });
+      }
+    }
+    for (const item of diff.replace) {
+      if (failedIndexes.has(item.index)) continue;
+      const deleted = await deps.deleteRaw(item.replace_alert_ids);
+      if (!deleted?.success) {
+        failed.push({
+          index: item.index,
+          definition: item.definition,
+          stage: 'delete_replaced_alert',
+          error: deleted?.error || 'Could not delete approved replacement alert',
+          replace_alert_ids: item.replace_alert_ids,
+        });
+        continue;
+      }
+      try {
+        const result = await createValidated(item.definition, deps, resolutions.get(item.index));
+        replaced.push({
+          alert_id: result.alert_id,
+          replaced_alert_ids: item.replace_alert_ids,
+          definition: item.definition,
+        });
+      } catch (err) {
+        failed.push({
+          index: item.index,
+          definition: item.definition,
+          stage: err.stage || 'create_replacement',
+          error: err.message,
+          deleted_alert_ids: item.replace_alert_ids,
+        });
+      }
+    }
+
+    const unchanged = diff.unchanged.map(item => ({ alert_ids: item.alert_ids, definition: item.definition }));
+    const final_alert_ids = [
+      ...unchanged.flatMap(item => item.alert_ids),
+      ...created.map(item => item.alert_id),
+      ...replaced.map(item => item.alert_id),
+    ];
+    return {
+      success: failed.length === 0 && diff.conflict.length === 0,
+      created,
+      unchanged,
+      replaced,
+      conflicts: diff.conflict,
+      failed,
+      final_alert_ids: [...new Set(final_alert_ids)],
+      unrelated_preserved: diff.unrelated.map(alert => alert.alert_id),
+    };
+  } catch (err) {
+    return errorResult(err, {
+      created: [],
+      unchanged: [],
+      replaced: [],
+      conflicts: [],
+      failed: err?.details?.failed || [],
+      final_alert_ids: [],
+    });
+  }
+}
+
+export async function deleteAlerts({ delete_all, alert_ids, alert_id, _deps } = {}) {
+  const deps = resolveDeps(_deps);
+  try {
+    let ids = [];
+    if (Array.isArray(alert_ids)) ids.push(...alert_ids);
+    if (alert_id != null) ids.push(alert_id);
+    if (delete_all) {
+      const listed = await getExistingAlerts(deps);
+      if (!listed?.success) throw new AlertCapabilityError('list', 'list_failed', 'Could not list alerts before deletion');
+      ids = (listed.alerts || []).map(alert => alert.alert_id);
+    }
+    ids = [...new Set(ids.map(Number).filter(id => Number.isSafeInteger(id) && id > 0))];
+    if (!ids.length) {
+      throw new AlertCapabilityError(
+        'validation',
+        'missing_alert_ids',
+        delete_all ? 'No alerts to delete' : 'Provide alert_id, alert_ids, or delete_all: true',
+      );
+    }
+    const result = await deps.deleteRaw(ids);
+    if (!result?.success) {
+      throw new AlertCapabilityError('delete', 'delete_failed', result?.error || 'Alert deletion failed');
+    }
+    return { success: true, source: 'internal_api', deleted_count: ids.length, alert_ids: ids };
+  } catch (err) {
+    return errorResult(err, { source: 'internal_api' });
+  }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -55,7 +55,7 @@ Screenshots: capture_screenshot → regions: "full", "chart", "strategy_tester"
 Replay: replay_start → replay_step → replay_trade → replay_status → replay_stop
 Batch: batch_run → run action across multiple symbols/timeframes
 Drawing: draw_shape → horizontal_line, trend_line, rectangle, text
-Alerts: alert_create, alert_list, alert_delete
+Alerts: alert_create → one exact definition; alerts_sync → preferred idempotent approved-plan diff/apply (dry_run first); alert_list, alert_delete
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -2,18 +2,35 @@ import { z } from 'zod';
 import { jsonResult } from './_format.js';
 import * as core from '../core/alerts.js';
 
+const alertDefinitionShape = {
+  symbol: z.string().describe('Exchange-qualified symbol, for example NASDAQ:NVDA'),
+  timeframe: z.string().describe('Exact TradingView resolution, for example 1, 5, 60, or 1D'),
+  kind: z.enum(['price', 'indicator']).describe('Price level or named Pine alertcondition'),
+  condition: z.string().describe('crossing/greater_than/less_than for price, or exact Pine condition name'),
+  price: z.number().positive().optional().describe('Required only for price alerts'),
+  indicator: z.string().optional().describe('Exact live indicator title, required only for indicator alerts'),
+  frequency: z.enum(['once', 'once_per_bar', 'once_per_bar_close']),
+  expiration: z.string().describe('ISO-8601 timestamp with Z or an explicit offset'),
+  message: z.string().describe('Exact deterministic alert message'),
+};
+
 export function registerAlertTools(server) {
-  server.tool('alert_create', 'Create a price alert on the current chart symbol via TradingView\'s alert API', {
-    condition: z.string().describe('Alert condition: "crossing", "greater_than", or "less_than"'),
-    price: z.coerce.number().describe('Price level for the alert'),
-    message: z.string().optional().describe('Alert message'),
-  }, async ({ condition, price, message }) => {
-    try { return jsonResult(await core.create({ condition, price, message })); }
+  server.tool('alert_create', 'Create one exact symbol/timeframe-specific price or live Pine-indicator alert. Indicator metadata is resolved from an already-open exact pane without changing chart state. Use dry_run first.', {
+    ...alertDefinitionShape,
+    dry_run: z.boolean().optional().describe('Validate and resolve the alert without creating it'),
+  }, async (args) => {
+    try {
+      const result = await core.create(args);
+      return jsonResult(result, !result.success);
+    }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('alert_list', 'List active alerts', {}, async () => {
-    try { return jsonResult(await core.list()); }
+  server.tool('alert_list', 'List TradingView alerts as normalized symbol/timeframe/kind/condition/frequency/expiration/message definitions', {}, async () => {
+    try {
+      const result = await core.list();
+      return jsonResult(result, !result.success);
+    }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
@@ -21,7 +38,23 @@ export function registerAlertTools(server) {
     alert_id: z.coerce.number().optional().describe('Alert id to delete (from alert_list)'),
     delete_all: z.coerce.boolean().optional().describe('Delete all active alerts'),
   }, async ({ alert_id, delete_all }) => {
-    try { return jsonResult(await core.deleteAlerts({ alert_id, delete_all })); }
+    try {
+      const result = await core.deleteAlerts({ alert_id, delete_all });
+      return jsonResult(result, !result.success);
+    }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('alerts_sync', 'Idempotently diff and synchronize a complete approved alert plan. Preserves unrelated alerts and replaces only explicitly approved conflicting IDs. Use dry_run before apply.', {
+    alerts: z.array(z.object(alertDefinitionShape)).describe('Complete approved alert definitions'),
+    replace_alert_ids: z.array(z.coerce.number().int().positive()).optional().describe('Exact conflicting alert IDs approved for replacement'),
+    dry_run: z.boolean().optional().describe('Return the complete diff with zero mutations'),
+  }, async (args) => {
+    try {
+      const result = await core.syncAlerts(args);
+      return jsonResult(result, !result.success);
+    } catch (err) {
+      return jsonResult({ success: false, error: err.message }, true);
+    }
   });
 }

--- a/tests/alerts.test.js
+++ b/tests/alerts.test.js
@@ -1,0 +1,340 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildAlertPayload,
+  create,
+  normalizeListedAlert,
+  syncAlerts,
+  validateAlertDefinition,
+} from '../src/core/alerts.js';
+import { registerAlertTools } from '../src/tools/alerts.js';
+
+const NOW = Date.parse('2026-08-01T12:00:00Z');
+const EXPIRATION = '2030-01-02T15:30:00-05:00';
+const NORMALIZED_EXPIRATION = '2030-01-02T20:30:00.000Z';
+
+function priceDefinition(overrides = {}) {
+  return {
+    symbol: 'NASDAQ:NVDA',
+    timeframe: '1',
+    kind: 'price',
+    condition: 'crossing',
+    price: 123.45,
+    frequency: 'once_per_bar_close',
+    expiration: EXPIRATION,
+    message: 'DT|2030-01-02|NASDAQ:NVDA|breakout|1|crossing',
+    ...overrides,
+  };
+}
+
+function indicatorDefinition(overrides = {}) {
+  return {
+    symbol: 'NASDAQ:NVDA',
+    timeframe: '1',
+    kind: 'indicator',
+    condition: 'Initial ORB opportunity',
+    indicator: 'MTF 5m-1m ORB Retest/Reclaim v3 [Live]',
+    frequency: 'once_per_bar_close',
+    expiration: EXPIRATION,
+    message: 'DT|2030-01-02|NASDAQ:NVDA|orb|1|Initial ORB opportunity',
+    ...overrides,
+  };
+}
+
+function resolvedIndicator() {
+  return {
+    pane_index: 2,
+    alert_condition_id: 'plot_7',
+    series: {
+      type: 'study',
+      study: 'Script@tv-scripting-101',
+      pine_id: 'USER;abc123',
+      pine_version: '3.0',
+      inputs: { in_0: '0930-0935', pineFeatures: '{"alertcondition":1}' },
+      offsets_by_plot: { plot_0: 0 },
+    },
+  };
+}
+
+function existingAlert(definition, alertId, overrides = {}) {
+  const normalized = validateAlertDefinition(definition, { now: NOW });
+  return { alert_id: alertId, active: true, ...normalized, ...overrides };
+}
+
+function mockDeps({ existing = [], createResults = [], resolveResult = resolvedIndicator() } = {}) {
+  const calls = { list: 0, create: [], delete: [], resolve: [] };
+  let createIndex = 0;
+  return {
+    calls,
+    deps: {
+      now: NOW,
+      async listAlerts() {
+        calls.list++;
+        return { success: true, alerts: structuredClone(existing) };
+      },
+      async createRaw(payload) {
+        calls.create.push(structuredClone(payload));
+        const configured = createResults[createIndex++];
+        return configured || { success: true, alert_id: 9000 + createIndex };
+      },
+      async deleteRaw(ids) {
+        calls.delete.push([...ids]);
+        return { success: true, alert_ids: [...ids] };
+      },
+      async resolveIndicator(definition) {
+        calls.resolve.push(structuredClone(definition));
+        if (resolveResult instanceof Error) throw resolveResult;
+        return structuredClone(resolveResult);
+      },
+    },
+  };
+}
+
+describe('alert definition validation and payloads', () => {
+  it('requires an exchange-qualified symbol and explicit timeframe', () => {
+    assert.throws(
+      () => validateAlertDefinition(priceDefinition({ symbol: 'NVDA' }), { now: NOW }),
+      /exchange-qualified/,
+    );
+    assert.throws(
+      () => validateAlertDefinition(priceDefinition({ timeframe: '' }), { now: NOW }),
+      /timeframe is required/,
+    );
+  });
+
+  for (const [condition, internal] of [
+    ['crossing', 'cross'],
+    ['greater_than', 'greater'],
+    ['less_than', 'less'],
+  ]) {
+    it(`preserves the ${condition} price condition exactly`, () => {
+      const definition = validateAlertDefinition(priceDefinition({ condition }), { now: NOW });
+      const payload = buildAlertPayload(definition);
+      assert.equal(payload.conditions[0].type, internal);
+      assert.equal(payload.conditions[0].series[1].value, 123.45);
+      assert.equal(payload.conditions[0].resolution, '1');
+      assert.equal(payload.symbol, '={"symbol":"NASDAQ:NVDA"}');
+    });
+  }
+
+  it('builds a named Pine alertcondition payload without substituting a price condition', async () => {
+    const mock = mockDeps();
+    const result = await create({ ...indicatorDefinition(), _deps: mock.deps });
+    assert.equal(result.success, true);
+    assert.equal(result.definition.kind, 'indicator');
+    assert.equal(result.definition.condition, 'Initial ORB opportunity');
+    assert.equal(mock.calls.resolve.length, 1);
+    const condition = mock.calls.create[0].conditions[0];
+    assert.equal(condition.type, 'alert_cond');
+    assert.equal(condition.alert_cond_id, 'plot_7');
+    assert.equal(condition.series[0].pine_id, 'USER;abc123');
+    assert.equal(condition.series.some(series => series.type === 'value'), false);
+  });
+
+  for (const [frequency, internal] of [
+    ['once', 'on_first_fire'],
+    ['once_per_bar', 'on_each_fire'],
+    ['once_per_bar_close', 'on_bar_close'],
+  ]) {
+    it(`preserves ${frequency} and an offset expiration`, () => {
+      const definition = validateAlertDefinition(priceDefinition({ frequency }), { now: NOW });
+      const payload = buildAlertPayload(definition);
+      assert.equal(definition.expiration, NORMALIZED_EXPIRATION);
+      assert.equal(payload.expiration, NORMALIZED_EXPIRATION);
+      assert.equal(payload.conditions[0].frequency, internal);
+    });
+  }
+
+  it('dry-run validates with zero mutations', async () => {
+    const mock = mockDeps();
+    const result = await create({ ...priceDefinition(), dry_run: true, _deps: mock.deps });
+    assert.equal(result.success, true);
+    assert.equal(result.action, 'dry_run');
+    assert.equal(result.chart_state_changed, false);
+    assert.equal(mock.calls.create.length, 0);
+    assert.equal(mock.calls.delete.length, 0);
+  });
+
+  it('fails closed when an exact Pine condition cannot be resolved', async () => {
+    const unsupported = new Error('Exact Pine condition is unavailable');
+    unsupported.stage = 'indicator_resolution';
+    const mock = mockDeps({ resolveResult: unsupported });
+    const result = await create({ ...indicatorDefinition(), _deps: mock.deps });
+    assert.equal(result.success, false);
+    assert.equal(result.stage, 'indicator_resolution');
+    assert.equal(mock.calls.create.length, 0, 'never substitutes a price alert');
+  });
+
+  it('normalizes exact Pine titles, frequency, expiration, and canonical pro symbol from list_alerts', () => {
+    const raw = {
+      alert_id: 77,
+      type: 'indicator',
+      symbol: '={"symbol":"BATS:NVDA"}',
+      pro_symbol: '={"symbol":"NASDAQ:NVDA"}',
+      resolution: '1',
+      message: 'deterministic',
+      expiration: '2030-01-02T20:30:00Z',
+      active: true,
+      condition: {
+        type: 'alert_cond',
+        frequency: 'on_bar_close',
+        resolution: '1',
+        alert_cond_id: 'plot_7',
+        series: [{ type: 'study', pine_id: 'USER;abc123' }],
+      },
+      presentation_data: {
+        studies: {
+          'Script$USER;abc123@tv-scripting-101_3.0': {
+            description: 'Exact Live Indicator',
+            alert_conditions: { plot_7: { title: 'Exact Pine Condition' } },
+          },
+        },
+      },
+    };
+    const normalized = normalizeListedAlert(raw);
+    assert.equal(normalized.symbol, 'NASDAQ:NVDA');
+    assert.equal(normalized.indicator, 'Exact Live Indicator');
+    assert.equal(normalized.condition, 'Exact Pine Condition');
+    assert.equal(normalized.frequency, 'once_per_bar_close');
+    assert.equal(normalized.expiration, NORMALIZED_EXPIRATION);
+  });
+});
+
+describe('alerts_sync', () => {
+  it('lists once and leaves an exact existing alert unchanged', async () => {
+    const definition = priceDefinition();
+    const mock = mockDeps({ existing: [existingAlert(definition, 101)] });
+    const result = await syncAlerts({ alerts: [definition], _deps: mock.deps });
+    assert.equal(result.success, true);
+    assert.equal(mock.calls.list, 1);
+    assert.equal(mock.calls.create.length, 0);
+    assert.equal(mock.calls.delete.length, 0);
+    assert.deepEqual(result.final_alert_ids, [101]);
+    assert.deepEqual(result.unchanged[0].alert_ids, [101]);
+  });
+
+  it('classifies a related non-exact alert as a conflict and avoids duplication', async () => {
+    const definition = priceDefinition();
+    const conflict = existingAlert(definition, 202, { frequency: 'once' });
+    const mock = mockDeps({ existing: [conflict] });
+    const result = await syncAlerts({ alerts: [definition], dry_run: true, _deps: mock.deps });
+    assert.equal(result.success, true);
+    assert.equal(result.conflicts.length, 1);
+    assert.equal(result.missing.length, 0);
+    assert.equal(mock.calls.create.length, 0);
+    assert.equal(mock.calls.delete.length, 0);
+  });
+
+  it('replaces only a conflicting alert whose exact ID is approved', async () => {
+    const definition = priceDefinition();
+    const conflict = existingAlert(definition, 303, { message: 'old message' });
+    const unrelated = existingAlert(priceDefinition({ symbol: 'NASDAQ:MSFT' }), 404);
+    const mock = mockDeps({ existing: [conflict, unrelated] });
+    const result = await syncAlerts({
+      alerts: [definition],
+      replace_alert_ids: [303],
+      _deps: mock.deps,
+    });
+    assert.equal(result.success, true);
+    assert.deepEqual(mock.calls.delete, [[303]]);
+    assert.equal(mock.calls.create.length, 1);
+    assert.deepEqual(result.unrelated_preserved, [404]);
+    assert.deepEqual(result.replaced[0].replaced_alert_ids, [303]);
+  });
+
+  it('never replaces a conflicting alert without its approved ID', async () => {
+    const definition = priceDefinition();
+    const mock = mockDeps({ existing: [existingAlert(definition, 505, { frequency: 'once' })] });
+    const result = await syncAlerts({ alerts: [definition], _deps: mock.deps });
+    assert.equal(result.success, false);
+    assert.equal(result.conflicts.length, 1);
+    assert.equal(mock.calls.delete.length, 0);
+    assert.equal(mock.calls.create.length, 0);
+  });
+
+  it('rejects a replace ID that belongs to an unrelated alert', async () => {
+    const definition = priceDefinition();
+    const unrelated = existingAlert(priceDefinition({ symbol: 'NASDAQ:MSFT' }), 515);
+    const mock = mockDeps({ existing: [unrelated] });
+    const result = await syncAlerts({ alerts: [definition], replace_alert_ids: [515], _deps: mock.deps });
+    assert.equal(result.success, false);
+    assert.equal(result.error.code, 'unrelated_replace_ids');
+    assert.equal(mock.calls.delete.length, 0);
+    assert.equal(mock.calls.create.length, 0);
+  });
+
+  it('rejects duplicate plan definitions before listing or mutating', async () => {
+    const definition = priceDefinition();
+    const mock = mockDeps();
+    const result = await syncAlerts({ alerts: [definition, { ...definition }], _deps: mock.deps });
+    assert.equal(result.success, false);
+    assert.equal(result.error.code, 'duplicate_plan_definitions');
+    assert.equal(mock.calls.list, 0);
+    assert.equal(mock.calls.create.length, 0);
+    assert.equal(mock.calls.delete.length, 0);
+  });
+
+  it('keeps chart symbol, timeframe, pane, and focus untouched during indicator resolution', async () => {
+    const mock = mockDeps();
+    const result = await syncAlerts({ alerts: [indicatorDefinition()], _deps: mock.deps });
+    assert.equal(result.success, true);
+    assert.equal(mock.calls.resolve.length, 1);
+    assert.equal(mock.calls.create.length, 1);
+    assert.equal(result.created[0].definition.symbol, 'NASDAQ:NVDA');
+    assert.equal(result.created[0].definition.timeframe, '1');
+    assert.equal('focus' in mock.calls, false);
+  });
+
+  it('reports partial creation failures while retaining successful alert IDs', async () => {
+    const first = priceDefinition();
+    const second = priceDefinition({
+      symbol: 'NASDAQ:MSFT',
+      message: 'DT|2030-01-02|NASDAQ:MSFT|breakout|1|crossing',
+    });
+    const mock = mockDeps({
+      createResults: [
+        { success: true, alert_id: 606 },
+        { success: false, error: 'server rejected second alert' },
+      ],
+    });
+    const result = await syncAlerts({ alerts: [first, second], _deps: mock.deps });
+    assert.equal(result.success, false);
+    assert.deepEqual(result.final_alert_ids, [606]);
+    assert.equal(result.created.length, 1);
+    assert.equal(result.failed.length, 1);
+    assert.match(result.failed[0].error, /second alert/);
+  });
+
+  it('dry-run returns a complete diff with zero mutations', async () => {
+    const exact = priceDefinition();
+    const missing = indicatorDefinition({ symbol: 'NASDAQ:MSFT' });
+    const mock = mockDeps({ existing: [existingAlert(exact, 707)] });
+    const result = await syncAlerts({ alerts: [exact, missing], dry_run: true, _deps: mock.deps });
+    assert.equal(result.success, true);
+    assert.equal(result.mutation_count, 0);
+    assert.equal(result.unchanged.length, 1);
+    assert.equal(result.missing.length, 1);
+    assert.equal(mock.calls.resolve.length, 1, 'dry-run resolves exact live Pine capability');
+    assert.equal(mock.calls.create.length, 0);
+    assert.equal(mock.calls.delete.length, 0);
+  });
+});
+
+describe('alert MCP contracts', () => {
+  it('extends alert_create and registers alerts_sync without duplicating alert_create', () => {
+    const registrations = [];
+    const server = {
+      tool(name, description, schema, handler) { registrations.push({ name, description, schema, handler }); },
+    };
+    registerAlertTools(server);
+    assert.equal(registrations.filter(tool => tool.name === 'alert_create').length, 1);
+    const createTool = registrations.find(tool => tool.name === 'alert_create');
+    assert.deepEqual(Object.keys(createTool.schema), [
+      'symbol', 'timeframe', 'kind', 'condition', 'price', 'indicator',
+      'frequency', 'expiration', 'message', 'dry_run',
+    ]);
+    const syncTool = registrations.find(tool => tool.name === 'alerts_sync');
+    assert.ok(syncTool);
+    assert.deepEqual(Object.keys(syncTool.schema), ['alerts', 'replace_alert_ids', 'dry_run']);
+  });
+});

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -78,6 +78,24 @@ describe('CLI — help and routing', () => {
     assert.ok(stdout.includes('--count'));
     assert.ok(stdout.includes('--summary'));
   });
+  it('alert create --help documents exact symbol/timeframe and Pine options', () => {
+    const { stdout, exitCode } = run(['alert', 'create', '--help']);
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes('--symbol'));
+    assert.ok(stdout.includes('--timeframe'));
+    assert.ok(stdout.includes('--kind'));
+    assert.ok(stdout.includes('--indicator'));
+    assert.ok(stdout.includes('--frequency'));
+    assert.ok(stdout.includes('--expiration'));
+    assert.ok(stdout.includes('--dry-run'));
+  });
+
+  it('alert sync --help documents file-based idempotent dry-run', () => {
+    const { stdout, exitCode } = run(['alert', 'sync', '--help']);
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes('--file'));
+    assert.ok(stdout.includes('--dry-run'));
+  });
 });
 
 describe('CLI — pine analyze (offline)', () => {


### PR DESCRIPTION
## Summary

- extend `alert_create` with exact symbol, timeframe, price/Pine condition, frequency, expiration, message, and dry-run support
- add idempotent `alerts_sync` plan diff/apply behavior that preserves unrelated alerts and replaces only approved IDs
- expose file-based CLI synchronization and normalized alert listing, with focused unit and CLI coverage

## Why

The existing alert path used the active chart symbol, hardcoded a one-minute resolution, first-fire frequency, and 30-day expiration, and could only create simple price alerts. That made it unsuitable for deterministic supervised Paper Trading preparation and named Pine `alertcondition()` alerts.

The new implementation validates complete definitions up front, resolves exact live Pine metadata without changing chart panes, fails closed when TradingView cannot represent a request exactly, and never falls back to order-entry or broker behavior.

## Impact

Clients can dry-run or synchronize an approved alert plan without duplicate creation or unrelated-alert deletion. Indicator alerts require an already-open pane with the exact canonical symbol, timeframe, live indicator title, and named Pine condition.

## Validation

- `npm run lint` — zero errors; four pre-existing warnings
- `npm run test:unit` — 175 tests passed
- read-only live `alert_list`, `alert_create --dry-run`, and `alert sync --dry-run` probes passed; no live alerts were created or deleted
