### PR TITLE
docs: correct MCP config path and stale tool counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Gives your AI assistant eyes and hands on your own chart:
 
 Paste this into Claude Code and it will handle the rest:
 
-> Install the TradingView MCP server. Clone https://github.com/tradesdontlie/tradingview-mcp.git, run npm install, add it to my MCP config at ~/.claude/.mcp.json, and launch TradingView with the debug port. Then verify the connection with tv_health_check.
+> Install the TradingView MCP server. Clone https://github.com/tradesdontlie/tradingview-mcp.git, run npm install, register it with `claude mcp add tradingview --scope user`, and launch TradingView with the debug port. Then verify the connection with tv_health_check.
 
 Or follow the manual steps below.
 
@@ -117,7 +117,13 @@ scripts\launch_tv_debug.bat
 
 ### 3. Add to Claude Code
 
-Add to your Claude Code MCP config (`~/.claude/.mcp.json` or project `.mcp.json`):
+Easiest — let the CLI write the config to the right place:
+
+```bash
+claude mcp add tradingview --scope user -- node /absolute/path/to/tradingview-mcp/src/server.js
+```
+
+To edit config by hand instead, add the entry to `~/.claude.json` (user scope, under top-level `mcpServers`) or to a `.mcp.json` in your project root. Note that `~/.claude/.mcp.json` is **not** a path Claude Code reads:
 
 ```json
 {
@@ -217,7 +223,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (84 MCP tools)
 
 ### Chart Reading
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -14,7 +14,27 @@ If the user specifies a different install path, use that instead of `~/tradingvi
 
 ## Step 2: Add to MCP Config
 
-Add the server to the user's Claude Code MCP configuration. The config file is at `~/.claude/.mcp.json` (global) or `.mcp.json` (project-level).
+**Preferred: use the `claude mcp add` CLI.** It writes to the correct config file and scope for you, so there is no path to get wrong:
+
+```bash
+claude mcp add tradingview --scope user -- node <INSTALL_PATH>/src/server.js
+```
+
+Replace `<INSTALL_PATH>` with the actual path where the repo was cloned (e.g., `/Users/username/tradingview-mcp`). Use `--scope user` to make the server available from every directory; use `--scope project` instead to write a shared `.mcp.json` in the repo root.
+
+Verify with `claude mcp list` — it should report `tradingview: ... - ✔ Connected`.
+
+**Manual alternative.** If you edit config by hand, the file Claude Code actually reads is one of:
+
+| Scope | File | Where the entry goes |
+|-------|------|----------------------|
+| User (global) | `~/.claude.json` | top-level `mcpServers` |
+| Project (shared, committed) | `<repo>/.mcp.json` | top-level `mcpServers` |
+| Project (local, private) | `~/.claude.json` | `projects["<repo path>"].mcpServers` |
+
+Note: `~/.claude/.mcp.json` is **not** read by Claude Code — a config placed there is silently ignored.
+
+The entry itself, in any of the above:
 
 ```json
 {
@@ -26,8 +46,6 @@ Add the server to the user's Claude Code MCP configuration. The config file is a
   }
 }
 ```
-
-Replace `<INSTALL_PATH>` with the actual path where the repo was cloned (e.g., `/Users/username/tradingview-mcp`).
 
 If the config file already exists and has other servers, merge the `tradingview` entry into the existing `mcpServers` object. Do not overwrite other servers.
 
@@ -117,7 +135,7 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 | `cdp_connected: false` | Launch TradingView with `--remote-debugging-port=9222` |
 | Windows: "Access is denied" launching from `WindowsApps` | Use `tv_launch` (auto copy-fallback) or the manual copy snippet in Step 3 — never `icacls` on WindowsApps |
 | `ECONNREFUSED` | TradingView isn't running or port 9222 is blocked |
-| MCP server not showing in Claude Code | Check `~/.claude/.mcp.json` syntax, restart Claude Code |
+| MCP server not showing in Claude Code | Run `claude mcp list` to confirm it is registered and connecting. If it is missing, the entry is in a file Claude Code does not read (e.g. `~/.claude/.mcp.json`) — re-add it with `claude mcp add` per Step 2. If it is listed but its tools are absent, restart Claude Code — servers load only at session start |
 | `tv` command not found | Run `npm link` from the project directory |
 | Tools return stale data | TradingView may still be loading — wait a few seconds |
 | Pine Editor tools fail | Open the Pine Editor panel first (`ui_open_panel pine-editor open`) |
@@ -125,5 +143,5 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 ## What to Read Next
 
 - `CLAUDE.md` — Decision tree for which tool to use when (auto-loaded by Claude Code)
-- `README.md` — Full tool reference (78 MCP tools, 30 CLI commands)
+- `README.md` — Full tool reference (84 MCP tools, 30 CLI commands)
 - `RESEARCH.md` — Research context and open questions


### PR DESCRIPTION
## Problem

`SETUP_GUIDE.md` Step 2 and `README.md` both tell the user (and, in README's agent-facing install prompt, an LLM directly) to write the server entry to `~/.claude/.mcp.json`. Claude Code does not read that path. A config placed there is silently ignored — no error, the server just never appears — so following the guide verbatim yields a non-working install that looks correctly configured.

Hit while setting this up on macOS: the entry was written exactly as documented, the server never loaded, and `~/.claude.json` showed empty `mcpServers` at both user and project scope.

## Changes

- **Recommend `claude mcp add --scope user`** as the primary route in both docs. It writes to the correct file and scope, so there is no path to get wrong.
- **Document the three locations Claude Code actually reads**, as a table: `~/.claude.json` (user), `<repo>/.mcp.json` (project, shared), `projects["<path>"].mcpServers` in `~/.claude.json` (project, local) — plus an explicit note that `~/.claude/.mcp.json` is ignored, since anyone who already followed the old instructions will be looking for that.
- **Fix the README install prompt** so it no longer instructs an agent to write to the dead path.
- **Troubleshooting row** now points at `claude mcp list` and separates "not registered" (wrong file) from "registered but tools absent" (needs a session restart) — previously it conflated the two and only suggested a restart, which never fixes the wrong-path case.
- **Tool count:** two mentions still read "78 MCP tools" ([README.md](README.md) tool-reference heading, [SETUP_GUIDE.md](SETUP_GUIDE.md) what-to-read-next), missed by d77ed4a. `tools/list` over stdio reports **84**, matching `CLAUDE.md` and the architecture line in README.

## Verification

Setup was re-run end to end against TradingView Desktop 3.3.0 (Electron 38) on macOS following the corrected Step 2:

- `claude mcp add tradingview --scope user -- node <path>/src/server.js` → written to `~/.claude.json`
- `claude mcp list` → `tradingview: ... - ✔ Connected`
- `tv status` → `cdp_connected: true`, `api_available: true`, live symbol and resolution returned from the chart

Tool count verified independently by piping `initialize` + `tools/list` to `src/server.js` over stdio and counting `result.tools` → 84.

Docs only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)