### PR TITLE
Fix complete active watchlist reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/watchlist_reader.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/watchlist_reader.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/core/watchlist.js
+++ b/src/core/watchlist.js
@@ -1,23 +1,236 @@
 /**
  * Core watchlist logic.
- * Reads via DOM rows (panel auto-opened when needed). Removal uses
- * TradingView's symbols_list REST API from the page context (cookie auth),
- * mirroring the proven alerts REST pattern. Add drives the Add-symbol
- * search UI so bare tickers resolve the same way they do for a human.
+ * Reads the complete active watchlist through TradingView's authenticated
+ * symbols_list REST API. Add/remove retain their established UI/API paths.
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
-// TV renamed the right-rail button: current builds use data-name="base" with
-// aria-label "Watchlist, details, and news"; older builds used
-// data-name="base-watchlist-widget-button" / aria-label "Watchlist".
-const WL_BUTTON_JS = `(document.querySelector('[data-name="base-watchlist-widget-button"]')
-  || document.querySelector('[aria-label="Watchlist, details, and news"]')
-  || document.querySelector('[aria-label^="Watchlist"]'))`;
+// Current builds use data-name="base" with this exact aria label. Keep the
+// legacy selectors as fallbacks, but scope the otherwise-generic "base" name.
+export const WATCHLIST_BUTTON_EXPRESSION = `(document.querySelector('button[data-name="base"][aria-label="Watchlist, details, and news"]')
+  || document.querySelector('[data-name="base-watchlist-widget-button"]')
+  || document.querySelector('button[aria-label="Watchlist, details, and news"]')
+  || document.querySelector('button[aria-label="Watchlist"]'))`;
+const WL_BUTTON_JS = WATCHLIST_BUTTON_EXPRESSION;
 
-// The watchlist widget lazy-loads after the panel opens; a fixed 500ms wait
-// raced it (issue #164). Poll until its Add-symbol button or rows exist.
-async function ensureWatchlistOpen(maxWaitMs = 5000) {
-  const state = await evaluate(`
+export const WATCHLIST_ACTIVE_READ_EXPRESSION = `(async function() {
+  /* watchlist-reader:active-rest-v1 */
+  async function readActive() {
+    var response;
+    try {
+      response = await fetch('/api/v1/symbols_list/active/', {
+        method: 'GET',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'Accept': 'application/json' }
+      });
+    } catch (_) {
+      return { ok: false, status: 0, error: 'network_error' };
+    }
+    if (!response.ok) {
+      return { ok: false, status: Number(response.status) || 0, error: 'http_error' };
+    }
+    var contentType = '';
+    try { contentType = response.headers && response.headers.get('content-type') || ''; } catch (_) {}
+    if (contentType && contentType.toLowerCase().indexOf('application/json') === -1) {
+      return { ok: false, status: Number(response.status) || 0, error: 'non_json_response' };
+    }
+    try {
+      return { ok: true, status: Number(response.status) || 200, data: await response.json() };
+    } catch (_) {
+      return { ok: false, status: Number(response.status) || 0, error: 'invalid_json' };
+    }
+  }
+
+  var first = await readActive();
+  var second = await readActive();
+  return { first: first, second: second };
+})()`;
+
+let watchlistMutexTail = Promise.resolve();
+
+async function withWatchlistMutex(operation) {
+  const previous = watchlistMutexTail;
+  let release;
+  watchlistMutexTail = new Promise(resolve => { release = resolve; });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+function dependencies(overrides = {}) {
+  return {
+    evaluate: overrides.evaluate || evaluate,
+    evaluateAsync: overrides.evaluateAsync || evaluateAsync,
+    getClient: overrides.getClient || getClient,
+    wait: overrides.wait || (ms => new Promise(resolve => setTimeout(resolve, ms))),
+  };
+}
+
+function cleanText(value, label, maxLength) {
+  if (typeof value !== 'string') throw watchlistError(`Active watchlist ${label} must be a string`);
+  const cleaned = value
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ')
+    .replace(/[\u202a-\u202e\u2066-\u2069]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) throw watchlistError(`Active watchlist ${label} is empty`);
+  if (cleaned.length > maxLength) throw watchlistError(`Active watchlist ${label} is too long`);
+  return cleaned;
+}
+
+function watchlistError(message) {
+  const error = new Error(message);
+  error.code = 'watchlist_active_read_failed';
+  return error;
+}
+
+function cleanId(value) {
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value < 0) throw watchlistError('Active watchlist id is invalid');
+    return String(value);
+  }
+  return cleanText(value, 'id', 160);
+}
+
+function cleanSymbol(value, index) {
+  if (typeof value !== 'string') {
+    throw watchlistError(`Active watchlist symbol at index ${index} must be a string`);
+  }
+  if (/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/.test(value)) {
+    throw watchlistError(`Active watchlist symbol at index ${index} contains control characters`);
+  }
+  const cleaned = value.trim();
+  if (!cleaned) throw watchlistError(`Active watchlist symbol at index ${index} is empty`);
+  if (cleaned.length > 256) throw watchlistError(`Active watchlist symbol at index ${index} is too long`);
+  return cleaned;
+}
+
+function normalizeActiveList(raw, phase) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw watchlistError(`Active watchlist ${phase} response is not an object`);
+  }
+  if (!Array.isArray(raw.symbols)) {
+    throw watchlistError(`Active watchlist ${phase} response has no symbols array`);
+  }
+  if (raw.symbols.length > 10_000
+    || (raw.symbol_count != null
+      && (!Number.isSafeInteger(raw.symbol_count)
+        || raw.symbol_count < 0
+        || raw.symbol_count > 10_000
+        || raw.symbol_count !== raw.symbols.length))) {
+    throw watchlistError(`Active watchlist ${phase} response has an invalid symbol count`);
+  }
+
+  const symbols = [];
+  const seen = new Set();
+  let sectionCount = 0;
+  for (let index = 0; index < raw.symbols.length; index++) {
+    const symbol = cleanSymbol(raw.symbols[index], index);
+    if (symbol.startsWith('###')) {
+      sectionCount++;
+      continue;
+    }
+    if (!/^[^:\s]+:[^:\s]+$/.test(symbol)) {
+      throw watchlistError(`Active watchlist symbol ${symbol} is not exchange-qualified`);
+    }
+    const identity = symbol.toUpperCase();
+    if (seen.has(identity)) throw watchlistError(`Active watchlist contains duplicate symbol ${symbol}`);
+    seen.add(identity);
+    symbols.push(symbol);
+  }
+
+  return {
+    id: cleanId(raw.id),
+    name: cleanText(raw.name, 'name', 200),
+    type: raw.type == null ? null : cleanText(raw.type, 'type', 80),
+    symbols,
+    section_count: sectionCount,
+  };
+}
+
+function sameSymbols(left, right) {
+  return left.length === right.length && left.every((symbol, index) => symbol === right[index]);
+}
+
+function validateRead(result, phase) {
+  const status = Number(result?.status) || 0;
+  const code = result?.error;
+  if (result?.ok === true && status >= 200 && status < 300) return result.data;
+  if (status === 401 || status === 403) {
+    throw watchlistError(`Active watchlist REST ${phase} read was not authorized (HTTP ${status})`);
+  }
+  if (code === 'invalid_json' || code === 'non_json_response') {
+    throw watchlistError(`Active watchlist REST ${phase} read returned invalid JSON`);
+  }
+  if (status) throw watchlistError(`Active watchlist REST ${phase} read failed (HTTP ${status})`);
+  throw watchlistError(`Active watchlist REST ${phase} read was unavailable`);
+}
+
+async function getUnlocked(deps) {
+  let result;
+  try {
+    result = await deps.evaluateAsync(WATCHLIST_ACTIVE_READ_EXPRESSION);
+  } catch (error) {
+    const detail = String(error?.message || error || 'unknown error')
+      .replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ').slice(0, 200);
+    throw watchlistError(`Active watchlist REST read was unavailable: ${detail}`);
+  }
+  const first = normalizeActiveList(validateRead(result?.first, 'first'), 'first');
+  const second = normalizeActiveList(validateRead(result?.second, 'second'), 'second');
+  if (first.id !== second.id || first.name !== second.name || first.type !== second.type
+    || !sameSymbols(first.symbols, second.symbols)) {
+    const error = new Error('Active watchlist identity or membership changed between the two authoritative reads');
+    error.code = 'watchlist_active_changed';
+    throw error;
+  }
+
+  return {
+    success: true,
+    count: second.symbols.length,
+    source: 'active_list_rest_api',
+    list_id: second.id,
+    list_name: second.name,
+    symbols: second.symbols.map(symbol => ({
+      symbol,
+      last: null,
+      change: null,
+      change_percent: null,
+      volume: null,
+    })),
+    traversal: {
+      complete: true,
+      metadata_verified: true,
+      consistency_reads: 2,
+      expected_count: second.symbols.length,
+      filtered_section_count: second.section_count,
+    },
+    restoration: {
+      ui_mutation: false,
+      panel: {
+        required: false,
+        attempted: false,
+        changed: false,
+        verified: true,
+        baseline_mode: 'not_touched',
+        final_mode: 'not_touched',
+      },
+      scroll: {
+        required: false,
+        verified: true,
+        initial_scroll_top: null,
+        final_scroll_top: null,
+      },
+    },
+  };
+}
+
+// The mutating add/remove paths still need the widget to be mounted.
+async function ensureWatchlistOpen(deps, maxWaitMs = 5000) {
+  const state = await deps.evaluate(`
     (function() {
       var btn = ${WL_BUTTON_JS};
       if (!btn) return { error: 'Watchlist button not found' };
@@ -33,24 +246,28 @@ async function ensureWatchlistOpen(maxWaitMs = 5000) {
 
   const deadline = Date.now() + maxWaitMs;
   while (Date.now() < deadline) {
-    const ready = await evaluate(`
+    const ready = await deps.evaluate(`
       !!(document.querySelector('[data-name="add-symbol-button"]')
         || document.querySelector('[class*="layout__area--right"] [data-symbol-full]'))
     `);
     if (ready) return { opened: !!state?.opened };
-    await new Promise(r => setTimeout(r, 250));
+    await deps.wait(250);
   }
-  throw new Error('Watchlist panel did not become ready. Is a watchlist widget configured in the right panel?');
+  throw new Error('Watchlist panel did not become ready. The right panel may be blank or unavailable.');
 }
 
-// Active watchlist metadata (id, name, symbols) read from the React fiber
-// tree — needed for the REST endpoints. Approach from PR #65.
-async function getActiveListInfo() {
-  return evaluate(`
+// Legacy React metadata is retained only for the established remove path.
+async function getActiveListInfo(deps) {
+  return deps.evaluate(`
     (function() {
-      var panel = document.querySelector('[class*="layout__area--right"]');
-      if (!panel) return null;
-      var rows = panel.querySelectorAll('[data-symbol-full]');
+      function visible(element) {
+        if (!element) return false;
+        var rect = element.getBoundingClientRect();
+        return rect.width > 10 && rect.height > 10;
+      }
+      var roots = Array.from(document.querySelectorAll('[data-name="symbol-list-wrap"]')).filter(visible);
+      if (roots.length !== 1) return null;
+      var rows = roots[0].querySelectorAll('[data-symbol-full]');
       if (!rows.length) return null;
       var row = rows[0];
       var reactKey = Object.keys(row).find(function(k) { return k.indexOf('__reactFiber') === 0; });
@@ -58,9 +275,11 @@ async function getActiveListInfo() {
       var fiber = row[reactKey];
       var count = 0;
       while (fiber && count < 45) {
-        if (fiber.memoizedProps && fiber.memoizedProps.current && fiber.memoizedProps.current.id) {
+        if (fiber.memoizedProps && fiber.memoizedProps.current
+          && fiber.memoizedProps.current.id
+          && Array.isArray(fiber.memoizedProps.current.symbols)) {
           var cur = fiber.memoizedProps.current;
-          return { id: cur.id, name: cur.name, symbols: cur.symbols || [] };
+          return { id: cur.id, name: cur.name, symbols: cur.symbols };
         }
         fiber = fiber.return;
         count++;
@@ -70,56 +289,11 @@ async function getActiveListInfo() {
   `);
 }
 
-export async function get() {
-  await ensureWatchlistOpen();
+async function addUnlocked({ symbol }, deps) {
+  const client = await deps.getClient();
+  await ensureWatchlistOpen(deps);
 
-  // Positional cell mapping (name, last, change, change%, volume) with
-  // Unicode-minus normalization. The old regex classifier dropped every
-  // negative value (TV renders U+2212, not ASCII '-') and all tick-notation
-  // prices like 106'28'7 — issue #111.
-  const data = await evaluate(`
-    (function() {
-      function norm(t) { return t.replace(/\\u2212/g, '-').trim(); }
-      var container = document.querySelector('[class*="layout__area--right"]');
-      if (!container) return { symbols: [], source: 'no_container' };
-      var results = [];
-      var seen = {};
-      var symbolEls = container.querySelectorAll('[data-symbol-full]');
-      for (var i = 0; i < symbolEls.length; i++) {
-        var sym = symbolEls[i].getAttribute('data-symbol-full');
-        if (!sym || seen[sym]) continue;
-        seen[sym] = true;
-        var row = symbolEls[i].closest('[class*="row"]') || symbolEls[i].parentElement;
-        var cells = row ? row.querySelectorAll('[class*="cell"], [class*="column"]') : [];
-        var texts = [];
-        for (var j = 0; j < cells.length; j++) texts.push(norm(cells[j].textContent));
-        results.push({
-          symbol: sym,
-          last: texts[1] || null,
-          change: texts[2] || null,
-          change_percent: texts[3] || null,
-          volume: texts[4] || null,
-        });
-      }
-      return { symbols: results, source: results.length ? 'dom_rows' : 'empty' };
-    })()
-  `);
-
-  const listInfo = await getActiveListInfo();
-  return {
-    success: true,
-    count: data?.symbols?.length || 0,
-    source: data?.source || 'unknown',
-    ...(listInfo && { list_id: listInfo.id, list_name: listInfo.name }),
-    symbols: data?.symbols || [],
-  };
-}
-
-export async function add({ symbol }) {
-  const c = await getClient();
-  await ensureWatchlistOpen();
-
-  const addClicked = await evaluate(`
+  const addClicked = await deps.evaluate(`
     (function() {
       var btn = document.querySelector('[data-name="add-symbol-button"]')
         || document.querySelector('[aria-label="Add symbol"]')
@@ -130,96 +304,90 @@ export async function add({ symbol }) {
     })()
   `);
   if (!addClicked?.found) throw new Error('Add symbol button not found in watchlist panel');
-  await new Promise(r => setTimeout(r, 400));
+  await deps.wait(400);
 
-  await c.Input.insertText({ text: symbol });
-  await new Promise(r => setTimeout(r, 700));
-  await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Enter', code: 'Enter' });
-  await new Promise(r => setTimeout(r, 400));
-  await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape' });
-  await new Promise(r => setTimeout(r, 400));
+  await client.Input.insertText({ text: symbol });
+  await deps.wait(700);
+  await client.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 });
+  await client.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Enter', code: 'Enter' });
+  await deps.wait(400);
+  await client.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
+  await client.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape' });
+  await deps.wait(400);
 
-  // Verify the row actually appeared instead of reporting blind success.
   const bare = symbol.split(':').pop().toUpperCase();
-  const verified = await evaluate(`
+  const verified = await deps.evaluate(`
     (function() {
       var rows = document.querySelectorAll('[class*="layout__area--right"] [data-symbol-full]');
       for (var i = 0; i < rows.length; i++) {
         var s = rows[i].getAttribute('data-symbol-full') || '';
-        if (s.toUpperCase() === ${JSON.stringify(symbol.toUpperCase())} || s.split(':').pop().toUpperCase() === ${JSON.stringify(bare)}) return s;
+        if (s.toUpperCase() === ${JSON.stringify(symbol.toUpperCase())}
+          || s.split(':').pop().toUpperCase() === ${JSON.stringify(bare)}) return s;
       }
       return null;
     })()
   `);
-
   return { success: !!verified, symbol, added_as: verified, action: verified ? 'added' : 'not_verified' };
 }
 
-export async function addBulk({ symbols }) {
+async function addBulkUnlocked({ symbols }, deps) {
   const results = [];
   for (const symbol of symbols) {
     try {
-      const r = await add({ symbol });
-      results.push({ symbol, success: r.success, added_as: r.added_as });
-    } catch (err) {
-      results.push({ symbol, success: false, error: err.message });
+      const result = await addUnlocked({ symbol }, deps);
+      results.push({ symbol, success: result.success, added_as: result.added_as });
+    } catch (error) {
+      results.push({ symbol, success: false, error: error.message });
     }
   }
-  const added = results.filter(r => r.success).length;
+  const added = results.filter(result => result.success).length;
   return { success: added > 0, added, failed: results.length - added, results };
 }
 
-export async function remove({ symbols }) {
-  await ensureWatchlistOpen();
-  const listInfo = await getActiveListInfo();
+async function removeUnlocked({ symbols }, deps) {
+  await ensureWatchlistOpen(deps);
+  const listInfo = await getActiveListInfo(deps);
   if (!listInfo) throw new Error('Cannot read active watchlist metadata (React fiber probe failed)');
 
-  // Match requested symbols (bare or EXCHANGE:SYMBOL) against the list.
   const toRemove = [];
   const skipped = [];
-  for (const sym of symbols) {
-    if (sym.includes(':')) {
-      if (listInfo.symbols.includes(sym)) toRemove.push(sym);
-      else skipped.push(sym);
+  for (const symbol of symbols) {
+    if (symbol.includes(':')) {
+      if (listInfo.symbols.includes(symbol)) toRemove.push(symbol);
+      else skipped.push(symbol);
     } else {
-      const match = listInfo.symbols.find(s => s.split(':').pop().toUpperCase() === sym.toUpperCase());
+      const match = listInfo.symbols.find(item => item.split(':').pop().toUpperCase() === symbol.toUpperCase());
       if (match) toRemove.push(match);
-      else skipped.push(sym);
+      else skipped.push(symbol);
     }
   }
   if (!toRemove.length) {
     return { success: false, removed: [], skipped, error: 'No matching symbols in the active watchlist' };
   }
 
-  // Page-context fetch — browser attaches session cookies automatically.
-  const resp = await evaluateAsync(`
+  const response = await deps.evaluateAsync(`
     fetch('https://www.tradingview.com/api/v1/symbols_list/custom/' + ${JSON.stringify(listInfo.id)} + '/remove/', {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-      body: JSON.stringify(${JSON.stringify(toRemove)}),
+      body: JSON.stringify(${JSON.stringify(toRemove)})
     })
       .then(function(r) { return r.text().then(function(t) { return { status: r.status, ok: r.ok, body: t.substring(0, 300) }; }); })
       .catch(function(e) { return { status: 0, ok: false, body: String(e) }; })
   `);
-
-  if (!resp?.ok) {
-    throw new Error(`Watchlist remove REST call failed (HTTP ${resp?.status}): ${resp?.body}`);
+  if (!response?.ok) {
+    throw new Error(`Watchlist remove REST call failed (HTTP ${response?.status}): ${response?.body}`);
   }
 
-  // The desktop widget doesn't live-sync API removals — remount it by
-  // toggling the panel, then verify the rows are actually gone.
-  await evaluate(`(function() { var btn = ${WL_BUTTON_JS}; if (btn) btn.click(); })()`);
-  await new Promise(r => setTimeout(r, 400));
-  await evaluate(`(function() { var btn = ${WL_BUTTON_JS}; if (btn) btn.click(); })()`);
+  await deps.evaluate(`(function() { var btn = ${WL_BUTTON_JS}; if (btn) btn.click(); })()`);
+  await deps.wait(400);
+  await deps.evaluate(`(function() { var btn = ${WL_BUTTON_JS}; if (btn) btn.click(); })()`);
 
   let stillPresent = toRemove;
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
-    await new Promise(r => setTimeout(r, 500));
-    stillPresent = await evaluate(`
+    await deps.wait(500);
+    stillPresent = await deps.evaluate(`
       (function() {
         var rows = document.querySelectorAll('[class*="layout__area--right"] [data-symbol-full]');
         var present = {};
@@ -231,8 +399,32 @@ export async function remove({ symbols }) {
   }
 
   return {
-    success: true, removed: toRemove, skipped,
+    success: true,
+    removed: toRemove,
+    skipped,
     verified: stillPresent.length === 0,
-    list_id: listInfo.id, list_name: listInfo.name, api: 'rest',
+    list_id: listInfo.id,
+    list_name: listInfo.name,
+    api: 'rest',
   };
+}
+
+export async function get({ _deps } = {}) {
+  const deps = dependencies(_deps);
+  return withWatchlistMutex(() => getUnlocked(deps));
+}
+
+export async function add({ symbol, _deps }) {
+  const deps = dependencies(_deps);
+  return withWatchlistMutex(() => addUnlocked({ symbol }, deps));
+}
+
+export async function addBulk({ symbols, _deps }) {
+  const deps = dependencies(_deps);
+  return withWatchlistMutex(() => addBulkUnlocked({ symbols }, deps));
+}
+
+export async function remove({ symbols, _deps }) {
+  const deps = dependencies(_deps);
+  return withWatchlistMutex(() => removeUnlocked({ symbols }, deps));
 }

--- a/src/tools/watchlist.js
+++ b/src/tools/watchlist.js
@@ -3,7 +3,7 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/watchlist.js';
 
 export function registerWatchlistTools(server) {
-  server.tool('watchlist_get', 'Get all symbols from the current TradingView watchlist with last price, change, and change%', {}, async () => {
+  server.tool('watchlist_get', 'Get every symbol from the exact active TradingView watchlist. Quote fields are null when the authoritative active-list API is used.', {}, async () => {
     try { return jsonResult(await core.get()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });

--- a/tests/watchlist_reader.test.js
+++ b/tests/watchlist_reader.test.js
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import test from 'node:test';
+
+import {
+  WATCHLIST_ACTIVE_READ_EXPRESSION,
+  get,
+} from '../src/core/watchlist.js';
+
+const ACTIVE = Object.freeze({
+  id: 329572122,
+  name: 'SMRs',
+  type: 'custom',
+  symbols: ['NYSE:OKLO', 'NYSE:SMR', 'NASDAQ:NNE'],
+});
+
+function read(value = ACTIVE, overrides = {}) {
+  return {
+    ok: true,
+    status: 200,
+    data: {
+      id: value.id,
+      name: value.name,
+      type: value.type,
+      symbols: [...value.symbols],
+      symbol_count: value.symbols.length,
+    },
+    ...overrides,
+  };
+}
+
+function pair(first = read(), second = read()) {
+  return { first, second };
+}
+
+function fixture(result = pair()) {
+  const calls = [];
+  return {
+    calls,
+    deps: {
+      evaluateAsync: async expression => {
+        calls.push(expression);
+        return result;
+      },
+    },
+  };
+}
+
+test('page expression performs exactly two authenticated no-store active-list reads', async () => {
+  const calls = [];
+  const payload = {
+    id: 7,
+    name: 'Core',
+    type: 'custom',
+    symbols: ['###Holdings', 'NASDAQ:AAPL'],
+  };
+  const fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: name => name === 'content-type' ? 'application/json' : null },
+      json: async () => payload,
+    };
+  };
+
+  const result = await vm.runInNewContext(WATCHLIST_ACTIVE_READ_EXPRESSION, { fetch });
+  const plain = JSON.parse(JSON.stringify(result));
+  assert.deepEqual(plain.first, plain.second);
+  assert.equal(calls.length, 2);
+  for (const call of calls) {
+    assert.equal(call.url, '/api/v1/symbols_list/active/');
+    assert.equal(call.options.method, 'GET');
+    assert.equal(call.options.credentials, 'include');
+    assert.equal(call.options.cache, 'no-store');
+    assert.equal(call.options.headers.Accept, 'application/json');
+  }
+});
+
+test('returns the complete canonical active list without touching panel or scroll state', async () => {
+  const first = read({
+    id: 'list-1',
+    name: ' Growth\u0000\nList ',
+    type: 'custom',
+    symbols: ['###Technology', 'NASDAQ:AAPL', 'NASDAQ:MSFT'],
+  });
+  const fixtureResult = fixture(pair(first, structuredClone(first)));
+  const result = await get({ _deps: fixtureResult.deps });
+
+  assert.equal(result.success, true);
+  assert.equal(result.source, 'active_list_rest_api');
+  assert.equal(result.list_id, 'list-1');
+  assert.equal(result.list_name, 'Growth List');
+  assert.equal(result.count, 2);
+  assert.deepEqual(result.symbols, [
+    { symbol: 'NASDAQ:AAPL', last: null, change: null, change_percent: null, volume: null },
+    { symbol: 'NASDAQ:MSFT', last: null, change: null, change_percent: null, volume: null },
+  ]);
+  assert.deepEqual(result.traversal, {
+    complete: true,
+    metadata_verified: true,
+    consistency_reads: 2,
+    expected_count: 2,
+    filtered_section_count: 1,
+  });
+  assert.equal(result.restoration.ui_mutation, false);
+  assert.deepEqual(result.restoration.panel, {
+    required: false,
+    attempted: false,
+    changed: false,
+    verified: true,
+    baseline_mode: 'not_touched',
+    final_mode: 'not_touched',
+  });
+  assert.equal(result.restoration.scroll.verified, true);
+  assert.equal(fixtureResult.calls.length, 1);
+  assert.match(fixtureResult.calls[0], /watchlist-reader:active-rest-v1/);
+  assert.doesNotMatch(fixtureResult.calls[0], /\.click\(|scrollTop/);
+});
+
+test('accepts an authoritative empty active list instead of inferring emptiness from the DOM', async () => {
+  const empty = read({ id: 8, name: 'Empty', type: 'custom', symbols: [] });
+  const result = await get({ _deps: fixture(pair(empty, structuredClone(empty))).deps });
+  assert.equal(result.success, true);
+  assert.equal(result.count, 0);
+  assert.deepEqual(result.symbols, []);
+  assert.equal(result.traversal.expected_count, 0);
+});
+
+test('fails closed if active-list identity, name, membership, or order changes', async () => {
+  const cases = [
+    read({ ...ACTIVE, id: 999 }),
+    read({ ...ACTIVE, name: 'Another' }),
+    read({ ...ACTIVE, symbols: ['NYSE:OKLO', 'NASDAQ:NNE'] }),
+    read({ ...ACTIVE, symbols: [...ACTIVE.symbols].reverse() }),
+  ];
+  for (const second of cases) {
+    await assert.rejects(
+      get({ _deps: fixture(pair(read(), second)).deps }),
+      error => error.code === 'watchlist_active_changed'
+        && /identity or membership changed/.test(error.message),
+    );
+  }
+});
+
+test('fails closed on HTTP, non-JSON, missing-field, or oversized responses', async () => {
+  const invalidReads = [
+    { ok: false, status: 401, error: 'http_error' },
+    { ok: false, status: 200, error: 'non_json_response' },
+    read({ id: null, name: 'Missing ID', type: 'custom', symbols: [] }),
+    read(ACTIVE, { data: { ...ACTIVE, symbols: ['NYSE:OKLO'], symbol_count: 10_001 } }),
+  ];
+  for (const invalid of invalidReads) {
+    await assert.rejects(
+      get({ _deps: fixture(pair(invalid, invalid)).deps }),
+      error => error.code === 'watchlist_active_read_failed',
+    );
+  }
+});
+
+test('rejects malformed, duplicate, unqualified, and control-bearing symbols', async () => {
+  const cases = [
+    ['NASDAQ:AAPL', 'nasdaq:aapl'],
+    ['AAPL'],
+    ['NASDAQ:AAPL\u0000'],
+    [null],
+  ];
+  for (const symbols of cases) {
+    const invalid = read({ id: 9, name: 'Bad', type: 'custom', symbols });
+    await assert.rejects(get({ _deps: fixture(pair(invalid, invalid)).deps }));
+  }
+});
+
+test('serializes simultaneous reads and releases the lock after completion', async () => {
+  let calls = 0;
+  let releaseFirst;
+  let markStarted;
+  const started = new Promise(resolve => { markStarted = resolve; });
+  const gate = new Promise(resolve => { releaseFirst = resolve; });
+  const deps = {
+    evaluateAsync: async () => {
+      calls++;
+      if (calls === 1) {
+        markStarted();
+        await gate;
+      }
+      return pair();
+    },
+  };
+
+  const first = get({ _deps: deps });
+  await started;
+  const second = get({ _deps: deps });
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.equal(calls, 1);
+  releaseFirst();
+  await Promise.all([first, second]);
+  assert.equal(calls, 2);
+});


### PR DESCRIPTION
## Summary

- Read the exact active TradingView watchlist through the authenticated same-origin active-list API instead of virtualized DOM rows.
- Perform two no-store reads and fail closed if list identity, order, membership, count, or payload validity changes.
- Preserve exchange-qualified symbols and list order without opening or scrolling the watchlist panel.
- Return null quote fields explicitly because the authoritative endpoint supplies membership, not quotes.
- Serialize watchlist operations and add focused contract tests.

## Why

The existing DOM reader can omit off-screen symbols because the watchlist is virtualized. That makes current-watchlist scans incomplete without any obvious error. The active-list endpoint returns authoritative membership and lets reads remain UI-neutral.

## Verification

- `node --test tests/watchlist_reader.test.js`: 7/7 passed.
- `npm run test:unit`: 159 tests passed.
- `npm run lint`: exit 0; four pre-existing warnings, zero errors.
- `git diff --check`: passed.
- Live desktop read: exact list `SMRs`, 9/9 symbols, two consistency reads, no panel or scroll mutation.
- Full end-to-end suite was not run because its drawing cleanup path is destructive to the active chart.

## Risks and rollout

- The active-list endpoint is an internal TradingView surface and may change; malformed or inconsistent responses fail closed.
- Quote fields are intentionally null on this path.
- Existing add/remove behavior is retained.
- Smoke test after merge with `tv watchlist get`; confirm exact list count/order and `restoration.ui_mutation=false`.
