### PR TITLE
Raise the MSIX detection timeout so Store installs are actually found

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -318,8 +318,12 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
-      const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
+      // 20s, not 5s: Get-AppxPackage plus PowerShell startup measured 6.1-7.8s
+      // on a normal Windows 11 box, so a 5s budget killed this call every time
+      // and MSIX installs were never found. -NonInteractive so it can never
+      // block on a prompt and burn the whole budget.
+      const ps = 'powershell -NoProfile -NonInteractive -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      const installDir = deps.execSync(ps, { timeout: 20000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;
         if (deps.existsSync(candidate)) tvPath = candidate;


### PR DESCRIPTION
tv_launch fails with "TradingView not found on win32" on machines where TradingView is installed from the Microsoft Store. The error lists only the three standard filesystem paths, so the MSIX branch looks like it never ran.

It runs, and gets killed. Get-AppxPackage plus PowerShell startup measured 6.1s, 6.1s and 7.8s across three consecutive runs on an idle Windows 11 box (TradingView.Desktop 3.3.0.7992). The call is given a 5s budget, so execSync kills it with ETIMEDOUT every time. The catch { /* ignore */ } swallows it, detection falls through to where TradingView.exe — which doesn't find MSIX apps either — and the user gets a not-found error naming paths that were never relevant.

Raises the budget to 20s and adds -NonInteractive so the call can't block on a prompt and burn it. The slower failure only affects the path where the three standard locations already missed.

Verified end-to-end: detection resolves C:\Program Files\WindowsApps\TradingView.Desktop_3.3.0.7992_x64__n534cwy3pjxzj, launch succeeds and CDP binds in 14.4s total, no local-copy fallback needed.

ESLint clean. test:unit 123/125 — the two failures (compiles valid Pine Script, returns errors for invalid Pine Script, plus source audit) reproduce identically on clean main at c05b8f5 without this commit, so they're pre-existing and unrelated.