### PR TITLE
test(drawing): regression coverage for the #413 DI fix

### DIFF
--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,9 +44,10 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
-  const apiPath = await _getChartApi();
-  const shapes = await _evaluate(`
+export async function listDrawings(_deps) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  const shapes = await evaluate(`
     (function() {
       var api = ${apiPath};
       var all = api.getAllShapes();
@@ -56,9 +57,10 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
-  const apiPath = await _getChartApi();
-  const result = await _evaluate(`
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  const result = await evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -85,9 +87,10 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
-  const apiPath = await _getChartApi();
-  const result = await _evaluate(`
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  const result = await evaluate(`
     (function() {
       var api = ${apiPath};
       var eid = ${safeString(entity_id)};
@@ -106,8 +109,9 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
-  const apiPath = await _getChartApi();
-  await _evaluate(`${apiPath}.removeAllShapes()`);
+export async function clearAll(_deps) {
+  const { evaluate, getChartApi } = _resolve(_deps);
+  const apiPath = await getChartApi();
+  await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };
 }

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -8,7 +8,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
-import { drawShape } from '../src/core/drawing.js';
+import { drawShape, listDrawings, getProperties, removeOne, clearAll } from '../src/core/drawing.js';
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
 
@@ -281,6 +281,59 @@ describe('drawing.js — sanitized evaluate calls', () => {
     const call = evaluate.calls.find(c => c.includes('createMultipointShape'));
     assert.ok(call, 'createMultipointShape called');
     assert.ok(call.includes('"trend_line"'), 'shape name via safeString');
+  });
+});
+
+// ── drawing.js — dependency resolution ───────────────────────────────────
+// Regression guard for #413: listDrawings, getProperties, removeOne and
+// clearAll referenced bare getChartApi/evaluate, which only exist under their
+// import aliases (_getChartApi/_evaluate), so every one of them threw
+// ReferenceError at runtime. The suite missed it because only drawShape was
+// exercised — these tests call the other four through _resolve(_deps).
+
+describe('drawing.js — all exports resolve deps via _resolve', () => {
+  it('listDrawings runs with injected deps and returns shapes', async () => {
+    const { _deps } = mockDeps({
+      evaluate: async () => [{ id: 'shape1', name: 'LineToolHorzLine' }],
+    });
+    const result = await listDrawings(_deps);
+    assert.equal(result.success, true);
+    assert.equal(result.count, 1);
+    assert.equal(result.shapes[0].id, 'shape1');
+  });
+
+  it('getProperties runs with injected deps and escapes entity_id', async () => {
+    const calls = [];
+    const { _deps } = mockDeps({
+      evaluate: async (expr) => { calls.push(expr); return { entity_id: 'abc', visible: true }; },
+    });
+    const result = await getProperties({ entity_id: 'abc"; alert(1); "', _deps });
+    assert.equal(result.success, true);
+    const call = calls.find(c => c.includes('getShapeById'));
+    assert.ok(call, 'getShapeById called');
+    assert.ok(call.includes('\\"; alert(1); \\"'), 'entity_id escaped via safeString');
+  });
+
+  it('getProperties throws on shape-not-found error result', async () => {
+    const { _deps } = mockDeps({ evaluate: async () => ({ error: 'Shape not found: xyz' }) });
+    await assert.rejects(() => getProperties({ entity_id: 'xyz', _deps }), /Shape not found/);
+  });
+
+  it('removeOne runs with injected deps and reports removal', async () => {
+    const { _deps } = mockDeps({
+      evaluate: async () => ({ removed: true, entity_id: 'shape1', remaining_shapes: 0 }),
+    });
+    const result = await removeOne({ entity_id: 'shape1', _deps });
+    assert.equal(result.success, true);
+    assert.equal(result.removed, true);
+    assert.equal(result.remaining_shapes, 0);
+  });
+
+  it('clearAll runs with injected deps', async () => {
+    const { _deps, evaluate } = mockDeps();
+    const result = await clearAll(_deps);
+    assert.equal(result.success, true);
+    assert.ok(evaluate.calls.some(c => c.includes('removeAllShapes')), 'removeAllShapes called');
   });
 });
 


### PR DESCRIPTION
Follow-up to #413, as offered [in this comment](https://github.com/tradesdontlie/tradingview-mcp/pull/413#issuecomment-5169195676).

**Stacked on #413.** This branch is based on that PR's head, so until it lands the diff here includes its commit as well — only `test(drawing): cover DI resolution for list/get/remove/clear` is mine. Happy to rebase onto `main` once #413 merges, or to close this if you'd rather fold the tests straight into that PR.

### What this adds

Five tests in `tests/sanitization.test.js`, built on the `mockDeps` helper already in the file:

- `listDrawings` — runs with injected deps, returns shapes
- `getProperties` — runs with injected deps and escapes `entity_id` via `safeString`
- `getProperties` — rejects on a shape-not-found error result
- `removeOne` — runs with injected deps and reports the removal
- `clearAll` — runs with injected deps and issues `removeAllShapes`

### Why the bug got through

The suite exercised only `drawShape` through `mockDeps`. The other four exports of `src/core/drawing.js` had no coverage at all, so nothing caught them referencing bare `getChartApi`/`evaluate` when the module only imports those aliased as `_getChartApi`/`_evaluate`.

### Verification

- With #413 applied: `node --test tests/sanitization.test.js` → **73/73 pass** (68 before this PR)
- With `src/core/drawing.js` reverted to `main`: **exactly these 5 fail**, each with the original `ReferenceError`

So they guard the actual regression rather than merely restating the new code.

### Two notes

- **Signatures.** The tests follow #413 as it currently stands: `listDrawings(_deps)` and `clearAll(_deps)` take deps positionally, `getProperties`/`removeOne` destructure `{ _deps }`. If that PR unifies on the object form, two call sites here need updating — happy to do it, just ping me.
- **Windows.** `tests/sanitization.test.js` cannot be run on Windows at all until #394 lands: the source-audit block resolves `CORE_DIR` via `new URL('../src/core/', import.meta.url).pathname`, which yields `/C:/...` and throws in `readdirSync` before any test executes. Deliberately not touched here to avoid duplicating that PR. Linux and CI are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
