### PR TITLE
Fix tv search aborting on Windows after printing its result

### DIFF
--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -3,6 +3,36 @@
  * Zero dependencies — uses only Node.js built-ins.
  */
 import { parseArgs } from 'node:util';
+import { disconnect } from '../connection.js';
+
+/**
+ * End the process without tripping libuv on Windows.
+ *
+ * Calling process.exit() while Node's global fetch (undici) still has a
+ * keep-alive socket unwinding aborts the process:
+ *
+ *   Assertion failed: !(handle->flags & UV_HANDLE_CLOSING),
+ *   file src\win\async.c, line 76
+ *
+ * `tv search` hit this every time: it is the one command that talks to a
+ * remote HTTPS host (symbol-search.tradingview.com) rather than to CDP on
+ * localhost, so it printed a correct, complete result and then died with a
+ * non-zero exit, making a working command look broken to any caller checking
+ * the exit code.
+ *
+ * process.exit() was presumably used because an open CDP websocket keeps the
+ * event loop alive. So: close CDP, set the code, and let the loop drain on its
+ * own — that path is clean and, measured, returns in ~0.3s. The unref'd timer
+ * is a backstop only: it cannot hold the loop open itself, and fires solely if
+ * something else still is, preserving the old hard-exit behaviour.
+ */
+async function finish(code) {
+  process.exitCode = code;
+  try {
+    await disconnect();
+  } catch { /* best effort: we are exiting anyway */ }
+  setTimeout(() => process.exit(code), 250).unref();
+}
 
 /** @type {Map<string, { description: string, options?: object, handler: Function, subcommands?: Map<string, object> }>} */
 const commands = new Map();
@@ -132,19 +162,20 @@ async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
     console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    await finish(0);
   } catch (err) {
-    handleError(err);
+    await handleError(err);
   }
 }
 
-function handleError(err) {
+async function handleError(err) {
   const message = err.message || String(err);
   // Connection failures get exit code 2
   if (/CDP|connection|ECONNREFUSED|not running/i.test(message)) {
     console.error(JSON.stringify({ success: false, error: message }, null, 2));
-    process.exit(2);
+    await finish(2);
+    return;
   }
   console.error(JSON.stringify({ success: false, error: message }, null, 2));
-  process.exit(1);
+  await finish(1);
 }

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,10 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  // fileURLToPath, not .pathname: on Windows the latter yields
+  // "/C:/Users/.../src/core/", and the leading slash makes readdirSync look for
+  // "C:\C:\Users\...", so this whole suite failed to load on Windows.
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## `tv search` aborts on Windows after printing a correct result

On Windows, `tv search <query>` prints a complete, valid result and then dies:

```
$ tv search tesla
{ "success": true, "query": "tesla", "source": "rest_api", "results": [ ... ], "count": 15 }
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

The exit code is non-zero, so anything checking it treats a working command as
failed. I hit this driving the CLI from another process, where the crash made
`search` look broken until I compared stdout against the exit status.

### Root cause

Not TradingView or CDP related. Six lines reproduce it with no part of this
project involved:

```js
const r = await fetch('https://symbol-search.tradingview.com/symbol_search/v3/?text=tesla&hl=1&lang=en&domain=production', {
  headers: { Origin: 'https://www.tradingview.com', Referer: 'https://www.tradingview.com/' },
});
await r.json();
process.exit(0);   // <- Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)
```

Calling `process.exit()` while Node's global `fetch` (undici) still has a
keep-alive socket unwinding aborts the process on Windows.

`search` is the only command affected because `symbolSearch()` is the only one
that reaches a remote HTTPS host (`symbol-search.tradingview.com`) instead of
CDP on localhost. Replacing `process.exit(0)` with `process.exitCode = 0` in the
repro above exits cleanly in ~0.3s.

### Fix

`process.exit()` is presumably there because an open CDP websocket keeps the
event loop alive. `router.js` now:

1. closes CDP through the existing `disconnect()`,
2. sets `process.exitCode`,
3. lets the loop drain naturally,
4. keeps an **unref'd** 250ms timer as a backstop, which preserves the previous
   hard-exit behaviour if something genuinely still holds the loop open. Being
   unref'd, it cannot keep the process alive by itself.

Measured on Windows 10, Node v24.13.1, against a live chart — every command
exits 0 with no assertion:

| command | exit | time |
| --- | --- | --- |
| `status` | 0 | 812ms |
| `state` | 0 | 288ms |
| `quote` | 0 | 271ms |
| `values` | 0 | 269ms |
| `search tesla` | 0 | 390ms |

Error codes are unchanged: `1` for an unknown command, `2` for a CDP connection
failure (verified with `TV_CDP_PORT=9999`).

### Second, unrelated fix in the same commit

`tests/sanitization.test.js` could not load on Windows at all:

```js
const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
```

On Windows that yields `/C:/Users/.../src/core/`, and the leading slash makes
`readdirSync` look for `C:\C:\Users\...`:

```
Error: ENOENT: no such file or directory, scandir 'C:\C:\Users\17173\tradingview-mcp\src\core\'
```

Switching to `fileURLToPath` takes the unit suite from a load error to
**159 passing, 0 failing**. Happy to split this into its own PR if you'd rather
keep them separate.

### Verification

- `node --test` across the unit suite: 159 pass, 0 fail
- CLI commands exercised against a live TradingView chart, table above
- No behaviour change intended beyond the exit path
