### PR TITLE
docs: fix stale tool count in Tool Reference heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (84 MCP tools)
 
 ### Chart Reading
 


### PR DESCRIPTION
## Summary
- The "Tool Reference" heading in README.md said **78 MCP tools**, but every other reference to the tool count — the README's own Transport line, CLAUDE.md, and the instructions string in src/server.js — says **84**.
- Looks like a prior doc-reconciliation commit (docs: reconcile tool count to 84 across all docs) missed this one heading.

## Change
- Updated the heading from `## Tool Reference (78 MCP tools)` to `## Tool Reference (84 MCP tools)`.

## Test plan
- Docs-only change, no code affected.
- Verified 84 is the correct count via CLAUDE.md and the instructions string in src/server.js.