### PR TITLE
Fix MSIX detection when powershell.exe is absent from PATH

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -21,8 +21,15 @@ if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMF
 REM Check MSIX / Windows Store installs.
 REM Get-AppxPackage resolves the install without elevation; enumerating
 REM %PROGRAMFILES%\WindowsApps with dir requires admin rights, so keep it as a fallback.
+REM Windows PowerShell runs Get-AppxPackage natively, so try it first.
 if "%TV_EXE%"=="" (
     for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
+        if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
+    )
+)
+REM Some machines ship PowerShell 7 only, with powershell.exe absent from PATH.
+if "%TV_EXE%"=="" (
+    for /f "usebackq tokens=*" %%i in (`pwsh -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
         if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
     )
 )

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -317,14 +317,20 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (!tvPath && platform === 'win32') {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
-    try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
-      const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
-      if (installDir) {
-        const candidate = `${installDir}\\TradingView.exe`;
-        if (deps.existsSync(candidate)) tvPath = candidate;
-      }
-    } catch { /* ignore */ }
+    // Try Windows PowerShell first (runs Get-AppxPackage natively, so it is fastest), then
+    // PowerShell 7: some machines ship pwsh only, with powershell.exe absent from PATH.
+    for (const host of ['powershell', 'pwsh']) {
+      try {
+        const ps = `${host} -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation"`;
+        // pwsh reaches Get-AppxPackage through the WinPS compatibility layer, which is
+        // slower to start than 5.1, so allow more headroom than a native call needs.
+        const installDir = deps.execSync(ps, { timeout: 15000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+        if (installDir) {
+          const candidate = `${installDir}\\TradingView.exe`;
+          if (deps.existsSync(candidate)) { tvPath = candidate; break; }
+        }
+      } catch { /* host missing or query failed — try the next one */ }
+    }
   }
 
   if (!tvPath) {

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -148,3 +148,57 @@ describe('launch() — classic install path', { skip: !onWindows }, () => {
     await assert.rejects(() => launch({ _deps: deps }), /TradingView not found/);
   });
 });
+
+/**
+ * Build a _deps bundle where the Get-AppxPackage query only succeeds under
+ * specific PowerShell hosts, and record which hosts were attempted.
+ * @param {string[]} workingHosts — hosts whose Get-AppxPackage call resolves
+ */
+function psHostDeps(workingHosts) {
+  const state = { hostsTried: [], spawned: [], cdpUp: false };
+  const deps = {
+    existsSync: (p) => p === MSIX_EXE,
+    execSync: (cmd) => {
+      if (cmd.includes('taskkill')) return '';
+      if (cmd.includes('Get-AppxPackage')) {
+        const host = cmd.split(' ')[0];
+        state.hostsTried.push(host);
+        if (!workingHosts.includes(host)) {
+          throw new Error(`'${host}' is not recognized as the name of a cmdlet`);
+        }
+        return 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\n';
+      }
+      throw new Error(`unexpected execSync: ${cmd}`);
+    },
+    spawn: (exe) => { state.spawned.push(exe); state.cdpUp = true; return mockChild(); },
+    cpSync: () => {}, rmSync: () => {}, readdirSync: () => [],
+    delay: async () => {},
+    probeCdp: async () => (state.cdpUp ? CDP_VERSION : null),
+  };
+  return { deps, state };
+}
+
+describe('launch() — PowerShell host resolution for MSIX detection', { skip: !onWindows }, () => {
+  it('resolves via powershell when present, without invoking pwsh', async () => {
+    const { deps, state } = psHostDeps(['powershell']);
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.binary, MSIX_EXE);
+    // Windows PowerShell runs Get-AppxPackage natively, so it must stay first.
+    assert.deepEqual(state.hostsTried, ['powershell']);
+  });
+
+  it('falls back to pwsh when powershell.exe is absent from PATH', async () => {
+    const { deps, state } = psHostDeps(['pwsh']);
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.binary, MSIX_EXE);
+    assert.deepEqual(state.hostsTried, ['powershell', 'pwsh']);
+  });
+
+  it('throws when no PowerShell host can resolve the package', async () => {
+    const { deps, state } = psHostDeps([]);
+    await assert.rejects(() => launch({ _deps: deps }), /TradingView not found/);
+    assert.deepEqual(state.hostsTried, ['powershell', 'pwsh']);
+  });
+});


### PR DESCRIPTION
MSIX install detection shells out to `powershell -NoProfile -Command "(Get-AppxPackage ...)"`. On machines that ship PowerShell 7 without powershell.exe on PATH, that call fails outright. The error is discarded by the surrounding catch (and by 2^>nul in the .bat), so detection silently falls through and tv_launch reports "TradingView not found" even though the package is installed and resolvable.

Try `powershell` first, since it runs Get-AppxPackage natively and is fastest, then fall back to `pwsh`. Windows PowerShell stays the primary path, so behaviour is unchanged wherever it is present.

Also allow more headroom on the retry: pwsh reaches Get-AppxPackage through the WinPS compatibility layer, which is slower to start than 5.1.

Adds three regression tests covering host ordering, the pwsh fallback, and the neither-host-available error path.