### PR TITLE
Fix lint warnings: remove unused catch bindings and import

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -381,7 +381,7 @@ async function _getQuoteInternal({ symbol } = {}) {
   let needsRestore = false;
 
   if (requested) {
-    try { originalSymbol = await evaluate(`${CHART_API}.symbol()`); } catch (e) {}
+    try { originalSymbol = await evaluate(`${CHART_API}.symbol()`); } catch {}
     const bare = (s) => (s || '').toString().split(':').pop().toUpperCase();
     if (bare(originalSymbol) !== bare(requested)) {
       needsRestore = true;
@@ -444,7 +444,7 @@ async function _getQuoteInternal({ symbol } = {}) {
           })()
         `);
         await waitForChartReady(originalSymbol);
-      } catch (e) {}
+      } catch {}
     }
   }
 }

--- a/src/core/pane.js
+++ b/src/core/pane.js
@@ -2,7 +2,7 @@
  * Core pane/layout management logic.
  * Controls multi-chart layouts (split panes) in TradingView.
  */
-import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
+import { evaluate, evaluateAsync, safeString } from '../connection.js';
 
 const CWC = 'window.TradingViewApi._chartWidgetCollection';
 

--- a/src/tools/watchlist.js
+++ b/src/tools/watchlist.js
@@ -19,7 +19,7 @@ export function registerWatchlistTools(server) {
         const c = await getClient();
         await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
         await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
-      } catch (_) {}
+      } catch {}
       return jsonResult({ success: false, error: err.message }, true);
     }
   });


### PR DESCRIPTION
## Summary
- Removed unused `e`/`_` catch-clause bindings in `src/core/data.js` and `src/tools/watchlist.js`
- Removed unused `getClient` import in `src/core/pane.js`

## Test plan
- [x] `npm run lint` passes with 0 warnings, 0 errors