### PR TITLE
test(e2e): resolve CDP host/port from env instead of hardcoding

### DIFF
--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1,8 +1,10 @@
 /**
  * Comprehensive E2E tests for all 70 TradingView MCP tools.
- * Requires TradingView Desktop running with --remote-debugging-port=9222
+ * Requires TradingView Desktop running with --remote-debugging-port=<CDP_PORT>
+ * (default 9222, override via TV_CDP_PORT/CDP_PORT — same convention as src/connection.js)
  *
  * Run: node --test tests/e2e.test.js
+ *      CDP_PORT=9333 node --test tests/e2e.test.js
  *
  * Coverage: 70+ tests across 12 tool modules
  * - Health & Connection (4 tools)
@@ -22,6 +24,12 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import CDP from 'chrome-remote-interface';
+
+// Same resolution convention as src/connection.js: TV_CDP_* wins over CDP_*,
+// and the host defaults to 127.0.0.1 (on Windows, localhost may resolve to ::1
+// first while Electron's --remote-debugging-port only listens on IPv4).
+const CDP_HOST = process.env.TV_CDP_HOST || process.env.CDP_HOST || '127.0.0.1';
+const CDP_PORT = Number(process.env.TV_CDP_PORT || process.env.CDP_PORT) || 9222;
 
 let client;
 let Runtime;
@@ -71,11 +79,11 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
 
   before(async () => {
     try {
-      const targets = await CDP.List({ host: 'localhost', port: 9222 });
+      const targets = await CDP.List({ host: CDP_HOST, port: CDP_PORT });
       const chartTarget = targets.find(t => t.url && t.url.includes('tradingview.com/chart'));
       if (!chartTarget) throw new Error('No TradingView chart target found');
 
-      client = await CDP({ host: 'localhost', port: 9222, target: chartTarget.id });
+      client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: chartTarget.id });
       await client.Runtime.enable();
       await client.Page.enable();
       await client.DOM.enable();
@@ -83,7 +91,9 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
       Input = client.Input;
       Page = client.Page;
     } catch (err) {
-      console.error('Cannot connect to TradingView. Make sure it is running with --remote-debugging-port=9222');
+      console.error(`Cannot connect to TradingView at ${CDP_HOST}:${CDP_PORT}. ` +
+        `Make sure it is running with --remote-debugging-port=${CDP_PORT} ` +
+        `(or set TV_CDP_PORT/CDP_PORT to the port it actually uses). Cause: ${err.message}`);
       process.exit(1);
     }
   });


### PR DESCRIPTION
`src/connection.js` already resolves the CDP endpoint from the environment:

```js
export const CDP_HOST = process.env.TV_CDP_HOST || process.env.CDP_HOST || '127.0.0.1';
export const CDP_PORT = Number(process.env.TV_CDP_PORT || process.env.CDP_PORT) || 9222;
```

`tests/e2e.test.js` did not, and hardcoded `localhost:9222` in three places. So on any machine where something else already owns 9222 — a Chrome instance with remote debugging on, another Electron app — the server connects fine but the e2e suite cannot, with no way to point it elsewhere.

### What changed

- The same two resolution lines as `src/connection.js`, so there is one convention rather than two.
- `127.0.0.1` rather than `localhost` for the default host, matching the reasoning already documented in `connection.js`: on Windows `localhost` can resolve to `::1` first, while Electron's `--remote-debugging-port` listens on IPv4 only.
- The connection-failure message now names the host and port actually tried and includes the underlying error, instead of always printing 9222 regardless of configuration.
- Header comment documents the override.

### Verification

Resolution exercised directly against a running TradingView Desktop, in the three cases that matter:

| Env | Resolved | Result |
|---|---|---|
| `CDP_PORT=9333` | `127.0.0.1:9333` | chart target found |
| `CDP_PORT=9222 TV_CDP_PORT=9333` | `127.0.0.1:9333` | chart target found — `TV_CDP_*` correctly wins |
| _(unset)_ | `127.0.0.1:9222` | unchanged default |

I did not run a full pass of the suite itself: it is destructive against whatever chart it attaches to (`removeAllShapes()` at line 945, plus symbol and study mutations), so it is not something to point at a chart with real drawings on it. The change is confined to endpoint resolution, which is what the table above covers.

No behaviour change when the variables are unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)