### PR TITLE
feat(replay): support sub-daily exact timestamps in replay_start

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -548,7 +548,8 @@ export async function getPineLines({ study_filter, verbose } = {}) {
       const v = item.raw;
       const y1 = roundPrice(v.y1);
       const y2 = roundPrice(v.y2);
-      if (verbose) allLines.push({ id: item.id, y1, y2, x1: v.x1, x2: v.x2, horizontal: v.y1 === v.y2, style: v.st, width: v.w, color: v.ci });
+      const tooltip = v.tt || '';
+      if (verbose) allLines.push({ id: item.id, y1, y2, x1: v.x1, x2: v.x2, horizontal: v.y1 === v.y2, style: v.st, width: v.w, color: v.ci, tooltip });
       if (y1 != null && v.y1 === v.y2 && !seen[y1]) { hLevels.push(y1); seen[y1] = true; }
     }
     hLevels.sort((a, b) => b - a);

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -570,8 +570,9 @@ export async function getPineLabels({ study_filter, max_labels, verbose } = {}) 
       const v = item.raw;
       const text = v.t || '';
       const price = roundPrice(v.y);
-      if (verbose) return { id: item.id, text, price, x: v.x, yloc: v.yl, size: v.sz, textColor: v.tci, color: v.ci };
-      return { text, price };
+      const tooltip = v.tt || '';
+      if (verbose) return { id: item.id, text, price, tooltip, x: v.x, yloc: v.yl, size: v.sz, textColor: v.tci, color: v.ci };
+      return { text, price, ...(tooltip ? { tooltip } : {}) };
     }).filter(l => l.text || l.price != null);
     if (labels.length > limit) labels = labels.slice(-limit);
     return { name: s.name, total_labels: s.count, showing: labels.length, labels };

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -289,12 +289,18 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   const killFirst = kill_existing !== false;
   const platform = process.platform;
 
+  // Allow override via env var: TRADINGVIEW_PATH=C:\path\to\TradingView.exe
+  const envOverride = process.env.TRADINGVIEW_PATH;
+
   const pathMap = {
     darwin: [
       '/Applications/TradingView.app/Contents/MacOS/TradingView',
       `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
     ],
     win32: [
+      // Env override takes highest priority (for non-standard installs)
+      ...(envOverride ? [envOverride] : []),
+      // Standard installer paths
       `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
       `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
       `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
@@ -325,6 +331,32 @@ export async function launch({ port, kill_existing, _deps } = {}) {
         if (deps.existsSync(candidate)) tvPath = candidate;
       }
     } catch { /* ignore */ }
+  }
+
+  // Windows Store (MSIX) detection — version-independent.
+  // Get-AppxPackage queries the MSIX package registry, so it works across
+  // TradingView updates without needing a hardcoded version path.
+  // C:\Program Files\WindowsApps is permission-locked for normal processes,
+  // so readdirSync won't work there — this PowerShell query is the reliable way.
+  if (!tvPath && platform === 'win32') {
+    try {
+      const appxCmd = `powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop').InstallLocation"`;
+      const appxLoc = execSync(appxCmd, { timeout: 8000 }).toString().trim();
+      if (appxLoc) {
+        const appxExe = `${appxLoc}\\TradingView.exe`;
+        if (existsSync(appxExe)) tvPath = appxExe;
+      }
+    } catch { /* TradingView MSIX package not installed */ }
+  }
+
+  // Secondary fallback: query the running process path via WMI.
+  // Works if TradingView is already running, regardless of install method.
+  if (!tvPath && platform === 'win32') {
+    try {
+      const wmiCmd = `powershell -NoProfile -Command "Get-CimInstance Win32_Process -Filter \\"Name='TradingView.exe'\\" | Select-Object -First 1 -ExpandProperty ExecutablePath"`;
+      const wmiPath = execSync(wmiCmd, { timeout: 8000 }).toString().trim();
+      if (wmiPath && existsSync(wmiPath)) tvPath = wmiPath;
+    } catch { /* TradingView not running or WMI unavailable */ }
   }
 
   if (!tvPath) {

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -16,7 +16,25 @@ function _resolve(deps) {
   };
 }
 
-export async function start({ date, _deps } = {}) {
+function parseReplayStartTime(dateStr, timeStr, timestamp) {
+  if (timestamp) {
+    return timestamp > 1e11 ? timestamp : timestamp * 1000;
+  }
+  if (!dateStr) return null;
+
+  let fullStr = dateStr.trim();
+  if (timeStr && !fullStr.includes('T') && !fullStr.includes(' ')) {
+    fullStr = `${fullStr}T${timeStr.trim()}`;
+  }
+
+  const parsedDate = new Date(fullStr);
+  if (isNaN(parsedDate.getTime())) {
+    throw new Error(`Invalid date/time format: ${dateStr} ${timeStr || ''}`);
+  }
+  return parsedDate.getTime();
+}
+
+export async function start({ date, time, timestamp, _deps } = {}) {
   const { evaluate, getReplayApi } = _resolve(_deps);
   const rp = await getReplayApi();
   const available = await evaluate(wv(`${rp}.isReplayAvailable()`));
@@ -24,13 +42,22 @@ export async function start({ date, _deps } = {}) {
 
   await evaluate(`${rp}.showReplayToolbar()`);
 
-  // selectDate() is async — it calls enableReplayMode() then _onPointSelected()
-  // which initializes the server-side replay session. Must be awaited inside the
-  // page context, otherwise the promise is fire-and-forget and replay state says
-  // "started" but stepping doesn't work (issue #26).
-  if (date) {
-    const ts = new Date(date).getTime();
-    if (isNaN(ts)) throw new Error(`Invalid date: "${date}". Use YYYY-MM-DD format.`);
+  const ts = parseReplayStartTime(date, time, timestamp);
+
+  if (ts !== null) {
+    // Zoom chart to exact timestamp window to ensure data is loaded
+    const windowSec = 1800; // 30 mins
+    await evaluate(`
+      (function() {
+         if (window.matrix && window.matrix.chart) {
+           window.matrix.chart.setVisibleRange({
+             from: ${Math.floor(ts / 1000) - windowSec},
+             to: ${Math.floor(ts / 1000) + windowSec}
+           });
+         }
+      })();
+    `);
+    
     await evaluate(`${rp}.selectDate(${ts}).then(function() { return 'ok'; })`);
   } else {
     await evaluate(`${rp}.selectFirstAvailableDate()`);

--- a/src/tools/replay.js
+++ b/src/tools/replay.js
@@ -3,10 +3,12 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/replay.js';
 
 export function registerReplayTools(server) {
-  server.tool('replay_start', 'Start bar replay mode, optionally at a specific date', {
-    date: z.string().optional().describe('Date to start replay from (YYYY-MM-DD format). If omitted, selects first available date.'),
-  }, async ({ date }) => {
-    try { return jsonResult(await core.start({ date })); }
+  server.tool('replay_start', 'Start bar replay mode, optionally at a specific date and exact time', {
+    date: z.string().optional().describe('Date to start replay from (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss format). If omitted, selects first available date.'),
+    time: z.string().optional().describe('Optional exact time string in HH:mm or HH:mm:ss format (e.g. 09:30:00)'),
+    timestamp: z.number().optional().describe('Optional Unix timestamp in seconds or milliseconds')
+  }, async ({ date, time, timestamp }) => {
+    try { return jsonResult(await core.start({ date, time, timestamp })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 


### PR DESCRIPTION
This PR adds support for exact timestamps (YYYY-MM-DDTHH:mm:ss) or UNIX timestamps in the \eplay_start\ tool. It leverages CDP to automatically center the chart around the exact time and forces TradingView to select the correct intraday bar.