### PR TITLE
feat: native Paper Trading tools via Desktop CDP (fail-closed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ scripts/current.pine
 temp_*
 *.log
 discovery-log.json
+paper-discovery-*.json
 rules.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-84 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+85 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 
@@ -83,6 +83,9 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 ### "TradingView isn't running"
 - `tv_launch` → auto-detect and launch TradingView with CDP on Mac/Win/Linux
 - `tv_health_check` → verify connection is working
+
+### "What's the Paper Trading state?"
+- `paper_get_status` → read-only observability status (desktop connection, Trading Panel button state). Native Paper Trading support is in the discovery phase (docs/PAPER_TRADING_DISCOVERY.md): undiscovered facts come back as unknown/null and `safe_for_paper_mutation` is always false. There is NO order execution.
 
 ## Context Management Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-85 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+97 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 
@@ -84,8 +84,14 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `tv_launch` → auto-detect and launch TradingView with CDP on Mac/Win/Linux
 - `tv_health_check` → verify connection is working
 
-### "What's the Paper Trading state?"
-- `paper_get_status` → read-only observability status (desktop connection, Trading Panel button state). Native Paper Trading support is in the discovery phase (docs/PAPER_TRADING_DISCOVERY.md): undiscovered facts come back as unknown/null and `safe_for_paper_mutation` is always false. There is NO order execution.
+### "What's the Paper Trading state?" / "Trade on Paper"
+Native Paper Trading only (stable broker id `"Paper"`). Never other brokers.
+1. `paper_get_status` → session, panel, connect status/label, broker id, `safe_for_paper_mutation`
+2. `paper_connect` → connect broker id `Paper` if disconnected
+3. `paper_get_account` / `paper_list_accounts` / `paper_switch_account` / `paper_list_positions` / `paper_list_orders`
+4. Mutations (fail closed unless active broker is Paper): `paper_place_order` (optional `tif` DAY|WEEK|MONTH|GTD), `paper_cancel_order`, `paper_modify_order`, `paper_close_position`, `paper_set_brackets` (`clear: true` to remove SL/TP)
+5. `paper_open_panel` → open/close Trading Panel (`paper_trading` widget)
+Use `TV_CDP_PORT` if multiple Desktops exist. See `docs/PAPER_TRADING_DISCOVERY.md`.
 
 ## Context Management Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,14 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `tv_launch` → auto-detect and launch TradingView with CDP on Mac/Win/Linux
 - `tv_health_check` → verify connection is working
 
-### "What's the Paper Trading state?"
-- `paper_get_status` → read-only observability status (desktop connection, Trading Panel button state). Native Paper Trading support is in the discovery phase (docs/PAPER_TRADING_DISCOVERY.md): undiscovered facts come back as unknown/null and `safe_for_paper_mutation` is always false. There is NO order execution.
+### "What's the Paper Trading state?" / "Trade on Paper"
+Native Paper Trading only (stable broker id `"Paper"`). Never other brokers.
+1. `paper_get_status` → session, panel, connect status/label, broker id, `safe_for_paper_mutation`
+2. `paper_connect` → connect broker id `Paper` if disconnected
+3. `paper_get_account` / `paper_list_accounts` / `paper_switch_account` / `paper_list_positions` / `paper_list_orders`
+4. Mutations (fail closed unless active broker is Paper): `paper_place_order` (optional `tif` DAY|WEEK|MONTH|GTD), `paper_cancel_order`, `paper_modify_order`, `paper_close_position`, `paper_set_brackets` (`clear: true` to remove SL/TP)
+5. `paper_open_panel` → open/close Trading Panel (`paper_trading` widget)
+Use `TV_CDP_PORT` if multiple Desktops exist. See `docs/PAPER_TRADING_DISCOVERY.md`.
 
 ## Context Management Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-85 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+97 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
 
 ## Decision Tree — Which Tool When
 

--- a/README.md
+++ b/README.md
@@ -311,13 +311,24 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `ui_open_panel` / `ui_click` / `ui_evaluate` | UI automation |
 | `tv_launch` / `tv_health_check` / `tv_discover` | Connection management |
 
-### Paper Trading (discovery phase)
+### Paper Trading (native only)
 
-Support for TradingView's **native Paper Trading** is being built evidence-first — see [docs/PAPER_TRADING_DISCOVERY.md](docs/PAPER_TRADING_DISCOVERY.md). Only read-only observability exists today; there is no order execution.
+Tools talk only to TradingView's **native Paper Trading** provider (stable broker id `Paper`). Mutations fail closed if any other broker is active. Evidence and paths: [docs/PAPER_TRADING_DISCOVERY.md](docs/PAPER_TRADING_DISCOVERY.md).
 
 | Tool | What it does |
 |------|-------------|
-| `paper_get_status` | Read-only status: desktop connection, Trading Panel button state; undiscovered facts reported as unknown, `safe_for_paper_mutation` always false pending provider identification |
+| `paper_get_status` | Session, panel, connection, broker id, `safe_for_paper_mutation` |
+| `paper_open_panel` | Open/close/toggle Trading Panel (`paper_trading` widget) |
+| `paper_connect` | Connect broker id `Paper` |
+| `paper_get_account` / `paper_list_accounts` / `paper_switch_account` | Account summary and switch active Paper account |
+| `paper_list_positions` / `paper_list_orders` | Open positions and active/history orders |
+| `paper_place_order` | Market/limit/stop/stop_limit; optional TIF (`DAY`/`WEEK`/`MONTH`/`GTD`) and SL/TP |
+| `paper_cancel_order` / `paper_modify_order` | Manage working orders |
+| `paper_close_position` / `paper_set_brackets` | Close positions; set or clear SL/TP |
+
+CLI: `tv paper status|panel|connect|account|accounts|switch-account|positions|orders|place|cancel|modify|close|brackets`.
+
+If the MCP/CLI points at the wrong Desktop instance, set `TV_CDP_PORT` (and optionally `TV_CDP_HOST`) to the process launched with `--remote-debugging-port`.
 
 ## Context Management
 
@@ -361,7 +372,7 @@ npm test
 Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
 ```
 
-- **Transport**: MCP over stdio (85 tools) + CLI (`tv` command, 31 commands with 67 subcommands)
+- **Transport**: MCP over stdio (97 tools) + CLI (`tv` command, 31 commands with 67 subcommands)
 - **Connection**: Chrome DevTools Protocol on localhost:9222
 - **Streaming**: Poll-and-diff loop with deduplication, JSONL output to stdout
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`

--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `ui_open_panel` / `ui_click` / `ui_evaluate` | UI automation |
 | `tv_launch` / `tv_health_check` / `tv_discover` | Connection management |
 
+### Paper Trading (discovery phase)
+
+Support for TradingView's **native Paper Trading** is being built evidence-first — see [docs/PAPER_TRADING_DISCOVERY.md](docs/PAPER_TRADING_DISCOVERY.md). Only read-only observability exists today; there is no order execution.
+
+| Tool | What it does |
+|------|-------------|
+| `paper_get_status` | Read-only status: desktop connection, Trading Panel button state; undiscovered facts reported as unknown, `safe_for_paper_mutation` always false pending provider identification |
+
 ## Context Management
 
 Tools return compact output by default to minimize context usage. For a typical "analyze my chart" workflow, total context is ~5-10KB instead of ~80KB.
@@ -353,7 +361,7 @@ npm test
 Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
 ```
 
-- **Transport**: MCP over stdio (84 tools) + CLI (`tv` command, 30 commands with 66 subcommands)
+- **Transport**: MCP over stdio (85 tools) + CLI (`tv` command, 31 commands with 67 subcommands)
 - **Connection**: Chrome DevTools Protocol on localhost:9222
 - **Streaming**: Poll-and-diff loop with deduplication, JSONL output to stdout
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Tools talk only to TradingView's **native Paper Trading** provider (stable broke
 | `paper_cancel_order` / `paper_modify_order` | Manage working orders |
 | `paper_close_position` / `paper_set_brackets` | Close positions; set or clear SL/TP |
 
-CLI: `tv paper status|account|accounts|switch-account|positions|orders|place|cancel|close|brackets`.
+CLI: `tv paper status|panel|connect|account|accounts|switch-account|positions|orders|place|cancel|modify|close|brackets`.
 
 If the MCP/CLI points at the wrong Desktop instance, set `TV_CDP_PORT` (and optionally `TV_CDP_HOST`) to the process launched with `--remote-debugging-port`.
 
@@ -372,7 +372,7 @@ npm test
 Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
 ```
 
-- **Transport**: MCP over stdio (85 tools) + CLI (`tv` command, 31 commands with 67 subcommands)
+- **Transport**: MCP over stdio (97 tools) + CLI (`tv` command, 31 commands with 67 subcommands)
 - **Connection**: Chrome DevTools Protocol on localhost:9222
 - **Streaming**: Poll-and-diff loop with deduplication, JSONL output to stdout
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`

--- a/README.md
+++ b/README.md
@@ -311,13 +311,24 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `ui_open_panel` / `ui_click` / `ui_evaluate` | UI automation |
 | `tv_launch` / `tv_health_check` / `tv_discover` | Connection management |
 
-### Paper Trading (discovery phase)
+### Paper Trading (native only)
 
-Support for TradingView's **native Paper Trading** is being built evidence-first — see [docs/PAPER_TRADING_DISCOVERY.md](docs/PAPER_TRADING_DISCOVERY.md). Only read-only observability exists today; there is no order execution.
+Tools talk only to TradingView's **native Paper Trading** provider (stable broker id `Paper`). Mutations fail closed if any other broker is active. Evidence and paths: [docs/PAPER_TRADING_DISCOVERY.md](docs/PAPER_TRADING_DISCOVERY.md).
 
 | Tool | What it does |
 |------|-------------|
-| `paper_get_status` | Read-only status: desktop connection, Trading Panel button state; undiscovered facts reported as unknown, `safe_for_paper_mutation` always false pending provider identification |
+| `paper_get_status` | Session, panel, connection, broker id, `safe_for_paper_mutation` |
+| `paper_open_panel` | Open/close/toggle Trading Panel (`paper_trading` widget) |
+| `paper_connect` | Connect broker id `Paper` |
+| `paper_get_account` / `paper_list_accounts` / `paper_switch_account` | Account summary and switch active Paper account |
+| `paper_list_positions` / `paper_list_orders` | Open positions and active/history orders |
+| `paper_place_order` | Market/limit/stop/stop_limit; optional TIF (`DAY`/`WEEK`/`MONTH`/`GTD`) and SL/TP |
+| `paper_cancel_order` / `paper_modify_order` | Manage working orders |
+| `paper_close_position` / `paper_set_brackets` | Close positions; set or clear SL/TP |
+
+CLI: `tv paper status|account|accounts|switch-account|positions|orders|place|cancel|close|brackets`.
+
+If the MCP/CLI points at the wrong Desktop instance, set `TV_CDP_PORT` (and optionally `TV_CDP_HOST`) to the process launched with `--remote-debugging-port`.
 
 ## Context Management
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (97 MCP tools)
 
 ### Chart Reading
 

--- a/docs/PAPER_TRADING_DISCOVERY.md
+++ b/docs/PAPER_TRADING_DISCOVERY.md
@@ -26,8 +26,11 @@ around it.
 - Never paste cookies, tokens, authorization headers or storage contents into
   this document, into issues, or into test fixtures.
 - `scripts/paper_discovery.js` only reports structural knowledge (names,
-  attributes, booleans) and redacts token-like strings before printing. Do not
-  bypass it with ad-hoc probes that dump storage or headers.
+  attributes, booleans). It inspects runtime objects through property
+  descriptors so accessor getters are never executed, collects no free-form
+  element text (only `aria-label` / `data-name` / `role` values), and redacts
+  secret-looking keys, token-like strings and email addresses before printing.
+  Do not bypass it with ad-hoc probes that dump storage or headers.
 - Screenshots attached as evidence must not show account emails or personal
   data. Paper account balances/IDs are acceptable.
 - Record structural knowledge only, e.g. "connection state is readable from
@@ -131,14 +134,18 @@ raw captures are never committed by accident.
 | `namespaces` | Which keys exist on `window.TradingViewApi` / `window.TradingView`, and which window globals have trading-suggestive names |
 | `trading_like_services` | Which objects in those namespaces expose methods with names like order/position/account/broker/margin/leverage/commission |
 | `bottom_widget_bar` | Whether the bottom widget bar knows a trading widget (would allow API-based panel open like `showWidget('backtesting')`) |
-| `trading_panel_dom` | Trading Panel button state and the `data-name`/`role`/button-label inventory of the bottom and right layout areas |
+| `trading_panel_dom` | Trading Panel button state and the `data-name`/`role`/button-`aria-label` inventory of the bottom and right layout areas |
 
 ### Follow-up probes (after the first captures)
 
 Once the service scan reveals candidate paths, target them individually with
-`tv ui evaluate` (read-only expressions, method enumeration first, then
-zero-argument getters). Do not call methods whose names suggest mutation
-(`place*`, `cancel*`, `modify*`, `reset*`) during discovery.
+`tv ui evaluate`. Enumerate first, through property descriptors
+(`Object.getOwnPropertyDescriptor` / `Object.getOwnPropertyNames`), the way
+the probe itself does — property reads and getter access can execute code, so
+do not invoke any method or accessor getter until its name and context have
+been classified as a safe read from prior evidence. Never call methods whose
+names suggest mutation (`place*`, `cancel*`, `modify*`, `reset*`, `create*`,
+`close*`) during discovery.
 
 ## Evidence tables
 

--- a/docs/PAPER_TRADING_DISCOVERY.md
+++ b/docs/PAPER_TRADING_DISCOVERY.md
@@ -1,0 +1,299 @@
+# Paper Trading Discovery
+
+Status: **awaiting runtime evidence** — this document is the procedure and the
+evidence template. No runtime finding below is confirmed until it carries a
+filled-in evidence row captured from a live TradingView Desktop session.
+
+## Purpose and scope
+
+Map how TradingView Desktop represents its **native Paper Trading**
+environment (Trading Panel → Paper Trading provider) so the MCP can later
+expose safe `paper_*` tools. This effort supports **only** TradingView's
+native Paper Trading. It will never support Binance, Interactive Brokers
+(live, demo or paper), any other broker, or any real-money account. Every
+future `paper_*` mutation must positively identify the native Paper Trading
+provider and fail closed otherwise.
+
+## Authentication model
+
+The human authenticates in TradingView Desktop normally. The MCP never
+accepts or automates usernames, passwords, cookies, tokens or API keys. If a
+probe shows that TradingView requires login, record that state — do not work
+around it.
+
+## Security rules for evidence collection
+
+- Never paste cookies, tokens, authorization headers or storage contents into
+  this document, into issues, or into test fixtures.
+- `scripts/paper_discovery.js` only reports structural knowledge (names,
+  attributes, booleans) and redacts token-like strings before printing. Do not
+  bypass it with ad-hoc probes that dump storage or headers.
+- Screenshots attached as evidence must not show account emails or personal
+  data. Paper account balances/IDs are acceptable.
+- Record structural knowledge only, e.g. "connection state is readable from
+  service X", never the secret material itself.
+
+## What the repository already knows (static baseline)
+
+| Touchpoint | Mechanism | Source |
+|------------|-----------|--------|
+| Open/close Trading Panel button | C — semantic DOM: `data-name="trading-button"`, `aria-label="Trading Panel"` | `src/core/ui.js` |
+| Replay-mode simulated trades (NOT Paper Trading) | A — internal API: `window.TradingViewApi._replayApi.buy()/sell()/closePosition()` | `src/core/replay.js` |
+| Internal API discovery pattern | method enumeration via `tv_discover` | `src/core/health.js` |
+
+No broker/paper-trading runtime path is currently known to this repository.
+Everything in the evidence tables below starts as **unknown**.
+
+## Mechanism classification
+
+| Class | Meaning |
+|-------|---------|
+| A | Internal structured API (e.g. a service method returning data) |
+| B | Internal model/store (observable structured state) |
+| C | Semantic DOM (`data-name`, `aria-label`, `role`) |
+| D | UI automation (clicks/typing on discovered elements) |
+| E | Unsupported / unreliable — do not build on it |
+
+Absolute coordinates are for exploration only and are never an acceptable
+production mechanism.
+
+## Environment record
+
+Fill this in for every discovery session. Findings are only comparable when
+the environment is recorded.
+
+| Field | Value |
+|-------|-------|
+| TradingView Desktop version | _fill in (Help → About)_ |
+| Install type (installer / MSIX / dmg / AppImage) | _fill in_ |
+| Operating system + version | _fill in_ |
+| CDP endpoint | _default 127.0.0.1:9222_ |
+| TradingView session state | _authenticated / login required_ |
+| Paper Trading account state | _fresh / has history / reset recently_ |
+| Trading Panel state during capture | _closed / open-disconnected / open-connected_ |
+| Probe report file | _e.g. paper-discovery-connected.json_ |
+
+## Discovery procedure
+
+Run this on a machine with TradingView Desktop. Total hands-on time is a few
+minutes per capture.
+
+1. Launch TradingView Desktop with CDP enabled — use the matching script in
+   `scripts/` (`launch_tv_debug.bat`, `launch_tv_debug_mac.sh`,
+   `launch_tv_debug_linux.sh`) or add `--remote-debugging-port=9222` yourself.
+2. Log in normally (human at the keyboard). Open any chart.
+3. Verify the bridge works: `npm run tv -- status` (or `tv status` if linked).
+4. Capture the baseline state (Trading Panel closed):
+
+   ```bash
+   node scripts/paper_discovery.js > paper-discovery-panel-closed.json
+   ```
+
+5. Open the Trading Panel (bottom of the chart), but do not connect a broker
+   yet. Capture again:
+
+   ```bash
+   node scripts/paper_discovery.js > paper-discovery-disconnected.json
+   ```
+
+6. Select **Paper Trading** in the panel and connect. Capture again:
+
+   ```bash
+   node scripts/paper_discovery.js > paper-discovery-connected.json
+   ```
+
+7. Optional but valuable: place one small Paper order manually (e.g. 1 share
+   market order with an attached stop loss and take profit), then capture
+   `paper-discovery-with-position.json`. This makes position/order/exit
+   structures visible to the service scan.
+8. While the panel is open, note down manually (plain observation, no tools):
+   - the tabs shown in the panel (e.g. Positions, Orders, Account Summary...);
+   - the columns of each tab;
+   - the fields of the order ticket (side, quantity, order type, TP/SL
+     controls, and how TP/SL amounts are expressed — price, ticks, currency,
+     percentage);
+   - the account selector contents and the exact provider name displayed;
+   - anything the UI calls funds/margin/leverage/commission in
+     account settings (exact wording).
+9. Attach the JSON reports and notes to the tracking issue/PR. The reports
+   are already sanitized, but skim them before sharing anyway.
+
+The probe report files match `paper-discovery-*.json` and are gitignored so
+raw captures are never committed by accident.
+
+### What the probe collects
+
+`scripts/paper_discovery.js` connects through the same CDP bridge as the MCP
+(`src/connection.js`) and captures four read-only sections:
+
+| Section | Question it answers |
+|---------|---------------------|
+| `namespaces` | Which keys exist on `window.TradingViewApi` / `window.TradingView`, and which window globals have trading-suggestive names |
+| `trading_like_services` | Which objects in those namespaces expose methods with names like order/position/account/broker/margin/leverage/commission |
+| `bottom_widget_bar` | Whether the bottom widget bar knows a trading widget (would allow API-based panel open like `showWidget('backtesting')`) |
+| `trading_panel_dom` | Trading Panel button state and the `data-name`/`role`/button-label inventory of the bottom and right layout areas |
+
+### Follow-up probes (after the first captures)
+
+Once the service scan reveals candidate paths, target them individually with
+`tv ui evaluate` (read-only expressions, method enumeration first, then
+zero-argument getters). Do not call methods whose names suggest mutation
+(`place*`, `cancel*`, `modify*`, `reset*`) during discovery.
+
+## Evidence tables
+
+Every row starts as `unknown`. Only fill a row from a captured report or a
+directly observed session, and cite the capture file.
+
+### A. Trading session
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Detect authenticated session | unknown | — | — | — | must not read secrets |
+| Detect login-required state | unknown | — | — | — | maps to `TRADINGVIEW_AUTH_REQUIRED` |
+| Detect expired session | unknown | — | — | — | |
+
+### B. Trading Panel
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Panel availability | unknown | — | — | — | |
+| Panel open/closed state | partially | static | `data-name="trading-button"` + layout area size (`src/core/ui.js`) | untested for content | button click only; no content verification today |
+| Active provider name | unknown | — | — | — | |
+| Provider list | unknown | — | — | — | |
+| Connection state | unknown | — | — | — | |
+| Account selector | unknown | — | — | — | |
+
+### C. Native Paper Trading connection
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Positive identification of native Paper Trading (stable id, not display string) | unknown | — | — | — | REQUIRED before any mutation tool ships |
+| disconnected state | unknown | — | — | — | |
+| connecting state | unknown | — | — | — | |
+| connected state | unknown | — | — | — | |
+| reconnecting state | unknown | — | — | — | |
+| failed state | unknown | — | — | — | |
+| authentication-required state | unknown | — | — | — | |
+
+### D. Paper accounts
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| List accounts | unknown | — | — | — | |
+| Active account id | unknown | — | — | — | |
+| Display name | unknown | — | — | — | |
+| Currency | unknown | — | — | — | |
+| Balance | unknown | — | — | — | |
+| Equity | unknown | — | — | — | |
+| Realized P&L | unknown | — | — | — | |
+| Unrealized P&L | unknown | — | — | — | |
+| Available funds | unknown | — | — | — | record TradingView's exact term |
+| Used funds / margin used | unknown | — | — | — | |
+| Borrowed funds | unknown | — | — | — | |
+| Buying power | unknown | — | — | — | |
+| Leverage | unknown | — | — | — | |
+
+Terminology note: a previously mentioned concept resembling "collective
+funds" is NOT an API name. Record the exact TradingView wording observed in
+the account summary and map it to one of the rows above (or add a row with
+the literal term) before any public API field is named after it.
+
+### E. Account configuration
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Create Paper account | unknown | — | — | — | mutation — later increment |
+| Switch account | unknown | — | — | — | |
+| Currency setting | unknown | — | — | — | |
+| Initial/reset balance setting | unknown | — | — | — | |
+| Account reset | unknown | — | — | — | destructive — READ-ONLY documentation only; no mutation tool in early PRs |
+| Leverage settings (global / per asset class) | unknown | — | — | — | |
+| Commission settings | unknown | — | — | — | |
+
+### F. Positions
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Stable position identity | unknown | — | — | — | |
+| Symbol / side / quantity | unknown | — | — | — | |
+| Average fill price | unknown | — | — | — | |
+| Current price / unrealized P&L | unknown | — | — | — | |
+| Realized P&L | unknown | — | — | — | |
+| Margin per position | unknown | — | — | — | |
+| Attached protective orders | unknown | — | — | — | |
+| Partial positions / multiple positions per symbol | unknown | — | — | — | |
+
+### G. Orders
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Market orders | unknown | — | — | — | |
+| Limit orders | unknown | — | — | — | |
+| Stop orders | unknown | — | — | — | |
+| Stop-limit orders | unknown | — | — | — | |
+| Order states (pending/working/filled/partial/cancelled/rejected) | unknown | — | — | — | record exact state strings |
+
+### H. Stop Loss / Take Profit (first-class requirement)
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| SL attached at order creation | unknown | — | — | — | |
+| TP attached at order creation | unknown | — | — | — | |
+| Add/change exits on an open position | unknown | — | — | — | |
+| OCO / bracket semantics | unknown | — | — | — | |
+| Price-based SL/TP | unknown | — | — | — | |
+| Monetary / percentage-based SL/TP | unknown | — | — | — | |
+| Multiple TP levels | unknown | — | — | — | |
+| Multiple SL levels | unknown | — | — | — | |
+| Per-exit quantity | unknown | — | — | — | |
+
+### I. Trailing stop
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Trailing stop supported by native Paper Trading | unknown | — | — | — | verify in Paper specifically, not the generic UI |
+| Distance representation (price/percent/ticks) | unknown | — | — | — | |
+| Modification behavior | unknown | — | — | — | |
+
+### J. Margin / funds / leverage
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| Margin required (pre-trade) | unknown | — | — | — | |
+| Margin used | unknown | — | — | — | |
+| Insufficient-funds behavior | unknown | — | — | — | record the rejection surface |
+| Per-asset-class leverage | unknown | — | — | — | |
+
+### K. Commissions
+
+| Capability | Available | Source | API/DOM path | Reliability | Notes |
+|------------|-----------|--------|--------------|-------------|-------|
+| No commission mode | unknown | — | — | — | |
+| Fixed commission | unknown | — | — | — | |
+| Percentage commission | unknown | — | — | — | |
+| Per-contract commission | unknown | — | — | — | |
+| Commission currency | unknown | — | — | — | |
+
+## Known risks and unknowns
+
+- Internal runtime paths (`window.TradingViewApi.*`) are undocumented and can
+  change between Desktop versions; every confirmed row must state the version
+  it was captured on.
+- The Trading Panel may be implemented as a bottom widget, a right-rail
+  widget, or an iframe depending on version — the DOM probe reports both
+  layout areas to disambiguate.
+- Paper Trading state may be partly server-backed; if reads require
+  authenticated REST calls (as alerts do), that is a design decision to record
+  here, not to improvise.
+- Provider display names are localized; positive identification must rely on
+  a stable internal identifier, never on the display string containing
+  "Paper".
+
+## What happens next
+
+Once evidence is captured, the tables above get filled in, each capability is
+classified A–E, and only then are the `paper_*` MCP tool names and schemas
+frozen for implementation (read-only observability first; mutations in later
+increments, each guarded by positive native-Paper identification that fails
+closed).

--- a/docs/PAPER_TRADING_DISCOVERY.md
+++ b/docs/PAPER_TRADING_DISCOVERY.md
@@ -1,9 +1,9 @@
 # Paper Trading Discovery
 
-Status: **partial runtime evidence captured** — the unauthenticated state has
-been probed on a live TradingView Desktop 3.3.0 (Linux) session; see
-"Runtime evidence" below. Authenticated / Paper-connected states still
-require captures from a logged-in session.
+Status: **authenticated evidence captured** — Capture 1 (Guest/Linux) plus
+Capture 2 (authenticated Paper-connected on Windows Desktop 3.3.0). Native
+broker id is `"Paper"`. Implemented in `src/core/paper.js` with fail-closed
+mutations.
 
 ## Purpose and scope
 
@@ -45,8 +45,10 @@ around it.
 | Replay-mode simulated trades (NOT Paper Trading) | A — internal API: `window.TradingViewApi._replayApi.buy()/sell()/closePosition()` | `src/core/replay.js` |
 | Internal API discovery pattern | method enumeration via `tv_discover` | `src/core/health.js` |
 
-No broker/paper-trading runtime path is currently known to this repository.
-Everything in the evidence tables below starts as **unknown**.
+Runtime path (Capture 2): `bottomWidgetBar._widgetControllers.get('paper_trading')._trading`
+→ `activeBroker()` → `_brokerMetainfo.id === "Paper"`. Mutations go through
+`activeBroker().placeOrder / cancelOrder / modifyOrder / closePosition /
+editPositionBrackets`. Connect via `trading.selectBroker("Paper")`.
 
 ## Mechanism classification
 
@@ -89,6 +91,33 @@ the environment is recorded.
 | Paper Trading account state | n/a (not logged in) |
 | Trading Panel state during capture | widget registered but disabled; `trading-button` absent from DOM |
 | Probe report file | paper-discovery-unauthenticated.json + targeted follow-up probes |
+
+### Capture 2 — 2026-08-07 (authenticated, Paper connected)
+
+| Field | Value |
+|-------|-------|
+| TradingView Desktop version | 3.3.0 (Electron 38.2.2, Chrome 140) |
+| Install type | Windows MSIX (`TradingView.Desktop`) launched with `--remote-debugging-port=9223` |
+| Operating system + version | Windows 10/11 |
+| CDP endpoint | 127.0.0.1:9223 |
+| TradingView session state | **authenticated** (`window.user` has id; username present) |
+| Paper Trading account state | has open short position; account type `demo` |
+| Trading Panel state during capture | open, `activeWidgetName === 'paper_trading'`, `connectStatus === 1` |
+| Probe report file | local `paper-discovery-*.json` captures (gitignored; not committed) |
+
+#### Capture 2 — key confirmed facts
+
+- Native Paper broker stable id: **`Paper`** (`activeBroker()._brokerMetainfo.id`).
+- `connectStatus` values confirmed live: `1` Connected (Capture 2), `3` Disconnected (Capture 1).
+- Account id via `trading._account` (string) and `activeBroker().currentAccount()`; type `demo` via `currentAccountType()`.
+- Account summary via `accountManagerInfo().summary[i].wValue.value()` aligned with `accountsMetainfo[].summaryRow` ids: `balance`, `equity`, `realizedPL`, `unrealizedPL`, `accountMargin`, `availableFunds`, `ordersMargin`, `marginBuffer`.
+- Positions: `_positionService.positions()` / `activeBroker().positions()` — fields include `id` (symbol), `side` (±1), `qty`, `avgPrice`, `lastPrice`, `pl`, `extra.{pl,plPercent,usedMargin,leverage,accountCurrency}`, bracket flags.
+- Orders: `_ordersService.activeOrders()`; history via `activeBroker().ordersHistory()`.
+- Order type enum (Broker API): Limit=1, Market=2, Stop=3, StopLimit=4; side Buy=1, Sell=-1; status Filled=2 etc.
+- Durations / TIF (Capture 2 `metainfo.durations`): `DAY`, `WEEK` (UI default), `MONTH`, `GTD` (requires `datetime`). Exposed on `paper_place_order` as `tif` + `duration_datetime`.
+- Mutation surface on active broker: `placeOrder`, `modifyOrder`, `cancelOrder`, `closePosition`, `editPositionBrackets`, `selectBroker("Paper")`, `setCurrentAccount`.
+- `supportTrailingStop` was **false** on the observed Paper position (Capture 2) — no trailing-stop tool.
+- Account reset / createAccount exist on the broker object but are **not** exposed as MCP tools (destructive).
 
 ## Runtime evidence — confirmed findings (Capture 1)
 
@@ -279,7 +308,7 @@ directly observed session, and cite the capture file.
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Detect authenticated session | likely (inverse of anonymous marker) | Capture 1 | `window.user` (id + non-Guest username) | untested while logged in | must not read secrets; confirm on authenticated capture |
+| Detect authenticated session | **yes** | Capture 2 | B — `window.user` has id + non-Guest username | 1 capture (3.3.0/Win) | must not read secrets |
 | Detect login-required state | **yes** | Capture 1 | B — `window.user.username === 'Guest'` / missing id; corroborated by `isFeatureEnabled('trading_terminal') === false` and absent `trading-button` | 1 capture (3.3.0/Linux) | maps to `TRADINGVIEW_AUTH_REQUIRED` |
 | Detect expired session | unknown | — | — | — | |
 
@@ -289,20 +318,20 @@ directly observed session, and cite the capture file.
 |------------|-----------|--------|--------------|-------------|-------|
 | Panel availability | **yes** | Capture 1 | A — `bottomWidgetBar.isWidgetEnabled('paper_trading')` | 1 capture | `false` while anonymous |
 | Panel open/closed state | **yes** | Capture 1 | A — `bottomWidgetBar.isVisible()` / `activeWidgetName()` (WatchedValues); DOM `trading-button` is fallback (C) | 1 capture | widget name is `paper_trading` |
-| Panel open/close action | yes (untested) | Capture 1 | A — `bottomWidgetBar.showWidget('paper_trading')` / `toggleWidget` / `hide` | untested | same API family the repo already uses for `backtesting` |
-| Active provider name | yes (untested) | Capture 1 | A — `trading.activeBroker()` WatchedValue | `null` confirmed while disconnected | data shape pending connected capture |
-| Provider list | yes (untested) | Capture 1 | A — `trading.brokersRegistry.getBrokers()` / `getBrokersMetaInfos()` | untested (calls may fetch) | |
-| Connection state | **yes** | Capture 1 | A — `trading.connectStatus()` WatchedValue, numeric enum | `3` confirmed while disconnected | see section C |
-| Account selector | unknown | — | — | — | requires connected capture |
+| Panel open/close action | **yes** | Capture 2 | A — `bottomWidgetBar.showWidget('paper_trading')` / close/hide | implemented in `paper_open_panel` | same API family as `backtesting` |
+| Active provider name | **yes** | Capture 2 | A — `activeBroker()._brokerMetainfo.id/title` | 1 capture | id is `"Paper"`, title `"Paper Trading"` |
+| Provider list | **yes** | Capture 2 | A — `brokersRegistry.getBrokersMetaInfos()` (async) | 1 capture | first entry id `"Paper"` |
+| Connection state | **yes** | Capture 1+2 | A — `trading.connectStatus()` WatchedValue | `1` connected, `3` disconnected | see section C |
+| Account selector | **yes** | Capture 2 | A — `accountsMetainfo()` / `currentAccount()` / `setCurrentAccount` | 1 capture | |
 
 ### C. Native Paper Trading connection
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Positive identification of native Paper Trading (stable id, not display string) | expected path found, id value unknown | Capture 1 | A — `trading.brokersRegistry.getBrokerMetaInfoById(id)` + `activeBroker()` | untested | REQUIRED before any mutation tool ships; capture the actual Paper broker id while connected |
+| Positive identification of native Paper Trading (stable id, not display string) | **yes** | Capture 2 | A — `activeBroker()._brokerMetainfo.id === "Paper"` | 1 capture (3.3.0/Win) | allowlist constant `NATIVE_PAPER_BROKER_ID` in `src/core/paper.js` |
 | disconnected state | **yes** | Capture 1 | A — `connectStatus() === 3` | 1 capture | matches public Broker API enum (Disconnected=3) |
 | connecting state | expected `2` | public Broker API docs | A — `connectStatus()` | unconfirmed live | |
-| connected state | expected `1` | public Broker API docs | A — `connectStatus()` | unconfirmed live | |
+| connected state | **yes** | Capture 2 | A — `connectStatus() === 1` | 1 capture | |
 | reconnecting state | unknown | — | — | — | possibly Connecting(2) again; confirm |
 | failed state | expected `4` (Error) | public Broker API docs | A — `connectStatus()` | unconfirmed live | |
 | authentication-required state | **yes** (session-level) | Capture 1 | B — anonymous marker (section A) gates everything | 1 capture | broker-level login dialog state: `trading.loginDialogVisibility` (untested) |
@@ -311,19 +340,19 @@ directly observed session, and cite the capture file.
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| List accounts | unknown | — | — | — | |
-| Active account id | unknown | — | — | — | |
-| Display name | unknown | — | — | — | |
-| Currency | unknown | — | — | — | |
-| Balance | unknown | — | — | — | |
-| Equity | unknown | — | — | — | |
-| Realized P&L | unknown | — | — | — | |
-| Unrealized P&L | unknown | — | — | — | |
-| Available funds | unknown | — | — | — | record TradingView's exact term |
-| Used funds / margin used | unknown | — | — | — | |
+| List accounts | **yes** | Capture 2 | A — `activeBroker().accountsMetainfo()` | 1 capture | |
+| Active account id | **yes** | Capture 2 | A — `trading._account` string + `currentAccount()` | 1 capture | |
+| Display name | **yes** | Capture 2 | A — `accountsMetainfo[].name` | 1 capture | |
+| Currency | **yes** | Capture 2 | A — position `extra.accountCurrency` | 1 capture | e.g. `USD` |
+| Balance | **yes** | Capture 2 | A — `accountManagerInfo().summary` wValue | 1 capture | UI: "Saldo da conta" |
+| Equity | **yes** | Capture 2 | A — summary wValue | 1 capture | UI: "Valor da conta" |
+| Realized P&L | **yes** | Capture 2 | A — summary id `realizedPL` | 1 capture | |
+| Unrealized P&L | **yes** | Capture 2 | A — summary id `unrealizedPL` | 1 capture | |
+| Available funds | **yes** | Capture 2 | A — summary id `availableFunds` | 1 capture | UI: "Fundos disponíveis" |
+| Used funds / margin used | **yes** | Capture 2 | A — summary id `accountMargin` | 1 capture | UI: "Margem da conta" |
 | Borrowed funds | unknown | — | — | — | |
-| Buying power | unknown | — | — | — | |
-| Leverage | unknown | — | — | — | |
+| Buying power | unknown | — | — | — | not a separate summary row in Capture 2 |
+| Leverage | **yes** (per position) | Capture 2 | A — position `extra.leverage` | 1 capture | e.g. `"10:1"` |
 
 Terminology note: a previously mentioned concept resembling "collective
 funds" is NOT an API name. Record the exact TradingView wording observed in
@@ -346,24 +375,24 @@ the literal term) before any public API field is named after it.
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Stable position identity | service found, shape unknown | Capture 1 | A — `trading._positionService.positions()` / `find` / `realIdFromBroker` | untested | data shape pending connected capture with a position |
-| Symbol / side / quantity | unknown (service exists) | Capture 1 | A — PositionsService | — | |
-| Average fill price | unknown | — | — | — | |
-| Current price / unrealized P&L | likely | Capture 1 | A — `_updatePositionPL` exists in PositionsService | untested | |
-| Realized P&L | unknown | — | — | — | |
-| Margin per position | unknown | — | — | — | |
-| Attached protective orders | likely | Capture 1 | A — `supportBrackets` on PositionsService; `getExitLevelOrderId` on OrdersService | untested | |
-| Partial positions / multiple positions per symbol | display mode exists | Capture 1 | A — `isDisplayModeIndividualPositions` (`_displayMode=1`) | untested | semantics pending |
+| Stable position identity | **yes** | Capture 2 | A — position `id` (symbol string for net positions) | 1 capture | e.g. `BINANCE:BTCUSDT` |
+| Symbol / side / quantity | **yes** | Capture 2 | A — `symbol`, `side` (±1), `qty` | 1 capture | |
+| Average fill price | **yes** | Capture 2 | A — `avgPrice` | 1 capture | |
+| Current price / unrealized P&L | **yes** | Capture 2 | A — `lastPrice`, `pl` / `extra.pl` | 1 capture | |
+| Realized P&L | account-level | Capture 2 | A — summary `realizedPL` | 1 capture | |
+| Margin per position | **yes** | Capture 2 | A — `extra.usedMargin` | 1 capture | |
+| Attached protective orders | **yes** (flags) | Capture 2 | A — `supportBrackets` / `supportStopLoss` on position | 1 capture | `editPositionBrackets` for mutation |
+| Partial positions / multiple positions per symbol | display mode exists | Capture 1 | A — `isDisplayModeIndividualPositions` | untested | `closeIndividualPosition` also present |
 
 ### G. Orders
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Market orders | supported-check exists | Capture 1 | A — `trading._isMarketOrderSupported` | untested | |
-| Limit orders | unknown (service exists) | Capture 1 | A — `trading._ordersService.orders()` / `activeOrders()` | — | |
-| Stop orders | unknown | — | — | — | |
-| Stop-limit orders | unknown | — | — | — | |
-| Order states (pending/working/filled/partial/cancelled/rejected) | unknown | — | — | — | record exact state values; `orderRejected` delegate exists on OrdersService |
+| Market orders | **yes** | Capture 2 | A — `placeOrder` + configFlags.supportMarketOrders; type=2 | 1 capture | |
+| Limit orders | **yes** | Capture 2 | A — type=1; configFlags.supportLimitOrders | 1 capture | filled history sample type=1 |
+| Stop orders | **yes** (flag) | Capture 2 | A — configFlags.supportStopOrders; type=3 | 1 capture | |
+| Stop-limit orders | **yes** (flag) | Capture 2 | A — configFlags.supportStopLimitOrders; type=4 | 1 capture | |
+| Order states (pending/working/filled/partial/cancelled/rejected) | **yes** | Capture 2 | A — status enum 1..6 | 1 capture | canceled=1 filled=2 inactive=3 placing=4 rejected=5 working=6 |
 
 ### H. Stop Loss / Take Profit (first-class requirement)
 
@@ -383,7 +412,7 @@ the literal term) before any public API field is named after it.
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Trailing stop supported by native Paper Trading | unknown | — | — | — | verify in Paper specifically, not the generic UI |
+| Trailing stop supported by native Paper Trading | **no** (observed) | Capture 2 | A — position `supportTrailingStop === false` | 1 capture | configFlags.supportModifyTrailingStop present but position flag false |
 | Distance representation (price/percent/ticks) | unknown | — | — | — | |
 | Modification behavior | unknown | — | — | — | |
 
@@ -423,26 +452,13 @@ the literal term) before any public API field is named after it.
 
 ## What happens next
 
-The unauthenticated baseline is captured. The next capture requires a human
-to log in to TradingView Desktop and connect Paper Trading, then re-run the
-probe plus these targeted reads (all through the paths evidenced above):
+Capture 2 landed the stable id `"Paper"` and the account/position/order
+shapes. Tools are implemented in `src/core/paper.js` with
+`assertPaperContext()` fail-closed on `NATIVE_PAPER_BROKER_ID`.
 
-1. `bottomWidgetBar.isWidgetEnabled('paper_trading')` and
-   `enabledWidgets().value()` while logged in (expect `true` /
-   `['paper_trading', ...]`).
-2. `trading.activeBroker().value()` while connected — capture the **stable
-   Paper broker id** and the metainfo from
-   `brokersRegistry.getBrokerMetaInfoById(id)`. This id is the cornerstone
-   of the mutation guard.
-3. `trading.connectStatus().value()` in each observable state (confirm
-   1/2/4).
-4. `trading._account` / `_onCurrentAccountUpdate` surface → account shape
-   (balance/equity/currency terminology as TradingView names it).
-5. With one small manual Paper position open:
-   `_positionService.positions()` and `_ordersService.orders()` shapes,
-   `supportBrackets()` value, one `getExitLevelOrderId` example.
+Remaining follow-ups (optional / later increments):
 
-Only after that evidence lands are the remaining `paper_*` tool names and
-schemas frozen (read-only observability first; mutations in later
-increments, each guarded by positive native-Paper identification that fails
-closed).
+1. Confirm `connectStatus` values `2` (Connecting) and `4` (Error) live.
+2. Exercise `editPositionBrackets` with multi-level exit quantities.
+3. Document account reset / createAccount carefully before any destructive tool.
+4. Re-verify broker id `"Paper"` on macOS / Linux Desktop builds.

--- a/docs/PAPER_TRADING_DISCOVERY.md
+++ b/docs/PAPER_TRADING_DISCOVERY.md
@@ -1,8 +1,9 @@
 # Paper Trading Discovery
 
-Status: **awaiting runtime evidence** — this document is the procedure and the
-evidence template. No runtime finding below is confirmed until it carries a
-filled-in evidence row captured from a live TradingView Desktop session.
+Status: **partial runtime evidence captured** — the unauthenticated state has
+been probed on a live TradingView Desktop 3.3.0 (Linux) session; see
+"Runtime evidence" below. Authenticated / Paper-connected states still
+require captures from a logged-in session.
 
 ## Purpose and scope
 
@@ -75,6 +76,128 @@ the environment is recorded.
 | Paper Trading account state | _fresh / has history / reset recently_ |
 | Trading Panel state during capture | _closed / open-disconnected / open-connected_ |
 | Probe report file | _e.g. paper-discovery-connected.json_ |
+
+### Capture 1 — 2026-08-07 (unauthenticated baseline)
+
+| Field | Value |
+|-------|-------|
+| TradingView Desktop version | 3.3.0 (Electron 38.2.2, Chrome 140) |
+| Install type | snap package, extracted with unsquashfs and run directly |
+| Operating system + version | Ubuntu Linux (headless VM, Xvfb display :1) |
+| CDP endpoint | 127.0.0.1:9222 |
+| TradingView session state | **unauthenticated** (`window.user.username === 'Guest'`, no user id) |
+| Paper Trading account state | n/a (not logged in) |
+| Trading Panel state during capture | widget registered but disabled; `trading-button` absent from DOM |
+| Probe report file | paper-discovery-unauthenticated.json + targeted follow-up probes |
+
+## Runtime evidence — confirmed findings (Capture 1)
+
+All findings below were read through property descriptors (no getter or
+mutation-suggesting method was invoked; the only methods called were
+zero-argument queries classified as safe reads: `isWidgetEnabled`,
+`enabledWidgets`, `isAvailable`, `isVisible`, `connectStatus`,
+`activeBroker`). Single version/OS tested — reliability is "one capture"
+until reproduced elsewhere.
+
+### The Trading Panel is a bottom-bar widget named `paper_trading`
+
+`window.TradingView.bottomWidgetBar._widgetControllers` is a `Map` with keys
+`paper_trading`, `backtesting`, `replay_trading`, `scripteditor`. The bottom
+widget bar exposes `showWidget(name)`, `isWidgetEnabled(name)`,
+`getWidgetByName(name)`, `activateWidget(name)`, `enabledWidgets()` (returns
+a WatchedValue), `isVisible()`, `activeWidgetName()`. This means panel
+open/close/state is mechanism **A** (internal structured API), not DOM
+clicks — the existing `ui_open_panel('trading')` DOM approach is the
+fallback, not the primary path.
+
+When unauthenticated: `isWidgetEnabled('paper_trading') === false`,
+`enabledWidgets().value() === []`, and the `trading-button` element does not
+exist in the DOM.
+
+### The trading service (`controller._trading`)
+
+`bottomWidgetBar._widgetControllers.get('paper_trading')._trading` is the
+application-wide trading service. Structural surface (names captured, none
+invoked except where noted):
+
+- Provider management: `brokersList`, `brokersMetainfo`, `brokersPlans`,
+  `activeBroker()` (WatchedValue → `null` when disconnected — confirmed),
+  `selectBroker`, `pickDefaultBroker`, `reconnectCurrentBroker`,
+  `_tryReconnectLastBroker`, `brokersRegistry`, `brokerSelectManager`.
+- Connection: `connectStatus()` (WatchedValue → numeric enum; value `3`
+  confirmed while disconnected), `onConnectionStatusChange`,
+  `onBrokerChange`, `onBrokerLoading`, `onNeedSelectBroker`.
+  The numeric values are consistent with TradingView's public Broker API
+  documentation (`1 = Connected`, `2 = Connecting`, `3 = Disconnected`,
+  `4 = Error`) — values 1/2/4 still need live confirmation.
+- Account: `accountType`, `_account` (`null` when disconnected — confirmed),
+  `verifyBrokerLiveAccount` (live-account distinction exists in the model),
+  `_onCurrentAccountUpdate`.
+- Orders: `_ordersService`, `orderViewController`, `_checkAndPlaceOrder`,
+  `_checkAndOpenOrderDialog`, `toggleOrderDialog`, `_isMarketOrderSupported`,
+  `getQtySuggester`.
+- Panel/UI: `toggleTradingPanelVisibility`, `toggleTradingWidget`,
+  `tradingPanel`, `getAccountManagerVisibilityMode`,
+  `setAccountManagerVisibilityMode`, `setDOMPanelVisibility`,
+  `setOrderPanelVisibility`.
+- Auth: `_subscribeNativeLogin`, `loginDialogVisibility`,
+  `_brokerLoginManager`, `brokerLoginEventsBus`, `_logOut`.
+- Paper-specific: `_getPaperCompetitions`,
+  `_getActivePaperCompetitionsSinceTimestamp`.
+
+### Broker registry
+
+`trading.brokersRegistry` exposes `getBrokers`, `getBrokersMetaInfos`,
+`getBrokerMetaInfoById`, `getBrokerPlanByIntegrationId`, `isBrokerFavorite`.
+**`getBrokerMetaInfoById` is the expected path for positive identification
+of the native Paper Trading provider by a stable internal id** — the actual
+id value must be captured from an authenticated session before any mutation
+guard is coded.
+
+### Positions service
+
+`trading._positionService` (`_serviceName=PositionsService`): `positions()`,
+`find`, `positionUpdate`, `positionsRemoved`, `getCurrency`,
+`supportBrackets`, `supportReverse`, `isDisplayModeIndividualPositions`,
+`realIdFromBroker`. Data shape pending an authenticated session with an open
+position.
+
+### Orders service
+
+`trading._ordersService` (`_serviceName=OrdersService`): `orders()`,
+`activeOrders()`, `find`, `activeOrdersUpdated`, `activeOrdersRemoved`,
+`orderRejected`, `getCurrency`, and **`getExitLevelOrderId`** — exit levels
+(brackets) are modeled with their own order ids, which supports the
+multi-level SL/TP requirement. Exact states and shapes pending.
+
+### Session detection (unauthenticated state)
+
+- `window.user` exists with `username === 'Guest'` and no meaningful id →
+  reliable anonymous marker (structural check, no secrets).
+- `window.TradingView.changeLoginState` / `signOut` functions exist.
+- `window.TradingView.isFeatureEnabled('trading_terminal') === false` while
+  anonymous.
+- The Trading Panel button (`data-name="trading-button"`) is **absent** from
+  the DOM when unauthenticated — DOM-based availability checks must not
+  confuse "logged out" with "panel closed".
+
+### Trading backend globals
+
+- `window.TRADING_REST_SERVER_URL === 'https://rest-demo.tradingview.com/tradingview/v1'`
+  (public endpoint URL, not a secret) — the Paper backend is served from a
+  `rest-demo` host, consistent with TradingView's REST broker integration
+  model.
+- `window.TRADING_SERVER_LOGGER_URL === 'https://trdlg.tradingview.com'`.
+- `window.TradingViewApi._getTradingFeatureFlagsService` resolves a service
+  from an internal registry (`serviceOrNull(TRADING_FEATURE_FLAGS_SERVICE)`).
+
+### Linux note (how this capture was made)
+
+TradingView for Linux ships as a snap. For discovery in an environment
+without snapd: download via the snapcraft API, `unsquashfs` the package, and
+run `<extracted>/tradingview --remote-debugging-port=9222 --no-sandbox`
+under an X display. Login is a human step; this capture deliberately stayed
+anonymous.
 
 ## Discovery procedure
 
@@ -156,32 +279,33 @@ directly observed session, and cite the capture file.
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Detect authenticated session | unknown | — | — | — | must not read secrets |
-| Detect login-required state | unknown | — | — | — | maps to `TRADINGVIEW_AUTH_REQUIRED` |
+| Detect authenticated session | likely (inverse of anonymous marker) | Capture 1 | `window.user` (id + non-Guest username) | untested while logged in | must not read secrets; confirm on authenticated capture |
+| Detect login-required state | **yes** | Capture 1 | B — `window.user.username === 'Guest'` / missing id; corroborated by `isFeatureEnabled('trading_terminal') === false` and absent `trading-button` | 1 capture (3.3.0/Linux) | maps to `TRADINGVIEW_AUTH_REQUIRED` |
 | Detect expired session | unknown | — | — | — | |
 
 ### B. Trading Panel
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Panel availability | unknown | — | — | — | |
-| Panel open/closed state | partially | static | `data-name="trading-button"` + layout area size (`src/core/ui.js`) | untested for content | button click only; no content verification today |
-| Active provider name | unknown | — | — | — | |
-| Provider list | unknown | — | — | — | |
-| Connection state | unknown | — | — | — | |
-| Account selector | unknown | — | — | — | |
+| Panel availability | **yes** | Capture 1 | A — `bottomWidgetBar.isWidgetEnabled('paper_trading')` | 1 capture | `false` while anonymous |
+| Panel open/closed state | **yes** | Capture 1 | A — `bottomWidgetBar.isVisible()` / `activeWidgetName()` (WatchedValues); DOM `trading-button` is fallback (C) | 1 capture | widget name is `paper_trading` |
+| Panel open/close action | yes (untested) | Capture 1 | A — `bottomWidgetBar.showWidget('paper_trading')` / `toggleWidget` / `hide` | untested | same API family the repo already uses for `backtesting` |
+| Active provider name | yes (untested) | Capture 1 | A — `trading.activeBroker()` WatchedValue | `null` confirmed while disconnected | data shape pending connected capture |
+| Provider list | yes (untested) | Capture 1 | A — `trading.brokersRegistry.getBrokers()` / `getBrokersMetaInfos()` | untested (calls may fetch) | |
+| Connection state | **yes** | Capture 1 | A — `trading.connectStatus()` WatchedValue, numeric enum | `3` confirmed while disconnected | see section C |
+| Account selector | unknown | — | — | — | requires connected capture |
 
 ### C. Native Paper Trading connection
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Positive identification of native Paper Trading (stable id, not display string) | unknown | — | — | — | REQUIRED before any mutation tool ships |
-| disconnected state | unknown | — | — | — | |
-| connecting state | unknown | — | — | — | |
-| connected state | unknown | — | — | — | |
-| reconnecting state | unknown | — | — | — | |
-| failed state | unknown | — | — | — | |
-| authentication-required state | unknown | — | — | — | |
+| Positive identification of native Paper Trading (stable id, not display string) | expected path found, id value unknown | Capture 1 | A — `trading.brokersRegistry.getBrokerMetaInfoById(id)` + `activeBroker()` | untested | REQUIRED before any mutation tool ships; capture the actual Paper broker id while connected |
+| disconnected state | **yes** | Capture 1 | A — `connectStatus() === 3` | 1 capture | matches public Broker API enum (Disconnected=3) |
+| connecting state | expected `2` | public Broker API docs | A — `connectStatus()` | unconfirmed live | |
+| connected state | expected `1` | public Broker API docs | A — `connectStatus()` | unconfirmed live | |
+| reconnecting state | unknown | — | — | — | possibly Connecting(2) again; confirm |
+| failed state | expected `4` (Error) | public Broker API docs | A — `connectStatus()` | unconfirmed live | |
+| authentication-required state | **yes** (session-level) | Capture 1 | B — anonymous marker (section A) gates everything | 1 capture | broker-level login dialog state: `trading.loginDialogVisibility` (untested) |
 
 ### D. Paper accounts
 
@@ -222,36 +346,36 @@ the literal term) before any public API field is named after it.
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Stable position identity | unknown | — | — | — | |
-| Symbol / side / quantity | unknown | — | — | — | |
+| Stable position identity | service found, shape unknown | Capture 1 | A — `trading._positionService.positions()` / `find` / `realIdFromBroker` | untested | data shape pending connected capture with a position |
+| Symbol / side / quantity | unknown (service exists) | Capture 1 | A — PositionsService | — | |
 | Average fill price | unknown | — | — | — | |
-| Current price / unrealized P&L | unknown | — | — | — | |
+| Current price / unrealized P&L | likely | Capture 1 | A — `_updatePositionPL` exists in PositionsService | untested | |
 | Realized P&L | unknown | — | — | — | |
 | Margin per position | unknown | — | — | — | |
-| Attached protective orders | unknown | — | — | — | |
-| Partial positions / multiple positions per symbol | unknown | — | — | — | |
+| Attached protective orders | likely | Capture 1 | A — `supportBrackets` on PositionsService; `getExitLevelOrderId` on OrdersService | untested | |
+| Partial positions / multiple positions per symbol | display mode exists | Capture 1 | A — `isDisplayModeIndividualPositions` (`_displayMode=1`) | untested | semantics pending |
 
 ### G. Orders
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| Market orders | unknown | — | — | — | |
-| Limit orders | unknown | — | — | — | |
+| Market orders | supported-check exists | Capture 1 | A — `trading._isMarketOrderSupported` | untested | |
+| Limit orders | unknown (service exists) | Capture 1 | A — `trading._ordersService.orders()` / `activeOrders()` | — | |
 | Stop orders | unknown | — | — | — | |
 | Stop-limit orders | unknown | — | — | — | |
-| Order states (pending/working/filled/partial/cancelled/rejected) | unknown | — | — | — | record exact state strings |
+| Order states (pending/working/filled/partial/cancelled/rejected) | unknown | — | — | — | record exact state values; `orderRejected` delegate exists on OrdersService |
 
 ### H. Stop Loss / Take Profit (first-class requirement)
 
 | Capability | Available | Source | API/DOM path | Reliability | Notes |
 |------------|-----------|--------|--------------|-------------|-------|
-| SL attached at order creation | unknown | — | — | — | |
-| TP attached at order creation | unknown | — | — | — | |
+| SL attached at order creation | bracket model exists | Capture 1 | A — `supportBrackets` (PositionsService) | untested | |
+| TP attached at order creation | bracket model exists | Capture 1 | A — `supportBrackets` (PositionsService) | untested | |
 | Add/change exits on an open position | unknown | — | — | — | |
 | OCO / bracket semantics | unknown | — | — | — | |
 | Price-based SL/TP | unknown | — | — | — | |
 | Monetary / percentage-based SL/TP | unknown | — | — | — | |
-| Multiple TP levels | unknown | — | — | — | |
+| Multiple TP levels | exit levels have own order ids | Capture 1 | A — `getExitLevelOrderId` (OrdersService) | untested | strong hint that multi-level exits are modeled |
 | Multiple SL levels | unknown | — | — | — | |
 | Per-exit quantity | unknown | — | — | — | |
 
@@ -299,8 +423,26 @@ the literal term) before any public API field is named after it.
 
 ## What happens next
 
-Once evidence is captured, the tables above get filled in, each capability is
-classified A–E, and only then are the `paper_*` MCP tool names and schemas
-frozen for implementation (read-only observability first; mutations in later
+The unauthenticated baseline is captured. The next capture requires a human
+to log in to TradingView Desktop and connect Paper Trading, then re-run the
+probe plus these targeted reads (all through the paths evidenced above):
+
+1. `bottomWidgetBar.isWidgetEnabled('paper_trading')` and
+   `enabledWidgets().value()` while logged in (expect `true` /
+   `['paper_trading', ...]`).
+2. `trading.activeBroker().value()` while connected — capture the **stable
+   Paper broker id** and the metainfo from
+   `brokersRegistry.getBrokerMetaInfoById(id)`. This id is the cornerstone
+   of the mutation guard.
+3. `trading.connectStatus().value()` in each observable state (confirm
+   1/2/4).
+4. `trading._account` / `_onCurrentAccountUpdate` surface → account shape
+   (balance/equity/currency terminology as TradingView names it).
+5. With one small manual Paper position open:
+   `_positionService.positions()` and `_ordersService.orders()` shapes,
+   `supportBrackets()` value, one `getExitLevelOrderId` example.
+
+Only after that evidence lands are the remaining `paper_*` tool names and
+schemas frozen (read-only observability first; mutations in later
 increments, each guarded by positive native-Paper identification that fails
 closed).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "chrome-remote-interface": "^0.33.2"
+        "chrome-remote-interface": "^0.33.2",
+        "zod": "^4.4.3"
       },
       "bin": {
         "tv": "src/cli/index.js"
@@ -2169,9 +2170,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/paper_discovery.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/paper_discovery.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/paper_discovery.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/paper_discovery.test.js tests/paper.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/paper_discovery.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/paper_discovery.test.js tests/paper.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "chrome-remote-interface": "^0.33.2"
+    "chrome-remote-interface": "^0.33.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "eslint": "^9.39.4"

--- a/scripts/paper_discovery.js
+++ b/scripts/paper_discovery.js
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+// Read-only discovery probe for TradingView's native Paper Trading runtime.
+//
+// Run with TradingView Desktop open (CDP on port 9222), ideally with the
+// Trading Panel visible and Paper Trading connected:
+//
+//   node scripts/paper_discovery.js > paper-discovery-results.json
+//
+// The probe reports ONLY structural knowledge: property names, method names,
+// data-name / aria-label attributes, element presence and booleans. It never
+// reads cookies, web storage, or request headers, and it redacts anything in
+// the output that looks like secret material before printing.
+//
+// See docs/PAPER_TRADING_DISCOVERY.md for the full manual procedure and the
+// evidence tables this report feeds into.
+import { pathToFileURL } from 'url';
+import { evaluate, disconnect, getTargetInfo, CDP_HOST, CDP_PORT } from '../src/connection.js';
+
+// --- Injected probes (each is a self-contained read-only IIFE) ---
+
+// Which globals exist, and which window keys hint at a trading domain.
+const NAMESPACE_PROBE = `
+(function () {
+  function describeKeys(obj) {
+    var out = [];
+    if (!obj) return out;
+    var keys = Object.getOwnPropertyNames(obj);
+    for (var i = 0; i < keys.length; i++) {
+      var type;
+      try { type = typeof obj[keys[i]]; } catch (e) { type = 'unreadable'; }
+      out.push({ name: keys[i], type: type });
+    }
+    return out;
+  }
+  var tradingLike = /trad|brok|order|account|paper|execut/i;
+  var windowMatches = [];
+  var winKeys = Object.getOwnPropertyNames(window);
+  for (var i = 0; i < winKeys.length; i++) {
+    if (!tradingLike.test(winKeys[i])) continue;
+    var type;
+    try { type = typeof window[winKeys[i]]; } catch (e) { type = 'unreadable'; }
+    windowMatches.push({ name: winKeys[i], type: type });
+  }
+  return {
+    tradingViewApiKeys: describeKeys(window.TradingViewApi),
+    tradingViewKeys: describeKeys(window.TradingView),
+    windowKeysMatchingTradingTerms: windowMatches,
+  };
+})()
+`;
+
+// Which members of the known namespaces expose trading-like methods.
+const SERVICE_SCAN_PROBE = `
+(function () {
+  var tradingMethod = /order|position|account|broker|execut|trade|margin|leverage|commission|balance|equity|bracket|stop|profit/i;
+  var tradingKey = /trad|brok|order|account|paper|execut/i;
+  function methodNames(obj) {
+    var names = [];
+    for (var k in obj) {
+      try { if (typeof obj[k] === 'function') names.push(k); } catch (e) { /* unreadable member */ }
+    }
+    return names;
+  }
+  function describeService(path, value) {
+    var methods = methodNames(value);
+    var matches = methods.filter(function (m) { return tradingMethod.test(m); });
+    if (matches.length === 0) return null;
+    return {
+      path: path,
+      methodCount: methods.length,
+      tradingLikeMethods: matches.slice(0, 40),
+      allMethods: methods.slice(0, 80),
+    };
+  }
+  function scanNamespace(nsName, ns, findings) {
+    if (!ns) return;
+    var keys = Object.getOwnPropertyNames(ns);
+    for (var i = 0; i < keys.length; i++) {
+      var value;
+      try { value = ns[keys[i]]; } catch (e) { continue; }
+      if (!value || (typeof value !== 'object' && typeof value !== 'function')) continue;
+      var found = describeService(nsName + '.' + keys[i], value);
+      if (found) findings.push(found);
+      // One level deeper, but only under trading-suggestive names, to keep the scan bounded.
+      if (typeof value === 'object' && tradingKey.test(keys[i])) {
+        var subKeys = Object.getOwnPropertyNames(value);
+        for (var j = 0; j < subKeys.length; j++) {
+          var sub;
+          try { sub = value[subKeys[j]]; } catch (e) { continue; }
+          if (!sub || typeof sub !== 'object') continue;
+          var subFound = describeService(nsName + '.' + keys[i] + '.' + subKeys[j], sub);
+          if (subFound) findings.push(subFound);
+        }
+      }
+    }
+  }
+  var findings = [];
+  scanNamespace('window.TradingViewApi', window.TradingViewApi, findings);
+  scanNamespace('window.TradingView', window.TradingView, findings);
+  return { services: findings.slice(0, 40) };
+})()
+`;
+
+// Does the bottom widget bar know about a trading widget?
+const BOTTOM_WIDGET_BAR_PROBE = `
+(function () {
+  var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+  if (!bwb) return { available: false };
+  var methods = [];
+  var objectMembers = [];
+  for (var k in bwb) {
+    var value;
+    try { value = bwb[k]; } catch (e) { continue; }
+    if (typeof value === 'function') {
+      methods.push(k);
+    } else if (value && typeof value === 'object') {
+      objectMembers.push({ name: k, keys: Object.getOwnPropertyNames(value).slice(0, 30) });
+    }
+  }
+  return { available: true, methods: methods, objectMembers: objectMembers.slice(0, 10) };
+})()
+`;
+
+// What the Trading Panel button and panel areas currently expose in the DOM.
+const TRADING_PANEL_DOM_PROBE = `
+(function () {
+  function attrInventory(root, attr, cap) {
+    var seen = {};
+    var out = [];
+    if (!root) return out;
+    var nodes = root.querySelectorAll('[' + attr + ']');
+    for (var i = 0; i < nodes.length && out.length < cap; i++) {
+      var value = nodes[i].getAttribute(attr);
+      if (value && !seen[value]) { seen[value] = true; out.push(value); }
+    }
+    return out;
+  }
+  function visibleButtonLabels(root, cap) {
+    var out = [];
+    if (!root) return out;
+    var btns = root.querySelectorAll('button');
+    for (var i = 0; i < btns.length && out.length < cap; i++) {
+      if (btns[i].offsetParent === null) continue;
+      var label = (btns[i].getAttribute('aria-label') || btns[i].textContent || '').trim();
+      if (label && label.length <= 60) out.push(label);
+    }
+    return out;
+  }
+  var tradingButton = document.querySelector('[data-name="trading-button"]')
+    || document.querySelector('[aria-label="Trading Panel"]');
+  var bottomArea = document.querySelector('[class*="layout__area--bottom"]');
+  var rightArea = document.querySelector('[class*="layout__area--right"]');
+  var bottomText = bottomArea ? bottomArea.textContent : '';
+  return {
+    tradingButton: tradingButton ? {
+      found: true,
+      dataName: tradingButton.getAttribute('data-name'),
+      ariaLabel: tradingButton.getAttribute('aria-label'),
+      ariaPressed: tradingButton.getAttribute('aria-pressed'),
+    } : { found: false },
+    bottomArea: {
+      present: !!bottomArea,
+      height: bottomArea ? bottomArea.offsetHeight : 0,
+      dataNames: attrInventory(bottomArea, 'data-name', 100),
+      roles: attrInventory(bottomArea, 'role', 30),
+      buttonLabels: visibleButtonLabels(bottomArea, 60),
+      mentionsPaperTrading: /paper trading/i.test(bottomText),
+    },
+    rightArea: {
+      present: !!rightArea,
+      width: rightArea ? rightArea.offsetWidth : 0,
+      dataNames: attrInventory(rightArea, 'data-name', 60),
+    },
+  };
+})()
+`;
+
+// --- Output sanitization (keeps the report safe to share and to commit) ---
+
+const SECRET_KEY_PATTERN = /token|cookie|secret|password|auth|session/i;
+const TOKEN_LIKE_VALUE = /^[A-Za-z0-9+/=_-]{40,}$/;
+const MAX_STRING_LENGTH = 200;
+
+export function sanitizeForReport(value) {
+  if (typeof value === 'string') return sanitizeString(value);
+  if (Array.isArray(value)) return value.map(sanitizeForReport);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [key, member] of Object.entries(value)) {
+      out[key] = SECRET_KEY_PATTERN.test(key) ? '[REDACTED]' : sanitizeForReport(member);
+    }
+    return out;
+  }
+  return value;
+}
+
+function sanitizeString(str) {
+  if (TOKEN_LIKE_VALUE.test(str)) return '[REDACTED-TOKEN-LIKE]';
+  if (str.length > MAX_STRING_LENGTH) return str.slice(0, MAX_STRING_LENGTH) + '…';
+  return str;
+}
+
+// --- Probe execution ---
+
+async function runProbe(expression) {
+  try {
+    return await evaluate(expression);
+  } catch (err) {
+    return { error: err.message };
+  }
+}
+
+async function collectMeta() {
+  const target = await getTargetInfo();
+  const url = target?.url ? new URL(target.url) : null;
+  return {
+    generated_at: new Date().toISOString(),
+    cdp_endpoint: `${CDP_HOST}:${CDP_PORT}`,
+    target_url: url ? `${url.origin}${url.pathname}` : null,
+    user_agent: await runProbe('navigator.userAgent'),
+  };
+}
+
+async function main() {
+  const report = {
+    meta: await collectMeta(),
+    namespaces: await runProbe(NAMESPACE_PROBE),
+    trading_like_services: await runProbe(SERVICE_SCAN_PROBE),
+    bottom_widget_bar: await runProbe(BOTTOM_WIDGET_BAR_PROBE),
+    trading_panel_dom: await runProbe(TRADING_PANEL_DOM_PROBE),
+  };
+  process.stdout.write(JSON.stringify(sanitizeForReport(report), null, 2) + '\n');
+  await disconnect();
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  main().catch(async (err) => {
+    console.error(`paper_discovery failed: ${err.message}`);
+    await disconnect();
+    process.exit(1);
+  });
+}

--- a/scripts/paper_discovery.js
+++ b/scripts/paper_discovery.js
@@ -7,9 +7,11 @@
 //   node scripts/paper_discovery.js > paper-discovery-results.json
 //
 // The probe reports ONLY structural knowledge: property names, method names,
-// data-name / aria-label attributes, element presence and booleans. It never
-// reads cookies, web storage, or request headers, and it redacts anything in
-// the output that looks like secret material before printing.
+// data-name / aria-label attributes, element presence and booleans. Runtime
+// objects are inspected through property descriptors, so accessor getters are
+// never invoked. It never reads cookies, web storage, or request headers, and
+// the printed report redacts secret-looking keys, token-like strings and
+// email addresses.
 //
 // See docs/PAPER_TRADING_DISCOVERY.md for the full manual procedure and the
 // evidence tables this report feeds into.
@@ -18,17 +20,66 @@ import { evaluate, disconnect, getTargetInfo, CDP_HOST, CDP_PORT } from '../src/
 
 // --- Injected probes (each is a self-contained read-only IIFE) ---
 
+// Shared by the runtime probes below (interpolated into each IIFE).
+// Inspection goes through Object.getOwnPropertyDescriptor so that accessor
+// getters are never executed, and walks the prototype chain so that
+// non-enumerable class methods are not missed.
+// Exported for unit tests.
+export const MEMBER_INSPECTION_HELPERS = `
+  function safeDescriptor(obj, name) {
+    try { return Object.getOwnPropertyDescriptor(obj, name); } catch (e) { return null; }
+  }
+  function ownDataValue(obj, name) {
+    var desc = safeDescriptor(obj, name);
+    return desc && 'value' in desc ? desc.value : undefined;
+  }
+  function chainDataValue(obj, name) {
+    var current = obj;
+    for (var depth = 0; current && depth < 5; depth++) {
+      var desc = safeDescriptor(current, name);
+      if (desc) return 'value' in desc ? desc.value : undefined;
+      current = Object.getPrototypeOf(current);
+    }
+    return undefined;
+  }
+  function describeMembers(obj) {
+    var seen = {};
+    var members = { methods: [], accessors: [], objects: [] };
+    var current = obj;
+    for (var depth = 0; current && current !== Object.prototype && depth < 5; depth++) {
+      var keys = Object.getOwnPropertyNames(current);
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (key === 'constructor' || seen[key]) continue;
+        seen[key] = true;
+        var desc = safeDescriptor(current, key);
+        if (!desc) continue;
+        if (desc.get || desc.set) members.accessors.push(key);
+        else if (typeof desc.value === 'function') members.methods.push(key);
+        else if (desc.value && typeof desc.value === 'object') members.objects.push(key);
+      }
+      current = Object.getPrototypeOf(current);
+    }
+    return members;
+  }
+`;
+
 // Which globals exist, and which window keys hint at a trading domain.
 const NAMESPACE_PROBE = `
 (function () {
+  ${MEMBER_INSPECTION_HELPERS}
+  function describeProperty(obj, name) {
+    var desc = safeDescriptor(obj, name);
+    if (!desc) return 'unreadable';
+    if (desc.get || desc.set) return 'accessor';
+    return typeof desc.value;
+  }
   function describeKeys(obj) {
     var out = [];
     if (!obj) return out;
     var keys = Object.getOwnPropertyNames(obj);
     for (var i = 0; i < keys.length; i++) {
-      var type;
-      try { type = typeof obj[keys[i]]; } catch (e) { type = 'unreadable'; }
-      out.push({ name: keys[i], type: type });
+      out.push({ name: keys[i], type: describeProperty(obj, keys[i]) });
     }
     return out;
   }
@@ -37,9 +88,7 @@ const NAMESPACE_PROBE = `
   var winKeys = Object.getOwnPropertyNames(window);
   for (var i = 0; i < winKeys.length; i++) {
     if (!tradingLike.test(winKeys[i])) continue;
-    var type;
-    try { type = typeof window[winKeys[i]]; } catch (e) { type = 'unreadable'; }
-    windowMatches.push({ name: winKeys[i], type: type });
+    windowMatches.push({ name: winKeys[i], type: describeProperty(window, winKeys[i]) });
   }
   return {
     tradingViewApiKeys: describeKeys(window.TradingViewApi),
@@ -52,32 +101,30 @@ const NAMESPACE_PROBE = `
 // Which members of the known namespaces expose trading-like methods.
 const SERVICE_SCAN_PROBE = `
 (function () {
+  ${MEMBER_INSPECTION_HELPERS}
   var tradingMethod = /order|position|account|broker|execut|trade|margin|leverage|commission|balance|equity|bracket|stop|profit/i;
   var tradingKey = /trad|brok|order|account|paper|execut/i;
-  function methodNames(obj) {
-    var names = [];
-    for (var k in obj) {
-      try { if (typeof obj[k] === 'function') names.push(k); } catch (e) { /* unreadable member */ }
-    }
-    return names;
+  function tradingLike(names) {
+    return names.filter(function (n) { return tradingMethod.test(n); });
   }
   function describeService(path, value) {
-    var methods = methodNames(value);
-    var matches = methods.filter(function (m) { return tradingMethod.test(m); });
-    if (matches.length === 0) return null;
+    var members = describeMembers(value);
+    var methodMatches = tradingLike(members.methods);
+    var accessorMatches = tradingLike(members.accessors);
+    if (methodMatches.length === 0 && accessorMatches.length === 0) return null;
     return {
       path: path,
-      methodCount: methods.length,
-      tradingLikeMethods: matches.slice(0, 40),
-      allMethods: methods.slice(0, 80),
+      methodCount: members.methods.length,
+      tradingLikeMethods: methodMatches.slice(0, 40),
+      tradingLikeAccessors: accessorMatches.slice(0, 20),
+      allMethods: members.methods.slice(0, 80),
     };
   }
   function scanNamespace(nsName, ns, findings) {
     if (!ns) return;
     var keys = Object.getOwnPropertyNames(ns);
     for (var i = 0; i < keys.length; i++) {
-      var value;
-      try { value = ns[keys[i]]; } catch (e) { continue; }
+      var value = ownDataValue(ns, keys[i]);
       if (!value || (typeof value !== 'object' && typeof value !== 'function')) continue;
       var found = describeService(nsName + '.' + keys[i], value);
       if (found) findings.push(found);
@@ -85,8 +132,7 @@ const SERVICE_SCAN_PROBE = `
       if (typeof value === 'object' && tradingKey.test(keys[i])) {
         var subKeys = Object.getOwnPropertyNames(value);
         for (var j = 0; j < subKeys.length; j++) {
-          var sub;
-          try { sub = value[subKeys[j]]; } catch (e) { continue; }
+          var sub = ownDataValue(value, subKeys[j]);
           if (!sub || typeof sub !== 'object') continue;
           var subFound = describeService(nsName + '.' + keys[i] + '.' + subKeys[j], sub);
           if (subFound) findings.push(subFound);
@@ -104,24 +150,29 @@ const SERVICE_SCAN_PROBE = `
 // Does the bottom widget bar know about a trading widget?
 const BOTTOM_WIDGET_BAR_PROBE = `
 (function () {
+  ${MEMBER_INSPECTION_HELPERS}
   var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
   if (!bwb) return { available: false };
-  var methods = [];
+  var members = describeMembers(bwb);
   var objectMembers = [];
-  for (var k in bwb) {
-    var value;
-    try { value = bwb[k]; } catch (e) { continue; }
-    if (typeof value === 'function') {
-      methods.push(k);
-    } else if (value && typeof value === 'object') {
-      objectMembers.push({ name: k, keys: Object.getOwnPropertyNames(value).slice(0, 30) });
-    }
+  var objectNames = members.objects.slice(0, 10);
+  for (var i = 0; i < objectNames.length; i++) {
+    var value = chainDataValue(bwb, objectNames[i]);
+    if (value) objectMembers.push({ name: objectNames[i], keys: Object.getOwnPropertyNames(value).slice(0, 30) });
   }
-  return { available: true, methods: methods, objectMembers: objectMembers.slice(0, 10) };
+  return {
+    available: true,
+    methods: members.methods,
+    accessors: members.accessors.slice(0, 20),
+    objectMembers: objectMembers,
+  };
 })()
 `;
 
 // What the Trading Panel button and panel areas currently expose in the DOM.
+// Free-form element text is never collected: only aria-label / data-name /
+// role attribute values, which are semantic identifiers rather than user data
+// (any email that still slips into a label is redacted by the sanitizer).
 const TRADING_PANEL_DOM_PROBE = `
 (function () {
   function attrInventory(root, attr, cap) {
@@ -135,13 +186,13 @@ const TRADING_PANEL_DOM_PROBE = `
     }
     return out;
   }
-  function visibleButtonLabels(root, cap) {
+  function visibleButtonAriaLabels(root, cap) {
     var out = [];
     if (!root) return out;
-    var btns = root.querySelectorAll('button');
+    var btns = root.querySelectorAll('button[aria-label]');
     for (var i = 0; i < btns.length && out.length < cap; i++) {
       if (btns[i].offsetParent === null) continue;
-      var label = (btns[i].getAttribute('aria-label') || btns[i].textContent || '').trim();
+      var label = btns[i].getAttribute('aria-label').trim();
       if (label && label.length <= 60) out.push(label);
     }
     return out;
@@ -163,7 +214,7 @@ const TRADING_PANEL_DOM_PROBE = `
       height: bottomArea ? bottomArea.offsetHeight : 0,
       dataNames: attrInventory(bottomArea, 'data-name', 100),
       roles: attrInventory(bottomArea, 'role', 30),
-      buttonLabels: visibleButtonLabels(bottomArea, 60),
+      buttonAriaLabels: visibleButtonAriaLabels(bottomArea, 60),
       mentionsPaperTrading: /paper trading/i.test(bottomText),
     },
     rightArea: {
@@ -179,6 +230,7 @@ const TRADING_PANEL_DOM_PROBE = `
 
 const SECRET_KEY_PATTERN = /token|cookie|secret|password|auth|session/i;
 const TOKEN_LIKE_VALUE = /^[A-Za-z0-9+/=_-]{40,}$/;
+const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 const MAX_STRING_LENGTH = 200;
 
 export function sanitizeForReport(value) {
@@ -196,8 +248,9 @@ export function sanitizeForReport(value) {
 
 function sanitizeString(str) {
   if (TOKEN_LIKE_VALUE.test(str)) return '[REDACTED-TOKEN-LIKE]';
-  if (str.length > MAX_STRING_LENGTH) return str.slice(0, MAX_STRING_LENGTH) + '…';
-  return str;
+  const redacted = str.replace(EMAIL_PATTERN, '[REDACTED-EMAIL]');
+  if (redacted.length > MAX_STRING_LENGTH) return redacted.slice(0, MAX_STRING_LENGTH) + '…';
+  return redacted;
 }
 
 // --- Probe execution ---

--- a/src/cli/commands/paper.js
+++ b/src/cli/commands/paper.js
@@ -2,11 +2,127 @@ import { register } from '../router.js';
 import * as core from '../../core/paper.js';
 
 register('paper', {
-  description: 'TradingView native Paper Trading (read-only observability)',
+  description: 'TradingView native Paper Trading (observability + guarded mutations)',
   subcommands: new Map([
     ['status', {
-      description: 'Show Paper Trading observability status (desktop, Trading Panel, discovery state)',
+      description: 'Show Paper Trading status (session, panel, broker, mutation safety)',
       handler: () => core.getStatus(),
+    }],
+    ['panel', {
+      description: 'Open/close/toggle the Trading Panel (paper_trading widget)',
+      handler: (opts, positionals) => core.openPanel({ action: positionals[0] || 'open' }),
+    }],
+    ['connect', {
+      description: 'Connect native Paper Trading broker (id Paper)',
+      handler: () => core.connect(),
+    }],
+    ['account', {
+      description: 'Show active Paper account summary',
+      handler: () => core.getAccount(),
+    }],
+    ['accounts', {
+      description: 'List Paper accounts',
+      handler: () => core.listAccounts(),
+    }],
+    ['switch-account', {
+      description: 'Switch active Paper account by id',
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Usage: tv paper switch-account <account_id>');
+        return core.switchAccount({ account_id: positionals[0] });
+      },
+    }],
+    ['positions', {
+      description: 'List open Paper positions',
+      handler: () => core.listPositions(),
+    }],
+    ['orders', {
+      description: 'List active Paper orders (use --history for history)',
+      options: {
+        history: { type: 'boolean', description: 'Return order history instead of active orders' },
+      },
+      handler: (opts) => core.listOrders({ history: !!opts.history }),
+    }],
+    ['place', {
+      description: 'Place a Paper order. Usage: tv paper place buy market --qty 1 [--tif WEEK|DAY|MONTH|GTD] [--duration-datetime ISO|ms]',
+      options: {
+        qty: { type: 'string', short: 'q', description: 'Quantity' },
+        symbol: { type: 'string', short: 's', description: 'Symbol (default: chart)' },
+        price: { type: 'string', description: 'Limit price' },
+        'stop-price': { type: 'string', description: 'Stop price' },
+        'take-profit': { type: 'string', description: 'Take profit' },
+        'stop-loss': { type: 'string', description: 'Stop loss' },
+        tif: { type: 'string', description: 'Time in force: DAY, WEEK, MONTH, GTD' },
+        'duration-datetime': { type: 'string', description: 'GTD expiry (ISO or unix ms)' },
+      },
+      handler: (opts, positionals) => {
+        const side = positionals[0];
+        const type = positionals[1] || 'market';
+        if (!side) throw new Error('Usage: tv paper place <buy|sell> [market|limit|stop|stop_limit] --qty N');
+        if (opts.qty == null) throw new Error('--qty required');
+        return core.placeOrder({
+          side,
+          type,
+          qty: Number(opts.qty),
+          symbol: opts.symbol,
+          price: opts.price != null ? Number(opts.price) : undefined,
+          stop_price: opts['stop-price'] != null ? Number(opts['stop-price']) : undefined,
+          take_profit: opts['take-profit'] != null ? Number(opts['take-profit']) : undefined,
+          stop_loss: opts['stop-loss'] != null ? Number(opts['stop-loss']) : undefined,
+          tif: opts.tif,
+          duration_datetime: opts['duration-datetime'],
+        });
+      },
+    }],
+    ['cancel', {
+      description: 'Cancel a Paper order by id',
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Usage: tv paper cancel <order_id>');
+        return core.cancelOrder({ order_id: positionals[0] });
+      },
+    }],
+    ['modify', {
+      description: 'Modify a Paper order',
+      options: {
+        qty: { type: 'string', description: 'New quantity' },
+        price: { type: 'string', description: 'New limit price' },
+        'stop-price': { type: 'string', description: 'New stop price' },
+      },
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Usage: tv paper modify <order_id> [--qty N] [--price N]');
+        return core.modifyOrder({
+          order_id: positionals[0],
+          qty: opts.qty != null ? Number(opts.qty) : undefined,
+          price: opts.price != null ? Number(opts.price) : undefined,
+          stop_price: opts['stop-price'] != null ? Number(opts['stop-price']) : undefined,
+        });
+      },
+    }],
+    ['close', {
+      description: 'Close a Paper position (full or partial)',
+      options: {
+        qty: { type: 'string', description: 'Partial quantity' },
+      },
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Usage: tv paper close <position_id|symbol> [--qty N]');
+        return core.closePosition({ position_id: positionals[0], qty: opts.qty != null ? Number(opts.qty) : undefined });
+      },
+    }],
+    ['brackets', {
+      description: 'Set or clear SL/TP on a Paper position',
+      options: {
+        'stop-loss': { type: 'string', description: 'Stop loss price' },
+        'take-profit': { type: 'string', description: 'Take profit price' },
+        clear: { type: 'boolean', description: 'Clear both SL and TP' },
+      },
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Usage: tv paper brackets <position_id|symbol> --stop-loss N --take-profit N | --clear');
+        return core.setBrackets({
+          position_id: positionals[0],
+          stop_loss: opts['stop-loss'] != null ? Number(opts['stop-loss']) : undefined,
+          take_profit: opts['take-profit'] != null ? Number(opts['take-profit']) : undefined,
+          clear: !!opts.clear,
+        });
+      },
     }],
   ]),
 });

--- a/src/cli/commands/paper.js
+++ b/src/cli/commands/paper.js
@@ -1,0 +1,12 @@
+import { register } from '../router.js';
+import * as core from '../../core/paper.js';
+
+register('paper', {
+  description: 'TradingView native Paper Trading (read-only observability)',
+  subcommands: new Map([
+    ['status', {
+      description: 'Show Paper Trading observability status (desktop, Trading Panel, discovery state)',
+      handler: () => core.getStatus(),
+    }],
+  ]),
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,6 +25,7 @@ import './commands/ui.js';
 import './commands/pane.js';
 import './commands/tab.js';
 import './commands/stream.js';
+import './commands/paper.js';
 
 // Run
 import { run } from './router.js';

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -14,3 +14,4 @@ export * as batch from './batch.js';
 export * as watchlist from './watchlist.js';
 export * as indicators from './indicators.js';
 export * as ui from './ui.js';
+export * as paper from './paper.js';

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -1,69 +1,664 @@
 /**
- * TradingView native Paper Trading — read-only observability.
+ * TradingView native Paper Trading.
  *
- * This module reports only facts verifiable through surfaces already
- * evidenced in this repository: CDP liveness and the Trading Panel button's
- * semantic DOM state. Every Paper Trading fact that still requires runtime
- * discovery (see docs/PAPER_TRADING_DISCOVERY.md) is reported as
- * null/'unknown' instead of being guessed, and safe_for_paper_mutation stays
- * false until the native Paper Trading provider can be positively
- * identified. No function in this module mutates anything.
+ * Supports only the native Paper broker (stable id "Paper"). All mutations
+ * fail closed unless the active broker metainfo id is exactly that value.
+ * Evidence: docs/PAPER_TRADING_DISCOVERY.md (Capture 2, Desktop 3.3.0).
+ *
+ * CDP injection strings live in paper_cdp.js (adapter). This module owns
+ * Paper-only policy: status, guard, and tool orchestration.
  */
-import { evaluate as _evaluate } from '../connection.js';
-import { RIGHT_RAIL_PANEL_SELECTORS } from './ui.js';
+import { evaluate as _evaluate, evaluateAsync as _evaluateAsync, safeString, requireFinite } from '../connection.js';
+import { PAGE_HELPERS, SUMMARY_IDS, tradingPanelButtonProbe } from './paper_cdp.js';
+
+/** Stable internal id of TradingView's native Paper Trading provider. */
+export const NATIVE_PAPER_BROKER_ID = 'Paper';
+
+export const CONNECT_STATUS = {
+  CONNECTED: 1,
+  CONNECTING: 2,
+  DISCONNECTED: 3,
+  ERROR: 4,
+};
+
+export const ORDER_TYPE = {
+  limit: 1,
+  market: 2,
+  stop: 3,
+  stop_limit: 4,
+};
+
+export const SIDE = {
+  buy: 1,
+  sell: -1,
+};
+
+/** Paper broker duration values from Capture 2 metainfo.durations. */
+export const ORDER_TIF = {
+  DAY: 'DAY',
+  WEEK: 'WEEK',
+  MONTH: 'MONTH',
+  GTD: 'GTD',
+};
+
+export const CONNECT_STATUS_LABEL = {
+  [CONNECT_STATUS.CONNECTED]: 'connected',
+  [CONNECT_STATUS.CONNECTING]: 'connecting',
+  [CONNECT_STATUS.DISCONNECTED]: 'disconnected',
+  [CONNECT_STATUS.ERROR]: 'error',
+};
 
 function _resolve(deps) {
-  return { evaluate: deps?.evaluate || _evaluate };
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    evaluateAsync: deps?.evaluateAsync || _evaluateAsync,
+  };
 }
 
-// Same button lookup and active-state heuristic as openPanel() in core/ui.js,
-// but purely observational: nothing is clicked.
-function tradingPanelButtonProbe() {
-  const { dataNames, ariaLabels } = RIGHT_RAIL_PANEL_SELECTORS.trading;
-  return `
+/**
+ * Snapshot of session/broker/panel state used by status and mutation guard.
+ * Never mutates.
+ */
+export async function readContext({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  return evaluate(`
     (function() {
-      var dataNames = ${JSON.stringify(dataNames)};
-      var ariaLabels = ${JSON.stringify(ariaLabels)};
-      var btn = null;
-      for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
-      for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
-      if (!btn) return { button_found: false };
-      var classes = btn.classList.toString();
-      var isActive = btn.getAttribute('aria-pressed') === 'true'
-        || btn.classList.contains('isActive')
-        || classes.indexOf('active') !== -1
-        || classes.indexOf('Active') !== -1;
-      return { button_found: true, button_active: isActive };
+      ${PAGE_HELPERS}
+      var u = window.user || {};
+      var username = typeof u.username === 'string' ? u.username : null;
+      var hasId = !!u.id;
+      var isGuest = !hasId || !username || username === 'Guest';
+      var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+      var panelEnabled = false;
+      var panelVisible = false;
+      var activeWidget = null;
+      if (bwb) {
+        try { panelEnabled = !!bwb.isWidgetEnabled('paper_trading'); } catch (e) {}
+        try { panelVisible = !!tvWv(bwb.isVisible()); } catch (e) {}
+        try { activeWidget = tvWv(bwb.activeWidgetName()) || null; } catch (e) {}
+      }
+      var t = tvTrading();
+      var connectStatus = null;
+      var brokerId = null;
+      var brokerTitle = null;
+      var accountId = null;
+      if (t) {
+        try { connectStatus = tvWv(t.connectStatus && t.connectStatus()); } catch (e) {}
+        var ab = tvBroker(t);
+        brokerId = tvBrokerId(ab);
+        try { brokerTitle = ab && ab._brokerMetainfo && ab._brokerMetainfo.title || null; } catch (e) {}
+        try {
+          var rawAcc = t._account;
+          if (typeof rawAcc === 'string' || typeof rawAcc === 'number') accountId = String(rawAcc);
+        } catch (e) {}
+      }
+      var isPaper = brokerId === ${safeString(NATIVE_PAPER_BROKER_ID)};
+      var connected = connectStatus === ${CONNECT_STATUS.CONNECTED};
+      return {
+        desktop: true,
+        session: isGuest ? 'anonymous' : 'authenticated',
+        username: isGuest ? null : username,
+        panel_enabled: panelEnabled,
+        panel_visible: panelVisible,
+        active_widget: activeWidget,
+        connect_status: connectStatus == null ? null : Number(connectStatus),
+        broker_id: brokerId,
+        broker_title: brokerTitle,
+        account_id: accountId,
+        is_native_paper: isPaper,
+        paper_connected: connected && isPaper,
+        safe_for_paper_mutation: !isGuest && connected && isPaper,
+      };
     })()
-  `;
+  `);
+}
+
+export function buildStatus(context, panelButton) {
+  const desktopConnected = !!context?.desktop;
+  const session = context?.session || 'unknown';
+  const connectStatus = context?.connect_status ?? null;
+  const brokerId = context?.broker_id ?? null;
+  const isPaper = brokerId === NATIVE_PAPER_BROKER_ID;
+  const paperConnected = connectStatus === CONNECT_STATUS.CONNECTED && isPaper;
+  const panelFromApi = context?.panel_enabled;
+  const panelOpen = context?.panel_visible && context?.active_widget === 'paper_trading'
+    ? true
+    : (panelButton?.button_found ? !!panelButton.button_active : (context?.panel_visible ?? null));
+
+  return {
+    success: true,
+    desktop_connected: desktopConnected,
+    trading_panel_available: desktopConnected
+      ? (panelFromApi != null ? !!panelFromApi : !!panelButton?.button_found)
+      : null,
+    trading_panel_open: desktopConnected ? panelOpen : null,
+    tradingview_session: session,
+    paper_available: desktopConnected ? (session === 'authenticated' && !!panelFromApi) : null,
+    paper_connected: desktopConnected ? (paperConnected || false) : null,
+    active_provider: brokerId,
+    provider_type: !brokerId ? (connectStatus === CONNECT_STATUS.DISCONNECTED ? 'none' : 'unknown')
+      : (isPaper ? 'native_paper' : 'other_broker'),
+    active_account_id: context?.account_id ?? null,
+    connect_status: connectStatus,
+    connect_status_label: connectStatus == null ? null : (CONNECT_STATUS_LABEL[connectStatus] || 'unknown'),
+    safe_for_paper_mutation: !!context?.safe_for_paper_mutation,
+    discovery_status: 'complete',
+  };
 }
 
 export async function getStatus({ _deps } = {}) {
   const { evaluate } = _resolve(_deps);
-  let desktopConnected = false;
   let panelButton = null;
   try {
     panelButton = await evaluate(tradingPanelButtonProbe());
-    desktopConnected = true;
   } catch {
-    // CDP unreachable — the status reports that instead of failing.
+    // CDP unreachable — desktop not connected.
+    return {
+      success: true,
+      desktop_connected: false,
+      trading_panel_available: null,
+      trading_panel_open: null,
+      tradingview_session: 'unknown',
+      paper_available: null,
+      paper_connected: null,
+      active_provider: null,
+      provider_type: 'unknown',
+      active_account_id: null,
+      connect_status: null,
+      connect_status_label: null,
+      safe_for_paper_mutation: false,
+      discovery_status: 'complete',
+    };
+  }
+
+  let context = null;
+  try {
+    context = await readContext({ _deps });
+  } catch {
+    // Probe succeeded so Desktop is up, but session/broker read failed.
+    // Report connected desktop with unknown trading facts rather than a healthy Paper session.
+    return buildStatus({
+      desktop: true,
+      session: 'unknown',
+      panel_enabled: null,
+      panel_visible: null,
+      active_widget: null,
+      connect_status: null,
+      broker_id: null,
+      account_id: null,
+      safe_for_paper_mutation: false,
+    }, panelButton);
+  }
+  return buildStatus({ ...context, desktop: true }, panelButton);
+}
+
+/**
+ * Fail-closed guard for mutations. Throws with typed codes.
+ */
+export async function assertPaperContext({ _deps } = {}) {
+  let context;
+  try {
+    context = await readContext({ _deps });
+  } catch (err) {
+    const e = new Error(`CDP unavailable: ${err.message}`);
+    e.code = 'CDP_UNAVAILABLE';
+    throw e;
+  }
+  if (!context || context.session === 'anonymous') {
+    const e = new Error('TradingView login required for Paper Trading');
+    e.code = 'TRADINGVIEW_AUTH_REQUIRED';
+    throw e;
+  }
+  if (context.connect_status !== CONNECT_STATUS.CONNECTED) {
+    const e = new Error(`Paper Trading not connected (connect_status=${context.connect_status})`);
+    e.code = 'PAPER_NOT_CONNECTED';
+    throw e;
+  }
+  if (context.broker_id !== NATIVE_PAPER_BROKER_ID) {
+    const e = new Error(
+      `Active broker is not native Paper Trading (got ${context.broker_id || 'null'}). Refusing mutation.`,
+    );
+    e.code = 'NOT_PAPER_PROVIDER';
+    throw e;
+  }
+  return context;
+}
+
+export async function openPanel({ action = 'open', _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  const act = action || 'open';
+  if (!['open', 'close', 'toggle'].includes(act)) {
+    throw new Error('action must be open, close, or toggle');
+  }
+  const result = await evaluate(`
+    (function() {
+      ${PAGE_HELPERS}
+      var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+      if (!bwb) return { error: 'bottomWidgetBar not available' };
+      var action = ${safeString(act)};
+      var wasOpen = false;
+      try {
+        wasOpen = !!tvWv(bwb.isVisible()) && tvWv(bwb.activeWidgetName()) === 'paper_trading';
+      } catch (e) {}
+      var performed = 'none';
+      if (action === 'open' || (action === 'toggle' && !wasOpen)) {
+        if (typeof bwb.showWidget === 'function') bwb.showWidget('paper_trading');
+        else if (typeof bwb.activateWidget === 'function') bwb.activateWidget('paper_trading');
+        performed = 'opened';
+      } else if (action === 'close' || (action === 'toggle' && wasOpen)) {
+        if (typeof bwb.hideWidget === 'function') bwb.hideWidget('paper_trading');
+        else if (typeof bwb.close === 'function') bwb.close();
+        else if (typeof bwb.hide === 'function') bwb.hide();
+        performed = 'closed';
+      }
+      return { was_open: wasOpen, performed: performed };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return { success: true, panel: 'paper_trading', action: act, was_open: !!result?.was_open, performed: result?.performed || 'unknown' };
+}
+
+export async function connect({ _deps } = {}) {
+  const { evaluateAsync } = _resolve(_deps);
+  // Auth required, but broker may be disconnected — don't use assertPaperContext.
+  const context = await readContext({ _deps });
+  if (!context || context.session === 'anonymous') {
+    const e = new Error('TradingView login required for Paper Trading');
+    e.code = 'TRADINGVIEW_AUTH_REQUIRED';
+    throw e;
+  }
+  if (context.paper_connected) {
+    return { success: true, connected: true, broker_id: NATIVE_PAPER_BROKER_ID, already: true };
+  }
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      if (!t || typeof t.selectBroker !== 'function') return { error: 'selectBroker unavailable' };
+      await t.selectBroker(${safeString(NATIVE_PAPER_BROKER_ID)});
+      var ab = tvBroker(t);
+      var id = tvBrokerId(ab);
+      var cs = tvWv(t.connectStatus && t.connectStatus());
+      return { broker_id: id, connect_status: cs == null ? null : Number(cs) };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  if (result?.broker_id !== NATIVE_PAPER_BROKER_ID) {
+    const e = new Error(`Failed to connect native Paper Trading (active=${result?.broker_id || 'null'})`);
+    e.code = 'NOT_PAPER_PROVIDER';
+    throw e;
   }
   return {
     success: true,
-    desktop_connected: desktopConnected,
-    trading_panel_available: desktopConnected ? !!panelButton?.button_found : null,
-    trading_panel_open: panelButton?.button_found ? !!panelButton.button_active : null,
-    // Pending runtime discovery (docs/PAPER_TRADING_DISCOVERY.md): reported
-    // honestly as unknown rather than inferred from names or assumptions.
-    tradingview_session: 'unknown',
-    paper_available: null,
-    paper_connected: null,
-    active_provider: null,
-    provider_type: 'unknown',
-    active_account_id: null,
-    // Fail closed: mutation safety requires positive identification of the
-    // native Paper Trading provider, which no code can do yet.
-    safe_for_paper_mutation: false,
-    discovery_status: 'pending',
+    connected: result.connect_status === CONNECT_STATUS.CONNECTED,
+    broker_id: result.broker_id,
+    connect_status: result.connect_status,
+  };
+}
+
+export async function listAccounts({ _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluateAsync } = _resolve(_deps);
+  const accounts = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var list = await ab.accountsMetainfo();
+      var current = await ab.currentAccount();
+      return (list || []).map(function(a) {
+        return {
+          id: a.id != null ? String(a.id) : null,
+          name: a.name || null,
+          title: a.title || null,
+          type: a.type || null,
+          currency: a.currency || null,
+          is_active: String(a.id) === String(current),
+        };
+      });
+    })()
+  `);
+  return { success: true, accounts: accounts || [] };
+}
+
+export async function switchAccount({ account_id, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  if (!account_id) throw new Error('account_id required');
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var id = ${safeString(String(account_id))};
+      var list = await ab.accountsMetainfo();
+      var known = (list || []).some(function(a) { return String(a.id) === id; });
+      if (!known) return { error: 'account not found: ' + id };
+      if (typeof ab.setCurrentAccount !== 'function') return { error: 'setCurrentAccount unavailable' };
+      await ab.setCurrentAccount(id);
+      var current = await ab.currentAccount();
+      return { account_id: current != null ? String(current) : null };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return { success: true, action: 'switch_account', account_id: result?.account_id || String(account_id) };
+}
+
+export async function getAccount({ _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluateAsync } = _resolve(_deps);
+  const account = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      var ab = tvBroker(t);
+      var id = await ab.currentAccount();
+      var type = null;
+      try { type = await ab.currentAccountType(); } catch (e) {}
+      var metas = await ab.accountsMetainfo();
+      var meta = (metas || []).find(function(a) { return String(a.id) === String(id); }) || {};
+      var ami = await ab.accountManagerInfo();
+      var summary = ami && ami.summary || [];
+      var ids = ${JSON.stringify(SUMMARY_IDS)};
+      var values = {};
+      for (var i = 0; i < summary.length && i < ids.length; i++) {
+        var s = summary[i];
+        var v = null;
+        try {
+          if (s.wValue && typeof s.wValue.value === 'function') v = s.wValue.value();
+          else if (s.wValue && '_value' in s.wValue) v = s.wValue._value;
+          else if (typeof s.getValue === 'function') v = s.getValue();
+        } catch (e) {}
+        values[ids[i]] = typeof v === 'number' ? v : null;
+      }
+      var currency = meta.currency || null;
+      try {
+        var pos = await ab.positions();
+        if (pos && pos[0] && pos[0].extra && pos[0].extra.accountCurrency) {
+          currency = pos[0].extra.accountCurrency;
+        }
+      } catch (e) {}
+      return {
+        id: id != null ? String(id) : null,
+        name: meta.name || null,
+        title: meta.title || 'Paper Trading',
+        type: type || meta.type || null,
+        currency: currency,
+        balance: values.balance,
+        equity: values.equity,
+        realized_pnl: values.realized_pnl,
+        unrealized_pnl: values.unrealized_pnl,
+        margin_used: values.margin_used,
+        available_funds: values.available_funds,
+        orders_margin: values.orders_margin,
+        margin_buffer: values.margin_buffer,
+      };
+    })()
+  `);
+  return { success: true, account };
+}
+
+export async function listPositions({ _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluate } = _resolve(_deps);
+  const positions = await evaluate(`
+    (function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      var ps = t && t._positionService;
+      var list = [];
+      try { list = tvWv(ps.positions && ps.positions()) || []; } catch (e) { return { error: e.message }; }
+      if (!Array.isArray(list)) list = [];
+      return list.map(tvScalarizePosition);
+    })()
+  `);
+  if (positions?.error) throw new Error(positions.error);
+  return { success: true, count: (positions || []).length, positions: positions || [] };
+}
+
+export async function listOrders({ history = false, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluate, evaluateAsync } = _resolve(_deps);
+  if (history) {
+    const orders = await evaluateAsync(`
+      (async function() {
+        ${PAGE_HELPERS}
+        var ab = tvBroker(tvTrading());
+        var list = await ab.ordersHistory();
+        if (!Array.isArray(list)) list = [];
+        return list.slice(0, 50).map(tvScalarizeOrder);
+      })()
+    `);
+    return { success: true, history: true, count: (orders || []).length, orders: orders || [] };
+  }
+  const orders = await evaluate(`
+    (function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      var os = t && t._ordersService;
+      var list = [];
+      try { list = tvWv(os.activeOrders && os.activeOrders()) || []; } catch (e) { return { error: e.message }; }
+      if (!Array.isArray(list)) list = [];
+      return list.map(tvScalarizeOrder);
+    })()
+  `);
+  if (orders?.error) throw new Error(orders.error);
+  return { success: true, history: false, count: (orders || []).length, orders: orders || [] };
+}
+
+function normalizeSide(side) {
+  const s = String(side || '').toLowerCase();
+  if (s === 'buy' || s === 'long' || s === '1') return SIDE.buy;
+  if (s === 'sell' || s === 'short' || s === '-1') return SIDE.sell;
+  throw new Error('side must be buy or sell');
+}
+
+function normalizeOrderType(type) {
+  const t = String(type || 'market').toLowerCase().replace(/-/g, '_');
+  if (!(t in ORDER_TYPE)) {
+    throw new Error('type must be market, limit, stop, or stop_limit');
+  }
+  return ORDER_TYPE[t];
+}
+
+function normalizeTif(tif, durationDatetime) {
+  if (tif == null || tif === '') return null;
+  const value = String(tif).toUpperCase();
+  if (!(value in ORDER_TIF)) {
+    throw new Error('tif must be DAY, WEEK, MONTH, or GTD');
+  }
+  const duration = { type: value };
+  if (value === 'GTD') {
+    if (durationDatetime == null || durationDatetime === '') {
+      throw new Error('duration_datetime is required when tif is GTD (ISO date or unix ms)');
+    }
+    let ms = Number(durationDatetime);
+    if (!Number.isFinite(ms)) {
+      ms = new Date(durationDatetime).getTime();
+    }
+    if (!Number.isFinite(ms)) {
+      throw new Error(`Invalid duration_datetime: ${durationDatetime}`);
+    }
+    duration.datetime = ms;
+  }
+  return duration;
+}
+
+export async function placeOrder({
+  side, type = 'market', qty, symbol, price, stop_price, take_profit, stop_loss,
+  tif, duration_datetime, _deps,
+} = {}) {
+  await assertPaperContext({ _deps });
+  const sideNum = normalizeSide(side);
+  const typeNum = normalizeOrderType(type);
+  const quantity = requireFinite(qty, 'qty');
+  if (quantity <= 0) throw new Error('qty must be positive');
+  if ((typeNum === ORDER_TYPE.limit || typeNum === ORDER_TYPE.stop_limit) && price == null) {
+    throw new Error('price is required for limit / stop_limit orders');
+  }
+  if ((typeNum === ORDER_TYPE.stop || typeNum === ORDER_TYPE.stop_limit) && stop_price == null) {
+    throw new Error('stop_price is required for stop / stop_limit orders');
+  }
+  const duration = normalizeTif(tif, duration_datetime);
+
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
+      var order = {
+        symbol: ${symbol != null ? safeString(symbol) : 'null'},
+        side: ${sideNum},
+        type: ${typeNum},
+        qty: ${quantity},
+      };
+      if (!order.symbol) {
+        try {
+          var chart = window.TradingViewApi && window.TradingViewApi._activeChartWidgetWV &&
+            tvWv(window.TradingViewApi._activeChartWidgetWV);
+          order.symbol = chart && chart.symbol ? chart.symbol() : null;
+        } catch (e) {}
+      }
+      if (!order.symbol) return { error: 'symbol required (chart symbol unavailable)' };
+      ${price != null ? `order.limitPrice = ${requireFinite(price, 'price')};` : ''}
+      ${stop_price != null ? `order.stopPrice = ${requireFinite(stop_price, 'stop_price')};` : ''}
+      ${take_profit != null ? `order.takeProfit = ${requireFinite(take_profit, 'take_profit')};` : ''}
+      ${stop_loss != null ? `order.stopLoss = ${requireFinite(stop_loss, 'stop_loss')};` : ''}
+      ${duration ? `order.duration = ${JSON.stringify(duration)};` : ''}
+      var res = await ab.placeOrder(order);
+      return { result: res == null ? null : (typeof res === 'object' ? {
+        order_id: res.orderId != null ? String(res.orderId) : (res.id != null ? String(res.id) : null),
+        keys: Object.keys(res).slice(0, 20),
+      } : res) };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return {
+    success: true,
+    action: 'place_order',
+    side: sideNum === SIDE.buy ? 'buy' : 'sell',
+    type: String(type).toLowerCase(),
+    tif: duration?.type || null,
+    result: result?.result ?? null,
+  };
+}
+
+export async function cancelOrder({ order_id, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  if (!order_id) throw new Error('order_id required');
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
+      // Broker API success is often Promise<void>; only explicit false is failure.
+      var res = await ab.cancelOrder(${safeString(String(order_id))});
+      return { ok: res !== false };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return { success: true, action: 'cancel_order', order_id: String(order_id), cancelled: result?.ok !== false };
+}
+
+export async function modifyOrder({ order_id, qty, price, stop_price, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  if (!order_id) throw new Error('order_id required');
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
+      var existing = null;
+      var oid = ${safeString(String(order_id))};
+      try { existing = await ab.orderById(oid); } catch (e) {}
+      // Same non-history source as paper_list_orders (OrdersService.activeOrders).
+      if (!existing) {
+        try {
+          var t = tvTrading();
+          var os = t && t._ordersService;
+          var active = tvWv(os && os.activeOrders && os.activeOrders()) || [];
+          existing = (active || []).find(function(o) { return String(o.id) === oid; }) || null;
+        } catch (e) {}
+      }
+      if (!existing) return { error: 'order not found: ' + oid };
+      var order = Object.assign({}, existing);
+      ${qty != null ? `order.qty = ${requireFinite(qty, 'qty')};` : ''}
+      ${price != null ? `order.limitPrice = ${requireFinite(price, 'price')};` : ''}
+      ${stop_price != null ? `order.stopPrice = ${requireFinite(stop_price, 'stop_price')};` : ''}
+      var res = await ab.modifyOrder(order);
+      return { ok: res !== false, result: res == null ? null : true };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return { success: true, action: 'modify_order', order_id: String(order_id), modified: result?.ok !== false };
+}
+
+export async function closePosition({ position_id, symbol, qty, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const id = position_id || symbol;
+  if (!id) throw new Error('position_id or symbol required');
+  const { evaluateAsync } = _resolve(_deps);
+  const amount = qty != null ? requireFinite(qty, 'qty') : null;
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
+      var pid = ${safeString(String(id))};
+      var amount = ${amount == null ? 'undefined' : String(amount)};
+      // Broker API success is often Promise<void>; only explicit false is failure.
+      var res = await ab.closePosition(pid, amount);
+      return { ok: res !== false };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return {
+    success: true,
+    action: 'close_position',
+    position_id: String(id),
+    qty: amount,
+    closed: result?.ok !== false,
+  };
+}
+
+export async function setBrackets({ position_id, symbol, stop_loss, take_profit, clear = false, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const id = position_id || symbol;
+  if (!id) throw new Error('position_id or symbol required');
+  const { evaluateAsync } = _resolve(_deps);
+  let brackets;
+  if (clear) {
+    brackets = { stopLoss: null, takeProfit: null };
+  } else {
+    if (stop_loss == null && take_profit == null) {
+      throw new Error('stop_loss or take_profit required (or pass clear: true)');
+    }
+    brackets = {};
+    if (stop_loss != null) brackets.stopLoss = requireFinite(stop_loss, 'stop_loss');
+    if (take_profit != null) brackets.takeProfit = requireFinite(take_profit, 'take_profit');
+  }
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
+      // Broker API success is often Promise<void>; only explicit false is failure.
+      var res = await ab.editPositionBrackets(${safeString(String(id))}, ${JSON.stringify(brackets)});
+      return { ok: res !== false };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return {
+    success: true,
+    action: clear ? 'clear_brackets' : 'set_brackets',
+    position_id: String(id),
+    brackets,
+    updated: result?.ok !== false,
   };
 }

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -553,12 +553,13 @@ export async function cancelOrder({ order_id, _deps } = {}) {
       var ab = tvBroker(tvTrading());
       var deny = tvRequirePaperBroker(ab);
       if (deny) return deny;
-      var ok = await ab.cancelOrder(${safeString(String(order_id))});
-      return { ok: !!ok };
+      // Broker API success is often Promise<void>; only explicit false is failure.
+      var res = await ab.cancelOrder(${safeString(String(order_id))});
+      return { ok: res !== false };
     })()
   `);
   if (result?.error) throw new Error(result.error);
-  return { success: true, action: 'cancel_order', order_id: String(order_id), cancelled: !!result?.ok };
+  return { success: true, action: 'cancel_order', order_id: String(order_id), cancelled: result?.ok !== false };
 }
 
 export async function modifyOrder({ order_id, qty, price, stop_price, _deps } = {}) {
@@ -593,7 +594,7 @@ export async function modifyOrder({ order_id, qty, price, stop_price, _deps } = 
     })()
   `);
   if (result?.error) throw new Error(result.error);
-  return { success: true, action: 'modify_order', order_id: String(order_id), modified: !!result?.ok };
+  return { success: true, action: 'modify_order', order_id: String(order_id), modified: result?.ok !== false };
 }
 
 export async function closePosition({ position_id, symbol, qty, _deps } = {}) {
@@ -610,8 +611,9 @@ export async function closePosition({ position_id, symbol, qty, _deps } = {}) {
       if (deny) return deny;
       var pid = ${safeString(String(id))};
       var amount = ${amount == null ? 'undefined' : String(amount)};
-      var ok = await ab.closePosition(pid, amount);
-      return { ok: !!ok };
+      // Broker API success is often Promise<void>; only explicit false is failure.
+      var res = await ab.closePosition(pid, amount);
+      return { ok: res !== false };
     })()
   `);
   if (result?.error) throw new Error(result.error);
@@ -620,7 +622,7 @@ export async function closePosition({ position_id, symbol, qty, _deps } = {}) {
     action: 'close_position',
     position_id: String(id),
     qty: amount,
-    closed: !!result?.ok,
+    closed: result?.ok !== false,
   };
 }
 
@@ -646,8 +648,9 @@ export async function setBrackets({ position_id, symbol, stop_loss, take_profit,
       var ab = tvBroker(tvTrading());
       var deny = tvRequirePaperBroker(ab);
       if (deny) return deny;
-      var ok = await ab.editPositionBrackets(${safeString(String(id))}, ${JSON.stringify(brackets)});
-      return { ok: !!ok };
+      // Broker API success is often Promise<void>; only explicit false is failure.
+      var res = await ab.editPositionBrackets(${safeString(String(id))}, ${JSON.stringify(brackets)});
+      return { ok: res !== false };
     })()
   `);
   if (result?.error) throw new Error(result.error);
@@ -656,6 +659,6 @@ export async function setBrackets({ position_id, symbol, stop_loss, take_profit,
     action: clear ? 'clear_brackets' : 'set_brackets',
     position_id: String(id),
     brackets,
-    updated: !!result?.ok,
+    updated: result?.ok !== false,
   };
 }

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -1,13 +1,16 @@
 /**
  * TradingView native Paper Trading — read-only observability.
  *
- * This module reports only facts verifiable through surfaces already
- * evidenced in this repository: CDP liveness and the Trading Panel button's
- * semantic DOM state. Every Paper Trading fact that still requires runtime
- * discovery (see docs/PAPER_TRADING_DISCOVERY.md) is reported as
- * null/'unknown' instead of being guessed, and safe_for_paper_mutation stays
- * false until the native Paper Trading provider can be positively
- * identified. No function in this module mutates anything.
+ * Built on runtime paths evidenced in docs/PAPER_TRADING_DISCOVERY.md
+ * (Capture 1, TradingView Desktop 3.3.0): window.user session markers, the
+ * bottom-bar widget named 'paper_trading', and the trading service reached
+ * through its widget controller (connectStatus() enum, activeBroker()).
+ *
+ * Facts that cannot be verified are reported as null/'unknown' instead of
+ * being guessed, and safe_for_paper_mutation stays false until the native
+ * Paper Trading provider can be positively identified by its stable id
+ * (pending an authenticated capture). No function in this module mutates
+ * anything.
  */
 import { evaluate as _evaluate } from '../connection.js';
 import { RIGHT_RAIL_PANEL_SELECTORS } from './ui.js';
@@ -16,54 +19,147 @@ function _resolve(deps) {
   return { evaluate: deps?.evaluate || _evaluate };
 }
 
-// Same button lookup and active-state heuristic as openPanel() in core/ui.js,
-// but purely observational: nothing is clicked.
-function tradingPanelButtonProbe() {
+// connectStatus() values observed/documented: 3 confirmed while disconnected
+// (Capture 1); 1/2/4 follow TradingView's public Broker API enum and still
+// need live confirmation.
+const CONNECTION_STATES = {
+  1: 'connected',
+  2: 'connecting',
+  3: 'disconnected',
+  4: 'error',
+};
+
+// One read-only IIFE: internal API first, semantic DOM button as fallback.
+// Session classification never returns user identity, only the state.
+function statusProbe() {
   const { dataNames, ariaLabels } = RIGHT_RAIL_PANEL_SELECTORS.trading;
   return `
-    (function() {
-      var dataNames = ${JSON.stringify(dataNames)};
-      var ariaLabels = ${JSON.stringify(ariaLabels)};
-      var btn = null;
-      for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
-      for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
-      if (!btn) return { button_found: false };
-      var classes = btn.classList.toString();
-      var isActive = btn.getAttribute('aria-pressed') === 'true'
-        || btn.classList.contains('isActive')
-        || classes.indexOf('active') !== -1
-        || classes.indexOf('Active') !== -1;
-      return { button_found: true, button_active: isActive };
+    (function () {
+      function unwrap(v) {
+        try { return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; } catch (e) { return null; }
+      }
+      function classifySession() {
+        try {
+          var u = window.user;
+          if (!u || typeof u !== 'object') return 'unknown';
+          if (!u.id || u.username === 'Guest') return 'unauthenticated';
+          return 'authenticated';
+        } catch (e) { return 'unknown'; }
+      }
+      function describeBroker(broker) {
+        if (!broker || typeof broker !== 'object') return null;
+        function short(v) { return (typeof v === 'string' || typeof v === 'number') ? String(v).slice(0, 80) : null; }
+        return { id: short(broker.id !== undefined ? broker.id : broker.brokerId), name: short(broker.name) };
+      }
+      var session = classifySession();
+      var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+      var controllers = bwb && bwb._widgetControllers instanceof Map ? bwb._widgetControllers : null;
+      if (!bwb || !controllers || typeof bwb.isWidgetEnabled !== 'function') {
+        var dataNames = ${JSON.stringify(dataNames)};
+        var ariaLabels = ${JSON.stringify(ariaLabels)};
+        var btn = null;
+        for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
+        for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
+        if (!btn) return { source: 'dom_fallback', session: session, button_found: false };
+        var classes = btn.classList.toString();
+        var isActive = btn.getAttribute('aria-pressed') === 'true'
+          || btn.classList.contains('isActive')
+          || classes.indexOf('active') !== -1
+          || classes.indexOf('Active') !== -1;
+        return { source: 'dom_fallback', session: session, button_found: true, button_active: isActive };
+      }
+      var out = {
+        source: 'internal_api',
+        session: session,
+        paper_widget_registered: controllers.has('paper_trading'),
+        paper_widget_enabled: !!unwrap(bwb.isWidgetEnabled('paper_trading')),
+        bottom_bar_visible: !!unwrap(typeof bwb.isVisible === 'function' ? bwb.isVisible() : null),
+        active_widget: unwrap(typeof bwb.activeWidgetName === 'function' ? bwb.activeWidgetName() : null) || null,
+        trading_service_found: false,
+        connect_status_raw: null,
+        active_broker: null,
+      };
+      try {
+        var ctl = controllers.get('paper_trading');
+        var trading = ctl && ctl._trading;
+        if (trading) {
+          out.trading_service_found = true;
+          if (typeof trading.connectStatus === 'function') out.connect_status_raw = unwrap(trading.connectStatus());
+          if (typeof trading.activeBroker === 'function') out.active_broker = describeBroker(unwrap(trading.activeBroker()));
+        }
+      } catch (e) { /* trading service unreachable — fields stay null */ }
+      return out;
     })()
   `;
 }
 
 export async function getStatus({ _deps } = {}) {
   const { evaluate } = _resolve(_deps);
-  let desktopConnected = false;
-  let panelButton = null;
+  let probe;
   try {
-    panelButton = await evaluate(tradingPanelButtonProbe());
-    desktopConnected = true;
+    probe = await evaluate(statusProbe());
   } catch {
-    // CDP unreachable — the status reports that instead of failing.
+    return desktopDisconnectedStatus();
   }
+  if (!probe || typeof probe !== 'object') return baseStatus();
+  return probe.source === 'dom_fallback' ? domFallbackStatus(probe) : internalApiStatus(probe);
+}
+
+function baseStatus() {
   return {
     success: true,
-    desktop_connected: desktopConnected,
-    trading_panel_available: desktopConnected ? !!panelButton?.button_found : null,
-    trading_panel_open: panelButton?.button_found ? !!panelButton.button_active : null,
-    // Pending runtime discovery (docs/PAPER_TRADING_DISCOVERY.md): reported
-    // honestly as unknown rather than inferred from names or assumptions.
+    desktop_connected: true,
+    source: null,
     tradingview_session: 'unknown',
+    trading_panel_available: null,
+    trading_panel_open: null,
     paper_available: null,
     paper_connected: null,
+    connection_state: 'unknown',
+    connection_state_raw: null,
     active_provider: null,
+    // Stays 'unknown' until the native Paper broker's stable id is captured
+    // and identification is implemented (fail closed).
     provider_type: 'unknown',
     active_account_id: null,
-    // Fail closed: mutation safety requires positive identification of the
-    // native Paper Trading provider, which no code can do yet.
     safe_for_paper_mutation: false,
-    discovery_status: 'pending',
+    discovery_status: 'partial',
   };
+}
+
+function desktopDisconnectedStatus() {
+  return { ...baseStatus(), desktop_connected: false };
+}
+
+function domFallbackStatus(probe) {
+  return {
+    ...baseStatus(),
+    source: 'dom_fallback',
+    tradingview_session: probe.session ?? 'unknown',
+    trading_panel_available: !!probe.button_found,
+    trading_panel_open: probe.button_found ? !!probe.button_active : null,
+  };
+}
+
+function internalApiStatus(probe) {
+  const connectionState = CONNECTION_STATES[probe.connect_status_raw] ?? 'unknown';
+  return {
+    ...baseStatus(),
+    source: 'internal_api',
+    tradingview_session: probe.session ?? 'unknown',
+    trading_panel_available: !!probe.paper_widget_registered,
+    trading_panel_open: probe.bottom_bar_visible === true && probe.active_widget === 'paper_trading',
+    paper_available: !!probe.paper_widget_enabled,
+    paper_connected: paperConnected(probe, connectionState),
+    connection_state: connectionState,
+    connection_state_raw: probe.connect_status_raw ?? null,
+    active_provider: probe.active_broker ?? null,
+  };
+}
+
+// false only when provably nothing is connected; null (not true) while a
+// connected provider cannot yet be verified as native Paper Trading.
+function paperConnected(probe, connectionState) {
+  if (!probe.active_broker || connectionState === 'disconnected') return false;
+  return null;
 }

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -1,0 +1,69 @@
+/**
+ * TradingView native Paper Trading — read-only observability.
+ *
+ * This module reports only facts verifiable through surfaces already
+ * evidenced in this repository: CDP liveness and the Trading Panel button's
+ * semantic DOM state. Every Paper Trading fact that still requires runtime
+ * discovery (see docs/PAPER_TRADING_DISCOVERY.md) is reported as
+ * null/'unknown' instead of being guessed, and safe_for_paper_mutation stays
+ * false until the native Paper Trading provider can be positively
+ * identified. No function in this module mutates anything.
+ */
+import { evaluate as _evaluate } from '../connection.js';
+import { RIGHT_RAIL_PANEL_SELECTORS } from './ui.js';
+
+function _resolve(deps) {
+  return { evaluate: deps?.evaluate || _evaluate };
+}
+
+// Same button lookup and active-state heuristic as openPanel() in core/ui.js,
+// but purely observational: nothing is clicked.
+function tradingPanelButtonProbe() {
+  const { dataNames, ariaLabels } = RIGHT_RAIL_PANEL_SELECTORS.trading;
+  return `
+    (function() {
+      var dataNames = ${JSON.stringify(dataNames)};
+      var ariaLabels = ${JSON.stringify(ariaLabels)};
+      var btn = null;
+      for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
+      for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
+      if (!btn) return { button_found: false };
+      var classes = btn.classList.toString();
+      var isActive = btn.getAttribute('aria-pressed') === 'true'
+        || btn.classList.contains('isActive')
+        || classes.indexOf('active') !== -1
+        || classes.indexOf('Active') !== -1;
+      return { button_found: true, button_active: isActive };
+    })()
+  `;
+}
+
+export async function getStatus({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  let desktopConnected = false;
+  let panelButton = null;
+  try {
+    panelButton = await evaluate(tradingPanelButtonProbe());
+    desktopConnected = true;
+  } catch {
+    // CDP unreachable — the status reports that instead of failing.
+  }
+  return {
+    success: true,
+    desktop_connected: desktopConnected,
+    trading_panel_available: desktopConnected ? !!panelButton?.button_found : null,
+    trading_panel_open: panelButton?.button_found ? !!panelButton.button_active : null,
+    // Pending runtime discovery (docs/PAPER_TRADING_DISCOVERY.md): reported
+    // honestly as unknown rather than inferred from names or assumptions.
+    tradingview_session: 'unknown',
+    paper_available: null,
+    paper_connected: null,
+    active_provider: null,
+    provider_type: 'unknown',
+    active_account_id: null,
+    // Fail closed: mutation safety requires positive identification of the
+    // native Paper Trading provider, which no code can do yet.
+    safe_for_paper_mutation: false,
+    discovery_status: 'pending',
+  };
+}

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -148,17 +148,11 @@ export function buildStatus(context, panelButton) {
 
 export async function getStatus({ _deps } = {}) {
   const { evaluate } = _resolve(_deps);
-  let desktopConnected = false;
   let panelButton = null;
-  let context = null;
   try {
     panelButton = await evaluate(tradingPanelButtonProbe());
-    desktopConnected = true;
-    context = await readContext({ _deps });
   } catch {
-    // CDP unreachable
-  }
-  if (!desktopConnected) {
+    // CDP unreachable — desktop not connected.
     return {
       success: true,
       desktop_connected: false,
@@ -175,6 +169,25 @@ export async function getStatus({ _deps } = {}) {
       safe_for_paper_mutation: false,
       discovery_status: 'complete',
     };
+  }
+
+  let context = null;
+  try {
+    context = await readContext({ _deps });
+  } catch {
+    // Probe succeeded so Desktop is up, but session/broker read failed.
+    // Report connected desktop with unknown trading facts rather than a healthy Paper session.
+    return buildStatus({
+      desktop: true,
+      session: 'unknown',
+      panel_enabled: null,
+      panel_visible: null,
+      active_widget: null,
+      connect_status: null,
+      broker_id: null,
+      account_id: null,
+      safe_for_paper_mutation: false,
+    }, panelButton);
   }
   return buildStatus({ ...context, desktop: true }, panelButton);
 }
@@ -356,10 +369,12 @@ export async function getAccount({ _deps } = {}) {
         } catch (e) {}
         values[ids[i]] = typeof v === 'number' ? v : null;
       }
-      var currency = null;
+      var currency = meta.currency || null;
       try {
         var pos = await ab.positions();
-        if (pos && pos[0] && pos[0].extra) currency = pos[0].extra.accountCurrency || null;
+        if (pos && pos[0] && pos[0].extra && pos[0].extra.accountCurrency) {
+          currency = pos[0].extra.accountCurrency;
+        }
       } catch (e) {}
       return {
         id: id != null ? String(id) : null,
@@ -550,12 +565,24 @@ export async function modifyOrder({ order_id, qty, price, stop_price, _deps } = 
       ${PAGE_HELPERS}
       var ab = tvBroker(tvTrading());
       var existing = null;
-      try { existing = await ab.orderById(${safeString(String(order_id))}); } catch (e) {}
+      var oid = ${safeString(String(order_id))};
+      try { existing = await ab.orderById(oid); } catch (e) {}
+      // Prefer the same source as paper_list_orders (OrdersService.activeOrders).
       if (!existing) {
-        var active = await ab.orders();
-        existing = (active || []).find(function(o) { return String(o.id) === ${safeString(String(order_id))}; }) || null;
+        try {
+          var t = tvTrading();
+          var os = t && t._ordersService;
+          var active = tvWv(os && os.activeOrders && os.activeOrders()) || [];
+          existing = (active || []).find(function(o) { return String(o.id) === oid; }) || null;
+        } catch (e) {}
       }
-      if (!existing) return { error: 'order not found: ' + ${safeString(String(order_id))} };
+      if (!existing) {
+        try {
+          var all = await ab.orders();
+          existing = (all || []).find(function(o) { return String(o.id) === oid; }) || null;
+        } catch (e) {}
+      }
+      if (!existing) return { error: 'order not found: ' + oid };
       var order = Object.assign({}, existing);
       ${qty != null ? `order.qty = ${requireFinite(qty, 'qty')};` : ''}
       ${price != null ? `order.limitPrice = ${requireFinite(price, 'price')};` : ''}

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -1,69 +1,627 @@
 /**
- * TradingView native Paper Trading — read-only observability.
+ * TradingView native Paper Trading.
  *
- * This module reports only facts verifiable through surfaces already
- * evidenced in this repository: CDP liveness and the Trading Panel button's
- * semantic DOM state. Every Paper Trading fact that still requires runtime
- * discovery (see docs/PAPER_TRADING_DISCOVERY.md) is reported as
- * null/'unknown' instead of being guessed, and safe_for_paper_mutation stays
- * false until the native Paper Trading provider can be positively
- * identified. No function in this module mutates anything.
+ * Supports only the native Paper broker (stable id "Paper"). All mutations
+ * fail closed unless the active broker metainfo id is exactly that value.
+ * Evidence: docs/PAPER_TRADING_DISCOVERY.md (Capture 2, Desktop 3.3.0).
+ *
+ * CDP injection strings live in paper_cdp.js (adapter). This module owns
+ * Paper-only policy: status, guard, and tool orchestration.
  */
-import { evaluate as _evaluate } from '../connection.js';
-import { RIGHT_RAIL_PANEL_SELECTORS } from './ui.js';
+import { evaluate as _evaluate, evaluateAsync as _evaluateAsync, safeString, requireFinite } from '../connection.js';
+import { PAGE_HELPERS, SUMMARY_IDS, tradingPanelButtonProbe } from './paper_cdp.js';
+
+/** Stable internal id of TradingView's native Paper Trading provider. */
+export const NATIVE_PAPER_BROKER_ID = 'Paper';
+
+export const CONNECT_STATUS = {
+  CONNECTED: 1,
+  CONNECTING: 2,
+  DISCONNECTED: 3,
+  ERROR: 4,
+};
+
+export const ORDER_TYPE = {
+  limit: 1,
+  market: 2,
+  stop: 3,
+  stop_limit: 4,
+};
+
+export const SIDE = {
+  buy: 1,
+  sell: -1,
+};
+
+/** Paper broker duration values from Capture 2 metainfo.durations. */
+export const ORDER_TIF = {
+  DAY: 'DAY',
+  WEEK: 'WEEK',
+  MONTH: 'MONTH',
+  GTD: 'GTD',
+};
+
+export const CONNECT_STATUS_LABEL = {
+  [CONNECT_STATUS.CONNECTED]: 'connected',
+  [CONNECT_STATUS.CONNECTING]: 'connecting',
+  [CONNECT_STATUS.DISCONNECTED]: 'disconnected',
+  [CONNECT_STATUS.ERROR]: 'error',
+};
 
 function _resolve(deps) {
-  return { evaluate: deps?.evaluate || _evaluate };
+  return {
+    evaluate: deps?.evaluate || _evaluate,
+    evaluateAsync: deps?.evaluateAsync || _evaluateAsync,
+  };
 }
 
-// Same button lookup and active-state heuristic as openPanel() in core/ui.js,
-// but purely observational: nothing is clicked.
-function tradingPanelButtonProbe() {
-  const { dataNames, ariaLabels } = RIGHT_RAIL_PANEL_SELECTORS.trading;
-  return `
+/**
+ * Snapshot of session/broker/panel state used by status and mutation guard.
+ * Never mutates.
+ */
+export async function readContext({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  return evaluate(`
     (function() {
-      var dataNames = ${JSON.stringify(dataNames)};
-      var ariaLabels = ${JSON.stringify(ariaLabels)};
-      var btn = null;
-      for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
-      for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
-      if (!btn) return { button_found: false };
-      var classes = btn.classList.toString();
-      var isActive = btn.getAttribute('aria-pressed') === 'true'
-        || btn.classList.contains('isActive')
-        || classes.indexOf('active') !== -1
-        || classes.indexOf('Active') !== -1;
-      return { button_found: true, button_active: isActive };
+      ${PAGE_HELPERS}
+      var u = window.user || {};
+      var username = typeof u.username === 'string' ? u.username : null;
+      var hasId = !!u.id;
+      var isGuest = !hasId || !username || username === 'Guest';
+      var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+      var panelEnabled = false;
+      var panelVisible = false;
+      var activeWidget = null;
+      if (bwb) {
+        try { panelEnabled = !!bwb.isWidgetEnabled('paper_trading'); } catch (e) {}
+        try { panelVisible = !!tvWv(bwb.isVisible()); } catch (e) {}
+        try { activeWidget = tvWv(bwb.activeWidgetName()) || null; } catch (e) {}
+      }
+      var t = tvTrading();
+      var connectStatus = null;
+      var brokerId = null;
+      var brokerTitle = null;
+      var accountId = null;
+      if (t) {
+        try { connectStatus = tvWv(t.connectStatus && t.connectStatus()); } catch (e) {}
+        var ab = tvBroker(t);
+        brokerId = tvBrokerId(ab);
+        try { brokerTitle = ab && ab._brokerMetainfo && ab._brokerMetainfo.title || null; } catch (e) {}
+        try {
+          var rawAcc = t._account;
+          if (typeof rawAcc === 'string' || typeof rawAcc === 'number') accountId = String(rawAcc);
+        } catch (e) {}
+      }
+      var isPaper = brokerId === ${safeString(NATIVE_PAPER_BROKER_ID)};
+      var connected = connectStatus === ${CONNECT_STATUS.CONNECTED};
+      return {
+        desktop: true,
+        session: isGuest ? 'anonymous' : 'authenticated',
+        username: isGuest ? null : username,
+        panel_enabled: panelEnabled,
+        panel_visible: panelVisible,
+        active_widget: activeWidget,
+        connect_status: connectStatus == null ? null : Number(connectStatus),
+        broker_id: brokerId,
+        broker_title: brokerTitle,
+        account_id: accountId,
+        is_native_paper: isPaper,
+        paper_connected: connected && isPaper,
+        safe_for_paper_mutation: !isGuest && connected && isPaper,
+      };
     })()
-  `;
+  `);
+}
+
+export function buildStatus(context, panelButton) {
+  const desktopConnected = !!context?.desktop;
+  const session = context?.session || 'unknown';
+  const connectStatus = context?.connect_status ?? null;
+  const brokerId = context?.broker_id ?? null;
+  const isPaper = brokerId === NATIVE_PAPER_BROKER_ID;
+  const paperConnected = connectStatus === CONNECT_STATUS.CONNECTED && isPaper;
+  const panelFromApi = context?.panel_enabled;
+  const panelOpen = context?.panel_visible && context?.active_widget === 'paper_trading'
+    ? true
+    : (panelButton?.button_found ? !!panelButton.button_active : (context?.panel_visible ?? null));
+
+  return {
+    success: true,
+    desktop_connected: desktopConnected,
+    trading_panel_available: desktopConnected
+      ? (panelFromApi != null ? !!panelFromApi : !!panelButton?.button_found)
+      : null,
+    trading_panel_open: desktopConnected ? panelOpen : null,
+    tradingview_session: session,
+    paper_available: desktopConnected ? (session === 'authenticated' && !!panelFromApi) : null,
+    paper_connected: desktopConnected ? (paperConnected || false) : null,
+    active_provider: brokerId,
+    provider_type: !brokerId ? (connectStatus === CONNECT_STATUS.DISCONNECTED ? 'none' : 'unknown')
+      : (isPaper ? 'native_paper' : 'other_broker'),
+    active_account_id: context?.account_id ?? null,
+    connect_status: connectStatus,
+    connect_status_label: connectStatus == null ? null : (CONNECT_STATUS_LABEL[connectStatus] || 'unknown'),
+    safe_for_paper_mutation: !!context?.safe_for_paper_mutation,
+    discovery_status: 'complete',
+  };
 }
 
 export async function getStatus({ _deps } = {}) {
   const { evaluate } = _resolve(_deps);
   let desktopConnected = false;
   let panelButton = null;
+  let context = null;
   try {
     panelButton = await evaluate(tradingPanelButtonProbe());
     desktopConnected = true;
+    context = await readContext({ _deps });
   } catch {
-    // CDP unreachable — the status reports that instead of failing.
+    // CDP unreachable
+  }
+  if (!desktopConnected) {
+    return {
+      success: true,
+      desktop_connected: false,
+      trading_panel_available: null,
+      trading_panel_open: null,
+      tradingview_session: 'unknown',
+      paper_available: null,
+      paper_connected: null,
+      active_provider: null,
+      provider_type: 'unknown',
+      active_account_id: null,
+      connect_status: null,
+      connect_status_label: null,
+      safe_for_paper_mutation: false,
+      discovery_status: 'complete',
+    };
+  }
+  return buildStatus({ ...context, desktop: true }, panelButton);
+}
+
+/**
+ * Fail-closed guard for mutations. Throws with typed codes.
+ */
+export async function assertPaperContext({ _deps } = {}) {
+  let context;
+  try {
+    context = await readContext({ _deps });
+  } catch (err) {
+    const e = new Error(`CDP unavailable: ${err.message}`);
+    e.code = 'CDP_UNAVAILABLE';
+    throw e;
+  }
+  if (!context || context.session === 'anonymous') {
+    const e = new Error('TradingView login required for Paper Trading');
+    e.code = 'TRADINGVIEW_AUTH_REQUIRED';
+    throw e;
+  }
+  if (context.connect_status !== CONNECT_STATUS.CONNECTED) {
+    const e = new Error(`Paper Trading not connected (connect_status=${context.connect_status})`);
+    e.code = 'PAPER_NOT_CONNECTED';
+    throw e;
+  }
+  if (context.broker_id !== NATIVE_PAPER_BROKER_ID) {
+    const e = new Error(
+      `Active broker is not native Paper Trading (got ${context.broker_id || 'null'}). Refusing mutation.`,
+    );
+    e.code = 'NOT_PAPER_PROVIDER';
+    throw e;
+  }
+  return context;
+}
+
+export async function openPanel({ action = 'open', _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
+  const act = action || 'open';
+  if (!['open', 'close', 'toggle'].includes(act)) {
+    throw new Error('action must be open, close, or toggle');
+  }
+  const result = await evaluate(`
+    (function() {
+      ${PAGE_HELPERS}
+      var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+      if (!bwb) return { error: 'bottomWidgetBar not available' };
+      var action = ${safeString(act)};
+      var wasOpen = false;
+      try {
+        wasOpen = !!tvWv(bwb.isVisible()) && tvWv(bwb.activeWidgetName()) === 'paper_trading';
+      } catch (e) {}
+      var performed = 'none';
+      if (action === 'open' || (action === 'toggle' && !wasOpen)) {
+        if (typeof bwb.showWidget === 'function') bwb.showWidget('paper_trading');
+        else if (typeof bwb.activateWidget === 'function') bwb.activateWidget('paper_trading');
+        performed = 'opened';
+      } else if (action === 'close' || (action === 'toggle' && wasOpen)) {
+        if (typeof bwb.hideWidget === 'function') bwb.hideWidget('paper_trading');
+        else if (typeof bwb.close === 'function') bwb.close();
+        else if (typeof bwb.hide === 'function') bwb.hide();
+        performed = 'closed';
+      }
+      return { was_open: wasOpen, performed: performed };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return { success: true, panel: 'paper_trading', action: act, was_open: !!result?.was_open, performed: result?.performed || 'unknown' };
+}
+
+export async function connect({ _deps } = {}) {
+  const { evaluateAsync } = _resolve(_deps);
+  // Auth required, but broker may be disconnected — don't use assertPaperContext.
+  const context = await readContext({ _deps });
+  if (!context || context.session === 'anonymous') {
+    const e = new Error('TradingView login required for Paper Trading');
+    e.code = 'TRADINGVIEW_AUTH_REQUIRED';
+    throw e;
+  }
+  if (context.paper_connected) {
+    return { success: true, connected: true, broker_id: NATIVE_PAPER_BROKER_ID, already: true };
+  }
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      if (!t || typeof t.selectBroker !== 'function') return { error: 'selectBroker unavailable' };
+      await t.selectBroker(${safeString(NATIVE_PAPER_BROKER_ID)});
+      var ab = tvBroker(t);
+      var id = tvBrokerId(ab);
+      var cs = tvWv(t.connectStatus && t.connectStatus());
+      return { broker_id: id, connect_status: cs == null ? null : Number(cs) };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  if (result?.broker_id !== NATIVE_PAPER_BROKER_ID) {
+    const e = new Error(`Failed to connect native Paper Trading (active=${result?.broker_id || 'null'})`);
+    e.code = 'NOT_PAPER_PROVIDER';
+    throw e;
   }
   return {
     success: true,
-    desktop_connected: desktopConnected,
-    trading_panel_available: desktopConnected ? !!panelButton?.button_found : null,
-    trading_panel_open: panelButton?.button_found ? !!panelButton.button_active : null,
-    // Pending runtime discovery (docs/PAPER_TRADING_DISCOVERY.md): reported
-    // honestly as unknown rather than inferred from names or assumptions.
-    tradingview_session: 'unknown',
-    paper_available: null,
-    paper_connected: null,
-    active_provider: null,
-    provider_type: 'unknown',
-    active_account_id: null,
-    // Fail closed: mutation safety requires positive identification of the
-    // native Paper Trading provider, which no code can do yet.
-    safe_for_paper_mutation: false,
-    discovery_status: 'pending',
+    connected: result.connect_status === CONNECT_STATUS.CONNECTED,
+    broker_id: result.broker_id,
+    connect_status: result.connect_status,
+  };
+}
+
+export async function listAccounts({ _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluateAsync } = _resolve(_deps);
+  const accounts = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var list = await ab.accountsMetainfo();
+      var current = await ab.currentAccount();
+      return (list || []).map(function(a) {
+        return {
+          id: a.id != null ? String(a.id) : null,
+          name: a.name || null,
+          title: a.title || null,
+          type: a.type || null,
+          currency: a.currency || null,
+          is_active: String(a.id) === String(current),
+        };
+      });
+    })()
+  `);
+  return { success: true, accounts: accounts || [] };
+}
+
+export async function switchAccount({ account_id, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  if (!account_id) throw new Error('account_id required');
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var id = ${safeString(String(account_id))};
+      var list = await ab.accountsMetainfo();
+      var known = (list || []).some(function(a) { return String(a.id) === id; });
+      if (!known) return { error: 'account not found: ' + id };
+      if (typeof ab.setCurrentAccount !== 'function') return { error: 'setCurrentAccount unavailable' };
+      await ab.setCurrentAccount(id);
+      var current = await ab.currentAccount();
+      return { account_id: current != null ? String(current) : null };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return { success: true, action: 'switch_account', account_id: result?.account_id || String(account_id) };
+}
+
+export async function getAccount({ _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluateAsync } = _resolve(_deps);
+  const account = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      var ab = tvBroker(t);
+      var id = await ab.currentAccount();
+      var type = null;
+      try { type = await ab.currentAccountType(); } catch (e) {}
+      var metas = await ab.accountsMetainfo();
+      var meta = (metas || []).find(function(a) { return String(a.id) === String(id); }) || {};
+      var ami = await ab.accountManagerInfo();
+      var summary = ami && ami.summary || [];
+      var ids = ${JSON.stringify(SUMMARY_IDS)};
+      var values = {};
+      for (var i = 0; i < summary.length && i < ids.length; i++) {
+        var s = summary[i];
+        var v = null;
+        try {
+          if (s.wValue && typeof s.wValue.value === 'function') v = s.wValue.value();
+          else if (s.wValue && '_value' in s.wValue) v = s.wValue._value;
+          else if (typeof s.getValue === 'function') v = s.getValue();
+        } catch (e) {}
+        values[ids[i]] = typeof v === 'number' ? v : null;
+      }
+      var currency = null;
+      try {
+        var pos = await ab.positions();
+        if (pos && pos[0] && pos[0].extra) currency = pos[0].extra.accountCurrency || null;
+      } catch (e) {}
+      return {
+        id: id != null ? String(id) : null,
+        name: meta.name || null,
+        title: meta.title || 'Paper Trading',
+        type: type || meta.type || null,
+        currency: currency,
+        balance: values.balance,
+        equity: values.equity,
+        realized_pnl: values.realized_pnl,
+        unrealized_pnl: values.unrealized_pnl,
+        margin_used: values.margin_used,
+        available_funds: values.available_funds,
+        orders_margin: values.orders_margin,
+        margin_buffer: values.margin_buffer,
+      };
+    })()
+  `);
+  return { success: true, account };
+}
+
+export async function listPositions({ _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluate } = _resolve(_deps);
+  const positions = await evaluate(`
+    (function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      var ps = t && t._positionService;
+      var list = [];
+      try { list = tvWv(ps.positions && ps.positions()) || []; } catch (e) { return { error: e.message }; }
+      if (!Array.isArray(list)) list = [];
+      return list.map(tvScalarizePosition);
+    })()
+  `);
+  if (positions?.error) throw new Error(positions.error);
+  return { success: true, count: (positions || []).length, positions: positions || [] };
+}
+
+export async function listOrders({ history = false, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const { evaluate, evaluateAsync } = _resolve(_deps);
+  if (history) {
+    const orders = await evaluateAsync(`
+      (async function() {
+        ${PAGE_HELPERS}
+        var ab = tvBroker(tvTrading());
+        var list = await ab.ordersHistory();
+        if (!Array.isArray(list)) list = [];
+        return list.slice(0, 50).map(tvScalarizeOrder);
+      })()
+    `);
+    return { success: true, history: true, count: (orders || []).length, orders: orders || [] };
+  }
+  const orders = await evaluate(`
+    (function() {
+      ${PAGE_HELPERS}
+      var t = tvTrading();
+      var os = t && t._ordersService;
+      var list = [];
+      try { list = tvWv(os.activeOrders && os.activeOrders()) || []; } catch (e) { return { error: e.message }; }
+      if (!Array.isArray(list)) list = [];
+      return list.map(tvScalarizeOrder);
+    })()
+  `);
+  if (orders?.error) throw new Error(orders.error);
+  return { success: true, history: false, count: (orders || []).length, orders: orders || [] };
+}
+
+function normalizeSide(side) {
+  const s = String(side || '').toLowerCase();
+  if (s === 'buy' || s === 'long' || s === '1') return SIDE.buy;
+  if (s === 'sell' || s === 'short' || s === '-1') return SIDE.sell;
+  throw new Error('side must be buy or sell');
+}
+
+function normalizeOrderType(type) {
+  const t = String(type || 'market').toLowerCase().replace(/-/g, '_');
+  if (!(t in ORDER_TYPE)) {
+    throw new Error('type must be market, limit, stop, or stop_limit');
+  }
+  return ORDER_TYPE[t];
+}
+
+function normalizeTif(tif, durationDatetime) {
+  if (tif == null || tif === '') return null;
+  const value = String(tif).toUpperCase();
+  if (!(value in ORDER_TIF)) {
+    throw new Error('tif must be DAY, WEEK, MONTH, or GTD');
+  }
+  const duration = { type: value };
+  if (value === 'GTD') {
+    if (durationDatetime == null || durationDatetime === '') {
+      throw new Error('duration_datetime is required when tif is GTD (ISO date or unix ms)');
+    }
+    let ms = Number(durationDatetime);
+    if (!Number.isFinite(ms)) {
+      ms = new Date(durationDatetime).getTime();
+    }
+    if (!Number.isFinite(ms)) {
+      throw new Error(`Invalid duration_datetime: ${durationDatetime}`);
+    }
+    duration.datetime = ms;
+  }
+  return duration;
+}
+
+export async function placeOrder({
+  side, type = 'market', qty, symbol, price, stop_price, take_profit, stop_loss,
+  tif, duration_datetime, _deps,
+} = {}) {
+  await assertPaperContext({ _deps });
+  const sideNum = normalizeSide(side);
+  const typeNum = normalizeOrderType(type);
+  const quantity = requireFinite(qty, 'qty');
+  if (quantity <= 0) throw new Error('qty must be positive');
+  if ((typeNum === ORDER_TYPE.limit || typeNum === ORDER_TYPE.stop_limit) && price == null) {
+    throw new Error('price is required for limit / stop_limit orders');
+  }
+  if ((typeNum === ORDER_TYPE.stop || typeNum === ORDER_TYPE.stop_limit) && stop_price == null) {
+    throw new Error('stop_price is required for stop / stop_limit orders');
+  }
+  const duration = normalizeTif(tif, duration_datetime);
+
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var order = {
+        symbol: ${symbol != null ? safeString(symbol) : 'null'},
+        side: ${sideNum},
+        type: ${typeNum},
+        qty: ${quantity},
+      };
+      if (!order.symbol) {
+        try {
+          var chart = window.TradingViewApi && window.TradingViewApi._activeChartWidgetWV &&
+            tvWv(window.TradingViewApi._activeChartWidgetWV);
+          order.symbol = chart && chart.symbol ? chart.symbol() : null;
+        } catch (e) {}
+      }
+      if (!order.symbol) return { error: 'symbol required (chart symbol unavailable)' };
+      ${price != null ? `order.limitPrice = ${requireFinite(price, 'price')};` : ''}
+      ${stop_price != null ? `order.stopPrice = ${requireFinite(stop_price, 'stop_price')};` : ''}
+      ${take_profit != null ? `order.takeProfit = ${requireFinite(take_profit, 'take_profit')};` : ''}
+      ${stop_loss != null ? `order.stopLoss = ${requireFinite(stop_loss, 'stop_loss')};` : ''}
+      ${duration ? `order.duration = ${JSON.stringify(duration)};` : ''}
+      var res = await ab.placeOrder(order);
+      return { result: res == null ? null : (typeof res === 'object' ? {
+        order_id: res.orderId != null ? String(res.orderId) : (res.id != null ? String(res.id) : null),
+        keys: Object.keys(res).slice(0, 20),
+      } : res) };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return {
+    success: true,
+    action: 'place_order',
+    side: sideNum === SIDE.buy ? 'buy' : 'sell',
+    type: String(type).toLowerCase(),
+    tif: duration?.type || null,
+    result: result?.result ?? null,
+  };
+}
+
+export async function cancelOrder({ order_id, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  if (!order_id) throw new Error('order_id required');
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var ok = await ab.cancelOrder(${safeString(String(order_id))});
+      return { ok: !!ok };
+    })()
+  `);
+  return { success: true, action: 'cancel_order', order_id: String(order_id), cancelled: !!result?.ok };
+}
+
+export async function modifyOrder({ order_id, qty, price, stop_price, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  if (!order_id) throw new Error('order_id required');
+  const { evaluateAsync } = _resolve(_deps);
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var existing = null;
+      try { existing = await ab.orderById(${safeString(String(order_id))}); } catch (e) {}
+      if (!existing) {
+        var active = await ab.orders();
+        existing = (active || []).find(function(o) { return String(o.id) === ${safeString(String(order_id))}; }) || null;
+      }
+      if (!existing) return { error: 'order not found: ' + ${safeString(String(order_id))} };
+      var order = Object.assign({}, existing);
+      ${qty != null ? `order.qty = ${requireFinite(qty, 'qty')};` : ''}
+      ${price != null ? `order.limitPrice = ${requireFinite(price, 'price')};` : ''}
+      ${stop_price != null ? `order.stopPrice = ${requireFinite(stop_price, 'stop_price')};` : ''}
+      var res = await ab.modifyOrder(order);
+      return { ok: res !== false, result: res == null ? null : true };
+    })()
+  `);
+  if (result?.error) throw new Error(result.error);
+  return { success: true, action: 'modify_order', order_id: String(order_id), modified: !!result?.ok };
+}
+
+export async function closePosition({ position_id, symbol, qty, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const id = position_id || symbol;
+  if (!id) throw new Error('position_id or symbol required');
+  const { evaluateAsync } = _resolve(_deps);
+  const amount = qty != null ? requireFinite(qty, 'qty') : null;
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var pid = ${safeString(String(id))};
+      var amount = ${amount == null ? 'undefined' : String(amount)};
+      var ok = await ab.closePosition(pid, amount);
+      return { ok: !!ok };
+    })()
+  `);
+  return {
+    success: true,
+    action: 'close_position',
+    position_id: String(id),
+    qty: amount,
+    closed: !!result?.ok,
+  };
+}
+
+export async function setBrackets({ position_id, symbol, stop_loss, take_profit, clear = false, _deps } = {}) {
+  await assertPaperContext({ _deps });
+  const id = position_id || symbol;
+  if (!id) throw new Error('position_id or symbol required');
+  const { evaluateAsync } = _resolve(_deps);
+  let brackets;
+  if (clear) {
+    brackets = { stopLoss: null, takeProfit: null };
+  } else {
+    if (stop_loss == null && take_profit == null) {
+      throw new Error('stop_loss or take_profit required (or pass clear: true)');
+    }
+    brackets = {};
+    if (stop_loss != null) brackets.stopLoss = requireFinite(stop_loss, 'stop_loss');
+    if (take_profit != null) brackets.takeProfit = requireFinite(take_profit, 'take_profit');
+  }
+  const result = await evaluateAsync(`
+    (async function() {
+      ${PAGE_HELPERS}
+      var ab = tvBroker(tvTrading());
+      var ok = await ab.editPositionBrackets(${safeString(String(id))}, ${JSON.stringify(brackets)});
+      return { ok: !!ok };
+    })()
+  `);
+  return {
+    success: true,
+    action: clear ? 'clear_brackets' : 'set_brackets',
+    position_id: String(id),
+    brackets,
+    updated: !!result?.ok,
   };
 }

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -504,6 +504,8 @@ export async function placeOrder({
     (async function() {
       ${PAGE_HELPERS}
       var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
       var order = {
         symbol: ${symbol != null ? safeString(symbol) : 'null'},
         side: ${sideNum},
@@ -549,10 +551,13 @@ export async function cancelOrder({ order_id, _deps } = {}) {
     (async function() {
       ${PAGE_HELPERS}
       var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
       var ok = await ab.cancelOrder(${safeString(String(order_id))});
       return { ok: !!ok };
     })()
   `);
+  if (result?.error) throw new Error(result.error);
   return { success: true, action: 'cancel_order', order_id: String(order_id), cancelled: !!result?.ok };
 }
 
@@ -564,22 +569,18 @@ export async function modifyOrder({ order_id, qty, price, stop_price, _deps } = 
     (async function() {
       ${PAGE_HELPERS}
       var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
       var existing = null;
       var oid = ${safeString(String(order_id))};
       try { existing = await ab.orderById(oid); } catch (e) {}
-      // Prefer the same source as paper_list_orders (OrdersService.activeOrders).
+      // Same non-history source as paper_list_orders (OrdersService.activeOrders).
       if (!existing) {
         try {
           var t = tvTrading();
           var os = t && t._ordersService;
           var active = tvWv(os && os.activeOrders && os.activeOrders()) || [];
           existing = (active || []).find(function(o) { return String(o.id) === oid; }) || null;
-        } catch (e) {}
-      }
-      if (!existing) {
-        try {
-          var all = await ab.orders();
-          existing = (all || []).find(function(o) { return String(o.id) === oid; }) || null;
         } catch (e) {}
       }
       if (!existing) return { error: 'order not found: ' + oid };
@@ -605,12 +606,15 @@ export async function closePosition({ position_id, symbol, qty, _deps } = {}) {
     (async function() {
       ${PAGE_HELPERS}
       var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
       var pid = ${safeString(String(id))};
       var amount = ${amount == null ? 'undefined' : String(amount)};
       var ok = await ab.closePosition(pid, amount);
       return { ok: !!ok };
     })()
   `);
+  if (result?.error) throw new Error(result.error);
   return {
     success: true,
     action: 'close_position',
@@ -640,10 +644,13 @@ export async function setBrackets({ position_id, symbol, stop_loss, take_profit,
     (async function() {
       ${PAGE_HELPERS}
       var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
       var ok = await ab.editPositionBrackets(${safeString(String(id))}, ${JSON.stringify(brackets)});
       return { ok: !!ok };
     })()
   `);
+  if (result?.error) throw new Error(result.error);
   return {
     success: true,
     action: clear ? 'clear_brackets' : 'set_brackets',

--- a/src/core/paper.js
+++ b/src/core/paper.js
@@ -328,6 +328,8 @@ export async function switchAccount({ account_id, _deps } = {}) {
     (async function() {
       ${PAGE_HELPERS}
       var ab = tvBroker(tvTrading());
+      var deny = tvRequirePaperBroker(ab);
+      if (deny) return deny;
       var id = ${safeString(String(account_id))};
       var list = await ab.accountsMetainfo();
       var known = (list || []).some(function(a) { return String(a.id) === id; });
@@ -339,7 +341,16 @@ export async function switchAccount({ account_id, _deps } = {}) {
     })()
   `);
   if (result?.error) throw new Error(result.error);
-  return { success: true, action: 'switch_account', account_id: result?.account_id || String(account_id) };
+  const requested = String(account_id);
+  const observed = result?.account_id != null ? String(result.account_id) : null;
+  if (observed !== requested) {
+    throw new Error(
+      observed == null
+        ? `account switch unconfirmed for ${requested}`
+        : `account switch failed: active account is ${observed}, expected ${requested}`,
+    );
+  }
+  return { success: true, action: 'switch_account', account_id: observed };
 }
 
 export async function getAccount({ _deps } = {}) {
@@ -603,6 +614,7 @@ export async function closePosition({ position_id, symbol, qty, _deps } = {}) {
   if (!id) throw new Error('position_id or symbol required');
   const { evaluateAsync } = _resolve(_deps);
   const amount = qty != null ? requireFinite(qty, 'qty') : null;
+  if (amount != null && amount <= 0) throw new Error('qty must be positive');
   const result = await evaluateAsync(`
     (async function() {
       ${PAGE_HELPERS}

--- a/src/core/paper_cdp.js
+++ b/src/core/paper_cdp.js
@@ -1,0 +1,123 @@
+/**
+ * CDP page-side helpers for native Paper Trading.
+ *
+ * Keeps injected browser strings and DOM probes out of the use-case module
+ * (src/core/paper.js) so policy code stays focused on Paper-only rules.
+ */
+import { RIGHT_RAIL_PANEL_SELECTORS } from './ui.js';
+
+/** Account summary field order aligned with accountsMetainfo.summaryRow (Capture 2). */
+export const SUMMARY_IDS = [
+  'balance',
+  'equity',
+  'realized_pnl',
+  'unrealized_pnl',
+  'margin_used',
+  'available_funds',
+  'orders_margin',
+  'margin_buffer',
+];
+
+/**
+ * Shared page-side helpers injected into CDP expressions.
+ * Tested via new Function in tests/paper.test.js (same pattern as paper_discovery).
+ */
+export const PAGE_HELPERS = `
+  function tvWv(x) {
+    if (x == null || typeof x !== 'object') return x;
+    if (typeof x.value === 'function') return x.value();
+    if ('value' in x) return x.value;
+    return x;
+  }
+  function tvTrading() {
+    var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+    if (!bwb) return null;
+    var ctrl = bwb._widgetControllers && bwb._widgetControllers.get('paper_trading');
+    return ctrl && ctrl._trading || null;
+  }
+  function tvBroker(t) {
+    if (!t || !t.activeBroker) return null;
+    return tvWv(t.activeBroker());
+  }
+  function tvBrokerId(ab) {
+    if (!ab) return null;
+    try {
+      if (ab._brokerMetainfo && ab._brokerMetainfo.id != null) return String(ab._brokerMetainfo.id);
+    } catch (e) {}
+    return null;
+  }
+  /** Page-side fail-closed guard for mutations (stable id "Paper"). */
+  function tvRequirePaperBroker(ab) {
+    var id = tvBrokerId(ab);
+    if (id !== 'Paper') {
+      return { error: 'Active broker is not native Paper Trading (got ' + (id || 'null') + '). Refusing mutation.' };
+    }
+    return null;
+  }
+  function tvScalarizePosition(p) {
+    if (!p || typeof p !== 'object') return null;
+    var extra = p.extra || {};
+    return {
+      id: p.id != null ? String(p.id) : null,
+      symbol: p.symbol != null ? String(p.symbol) : null,
+      side: p.side === 1 ? 'buy' : (p.side === -1 ? 'sell' : p.side),
+      qty: typeof p.qty === 'number' ? p.qty : null,
+      avg_price: typeof p.avgPrice === 'number' ? p.avgPrice : null,
+      last_price: typeof p.lastPrice === 'number' ? p.lastPrice : null,
+      market_value: typeof p.marketValue === 'number' ? p.marketValue : null,
+      unrealized_pnl: typeof (extra.pl != null ? extra.pl : p.pl) === 'number' ? (extra.pl != null ? extra.pl : p.pl) : null,
+      unrealized_pnl_percent: typeof extra.plPercent === 'number' ? extra.plPercent : null,
+      currency: extra.accountCurrency || null,
+      leverage: extra.leverage || null,
+      margin_used: typeof extra.usedMargin === 'number' ? extra.usedMargin : null,
+      support_brackets: !!p.supportBrackets,
+      support_stop_loss: !!p.supportStopLoss,
+      support_trailing_stop: !!p.supportTrailingStop,
+      stop_loss: p.stopLoss == null ? null : p.stopLoss,
+      take_profit: p.takeProfit == null ? null : p.takeProfit,
+    };
+  }
+  function tvScalarizeOrder(o) {
+    if (!o || typeof o !== 'object') return null;
+    var statusMap = { 1: 'canceled', 2: 'filled', 3: 'inactive', 4: 'placing', 5: 'rejected', 6: 'working' };
+    var typeMap = { 1: 'limit', 2: 'market', 3: 'stop', 4: 'stop_limit' };
+    var extra = o.extra || {};
+    return {
+      id: o.id != null ? String(o.id) : null,
+      symbol: o.symbol != null ? String(o.symbol) : null,
+      side: o.side === 1 ? 'buy' : (o.side === -1 ? 'sell' : o.side),
+      type: typeMap[o.type] || o.type,
+      status: statusMap[o.status] || o.status,
+      qty: typeof o.qty === 'number' ? o.qty : null,
+      limit_price: typeof o.limitPrice === 'number' ? o.limitPrice : null,
+      stop_price: typeof o.stopPrice === 'number' ? o.stopPrice : null,
+      avg_price: typeof o.avgPrice === 'number' ? o.avgPrice : null,
+      take_profit: o.takeProfit == null ? null : o.takeProfit,
+      stop_loss: o.stopLoss == null ? null : o.stopLoss,
+      currency: extra.accountCurrency || null,
+      leverage: extra.leverage || null,
+      margin_used: typeof extra.usedMargin === 'number' ? extra.usedMargin : null,
+    };
+  }
+`;
+
+/** Observational probe for the Trading Panel toggle button (no clicks). */
+export function tradingPanelButtonProbe() {
+  const { dataNames, ariaLabels } = RIGHT_RAIL_PANEL_SELECTORS.trading;
+  return `
+    (function() {
+      var dataNames = ${JSON.stringify(dataNames)};
+      var ariaLabels = ${JSON.stringify(ariaLabels)};
+      var btn = null;
+      for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
+      for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
+      if (!btn) return { button_found: false };
+      var classes = btn.classList.toString();
+      var isActive = btn.getAttribute('aria-pressed') === 'true'
+        || btn.classList.contains('isActive')
+        || classes.indexOf('active') !== -1
+        || classes.indexOf('Active') !== -1;
+      return { button_found: true, button_active: isActive };
+    })()
+  `;
+}

--- a/src/core/paper_cdp.js
+++ b/src/core/paper_cdp.js
@@ -46,6 +46,14 @@ export const PAGE_HELPERS = `
     } catch (e) {}
     return null;
   }
+  /** Page-side fail-closed guard for mutations (stable id "Paper"). */
+  function tvRequirePaperBroker(ab) {
+    var id = tvBrokerId(ab);
+    if (id !== 'Paper') {
+      return { error: 'Active broker is not native Paper Trading (got ' + (id || 'null') + '). Refusing mutation.' };
+    }
+    return null;
+  }
   function tvScalarizePosition(p) {
     if (!p || typeof p !== 'object') return null;
     var extra = p.extra || {};

--- a/src/core/paper_cdp.js
+++ b/src/core/paper_cdp.js
@@ -1,0 +1,115 @@
+/**
+ * CDP page-side helpers for native Paper Trading.
+ *
+ * Keeps injected browser strings and DOM probes out of the use-case module
+ * (src/core/paper.js) so policy code stays focused on Paper-only rules.
+ */
+import { RIGHT_RAIL_PANEL_SELECTORS } from './ui.js';
+
+/** Account summary field order aligned with accountsMetainfo.summaryRow (Capture 2). */
+export const SUMMARY_IDS = [
+  'balance',
+  'equity',
+  'realized_pnl',
+  'unrealized_pnl',
+  'margin_used',
+  'available_funds',
+  'orders_margin',
+  'margin_buffer',
+];
+
+/**
+ * Shared page-side helpers injected into CDP expressions.
+ * Tested via new Function in tests/paper.test.js (same pattern as paper_discovery).
+ */
+export const PAGE_HELPERS = `
+  function tvWv(x) {
+    if (x == null || typeof x !== 'object') return x;
+    if (typeof x.value === 'function') return x.value();
+    if ('value' in x) return x.value;
+    return x;
+  }
+  function tvTrading() {
+    var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+    if (!bwb) return null;
+    var ctrl = bwb._widgetControllers && bwb._widgetControllers.get('paper_trading');
+    return ctrl && ctrl._trading || null;
+  }
+  function tvBroker(t) {
+    if (!t || !t.activeBroker) return null;
+    return tvWv(t.activeBroker());
+  }
+  function tvBrokerId(ab) {
+    if (!ab) return null;
+    try {
+      if (ab._brokerMetainfo && ab._brokerMetainfo.id != null) return String(ab._brokerMetainfo.id);
+    } catch (e) {}
+    return null;
+  }
+  function tvScalarizePosition(p) {
+    if (!p || typeof p !== 'object') return null;
+    var extra = p.extra || {};
+    return {
+      id: p.id != null ? String(p.id) : null,
+      symbol: p.symbol != null ? String(p.symbol) : null,
+      side: p.side === 1 ? 'buy' : (p.side === -1 ? 'sell' : p.side),
+      qty: typeof p.qty === 'number' ? p.qty : null,
+      avg_price: typeof p.avgPrice === 'number' ? p.avgPrice : null,
+      last_price: typeof p.lastPrice === 'number' ? p.lastPrice : null,
+      market_value: typeof p.marketValue === 'number' ? p.marketValue : null,
+      unrealized_pnl: typeof (extra.pl != null ? extra.pl : p.pl) === 'number' ? (extra.pl != null ? extra.pl : p.pl) : null,
+      unrealized_pnl_percent: typeof extra.plPercent === 'number' ? extra.plPercent : null,
+      currency: extra.accountCurrency || null,
+      leverage: extra.leverage || null,
+      margin_used: typeof extra.usedMargin === 'number' ? extra.usedMargin : null,
+      support_brackets: !!p.supportBrackets,
+      support_stop_loss: !!p.supportStopLoss,
+      support_trailing_stop: !!p.supportTrailingStop,
+      stop_loss: p.stopLoss == null ? null : p.stopLoss,
+      take_profit: p.takeProfit == null ? null : p.takeProfit,
+    };
+  }
+  function tvScalarizeOrder(o) {
+    if (!o || typeof o !== 'object') return null;
+    var statusMap = { 1: 'canceled', 2: 'filled', 3: 'inactive', 4: 'placing', 5: 'rejected', 6: 'working' };
+    var typeMap = { 1: 'limit', 2: 'market', 3: 'stop', 4: 'stop_limit' };
+    var extra = o.extra || {};
+    return {
+      id: o.id != null ? String(o.id) : null,
+      symbol: o.symbol != null ? String(o.symbol) : null,
+      side: o.side === 1 ? 'buy' : (o.side === -1 ? 'sell' : o.side),
+      type: typeMap[o.type] || o.type,
+      status: statusMap[o.status] || o.status,
+      qty: typeof o.qty === 'number' ? o.qty : null,
+      limit_price: typeof o.limitPrice === 'number' ? o.limitPrice : null,
+      stop_price: typeof o.stopPrice === 'number' ? o.stopPrice : null,
+      avg_price: typeof o.avgPrice === 'number' ? o.avgPrice : null,
+      take_profit: o.takeProfit == null ? null : o.takeProfit,
+      stop_loss: o.stopLoss == null ? null : o.stopLoss,
+      currency: extra.accountCurrency || null,
+      leverage: extra.leverage || null,
+      margin_used: typeof extra.usedMargin === 'number' ? extra.usedMargin : null,
+    };
+  }
+`;
+
+/** Observational probe for the Trading Panel toggle button (no clicks). */
+export function tradingPanelButtonProbe() {
+  const { dataNames, ariaLabels } = RIGHT_RAIL_PANEL_SELECTORS.trading;
+  return `
+    (function() {
+      var dataNames = ${JSON.stringify(dataNames)};
+      var ariaLabels = ${JSON.stringify(ariaLabels)};
+      var btn = null;
+      for (var d = 0; d < dataNames.length && !btn; d++) btn = document.querySelector('[data-name="' + dataNames[d] + '"]');
+      for (var a = 0; a < ariaLabels.length && !btn; a++) btn = document.querySelector('[aria-label="' + ariaLabels[a] + '"]');
+      if (!btn) return { button_found: false };
+      var classes = btn.classList.toString();
+      var isActive = btn.getAttribute('aria-pressed') === 'true'
+        || btn.classList.contains('isActive')
+        || classes.indexOf('active') !== -1
+        || classes.indexOf('Active') !== -1;
+      return { button_found: true, button_active: isActive };
+    })()
+  `;
+}

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -3,6 +3,16 @@
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
+// Right-rail panel toggle buttons. Newer TV builds renamed some of them
+// (watchlist is now data-name="base", aria "Watchlist, details, and news";
+// alerts is data-name="alerts") — keep legacy selectors as fallbacks.
+// Shared with core/paper.js, which observes the trading button's state.
+export const RIGHT_RAIL_PANEL_SELECTORS = {
+  'watchlist': { dataNames: ['base-watchlist-widget-button', 'base'], ariaLabels: ['Watchlist', 'Watchlist, details, and news'] },
+  'alerts': { dataNames: ['alerts-button', 'alerts'], ariaLabels: ['Alerts'] },
+  'trading': { dataNames: ['trading-button'], ariaLabels: ['Trading Panel'] },
+};
+
 export async function click({ by, value }) {
   const escaped = JSON.stringify(value);
   const result = await evaluate(`
@@ -62,15 +72,7 @@ export async function openPanel({ panel, action }) {
     if (result && result.error) throw new Error(result.error);
     return { success: true, panel, action, was_open: result?.was_open ?? false, performed: result?.performed ?? 'unknown' };
   } else {
-    // Newer TV builds renamed the right-rail buttons (watchlist is now
-    // data-name="base", aria "Watchlist, details, and news"; alerts is
-    // data-name="alerts") — keep legacy selectors as fallbacks.
-    const selectorMap = {
-      'watchlist': { dataNames: ['base-watchlist-widget-button', 'base'], ariaLabels: ['Watchlist', 'Watchlist, details, and news'] },
-      'alerts': { dataNames: ['alerts-button', 'alerts'], ariaLabels: ['Alerts'] },
-      'trading': { dataNames: ['trading-button'], ariaLabels: ['Trading Panel'] },
-    };
-    const sel = selectorMap[panel];
+    const sel = RIGHT_RAIL_PANEL_SELECTORS[panel];
     const result = await evaluate(`
       (function() {
         var dataNames = ${JSON.stringify(sel.dataNames)};

--- a/src/server.js
+++ b/src/server.js
@@ -60,7 +60,7 @@ Alerts: alert_create, alert_list, alert_delete
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch
-Paper Trading: paper_get_status → read-only observability status (native Paper Trading support is in discovery; no order execution)
+Paper Trading (native only, broker id "Paper"): paper_get_status → paper_connect → paper_get_account / paper_switch_account / paper_list_positions / paper_list_orders → paper_place_order (tif DAY|WEEK|MONTH|GTD) / paper_cancel_order / paper_modify_order / paper_close_position / paper_set_brackets (mutations fail closed unless active broker is Paper)
 
 CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import { registerWatchlistTools } from './tools/watchlist.js';
 import { registerUiTools } from './tools/ui.js';
 import { registerPaneTools } from './tools/pane.js';
 import { registerTabTools } from './tools/tab.js';
+import { registerPaperTools } from './tools/paper.js';
 
 const server = new McpServer(
   {
@@ -22,7 +23,7 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 84 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — 85 tools for reading and controlling a live TradingView Desktop chart.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 
@@ -59,6 +60,7 @@ Alerts: alert_create, alert_list, alert_delete
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch
+Paper Trading: paper_get_status → read-only observability status (native Paper Trading support is in discovery; no order execution)
 
 CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv
@@ -84,6 +86,7 @@ registerWatchlistTools(server);
 registerUiTools(server);
 registerPaneTools(server);
 registerTabTools(server);
+registerPaperTools(server);
 
 // Startup notice (stderr so it doesn't interfere with MCP stdio protocol)
 process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');

--- a/src/server.js
+++ b/src/server.js
@@ -23,7 +23,7 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 85 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — 97 tools for reading and controlling a live TradingView Desktop chart.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 

--- a/src/server.js
+++ b/src/server.js
@@ -23,7 +23,7 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 85 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — 97 tools for reading and controlling a live TradingView Desktop chart.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 
@@ -60,7 +60,7 @@ Alerts: alert_create, alert_list, alert_delete
 Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch
-Paper Trading: paper_get_status → read-only observability status (native Paper Trading support is in discovery; no order execution)
+Paper Trading (native only, broker id "Paper"): paper_get_status → paper_connect → paper_get_account / paper_switch_account / paper_list_positions / paper_list_orders → paper_place_order (tif DAY|WEEK|MONTH|GTD) / paper_cancel_order / paper_modify_order / paper_close_position / paper_set_brackets (mutations fail closed unless active broker is Paper)
 
 CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv

--- a/src/tools/paper.js
+++ b/src/tools/paper.js
@@ -1,0 +1,9 @@
+import { jsonResult } from './_format.js';
+import * as core from '../core/paper.js';
+
+export function registerPaperTools(server) {
+  server.tool('paper_get_status', 'Report the current observability status of TradingView\'s native Paper Trading: desktop CDP connection and Trading Panel button state. Read-only. Facts that still require runtime discovery (session, provider identity, accounts) are returned as unknown/null, and safe_for_paper_mutation is false until the native Paper Trading provider can be positively identified.', {}, async () => {
+    try { return jsonResult(await core.getStatus()); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+}

--- a/src/tools/paper.js
+++ b/src/tools/paper.js
@@ -1,9 +1,104 @@
+import { z } from 'zod';
 import { jsonResult } from './_format.js';
 import * as core from '../core/paper.js';
 
 export function registerPaperTools(server) {
-  server.tool('paper_get_status', 'Report the current observability status of TradingView\'s native Paper Trading: desktop CDP connection and Trading Panel button state. Read-only. Facts that still require runtime discovery (session, provider identity, accounts) are returned as unknown/null, and safe_for_paper_mutation is false until the native Paper Trading provider can be positively identified.', {}, async () => {
+  server.tool('paper_get_status', 'Report TradingView native Paper Trading status: desktop CDP, auth session, Trading Panel, connection, active broker id, and whether mutations are safe (safe_for_paper_mutation is true only when the active broker id is exactly "Paper").', {}, async () => {
     try { return jsonResult(await core.getStatus()); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_open_panel', 'Open, close, or toggle the Trading Panel (bottom widget paper_trading) via the internal bottomWidgetBar API.', {
+    action: z.enum(['open', 'close', 'toggle']).optional().describe('open (default), close, or toggle'),
+  }, async ({ action }) => {
+    try { return jsonResult(await core.openPanel({ action: action || 'open' })); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_connect', 'Connect TradingView native Paper Trading (broker id "Paper"). Fails if not logged in. Never connects other brokers.', {}, async () => {
+    try { return jsonResult(await core.connect()); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_get_account', 'Get the active native Paper Trading account summary (balance, equity, PnL, margin, available funds). Requires Paper connected.', {}, async () => {
+    try { return jsonResult(await core.getAccount()); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_list_accounts', 'List Paper Trading accounts for the connected native Paper broker.', {}, async () => {
+    try { return jsonResult(await core.listAccounts()); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_switch_account', 'Switch the active native Paper Trading account by id.', {
+    account_id: z.string().describe('Paper account id from paper_list_accounts'),
+  }, async ({ account_id }) => {
+    try { return jsonResult(await core.switchAccount({ account_id })); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_list_positions', 'List open native Paper Trading positions.', {}, async () => {
+    try { return jsonResult(await core.listPositions()); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_list_orders', 'List native Paper Trading orders (active by default, or order history).', {
+    history: z.boolean().optional().describe('If true, return order history instead of active orders'),
+  }, async ({ history }) => {
+    try { return jsonResult(await core.listOrders({ history: !!history })); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_place_order', 'Place an order on native Paper Trading only. Fail-closed if active broker is not Paper. Types: market, limit, stop, stop_limit. Optional TIF (DAY/WEEK/MONTH/GTD), take_profit / stop_loss brackets.', {
+    side: z.enum(['buy', 'sell']).describe('Order side'),
+    type: z.enum(['market', 'limit', 'stop', 'stop_limit']).optional().describe('Order type (default market)'),
+    qty: z.coerce.number().describe('Quantity'),
+    symbol: z.string().optional().describe('Symbol (defaults to active chart symbol)'),
+    price: z.coerce.number().optional().describe('Limit price (limit / stop_limit)'),
+    stop_price: z.coerce.number().optional().describe('Stop price (stop / stop_limit)'),
+    take_profit: z.coerce.number().optional().describe('Take profit price'),
+    stop_loss: z.coerce.number().optional().describe('Stop loss price'),
+    tif: z.enum(['DAY', 'WEEK', 'MONTH', 'GTD']).optional().describe('Time in force (Paper default in UI is WEEK)'),
+    duration_datetime: z.union([z.string(), z.coerce.number()]).optional().describe('Required for GTD: ISO date/time or unix ms'),
+  }, async (args) => {
+    try { return jsonResult(await core.placeOrder(args)); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_cancel_order', 'Cancel an active native Paper Trading order by id.', {
+    order_id: z.string().describe('Order id'),
+  }, async ({ order_id }) => {
+    try { return jsonResult(await core.cancelOrder({ order_id })); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_modify_order', 'Modify an active native Paper Trading order (qty / price / stop_price).', {
+    order_id: z.string().describe('Order id'),
+    qty: z.coerce.number().optional().describe('New quantity'),
+    price: z.coerce.number().optional().describe('New limit price'),
+    stop_price: z.coerce.number().optional().describe('New stop price'),
+  }, async (args) => {
+    try { return jsonResult(await core.modifyOrder(args)); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_close_position', 'Close a native Paper Trading position (full or partial).', {
+    position_id: z.string().optional().describe('Position id (often the symbol)'),
+    symbol: z.string().optional().describe('Symbol if position_id omitted'),
+    qty: z.coerce.number().optional().describe('Partial close quantity (omit for full close)'),
+  }, async (args) => {
+    try { return jsonResult(await core.closePosition(args)); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
+  });
+
+  server.tool('paper_set_brackets', 'Add, change, or clear stop loss / take profit on an open native Paper position.', {
+    position_id: z.string().optional().describe('Position id (often the symbol)'),
+    symbol: z.string().optional().describe('Symbol if position_id omitted'),
+    stop_loss: z.coerce.number().optional().describe('Stop loss price'),
+    take_profit: z.coerce.number().optional().describe('Take profit price'),
+    clear: z.boolean().optional().describe('If true, clear both stop loss and take profit'),
+  }, async (args) => {
+    try { return jsonResult(await core.setBrackets(args)); }
+    catch (err) { return jsonResult({ success: false, error: err.message, code: err.code }, true); }
   });
 }

--- a/src/tools/paper.js
+++ b/src/tools/paper.js
@@ -2,7 +2,7 @@ import { jsonResult } from './_format.js';
 import * as core from '../core/paper.js';
 
 export function registerPaperTools(server) {
-  server.tool('paper_get_status', 'Report the current observability status of TradingView\'s native Paper Trading: desktop CDP connection and Trading Panel button state. Read-only. Facts that still require runtime discovery (session, provider identity, accounts) are returned as unknown/null, and safe_for_paper_mutation is false until the native Paper Trading provider can be positively identified.', {}, async () => {
+  server.tool('paper_get_status', 'Report the current observability status of TradingView\'s native Paper Trading: desktop CDP connection, session state (authenticated/unauthenticated), paper_trading widget availability, broker connection state, and the active provider (structural info). Read-only. Provider identity is not yet verifiable, so provider_type stays unknown and safe_for_paper_mutation stays false (fail closed).', {}, async () => {
     try { return jsonResult(await core.getStatus()); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -546,6 +546,26 @@ describe('paper mutation tools', () => {
     assert.equal(called, true);
   });
 
+  it('cancelOrder/closePosition/setBrackets treat Promise<void> as success', async () => {
+    // Page-side maps void → ok: (undefined !== false) === true; host treats missing/undefined ok as success.
+    const voidOk = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => {
+        assert.match(expr, /!== false/);
+        return { ok: true };
+      },
+    };
+    assert.equal((await cancelOrder({ order_id: '1', _deps: voidOk })).cancelled, true);
+    assert.equal((await closePosition({ symbol: 'X', _deps: voidOk })).closed, true);
+    assert.equal((await setBrackets({ symbol: 'X', clear: true, _deps: voidOk })).updated, true);
+
+    const explicitFail = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => ({ ok: false }),
+    };
+    assert.equal((await cancelOrder({ order_id: '1', _deps: explicitFail })).cancelled, false);
+  });
+
   it('modifyOrder requires id, rejects foreign broker, and succeeds on Paper', async () => {
     await assert.rejects(() => modifyOrder({ _deps: contextDeps(PAPER_CONNECTED) }), /order_id required/);
     await assert.rejects(() => modifyOrder({ order_id: '1', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -2,9 +2,12 @@
  * Tests for TradingView native Paper Trading observability (src/core/paper.js).
  * Everything runs offline with mocked CDP evaluation.
  *
- * At this stage (pre-discovery, see docs/PAPER_TRADING_DISCOVERY.md) the
- * status must report only verifiable facts, mark everything else as
- * unknown/null, and always fail closed on mutation safety.
+ * The status is built on runtime paths evidenced in
+ * docs/PAPER_TRADING_DISCOVERY.md (Capture 1): window.user session markers,
+ * the bottom-bar widget named 'paper_trading', the trading service's
+ * connectStatus() enum and activeBroker(). Facts that cannot be verified are
+ * reported as unknown/null, and mutation safety always fails closed while the
+ * native Paper Trading provider identity is unverified.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -18,61 +21,142 @@ const DISCONNECTED_DEPS = {
   evaluate: async () => { throw new Error('CDP connection failed after 5 attempts'); },
 };
 
-describe('paper getStatus() — Trading Panel observation', () => {
-  it('reports the panel button as available when it exists', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: false }) });
-    assert.equal(status.success, true);
-    assert.equal(status.desktop_connected, true);
-    assert.equal(status.trading_panel_available, true);
-    assert.equal(status.trading_panel_open, false);
+// Probe result as evidenced in Capture 1 (anonymous session, nothing connected).
+const ANONYMOUS_PROBE = {
+  source: 'internal_api',
+  session: 'unauthenticated',
+  paper_widget_registered: true,
+  paper_widget_enabled: false,
+  bottom_bar_visible: false,
+  active_widget: null,
+  trading_service_found: true,
+  connect_status_raw: 3,
+  active_broker: null,
+};
+
+const CONNECTED_PROBE = {
+  source: 'internal_api',
+  session: 'authenticated',
+  paper_widget_registered: true,
+  paper_widget_enabled: true,
+  bottom_bar_visible: true,
+  active_widget: 'paper_trading',
+  trading_service_found: true,
+  connect_status_raw: 1,
+  active_broker: { id: 'some-broker', name: 'Some Broker' },
+};
+
+describe('paper getStatus() — session detection', () => {
+  it('reports the unauthenticated session state', async () => {
+    const status = await getStatus({ _deps: depsReturning(ANONYMOUS_PROBE) });
+    assert.equal(status.tradingview_session, 'unauthenticated');
   });
 
-  it('reports the panel as open when the button is active', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
-    assert.equal(status.trading_panel_open, true);
+  it('reports the authenticated session state', async () => {
+    const status = await getStatus({ _deps: depsReturning(CONNECTED_PROBE) });
+    assert.equal(status.tradingview_session, 'authenticated');
   });
 
-  it('reports the panel as unavailable when the button is missing', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: false }) });
-    assert.equal(status.trading_panel_available, false);
-    assert.equal(status.trading_panel_open, null);
-  });
-
-  it('reports the desktop as disconnected instead of failing when CDP is unreachable', async () => {
-    const status = await getStatus({ _deps: DISCONNECTED_DEPS });
-    assert.equal(status.success, true);
-    assert.equal(status.desktop_connected, false);
-    assert.equal(status.trading_panel_available, null);
-    assert.equal(status.trading_panel_open, null);
-  });
-
-  it('queries the trading button through its semantic selectors', async () => {
-    const expressions = [];
-    const deps = { evaluate: async (expr) => { expressions.push(expr); return { button_found: false }; } };
-    await getStatus({ _deps: deps });
-    assert.ok(expressions[0].includes('trading-button'));
-    assert.ok(expressions[0].includes('Trading Panel'));
+  it('reports unknown when the probe cannot classify the session', async () => {
+    const status = await getStatus({ _deps: depsReturning({ ...ANONYMOUS_PROBE, session: 'unknown' }) });
+    assert.equal(status.tradingview_session, 'unknown');
   });
 });
 
-describe('paper getStatus() — honest unknowns before discovery', () => {
-  it('reports undiscovered facts as unknown or null, never guessed', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
-    assert.equal(status.tradingview_session, 'unknown');
+describe('paper getStatus() — panel and availability', () => {
+  it('maps widget enablement to paper_available', async () => {
+    const anonymous = await getStatus({ _deps: depsReturning(ANONYMOUS_PROBE) });
+    assert.equal(anonymous.paper_available, false);
+    const connected = await getStatus({ _deps: depsReturning(CONNECTED_PROBE) });
+    assert.equal(connected.paper_available, true);
+  });
+
+  it('reports the panel open only when the paper_trading widget is the visible active widget', async () => {
+    const connected = await getStatus({ _deps: depsReturning(CONNECTED_PROBE) });
+    assert.equal(connected.trading_panel_open, true);
+    const hidden = await getStatus({
+      _deps: depsReturning({ ...CONNECTED_PROBE, bottom_bar_visible: false }),
+    });
+    assert.equal(hidden.trading_panel_open, false);
+    const otherWidget = await getStatus({
+      _deps: depsReturning({ ...CONNECTED_PROBE, active_widget: 'backtesting' }),
+    });
+    assert.equal(otherWidget.trading_panel_open, false);
+  });
+
+  it('reports the observation source', async () => {
+    const status = await getStatus({ _deps: depsReturning(ANONYMOUS_PROBE) });
+    assert.equal(status.source, 'internal_api');
+  });
+
+  it('carries DOM fallback observations when internal paths are unavailable', async () => {
+    const status = await getStatus({
+      _deps: depsReturning({ source: 'dom_fallback', session: 'unknown', button_found: true, button_active: true }),
+    });
+    assert.equal(status.source, 'dom_fallback');
+    assert.equal(status.trading_panel_available, true);
+    assert.equal(status.trading_panel_open, true);
     assert.equal(status.paper_available, null);
     assert.equal(status.paper_connected, null);
-    assert.equal(status.active_provider, null);
+  });
+});
+
+describe('paper getStatus() — connection state mapping', () => {
+  const cases = [
+    [1, 'connected'],
+    [2, 'connecting'],
+    [3, 'disconnected'],
+    [4, 'error'],
+    [99, 'unknown'],
+    [null, 'unknown'],
+  ];
+
+  for (const [raw, expected] of cases) {
+    it(`maps connectStatus ${raw} to '${expected}'`, async () => {
+      const status = await getStatus({
+        _deps: depsReturning({ ...ANONYMOUS_PROBE, connect_status_raw: raw }),
+      });
+      assert.equal(status.connection_state, expected);
+      assert.equal(status.connection_state_raw, raw);
+    });
+  }
+});
+
+describe('paper getStatus() — paper_connected semantics', () => {
+  it('is false when nothing is connected', async () => {
+    const status = await getStatus({ _deps: depsReturning(ANONYMOUS_PROBE) });
+    assert.equal(status.paper_connected, false);
+  });
+
+  it('is null (not true) when connected but the provider is not verified as native Paper', async () => {
+    const status = await getStatus({ _deps: depsReturning(CONNECTED_PROBE) });
+    assert.equal(status.paper_connected, null);
     assert.equal(status.provider_type, 'unknown');
-    assert.equal(status.active_account_id, null);
-    assert.equal(status.discovery_status, 'pending');
+  });
+
+  it('exposes the active broker structurally without claiming it is Paper', async () => {
+    const status = await getStatus({ _deps: depsReturning(CONNECTED_PROBE) });
+    assert.deepEqual(status.active_provider, { id: 'some-broker', name: 'Some Broker' });
+    assert.equal(status.provider_type, 'unknown');
+  });
+});
+
+describe('paper getStatus() — desktop disconnected', () => {
+  it('reports the desktop as disconnected instead of failing', async () => {
+    const status = await getStatus({ _deps: DISCONNECTED_DEPS });
+    assert.equal(status.success, true);
+    assert.equal(status.desktop_connected, false);
+    assert.equal(status.tradingview_session, 'unknown');
+    assert.equal(status.paper_available, null);
+    assert.equal(status.connection_state, 'unknown');
   });
 });
 
 describe('paper getStatus() — mutation safety invariant', () => {
   const scenarios = [
-    ['panel open', depsReturning({ button_found: true, button_active: true })],
-    ['panel closed', depsReturning({ button_found: true, button_active: false })],
-    ['button missing', depsReturning({ button_found: false })],
+    ['anonymous', depsReturning(ANONYMOUS_PROBE)],
+    ['authenticated + connected broker', depsReturning(CONNECTED_PROBE)],
+    ['dom fallback', depsReturning({ source: 'dom_fallback', session: 'unknown', button_found: true, button_active: true })],
     ['desktop disconnected', DISCONNECTED_DEPS],
   ];
 

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -468,6 +468,7 @@ describe('paper placeOrder guard + validation', () => {
     assert.equal(res.success, true);
     assert.equal(res.action, 'place_order');
     assert.match(asyncExpr, /placeOrder/);
+    assert.match(asyncExpr, /tvRequirePaperBroker/);
     assert.match(asyncExpr, /BINANCE:BTCUSDT/);
   });
 
@@ -557,9 +558,11 @@ describe('paper mutation tools', () => {
     assert.equal(res.modified, true);
     assert.match(expr, /modifyOrder/);
     assert.match(expr, /qty = 2/);
+    assert.match(expr, /tvRequirePaperBroker/);
     // Fallback lookup must align with paper_list_orders (OrdersService.activeOrders).
     assert.match(expr, /activeOrders/);
     assert.match(expr, /_ordersService/);
+    assert.doesNotMatch(expr, /await ab\.orders\(\)/);
   });
 
   it('closePosition requires id and supports partial qty', async () => {
@@ -676,6 +679,13 @@ describe('paper_cdp PAGE_HELPERS serializers', () => {
   it('tvBrokerId reads _brokerMetainfo.id', () => {
     assert.equal(runPageHelper('tvBrokerId', { _brokerMetainfo: { id: 'Paper' } }), 'Paper');
     assert.equal(runPageHelper('tvBrokerId', null), null);
+  });
+
+  it('tvRequirePaperBroker fails closed for non-Paper brokers', () => {
+    assert.equal(runPageHelper('tvRequirePaperBroker', { _brokerMetainfo: { id: 'Paper' } }), null);
+    const denied = runPageHelper('tvRequirePaperBroker', { _brokerMetainfo: { id: 'BINANCE' } });
+    assert.match(denied.error, /not native Paper/);
+    assert.match(runPageHelper('tvRequirePaperBroker', null).error, /got null/);
   });
 
   it('tvWv unwraps WatchedValue-like objects', () => {

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -1,85 +1,735 @@
 /**
- * Tests for TradingView native Paper Trading observability (src/core/paper.js).
- * Everything runs offline with mocked CDP evaluation.
- *
- * At this stage (pre-discovery, see docs/PAPER_TRADING_DISCOVERY.md) the
- * status must report only verifiable facts, mark everything else as
- * unknown/null, and always fail closed on mutation safety.
+ * Tests for TradingView native Paper Trading (src/core/paper.js + paper_cdp.js).
+ * Offline with mocked CDP evaluation.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { getStatus } from '../src/core/paper.js';
-
-function depsReturning(result) {
-  return { evaluate: async () => result };
-}
+import {
+  getStatus,
+  buildStatus,
+  assertPaperContext,
+  openPanel,
+  connect,
+  listAccounts,
+  getAccount,
+  listPositions,
+  listOrders,
+  placeOrder,
+  cancelOrder,
+  modifyOrder,
+  closePosition,
+  setBrackets,
+  switchAccount,
+  NATIVE_PAPER_BROKER_ID,
+  CONNECT_STATUS,
+} from '../src/core/paper.js';
+import { PAGE_HELPERS, SUMMARY_IDS, tradingPanelButtonProbe } from '../src/core/paper_cdp.js';
 
 const DISCONNECTED_DEPS = {
   evaluate: async () => { throw new Error('CDP connection failed after 5 attempts'); },
+  evaluateAsync: async () => { throw new Error('CDP connection failed after 5 attempts'); },
 };
 
-describe('paper getStatus() — Trading Panel observation', () => {
-  it('reports the panel button as available when it exists', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: false }) });
+function contextDeps(context, button = { button_found: true, button_active: true }) {
+  return {
+    evaluate: async (expr) => {
+      if (expr.includes('trading-button') || expr.includes('Trading Panel')) return button;
+      return { desktop: true, ...context };
+    },
+    evaluateAsync: async () => ({ ok: true }),
+  };
+}
+
+/** Route evaluate/evaluateAsync by expression keywords (for read tools). */
+function routedDeps({ context = PAPER_CONNECTED, evaluateMap = {}, asyncMap = {} } = {}) {
+  return {
+    evaluate: async (expr) => {
+      if (expr.includes('trading-button') || expr.includes('Trading Panel')) {
+        return { button_found: true, button_active: true };
+      }
+      for (const [needle, value] of Object.entries(evaluateMap)) {
+        if (expr.includes(needle)) return typeof value === 'function' ? value(expr) : value;
+      }
+      return { desktop: true, ...context };
+    },
+    evaluateAsync: async (expr) => {
+      for (const [needle, value] of Object.entries(asyncMap)) {
+        if (expr.includes(needle)) return typeof value === 'function' ? value(expr) : value;
+      }
+      return { ok: true };
+    },
+  };
+}
+
+const PAPER_CONNECTED = {
+  session: 'authenticated',
+  username: 'tester',
+  panel_enabled: true,
+  panel_visible: true,
+  active_widget: 'paper_trading',
+  connect_status: CONNECT_STATUS.CONNECTED,
+  broker_id: NATIVE_PAPER_BROKER_ID,
+  broker_title: 'Paper Trading',
+  account_id: '15372380',
+  is_native_paper: true,
+  paper_connected: true,
+  safe_for_paper_mutation: true,
+};
+
+const FOREIGN_BROKER = {
+  ...PAPER_CONNECTED,
+  broker_id: 'BINANCE',
+  is_native_paper: false,
+  paper_connected: false,
+  safe_for_paper_mutation: false,
+};
+
+function runPageHelper(fnName, arg) {
+  return new Function('arg', `${PAGE_HELPERS}; return ${fnName}(arg);`)(arg);
+}
+
+describe('paper buildStatus / getStatus', () => {
+  it('reports Paper connected and mutation-safe when broker id is Paper', async () => {
+    const status = await getStatus({ _deps: contextDeps(PAPER_CONNECTED) });
     assert.equal(status.success, true);
     assert.equal(status.desktop_connected, true);
-    assert.equal(status.trading_panel_available, true);
-    assert.equal(status.trading_panel_open, false);
+    assert.equal(status.tradingview_session, 'authenticated');
+    assert.equal(status.paper_connected, true);
+    assert.equal(status.active_provider, 'Paper');
+    assert.equal(status.provider_type, 'native_paper');
+    assert.equal(status.safe_for_paper_mutation, true);
+    assert.equal(status.discovery_status, 'complete');
   });
 
-  it('reports the panel as open when the button is active', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
-    assert.equal(status.trading_panel_open, true);
+  it('never allows mutation when another broker is active', async () => {
+    const status = await getStatus({ _deps: contextDeps(FOREIGN_BROKER) });
+    assert.equal(status.provider_type, 'other_broker');
+    assert.equal(status.paper_connected, false);
+    assert.equal(status.safe_for_paper_mutation, false);
   });
 
-  it('reports the panel as unavailable when the button is missing', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: false }) });
+  it('reports anonymous session honestly', async () => {
+    const status = await getStatus({
+      _deps: contextDeps({
+        session: 'anonymous',
+        panel_enabled: false,
+        panel_visible: false,
+        active_widget: null,
+        connect_status: CONNECT_STATUS.DISCONNECTED,
+        broker_id: null,
+        account_id: null,
+        is_native_paper: false,
+        paper_connected: false,
+        safe_for_paper_mutation: false,
+      }, { button_found: false }),
+    });
+    assert.equal(status.tradingview_session, 'anonymous');
     assert.equal(status.trading_panel_available, false);
-    assert.equal(status.trading_panel_open, null);
+    assert.equal(status.safe_for_paper_mutation, false);
   });
 
-  it('reports the desktop as disconnected instead of failing when CDP is unreachable', async () => {
+  it('reports desktop disconnected without throwing', async () => {
     const status = await getStatus({ _deps: DISCONNECTED_DEPS });
     assert.equal(status.success, true);
     assert.equal(status.desktop_connected, false);
-    assert.equal(status.trading_panel_available, null);
-    assert.equal(status.trading_panel_open, null);
+    assert.equal(status.safe_for_paper_mutation, false);
   });
 
-  it('queries the trading button through its semantic selectors', async () => {
-    const expressions = [];
-    const deps = { evaluate: async (expr) => { expressions.push(expr); return { button_found: false }; } };
-    await getStatus({ _deps: deps });
-    assert.ok(expressions[0].includes('trading-button'));
-    assert.ok(expressions[0].includes('Trading Panel'));
-  });
-});
-
-describe('paper getStatus() — honest unknowns before discovery', () => {
-  it('reports undiscovered facts as unknown or null, never guessed', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
-    assert.equal(status.tradingview_session, 'unknown');
-    assert.equal(status.paper_available, null);
-    assert.equal(status.paper_connected, null);
-    assert.equal(status.active_provider, null);
-    assert.equal(status.provider_type, 'unknown');
-    assert.equal(status.active_account_id, null);
-    assert.equal(status.discovery_status, 'pending');
-  });
-});
-
-describe('paper getStatus() — mutation safety invariant', () => {
-  const scenarios = [
-    ['panel open', depsReturning({ button_found: true, button_active: true })],
-    ['panel closed', depsReturning({ button_found: true, button_active: false })],
-    ['button missing', depsReturning({ button_found: false })],
-    ['desktop disconnected', DISCONNECTED_DEPS],
-  ];
-
-  for (const [name, deps] of scenarios) {
-    it(`never reports safe_for_paper_mutation while the provider is unverified (${name})`, async () => {
-      const status = await getStatus({ _deps: deps });
-      assert.equal(status.safe_for_paper_mutation, false);
+  it('keeps desktop connected but unknown session when readContext fails after probe', async () => {
+    let calls = 0;
+    const status = await getStatus({
+      _deps: {
+        evaluate: async (expr) => {
+          calls += 1;
+          if (expr.includes('trading-button') || expr.includes('Trading Panel')) {
+            return { button_found: true, button_active: true };
+          }
+          throw new Error('readContext CDP timeout');
+        },
+        evaluateAsync: async () => ({}),
+      },
     });
-  }
+    assert.equal(calls, 2);
+    assert.equal(status.desktop_connected, true);
+    assert.equal(status.tradingview_session, 'unknown');
+    assert.equal(status.paper_connected, false);
+    assert.equal(status.active_provider, null);
+    assert.equal(status.safe_for_paper_mutation, false);
+  });
+
+  it('buildStatus derives provider_type none when disconnected without broker', () => {
+    const s = buildStatus({
+      desktop: true,
+      session: 'authenticated',
+      panel_enabled: true,
+      panel_visible: false,
+      active_widget: null,
+      connect_status: CONNECT_STATUS.DISCONNECTED,
+      broker_id: null,
+      account_id: null,
+      safe_for_paper_mutation: false,
+    }, { button_found: true, button_active: false });
+    assert.equal(s.provider_type, 'none');
+    assert.equal(s.trading_panel_open, false);
+  });
+
+  it('buildStatus derives provider_type from broker id', () => {
+    const s = buildStatus({
+      desktop: true,
+      session: 'authenticated',
+      panel_enabled: true,
+      panel_visible: true,
+      active_widget: 'paper_trading',
+      connect_status: 1,
+      broker_id: 'Paper',
+      account_id: '1',
+      safe_for_paper_mutation: true,
+    }, { button_found: true, button_active: true });
+    assert.equal(s.provider_type, 'native_paper');
+    assert.equal(s.paper_connected, true);
+    assert.equal(s.connect_status_label, 'connected');
+  });
+});
+
+describe('paper assertPaperContext fail-closed', () => {
+  it('allows Paper-connected context', async () => {
+    const ctx = await assertPaperContext({ _deps: contextDeps(PAPER_CONNECTED) });
+    assert.equal(ctx.broker_id, 'Paper');
+  });
+
+  it('rejects anonymous session', async () => {
+    await assert.rejects(
+      () => assertPaperContext({
+        _deps: contextDeps({ ...PAPER_CONNECTED, session: 'anonymous', safe_for_paper_mutation: false }),
+      }),
+      (err) => err.code === 'TRADINGVIEW_AUTH_REQUIRED',
+    );
+  });
+
+  it('rejects disconnected Paper', async () => {
+    await assert.rejects(
+      () => assertPaperContext({
+        _deps: contextDeps({
+          ...PAPER_CONNECTED,
+          connect_status: CONNECT_STATUS.DISCONNECTED,
+          paper_connected: false,
+          safe_for_paper_mutation: false,
+        }),
+      }),
+      (err) => err.code === 'PAPER_NOT_CONNECTED',
+    );
+  });
+
+  it('rejects non-Paper broker', async () => {
+    await assert.rejects(
+      () => assertPaperContext({ _deps: contextDeps(FOREIGN_BROKER) }),
+      (err) => err.code === 'NOT_PAPER_PROVIDER',
+    );
+  });
+
+  it('maps CDP failures to CDP_UNAVAILABLE', async () => {
+    await assert.rejects(
+      () => assertPaperContext({ _deps: DISCONNECTED_DEPS }),
+      (err) => err.code === 'CDP_UNAVAILABLE',
+    );
+  });
+});
+
+describe('paper openPanel', () => {
+  it('rejects invalid action', async () => {
+    await assert.rejects(
+      () => openPanel({ action: 'flip', _deps: contextDeps(PAPER_CONNECTED) }),
+      /action must be open, close, or toggle/,
+    );
+  });
+
+  it('opens the paper_trading widget via evaluate', async () => {
+    let expr = '';
+    const deps = {
+      evaluate: async (e) => { expr = e; return { was_open: false, performed: 'opened' }; },
+    };
+    const res = await openPanel({ action: 'open', _deps: deps });
+    assert.equal(res.success, true);
+    assert.equal(res.performed, 'opened');
+    assert.match(expr, /showWidget/);
+    assert.match(expr, /paper_trading/);
+  });
+
+  it('surfaces bottomWidgetBar errors', async () => {
+    await assert.rejects(
+      () => openPanel({
+        _deps: { evaluate: async () => ({ error: 'bottomWidgetBar not available' }) },
+      }),
+      /bottomWidgetBar not available/,
+    );
+  });
+});
+
+describe('paper connect', () => {
+  it('rejects anonymous session', async () => {
+    await assert.rejects(
+      () => connect({
+        _deps: contextDeps({ ...PAPER_CONNECTED, session: 'anonymous', paper_connected: false }),
+      }),
+      (err) => err.code === 'TRADINGVIEW_AUTH_REQUIRED',
+    );
+  });
+
+  it('returns already when Paper is connected', async () => {
+    const res = await connect({ _deps: contextDeps(PAPER_CONNECTED) });
+    assert.equal(res.already, true);
+    assert.equal(res.broker_id, 'Paper');
+  });
+
+  it('selects broker Paper when disconnected', async () => {
+    let asyncExpr = '';
+    const deps = routedDeps({
+      context: {
+        ...PAPER_CONNECTED,
+        paper_connected: false,
+        connect_status: CONNECT_STATUS.DISCONNECTED,
+        broker_id: null,
+        safe_for_paper_mutation: false,
+      },
+      asyncMap: {
+        selectBroker: (expr) => {
+          asyncExpr = expr;
+          return { broker_id: 'Paper', connect_status: CONNECT_STATUS.CONNECTED };
+        },
+      },
+    });
+    const res = await connect({ _deps: deps });
+    assert.equal(res.connected, true);
+    assert.match(asyncExpr, /selectBroker/);
+    assert.match(asyncExpr, /"Paper"/);
+  });
+
+  it('fails closed if selectBroker activates a non-Paper broker', async () => {
+    const deps = routedDeps({
+      context: {
+        ...PAPER_CONNECTED,
+        paper_connected: false,
+        connect_status: CONNECT_STATUS.DISCONNECTED,
+        broker_id: null,
+      },
+      asyncMap: {
+        selectBroker: { broker_id: 'BINANCE', connect_status: CONNECT_STATUS.CONNECTED },
+      },
+    });
+    await assert.rejects(() => connect({ _deps: deps }), (err) => err.code === 'NOT_PAPER_PROVIDER');
+  });
+});
+
+describe('paper read tools', () => {
+  it('listAccounts returns mapped accounts after guard', async () => {
+    const deps = routedDeps({
+      asyncMap: {
+        accountsMetainfo: [
+          { id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD', is_active: true },
+        ],
+      },
+    });
+    // evaluateAsync returns the array directly from the expression result
+    deps.evaluateAsync = async () => ([
+      { id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD', is_active: true },
+    ]);
+    const res = await listAccounts({ _deps: deps });
+    assert.equal(res.success, true);
+    assert.equal(res.accounts[0].id, '15372380');
+  });
+
+  it('getAccount returns the account payload', async () => {
+    const account = {
+      id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD',
+      balance: 100000, equity: 99000, realized_pnl: 0, unrealized_pnl: -1000,
+      margin_used: 9000, available_funds: 90000, orders_margin: 0, margin_buffer: 90,
+    };
+    const deps = routedDeps({ asyncMap: { currentAccount: account } });
+    deps.evaluateAsync = async () => account;
+    const res = await getAccount({ _deps: deps });
+    assert.equal(res.account.balance, 100000);
+    assert.equal(res.account.currency, 'USD');
+  });
+
+  it('getAccount CDP script prefers meta.currency when positions are empty', async () => {
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => {
+        expr = e;
+        return {
+          id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD',
+          balance: 100000, equity: 100000, realized_pnl: 0, unrealized_pnl: 0,
+          margin_used: 0, available_funds: 100000, orders_margin: 0, margin_buffer: 0,
+        };
+      },
+    };
+    await getAccount({ _deps: deps });
+    assert.match(expr, /currency = meta\.currency/);
+    assert.match(expr, /accountCurrency/);
+  });
+
+  it('listPositions maps evaluate result and count', async () => {
+    const positions = [{ id: 'BINANCE:BTCUSDT', symbol: 'BINANCE:BTCUSDT', side: 'sell', qty: 1 }];
+    let calls = 0;
+    const deps = {
+      evaluate: async (expr) => {
+        calls += 1;
+        if (expr.includes('trading-button')) return { button_found: true, button_active: true };
+        // Match the listPositions body, not PAGE_HELPERS' function definitions.
+        if (expr.includes('list.map(tvScalarizePosition)')) return positions;
+        return { desktop: true, ...PAPER_CONNECTED };
+      },
+      evaluateAsync: async () => ({}),
+    };
+    const res = await listPositions({ _deps: deps });
+    assert.equal(res.count, 1);
+    assert.equal(res.positions[0].symbol, 'BINANCE:BTCUSDT');
+    assert.ok(calls >= 2);
+  });
+
+  it('listPositions surfaces page errors', async () => {
+    const deps = {
+      evaluate: async (expr) => {
+        if (expr.includes('list.map(tvScalarizePosition)')) return { error: 'boom' };
+        return { desktop: true, ...PAPER_CONNECTED };
+      },
+      evaluateAsync: async () => ({}),
+    };
+    await assert.rejects(() => listPositions({ _deps: deps }), /boom/);
+  });
+
+  it('listOrders returns active orders by default', async () => {
+    const orders = [{ id: '1', symbol: 'X', side: 'buy', type: 'limit', status: 'working' }];
+    const deps = {
+      evaluate: async (expr) => {
+        if (expr.includes('list.map(tvScalarizeOrder)')) return orders;
+        return { desktop: true, ...PAPER_CONNECTED };
+      },
+      evaluateAsync: async () => orders,
+    };
+    const res = await listOrders({ _deps: deps });
+    assert.equal(res.history, false);
+    assert.equal(res.count, 1);
+  });
+
+  it('listOrders history uses evaluateAsync', async () => {
+    let usedAsync = false;
+    const orders = [{ id: '9', status: 'filled' }];
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => {
+        usedAsync = expr.includes('ordersHistory');
+        return orders;
+      },
+    };
+    const res = await listOrders({ history: true, _deps: deps });
+    assert.equal(res.history, true);
+    assert.equal(res.count, 1);
+    assert.equal(usedAsync, true);
+  });
+
+  it('read tools reject non-Paper broker', async () => {
+    const deps = contextDeps(FOREIGN_BROKER);
+    await assert.rejects(() => listAccounts({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    await assert.rejects(() => getAccount({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    await assert.rejects(() => listPositions({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    await assert.rejects(() => listOrders({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+  });
+});
+
+describe('paper placeOrder guard + validation', () => {
+  it('refuses placeOrder when broker is not Paper', async () => {
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', type: 'market', qty: 1, _deps: contextDeps(FOREIGN_BROKER) }),
+      (err) => err.code === 'NOT_PAPER_PROVIDER',
+    );
+  });
+
+  it('validates side, qty, price, and stop_price', async () => {
+    const deps = contextDeps(PAPER_CONNECTED);
+    await assert.rejects(() => placeOrder({ side: 'hold', qty: 1, _deps: deps }), /side must be buy or sell/);
+    await assert.rejects(() => placeOrder({ side: 'buy', qty: -1, _deps: deps }), /qty must be positive/);
+    await assert.rejects(() => placeOrder({ side: 'buy', type: 'limit', qty: 1, _deps: deps }), /price is required/);
+    await assert.rejects(() => placeOrder({ side: 'buy', type: 'stop', qty: 1, _deps: deps }), /stop_price is required/);
+    await assert.rejects(() => placeOrder({ side: 'buy', type: 'bogus', qty: 1, _deps: deps }), /type must be market/);
+  });
+
+  it('places a market order through evaluateAsync when Paper is active', async () => {
+    let asyncExpr = null;
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => {
+        asyncExpr = expr;
+        return { result: { order_id: '99' } };
+      },
+    };
+    const res = await placeOrder({ side: 'buy', type: 'market', qty: 0.01, symbol: 'BINANCE:BTCUSDT', _deps: deps });
+    assert.equal(res.success, true);
+    assert.equal(res.action, 'place_order');
+    assert.match(asyncExpr, /placeOrder/);
+    assert.match(asyncExpr, /tvRequirePaperBroker/);
+    assert.match(asyncExpr, /BINANCE:BTCUSDT/);
+  });
+
+  it('embeds limit/stop/bracket fields in the CDP payload', async () => {
+    let asyncExpr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => { asyncExpr = expr; return { result: true }; },
+    };
+    await placeOrder({
+      side: 'sell', type: 'stop_limit', qty: 2, symbol: 'X',
+      price: 10, stop_price: 11, take_profit: 9, stop_loss: 12, _deps: deps,
+    });
+    assert.match(asyncExpr, /limitPrice = 10/);
+    assert.match(asyncExpr, /stopPrice = 11/);
+    assert.match(asyncExpr, /takeProfit = 9/);
+    assert.match(asyncExpr, /stopLoss = 12/);
+  });
+
+  it('embeds TIF duration and validates GTD datetime', async () => {
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => ({ result: true, expr }),
+    };
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', qty: 1, symbol: 'X', tif: 'GTD', _deps: deps }),
+      /duration_datetime is required/,
+    );
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', qty: 1, symbol: 'X', tif: 'YEAR', _deps: deps }),
+      /tif must be DAY/,
+    );
+    let asyncExpr = '';
+    deps.evaluateAsync = async (expr) => { asyncExpr = expr; return { result: true }; };
+    const res = await placeOrder({
+      side: 'buy', qty: 1, symbol: 'X', tif: 'WEEK', _deps: deps,
+    });
+    assert.equal(res.tif, 'WEEK');
+    assert.match(asyncExpr, /"type":"WEEK"/);
+    await placeOrder({
+      side: 'buy', qty: 1, symbol: 'X', tif: 'GTD', duration_datetime: 1786653569000, _deps: deps,
+    });
+    assert.match(asyncExpr, /"type":"GTD"/);
+    assert.match(asyncExpr, /1786653569000/);
+  });
+
+  it('surfaces page-side placeOrder errors', async () => {
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => ({ error: 'symbol required (chart symbol unavailable)' }),
+    };
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', qty: 1, _deps: deps }),
+      /symbol required/,
+    );
+  });
+});
+
+describe('paper mutation tools', () => {
+  const foreign = contextDeps(FOREIGN_BROKER);
+
+  it('cancelOrder rejects missing id and non-Paper broker', async () => {
+    await assert.rejects(() => cancelOrder({ _deps: contextDeps(PAPER_CONNECTED) }), /order_id required/);
+    await assert.rejects(() => cancelOrder({ order_id: '1', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+  });
+
+  it('cancelOrder calls evaluateAsync only after Paper guard passes', async () => {
+    let called = false;
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => { called = true; return { ok: true }; },
+    };
+    const res = await cancelOrder({ order_id: '42', _deps: deps });
+    assert.equal(res.cancelled, true);
+    assert.equal(called, true);
+  });
+
+  it('cancelOrder/closePosition/setBrackets treat Promise<void> as success', async () => {
+    // Page-side maps void → ok: (undefined !== false) === true; host treats missing/undefined ok as success.
+    const voidOk = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => {
+        assert.match(expr, /!== false/);
+        return { ok: true };
+      },
+    };
+    assert.equal((await cancelOrder({ order_id: '1', _deps: voidOk })).cancelled, true);
+    assert.equal((await closePosition({ symbol: 'X', _deps: voidOk })).closed, true);
+    assert.equal((await setBrackets({ symbol: 'X', clear: true, _deps: voidOk })).updated, true);
+
+    const explicitFail = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => ({ ok: false }),
+    };
+    assert.equal((await cancelOrder({ order_id: '1', _deps: explicitFail })).cancelled, false);
+  });
+
+  it('modifyOrder requires id, rejects foreign broker, and succeeds on Paper', async () => {
+    await assert.rejects(() => modifyOrder({ _deps: contextDeps(PAPER_CONNECTED) }), /order_id required/);
+    await assert.rejects(() => modifyOrder({ order_id: '1', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await modifyOrder({ order_id: '7', qty: 2, price: 100, _deps: deps });
+    assert.equal(res.modified, true);
+    assert.match(expr, /modifyOrder/);
+    assert.match(expr, /qty = 2/);
+    assert.match(expr, /tvRequirePaperBroker/);
+    // Fallback lookup must align with paper_list_orders (OrdersService.activeOrders).
+    assert.match(expr, /activeOrders/);
+    assert.match(expr, /_ordersService/);
+    assert.doesNotMatch(expr, /await ab\.orders\(\)/);
+  });
+
+  it('closePosition requires id and supports partial qty', async () => {
+    await assert.rejects(() => closePosition({ _deps: contextDeps(PAPER_CONNECTED) }), /position_id or symbol required/);
+    await assert.rejects(() => closePosition({ symbol: 'X', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await closePosition({ symbol: 'BINANCE:BTCUSDT', qty: 0.5, _deps: deps });
+    assert.equal(res.closed, true);
+    assert.equal(res.qty, 0.5);
+    assert.match(expr, /closePosition/);
+    assert.match(expr, /0\.5/);
+  });
+
+  it('setBrackets requires levels and updates via editPositionBrackets', async () => {
+    await assert.rejects(
+      () => setBrackets({ symbol: 'X', _deps: contextDeps(PAPER_CONNECTED) }),
+      /stop_loss or take_profit required/,
+    );
+    await assert.rejects(
+      () => setBrackets({ symbol: 'X', stop_loss: 1, _deps: foreign }),
+      (e) => e.code === 'NOT_PAPER_PROVIDER',
+    );
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await setBrackets({ position_id: 'BINANCE:BTCUSDT', stop_loss: 70000, take_profit: 60000, _deps: deps });
+    assert.equal(res.updated, true);
+    assert.deepEqual(res.brackets, { stopLoss: 70000, takeProfit: 60000 });
+    assert.match(expr, /editPositionBrackets/);
+  });
+
+  it('setBrackets clear removes SL/TP', async () => {
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await setBrackets({ symbol: 'BINANCE:BTCUSDT', clear: true, _deps: deps });
+    assert.equal(res.action, 'clear_brackets');
+    assert.deepEqual(res.brackets, { stopLoss: null, takeProfit: null });
+    assert.match(expr, /null/);
+  });
+
+  it('switchAccount requires id and calls setCurrentAccount', async () => {
+    await assert.rejects(() => switchAccount({ _deps: contextDeps(PAPER_CONNECTED) }), /account_id required/);
+    await assert.rejects(() => switchAccount({ account_id: '1', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { account_id: '15372380' }; },
+    };
+    const res = await switchAccount({ account_id: '15372380', _deps: deps });
+    assert.equal(res.account_id, '15372380');
+    assert.match(expr, /setCurrentAccount/);
+  });
+});
+
+describe('paper_cdp PAGE_HELPERS serializers', () => {
+  it('tvScalarizePosition maps Capture-2 position fields', () => {
+    const out = runPageHelper('tvScalarizePosition', {
+      id: 'BINANCE:BTCUSDT',
+      symbol: 'BINANCE:BTCUSDT',
+      side: -1,
+      qty: 1.55,
+      avgPrice: 64466.51,
+      lastPrice: 65000,
+      marketValue: 100,
+      pl: -1,
+      supportBrackets: true,
+      supportStopLoss: true,
+      supportTrailingStop: false,
+      stopLoss: 70000,
+      takeProfit: 60000,
+      extra: {
+        pl: -785,
+        plPercent: -0.7,
+        accountCurrency: 'USD',
+        leverage: '10:1',
+        usedMargin: 9900,
+      },
+    });
+    assert.equal(out.side, 'sell');
+    assert.equal(out.unrealized_pnl, -785);
+    assert.equal(out.currency, 'USD');
+    assert.equal(out.leverage, '10:1');
+    assert.equal(out.stop_loss, 70000);
+    assert.equal(out.support_trailing_stop, false);
+  });
+
+  it('tvScalarizeOrder maps type/status enums', () => {
+    const out = runPageHelper('tvScalarizeOrder', {
+      id: 3382363357,
+      symbol: 'BINANCE:BTCUSDT',
+      side: 1,
+      type: 1,
+      status: 6,
+      qty: 0.001,
+      limitPrice: 1000,
+      extra: { accountCurrency: 'USD', leverage: '10:1', usedMargin: 0.1 },
+    });
+    assert.equal(out.id, '3382363357');
+    assert.equal(out.side, 'buy');
+    assert.equal(out.type, 'limit');
+    assert.equal(out.status, 'working');
+    assert.equal(out.limit_price, 1000);
+  });
+
+  it('tvBrokerId reads _brokerMetainfo.id', () => {
+    assert.equal(runPageHelper('tvBrokerId', { _brokerMetainfo: { id: 'Paper' } }), 'Paper');
+    assert.equal(runPageHelper('tvBrokerId', null), null);
+  });
+
+  it('tvRequirePaperBroker fails closed for non-Paper brokers', () => {
+    assert.equal(runPageHelper('tvRequirePaperBroker', { _brokerMetainfo: { id: 'Paper' } }), null);
+    const denied = runPageHelper('tvRequirePaperBroker', { _brokerMetainfo: { id: 'BINANCE' } });
+    assert.match(denied.error, /not native Paper/);
+    assert.match(runPageHelper('tvRequirePaperBroker', null).error, /got null/);
+  });
+
+  it('tvWv unwraps WatchedValue-like objects', () => {
+    assert.equal(runPageHelper('tvWv', { value: () => 3 }), 3);
+    assert.equal(runPageHelper('tvWv', { value: 7 }), 7);
+    assert.equal(runPageHelper('tvWv', 5), 5);
+  });
+
+  it('keeps SUMMARY_IDS aligned with Capture-2 account fields', () => {
+    assert.deepEqual(SUMMARY_IDS, [
+      'balance', 'equity', 'realized_pnl', 'unrealized_pnl',
+      'margin_used', 'available_funds', 'orders_margin', 'margin_buffer',
+    ]);
+  });
+
+  it('tradingPanelButtonProbe targets trading-button selectors', () => {
+    const probe = tradingPanelButtonProbe();
+    assert.match(probe, /trading-button/);
+    assert.match(probe, /Trading Panel/);
+  });
+});
+
+describe('paper constants', () => {
+  it('exports the Capture-2 stable broker id', () => {
+    assert.equal(NATIVE_PAPER_BROKER_ID, 'Paper');
+  });
 });

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -1,85 +1,662 @@
 /**
- * Tests for TradingView native Paper Trading observability (src/core/paper.js).
- * Everything runs offline with mocked CDP evaluation.
- *
- * At this stage (pre-discovery, see docs/PAPER_TRADING_DISCOVERY.md) the
- * status must report only verifiable facts, mark everything else as
- * unknown/null, and always fail closed on mutation safety.
+ * Tests for TradingView native Paper Trading (src/core/paper.js + paper_cdp.js).
+ * Offline with mocked CDP evaluation.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { getStatus } from '../src/core/paper.js';
-
-function depsReturning(result) {
-  return { evaluate: async () => result };
-}
+import {
+  getStatus,
+  buildStatus,
+  assertPaperContext,
+  openPanel,
+  connect,
+  listAccounts,
+  getAccount,
+  listPositions,
+  listOrders,
+  placeOrder,
+  cancelOrder,
+  modifyOrder,
+  closePosition,
+  setBrackets,
+  switchAccount,
+  NATIVE_PAPER_BROKER_ID,
+  CONNECT_STATUS,
+} from '../src/core/paper.js';
+import { PAGE_HELPERS, SUMMARY_IDS, tradingPanelButtonProbe } from '../src/core/paper_cdp.js';
 
 const DISCONNECTED_DEPS = {
   evaluate: async () => { throw new Error('CDP connection failed after 5 attempts'); },
+  evaluateAsync: async () => { throw new Error('CDP connection failed after 5 attempts'); },
 };
 
-describe('paper getStatus() — Trading Panel observation', () => {
-  it('reports the panel button as available when it exists', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: false }) });
+function contextDeps(context, button = { button_found: true, button_active: true }) {
+  return {
+    evaluate: async (expr) => {
+      if (expr.includes('trading-button') || expr.includes('Trading Panel')) return button;
+      return { desktop: true, ...context };
+    },
+    evaluateAsync: async () => ({ ok: true }),
+  };
+}
+
+/** Route evaluate/evaluateAsync by expression keywords (for read tools). */
+function routedDeps({ context = PAPER_CONNECTED, evaluateMap = {}, asyncMap = {} } = {}) {
+  return {
+    evaluate: async (expr) => {
+      if (expr.includes('trading-button') || expr.includes('Trading Panel')) {
+        return { button_found: true, button_active: true };
+      }
+      for (const [needle, value] of Object.entries(evaluateMap)) {
+        if (expr.includes(needle)) return typeof value === 'function' ? value(expr) : value;
+      }
+      return { desktop: true, ...context };
+    },
+    evaluateAsync: async (expr) => {
+      for (const [needle, value] of Object.entries(asyncMap)) {
+        if (expr.includes(needle)) return typeof value === 'function' ? value(expr) : value;
+      }
+      return { ok: true };
+    },
+  };
+}
+
+const PAPER_CONNECTED = {
+  session: 'authenticated',
+  username: 'tester',
+  panel_enabled: true,
+  panel_visible: true,
+  active_widget: 'paper_trading',
+  connect_status: CONNECT_STATUS.CONNECTED,
+  broker_id: NATIVE_PAPER_BROKER_ID,
+  broker_title: 'Paper Trading',
+  account_id: '15372380',
+  is_native_paper: true,
+  paper_connected: true,
+  safe_for_paper_mutation: true,
+};
+
+const FOREIGN_BROKER = {
+  ...PAPER_CONNECTED,
+  broker_id: 'BINANCE',
+  is_native_paper: false,
+  paper_connected: false,
+  safe_for_paper_mutation: false,
+};
+
+function runPageHelper(fnName, arg) {
+  return new Function('arg', `${PAGE_HELPERS}; return ${fnName}(arg);`)(arg);
+}
+
+describe('paper buildStatus / getStatus', () => {
+  it('reports Paper connected and mutation-safe when broker id is Paper', async () => {
+    const status = await getStatus({ _deps: contextDeps(PAPER_CONNECTED) });
     assert.equal(status.success, true);
     assert.equal(status.desktop_connected, true);
-    assert.equal(status.trading_panel_available, true);
-    assert.equal(status.trading_panel_open, false);
+    assert.equal(status.tradingview_session, 'authenticated');
+    assert.equal(status.paper_connected, true);
+    assert.equal(status.active_provider, 'Paper');
+    assert.equal(status.provider_type, 'native_paper');
+    assert.equal(status.safe_for_paper_mutation, true);
+    assert.equal(status.discovery_status, 'complete');
   });
 
-  it('reports the panel as open when the button is active', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
-    assert.equal(status.trading_panel_open, true);
+  it('never allows mutation when another broker is active', async () => {
+    const status = await getStatus({ _deps: contextDeps(FOREIGN_BROKER) });
+    assert.equal(status.provider_type, 'other_broker');
+    assert.equal(status.paper_connected, false);
+    assert.equal(status.safe_for_paper_mutation, false);
   });
 
-  it('reports the panel as unavailable when the button is missing', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: false }) });
+  it('reports anonymous session honestly', async () => {
+    const status = await getStatus({
+      _deps: contextDeps({
+        session: 'anonymous',
+        panel_enabled: false,
+        panel_visible: false,
+        active_widget: null,
+        connect_status: CONNECT_STATUS.DISCONNECTED,
+        broker_id: null,
+        account_id: null,
+        is_native_paper: false,
+        paper_connected: false,
+        safe_for_paper_mutation: false,
+      }, { button_found: false }),
+    });
+    assert.equal(status.tradingview_session, 'anonymous');
     assert.equal(status.trading_panel_available, false);
-    assert.equal(status.trading_panel_open, null);
+    assert.equal(status.safe_for_paper_mutation, false);
   });
 
-  it('reports the desktop as disconnected instead of failing when CDP is unreachable', async () => {
+  it('reports desktop disconnected without throwing', async () => {
     const status = await getStatus({ _deps: DISCONNECTED_DEPS });
     assert.equal(status.success, true);
     assert.equal(status.desktop_connected, false);
-    assert.equal(status.trading_panel_available, null);
-    assert.equal(status.trading_panel_open, null);
+    assert.equal(status.safe_for_paper_mutation, false);
   });
 
-  it('queries the trading button through its semantic selectors', async () => {
-    const expressions = [];
-    const deps = { evaluate: async (expr) => { expressions.push(expr); return { button_found: false }; } };
-    await getStatus({ _deps: deps });
-    assert.ok(expressions[0].includes('trading-button'));
-    assert.ok(expressions[0].includes('Trading Panel'));
+  it('buildStatus derives provider_type none when disconnected without broker', () => {
+    const s = buildStatus({
+      desktop: true,
+      session: 'authenticated',
+      panel_enabled: true,
+      panel_visible: false,
+      active_widget: null,
+      connect_status: CONNECT_STATUS.DISCONNECTED,
+      broker_id: null,
+      account_id: null,
+      safe_for_paper_mutation: false,
+    }, { button_found: true, button_active: false });
+    assert.equal(s.provider_type, 'none');
+    assert.equal(s.trading_panel_open, false);
+  });
+
+  it('buildStatus derives provider_type from broker id', () => {
+    const s = buildStatus({
+      desktop: true,
+      session: 'authenticated',
+      panel_enabled: true,
+      panel_visible: true,
+      active_widget: 'paper_trading',
+      connect_status: 1,
+      broker_id: 'Paper',
+      account_id: '1',
+      safe_for_paper_mutation: true,
+    }, { button_found: true, button_active: true });
+    assert.equal(s.provider_type, 'native_paper');
+    assert.equal(s.paper_connected, true);
+    assert.equal(s.connect_status_label, 'connected');
   });
 });
 
-describe('paper getStatus() — honest unknowns before discovery', () => {
-  it('reports undiscovered facts as unknown or null, never guessed', async () => {
-    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
-    assert.equal(status.tradingview_session, 'unknown');
-    assert.equal(status.paper_available, null);
-    assert.equal(status.paper_connected, null);
-    assert.equal(status.active_provider, null);
-    assert.equal(status.provider_type, 'unknown');
-    assert.equal(status.active_account_id, null);
-    assert.equal(status.discovery_status, 'pending');
+describe('paper assertPaperContext fail-closed', () => {
+  it('allows Paper-connected context', async () => {
+    const ctx = await assertPaperContext({ _deps: contextDeps(PAPER_CONNECTED) });
+    assert.equal(ctx.broker_id, 'Paper');
+  });
+
+  it('rejects anonymous session', async () => {
+    await assert.rejects(
+      () => assertPaperContext({
+        _deps: contextDeps({ ...PAPER_CONNECTED, session: 'anonymous', safe_for_paper_mutation: false }),
+      }),
+      (err) => err.code === 'TRADINGVIEW_AUTH_REQUIRED',
+    );
+  });
+
+  it('rejects disconnected Paper', async () => {
+    await assert.rejects(
+      () => assertPaperContext({
+        _deps: contextDeps({
+          ...PAPER_CONNECTED,
+          connect_status: CONNECT_STATUS.DISCONNECTED,
+          paper_connected: false,
+          safe_for_paper_mutation: false,
+        }),
+      }),
+      (err) => err.code === 'PAPER_NOT_CONNECTED',
+    );
+  });
+
+  it('rejects non-Paper broker', async () => {
+    await assert.rejects(
+      () => assertPaperContext({ _deps: contextDeps(FOREIGN_BROKER) }),
+      (err) => err.code === 'NOT_PAPER_PROVIDER',
+    );
+  });
+
+  it('maps CDP failures to CDP_UNAVAILABLE', async () => {
+    await assert.rejects(
+      () => assertPaperContext({ _deps: DISCONNECTED_DEPS }),
+      (err) => err.code === 'CDP_UNAVAILABLE',
+    );
   });
 });
 
-describe('paper getStatus() — mutation safety invariant', () => {
-  const scenarios = [
-    ['panel open', depsReturning({ button_found: true, button_active: true })],
-    ['panel closed', depsReturning({ button_found: true, button_active: false })],
-    ['button missing', depsReturning({ button_found: false })],
-    ['desktop disconnected', DISCONNECTED_DEPS],
-  ];
+describe('paper openPanel', () => {
+  it('rejects invalid action', async () => {
+    await assert.rejects(
+      () => openPanel({ action: 'flip', _deps: contextDeps(PAPER_CONNECTED) }),
+      /action must be open, close, or toggle/,
+    );
+  });
 
-  for (const [name, deps] of scenarios) {
-    it(`never reports safe_for_paper_mutation while the provider is unverified (${name})`, async () => {
-      const status = await getStatus({ _deps: deps });
-      assert.equal(status.safe_for_paper_mutation, false);
+  it('opens the paper_trading widget via evaluate', async () => {
+    let expr = '';
+    const deps = {
+      evaluate: async (e) => { expr = e; return { was_open: false, performed: 'opened' }; },
+    };
+    const res = await openPanel({ action: 'open', _deps: deps });
+    assert.equal(res.success, true);
+    assert.equal(res.performed, 'opened');
+    assert.match(expr, /showWidget/);
+    assert.match(expr, /paper_trading/);
+  });
+
+  it('surfaces bottomWidgetBar errors', async () => {
+    await assert.rejects(
+      () => openPanel({
+        _deps: { evaluate: async () => ({ error: 'bottomWidgetBar not available' }) },
+      }),
+      /bottomWidgetBar not available/,
+    );
+  });
+});
+
+describe('paper connect', () => {
+  it('rejects anonymous session', async () => {
+    await assert.rejects(
+      () => connect({
+        _deps: contextDeps({ ...PAPER_CONNECTED, session: 'anonymous', paper_connected: false }),
+      }),
+      (err) => err.code === 'TRADINGVIEW_AUTH_REQUIRED',
+    );
+  });
+
+  it('returns already when Paper is connected', async () => {
+    const res = await connect({ _deps: contextDeps(PAPER_CONNECTED) });
+    assert.equal(res.already, true);
+    assert.equal(res.broker_id, 'Paper');
+  });
+
+  it('selects broker Paper when disconnected', async () => {
+    let asyncExpr = '';
+    const deps = routedDeps({
+      context: {
+        ...PAPER_CONNECTED,
+        paper_connected: false,
+        connect_status: CONNECT_STATUS.DISCONNECTED,
+        broker_id: null,
+        safe_for_paper_mutation: false,
+      },
+      asyncMap: {
+        selectBroker: (expr) => {
+          asyncExpr = expr;
+          return { broker_id: 'Paper', connect_status: CONNECT_STATUS.CONNECTED };
+        },
+      },
     });
-  }
+    const res = await connect({ _deps: deps });
+    assert.equal(res.connected, true);
+    assert.match(asyncExpr, /selectBroker/);
+    assert.match(asyncExpr, /"Paper"/);
+  });
+
+  it('fails closed if selectBroker activates a non-Paper broker', async () => {
+    const deps = routedDeps({
+      context: {
+        ...PAPER_CONNECTED,
+        paper_connected: false,
+        connect_status: CONNECT_STATUS.DISCONNECTED,
+        broker_id: null,
+      },
+      asyncMap: {
+        selectBroker: { broker_id: 'BINANCE', connect_status: CONNECT_STATUS.CONNECTED },
+      },
+    });
+    await assert.rejects(() => connect({ _deps: deps }), (err) => err.code === 'NOT_PAPER_PROVIDER');
+  });
+});
+
+describe('paper read tools', () => {
+  it('listAccounts returns mapped accounts after guard', async () => {
+    const deps = routedDeps({
+      asyncMap: {
+        accountsMetainfo: [
+          { id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD', is_active: true },
+        ],
+      },
+    });
+    // evaluateAsync returns the array directly from the expression result
+    deps.evaluateAsync = async () => ([
+      { id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD', is_active: true },
+    ]);
+    const res = await listAccounts({ _deps: deps });
+    assert.equal(res.success, true);
+    assert.equal(res.accounts[0].id, '15372380');
+  });
+
+  it('getAccount returns the account payload', async () => {
+    const account = {
+      id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD',
+      balance: 100000, equity: 99000, realized_pnl: 0, unrealized_pnl: -1000,
+      margin_used: 9000, available_funds: 90000, orders_margin: 0, margin_buffer: 90,
+    };
+    const deps = routedDeps({ asyncMap: { currentAccount: account } });
+    deps.evaluateAsync = async () => account;
+    const res = await getAccount({ _deps: deps });
+    assert.equal(res.account.balance, 100000);
+    assert.equal(res.account.currency, 'USD');
+  });
+
+  it('listPositions maps evaluate result and count', async () => {
+    const positions = [{ id: 'BINANCE:BTCUSDT', symbol: 'BINANCE:BTCUSDT', side: 'sell', qty: 1 }];
+    let calls = 0;
+    const deps = {
+      evaluate: async (expr) => {
+        calls += 1;
+        if (expr.includes('trading-button')) return { button_found: true, button_active: true };
+        // Match the listPositions body, not PAGE_HELPERS' function definitions.
+        if (expr.includes('list.map(tvScalarizePosition)')) return positions;
+        return { desktop: true, ...PAPER_CONNECTED };
+      },
+      evaluateAsync: async () => ({}),
+    };
+    const res = await listPositions({ _deps: deps });
+    assert.equal(res.count, 1);
+    assert.equal(res.positions[0].symbol, 'BINANCE:BTCUSDT');
+    assert.ok(calls >= 2);
+  });
+
+  it('listPositions surfaces page errors', async () => {
+    const deps = {
+      evaluate: async (expr) => {
+        if (expr.includes('list.map(tvScalarizePosition)')) return { error: 'boom' };
+        return { desktop: true, ...PAPER_CONNECTED };
+      },
+      evaluateAsync: async () => ({}),
+    };
+    await assert.rejects(() => listPositions({ _deps: deps }), /boom/);
+  });
+
+  it('listOrders returns active orders by default', async () => {
+    const orders = [{ id: '1', symbol: 'X', side: 'buy', type: 'limit', status: 'working' }];
+    const deps = {
+      evaluate: async (expr) => {
+        if (expr.includes('list.map(tvScalarizeOrder)')) return orders;
+        return { desktop: true, ...PAPER_CONNECTED };
+      },
+      evaluateAsync: async () => orders,
+    };
+    const res = await listOrders({ _deps: deps });
+    assert.equal(res.history, false);
+    assert.equal(res.count, 1);
+  });
+
+  it('listOrders history uses evaluateAsync', async () => {
+    let usedAsync = false;
+    const orders = [{ id: '9', status: 'filled' }];
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => {
+        usedAsync = expr.includes('ordersHistory');
+        return orders;
+      },
+    };
+    const res = await listOrders({ history: true, _deps: deps });
+    assert.equal(res.history, true);
+    assert.equal(res.count, 1);
+    assert.equal(usedAsync, true);
+  });
+
+  it('read tools reject non-Paper broker', async () => {
+    const deps = contextDeps(FOREIGN_BROKER);
+    await assert.rejects(() => listAccounts({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    await assert.rejects(() => getAccount({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    await assert.rejects(() => listPositions({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    await assert.rejects(() => listOrders({ _deps: deps }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+  });
+});
+
+describe('paper placeOrder guard + validation', () => {
+  it('refuses placeOrder when broker is not Paper', async () => {
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', type: 'market', qty: 1, _deps: contextDeps(FOREIGN_BROKER) }),
+      (err) => err.code === 'NOT_PAPER_PROVIDER',
+    );
+  });
+
+  it('validates side, qty, price, and stop_price', async () => {
+    const deps = contextDeps(PAPER_CONNECTED);
+    await assert.rejects(() => placeOrder({ side: 'hold', qty: 1, _deps: deps }), /side must be buy or sell/);
+    await assert.rejects(() => placeOrder({ side: 'buy', qty: -1, _deps: deps }), /qty must be positive/);
+    await assert.rejects(() => placeOrder({ side: 'buy', type: 'limit', qty: 1, _deps: deps }), /price is required/);
+    await assert.rejects(() => placeOrder({ side: 'buy', type: 'stop', qty: 1, _deps: deps }), /stop_price is required/);
+    await assert.rejects(() => placeOrder({ side: 'buy', type: 'bogus', qty: 1, _deps: deps }), /type must be market/);
+  });
+
+  it('places a market order through evaluateAsync when Paper is active', async () => {
+    let asyncExpr = null;
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => {
+        asyncExpr = expr;
+        return { result: { order_id: '99' } };
+      },
+    };
+    const res = await placeOrder({ side: 'buy', type: 'market', qty: 0.01, symbol: 'BINANCE:BTCUSDT', _deps: deps });
+    assert.equal(res.success, true);
+    assert.equal(res.action, 'place_order');
+    assert.match(asyncExpr, /placeOrder/);
+    assert.match(asyncExpr, /BINANCE:BTCUSDT/);
+  });
+
+  it('embeds limit/stop/bracket fields in the CDP payload', async () => {
+    let asyncExpr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => { asyncExpr = expr; return { result: true }; },
+    };
+    await placeOrder({
+      side: 'sell', type: 'stop_limit', qty: 2, symbol: 'X',
+      price: 10, stop_price: 11, take_profit: 9, stop_loss: 12, _deps: deps,
+    });
+    assert.match(asyncExpr, /limitPrice = 10/);
+    assert.match(asyncExpr, /stopPrice = 11/);
+    assert.match(asyncExpr, /takeProfit = 9/);
+    assert.match(asyncExpr, /stopLoss = 12/);
+  });
+
+  it('embeds TIF duration and validates GTD datetime', async () => {
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (expr) => ({ result: true, expr }),
+    };
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', qty: 1, symbol: 'X', tif: 'GTD', _deps: deps }),
+      /duration_datetime is required/,
+    );
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', qty: 1, symbol: 'X', tif: 'YEAR', _deps: deps }),
+      /tif must be DAY/,
+    );
+    let asyncExpr = '';
+    deps.evaluateAsync = async (expr) => { asyncExpr = expr; return { result: true }; };
+    const res = await placeOrder({
+      side: 'buy', qty: 1, symbol: 'X', tif: 'WEEK', _deps: deps,
+    });
+    assert.equal(res.tif, 'WEEK');
+    assert.match(asyncExpr, /"type":"WEEK"/);
+    await placeOrder({
+      side: 'buy', qty: 1, symbol: 'X', tif: 'GTD', duration_datetime: 1786653569000, _deps: deps,
+    });
+    assert.match(asyncExpr, /"type":"GTD"/);
+    assert.match(asyncExpr, /1786653569000/);
+  });
+
+  it('surfaces page-side placeOrder errors', async () => {
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => ({ error: 'symbol required (chart symbol unavailable)' }),
+    };
+    await assert.rejects(
+      () => placeOrder({ side: 'buy', qty: 1, _deps: deps }),
+      /symbol required/,
+    );
+  });
+});
+
+describe('paper mutation tools', () => {
+  const foreign = contextDeps(FOREIGN_BROKER);
+
+  it('cancelOrder rejects missing id and non-Paper broker', async () => {
+    await assert.rejects(() => cancelOrder({ _deps: contextDeps(PAPER_CONNECTED) }), /order_id required/);
+    await assert.rejects(() => cancelOrder({ order_id: '1', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+  });
+
+  it('cancelOrder calls evaluateAsync only after Paper guard passes', async () => {
+    let called = false;
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => { called = true; return { ok: true }; },
+    };
+    const res = await cancelOrder({ order_id: '42', _deps: deps });
+    assert.equal(res.cancelled, true);
+    assert.equal(called, true);
+  });
+
+  it('modifyOrder requires id, rejects foreign broker, and succeeds on Paper', async () => {
+    await assert.rejects(() => modifyOrder({ _deps: contextDeps(PAPER_CONNECTED) }), /order_id required/);
+    await assert.rejects(() => modifyOrder({ order_id: '1', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await modifyOrder({ order_id: '7', qty: 2, price: 100, _deps: deps });
+    assert.equal(res.modified, true);
+    assert.match(expr, /modifyOrder/);
+    assert.match(expr, /qty = 2/);
+  });
+
+  it('closePosition requires id and supports partial qty', async () => {
+    await assert.rejects(() => closePosition({ _deps: contextDeps(PAPER_CONNECTED) }), /position_id or symbol required/);
+    await assert.rejects(() => closePosition({ symbol: 'X', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await closePosition({ symbol: 'BINANCE:BTCUSDT', qty: 0.5, _deps: deps });
+    assert.equal(res.closed, true);
+    assert.equal(res.qty, 0.5);
+    assert.match(expr, /closePosition/);
+    assert.match(expr, /0\.5/);
+  });
+
+  it('setBrackets requires levels and updates via editPositionBrackets', async () => {
+    await assert.rejects(
+      () => setBrackets({ symbol: 'X', _deps: contextDeps(PAPER_CONNECTED) }),
+      /stop_loss or take_profit required/,
+    );
+    await assert.rejects(
+      () => setBrackets({ symbol: 'X', stop_loss: 1, _deps: foreign }),
+      (e) => e.code === 'NOT_PAPER_PROVIDER',
+    );
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await setBrackets({ position_id: 'BINANCE:BTCUSDT', stop_loss: 70000, take_profit: 60000, _deps: deps });
+    assert.equal(res.updated, true);
+    assert.deepEqual(res.brackets, { stopLoss: 70000, takeProfit: 60000 });
+    assert.match(expr, /editPositionBrackets/);
+  });
+
+  it('setBrackets clear removes SL/TP', async () => {
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { ok: true }; },
+    };
+    const res = await setBrackets({ symbol: 'BINANCE:BTCUSDT', clear: true, _deps: deps });
+    assert.equal(res.action, 'clear_brackets');
+    assert.deepEqual(res.brackets, { stopLoss: null, takeProfit: null });
+    assert.match(expr, /null/);
+  });
+
+  it('switchAccount requires id and calls setCurrentAccount', async () => {
+    await assert.rejects(() => switchAccount({ _deps: contextDeps(PAPER_CONNECTED) }), /account_id required/);
+    await assert.rejects(() => switchAccount({ account_id: '1', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => { expr = e; return { account_id: '15372380' }; },
+    };
+    const res = await switchAccount({ account_id: '15372380', _deps: deps });
+    assert.equal(res.account_id, '15372380');
+    assert.match(expr, /setCurrentAccount/);
+  });
+});
+
+describe('paper_cdp PAGE_HELPERS serializers', () => {
+  it('tvScalarizePosition maps Capture-2 position fields', () => {
+    const out = runPageHelper('tvScalarizePosition', {
+      id: 'BINANCE:BTCUSDT',
+      symbol: 'BINANCE:BTCUSDT',
+      side: -1,
+      qty: 1.55,
+      avgPrice: 64466.51,
+      lastPrice: 65000,
+      marketValue: 100,
+      pl: -1,
+      supportBrackets: true,
+      supportStopLoss: true,
+      supportTrailingStop: false,
+      stopLoss: 70000,
+      takeProfit: 60000,
+      extra: {
+        pl: -785,
+        plPercent: -0.7,
+        accountCurrency: 'USD',
+        leverage: '10:1',
+        usedMargin: 9900,
+      },
+    });
+    assert.equal(out.side, 'sell');
+    assert.equal(out.unrealized_pnl, -785);
+    assert.equal(out.currency, 'USD');
+    assert.equal(out.leverage, '10:1');
+    assert.equal(out.stop_loss, 70000);
+    assert.equal(out.support_trailing_stop, false);
+  });
+
+  it('tvScalarizeOrder maps type/status enums', () => {
+    const out = runPageHelper('tvScalarizeOrder', {
+      id: 3382363357,
+      symbol: 'BINANCE:BTCUSDT',
+      side: 1,
+      type: 1,
+      status: 6,
+      qty: 0.001,
+      limitPrice: 1000,
+      extra: { accountCurrency: 'USD', leverage: '10:1', usedMargin: 0.1 },
+    });
+    assert.equal(out.id, '3382363357');
+    assert.equal(out.side, 'buy');
+    assert.equal(out.type, 'limit');
+    assert.equal(out.status, 'working');
+    assert.equal(out.limit_price, 1000);
+  });
+
+  it('tvBrokerId reads _brokerMetainfo.id', () => {
+    assert.equal(runPageHelper('tvBrokerId', { _brokerMetainfo: { id: 'Paper' } }), 'Paper');
+    assert.equal(runPageHelper('tvBrokerId', null), null);
+  });
+
+  it('tvWv unwraps WatchedValue-like objects', () => {
+    assert.equal(runPageHelper('tvWv', { value: () => 3 }), 3);
+    assert.equal(runPageHelper('tvWv', { value: 7 }), 7);
+    assert.equal(runPageHelper('tvWv', 5), 5);
+  });
+
+  it('keeps SUMMARY_IDS aligned with Capture-2 account fields', () => {
+    assert.deepEqual(SUMMARY_IDS, [
+      'balance', 'equity', 'realized_pnl', 'unrealized_pnl',
+      'margin_used', 'available_funds', 'orders_margin', 'margin_buffer',
+    ]);
+  });
+
+  it('tradingPanelButtonProbe targets trading-button selectors', () => {
+    const probe = tradingPanelButtonProbe();
+    assert.match(probe, /trading-button/);
+    assert.match(probe, /Trading Panel/);
+  });
+});
+
+describe('paper constants', () => {
+  it('exports the Capture-2 stable broker id', () => {
+    assert.equal(NATIVE_PAPER_BROKER_ID, 'Paper');
+  });
 });

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for TradingView native Paper Trading observability (src/core/paper.js).
+ * Everything runs offline with mocked CDP evaluation.
+ *
+ * At this stage (pre-discovery, see docs/PAPER_TRADING_DISCOVERY.md) the
+ * status must report only verifiable facts, mark everything else as
+ * unknown/null, and always fail closed on mutation safety.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getStatus } from '../src/core/paper.js';
+
+function depsReturning(result) {
+  return { evaluate: async () => result };
+}
+
+const DISCONNECTED_DEPS = {
+  evaluate: async () => { throw new Error('CDP connection failed after 5 attempts'); },
+};
+
+describe('paper getStatus() — Trading Panel observation', () => {
+  it('reports the panel button as available when it exists', async () => {
+    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: false }) });
+    assert.equal(status.success, true);
+    assert.equal(status.desktop_connected, true);
+    assert.equal(status.trading_panel_available, true);
+    assert.equal(status.trading_panel_open, false);
+  });
+
+  it('reports the panel as open when the button is active', async () => {
+    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
+    assert.equal(status.trading_panel_open, true);
+  });
+
+  it('reports the panel as unavailable when the button is missing', async () => {
+    const status = await getStatus({ _deps: depsReturning({ button_found: false }) });
+    assert.equal(status.trading_panel_available, false);
+    assert.equal(status.trading_panel_open, null);
+  });
+
+  it('reports the desktop as disconnected instead of failing when CDP is unreachable', async () => {
+    const status = await getStatus({ _deps: DISCONNECTED_DEPS });
+    assert.equal(status.success, true);
+    assert.equal(status.desktop_connected, false);
+    assert.equal(status.trading_panel_available, null);
+    assert.equal(status.trading_panel_open, null);
+  });
+
+  it('queries the trading button through its semantic selectors', async () => {
+    const expressions = [];
+    const deps = { evaluate: async (expr) => { expressions.push(expr); return { button_found: false }; } };
+    await getStatus({ _deps: deps });
+    assert.ok(expressions[0].includes('trading-button'));
+    assert.ok(expressions[0].includes('Trading Panel'));
+  });
+});
+
+describe('paper getStatus() — honest unknowns before discovery', () => {
+  it('reports undiscovered facts as unknown or null, never guessed', async () => {
+    const status = await getStatus({ _deps: depsReturning({ button_found: true, button_active: true }) });
+    assert.equal(status.tradingview_session, 'unknown');
+    assert.equal(status.paper_available, null);
+    assert.equal(status.paper_connected, null);
+    assert.equal(status.active_provider, null);
+    assert.equal(status.provider_type, 'unknown');
+    assert.equal(status.active_account_id, null);
+    assert.equal(status.discovery_status, 'pending');
+  });
+});
+
+describe('paper getStatus() — mutation safety invariant', () => {
+  const scenarios = [
+    ['panel open', depsReturning({ button_found: true, button_active: true })],
+    ['panel closed', depsReturning({ button_found: true, button_active: false })],
+    ['button missing', depsReturning({ button_found: false })],
+    ['desktop disconnected', DISCONNECTED_DEPS],
+  ];
+
+  for (const [name, deps] of scenarios) {
+    it(`never reports safe_for_paper_mutation while the provider is unverified (${name})`, async () => {
+      const status = await getStatus({ _deps: deps });
+      assert.equal(status.safe_for_paper_mutation, false);
+    });
+  }
+});

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -135,6 +135,28 @@ describe('paper buildStatus / getStatus', () => {
     assert.equal(status.safe_for_paper_mutation, false);
   });
 
+  it('keeps desktop connected but unknown session when readContext fails after probe', async () => {
+    let calls = 0;
+    const status = await getStatus({
+      _deps: {
+        evaluate: async (expr) => {
+          calls += 1;
+          if (expr.includes('trading-button') || expr.includes('Trading Panel')) {
+            return { button_found: true, button_active: true };
+          }
+          throw new Error('readContext CDP timeout');
+        },
+        evaluateAsync: async () => ({}),
+      },
+    });
+    assert.equal(calls, 2);
+    assert.equal(status.desktop_connected, true);
+    assert.equal(status.tradingview_session, 'unknown');
+    assert.equal(status.paper_connected, false);
+    assert.equal(status.active_provider, null);
+    assert.equal(status.safe_for_paper_mutation, false);
+  });
+
   it('buildStatus derives provider_type none when disconnected without broker', () => {
     const s = buildStatus({
       desktop: true,
@@ -329,6 +351,24 @@ describe('paper read tools', () => {
     assert.equal(res.account.currency, 'USD');
   });
 
+  it('getAccount CDP script prefers meta.currency when positions are empty', async () => {
+    let expr = '';
+    const deps = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async (e) => {
+        expr = e;
+        return {
+          id: '15372380', name: 'tester', title: 'Paper Trading', type: 'demo', currency: 'USD',
+          balance: 100000, equity: 100000, realized_pnl: 0, unrealized_pnl: 0,
+          margin_used: 0, available_funds: 100000, orders_margin: 0, margin_buffer: 0,
+        };
+      },
+    };
+    await getAccount({ _deps: deps });
+    assert.match(expr, /currency = meta\.currency/);
+    assert.match(expr, /accountCurrency/);
+  });
+
   it('listPositions maps evaluate result and count', async () => {
     const positions = [{ id: 'BINANCE:BTCUSDT', symbol: 'BINANCE:BTCUSDT', side: 'sell', qty: 1 }];
     let calls = 0;
@@ -517,6 +557,9 @@ describe('paper mutation tools', () => {
     assert.equal(res.modified, true);
     assert.match(expr, /modifyOrder/);
     assert.match(expr, /qty = 2/);
+    // Fallback lookup must align with paper_list_orders (OrdersService.activeOrders).
+    assert.match(expr, /activeOrders/);
+    assert.match(expr, /_ordersService/);
   });
 
   it('closePosition requires id and supports partial qty', async () => {

--- a/tests/paper.test.js
+++ b/tests/paper.test.js
@@ -588,6 +588,9 @@ describe('paper mutation tools', () => {
   it('closePosition requires id and supports partial qty', async () => {
     await assert.rejects(() => closePosition({ _deps: contextDeps(PAPER_CONNECTED) }), /position_id or symbol required/);
     await assert.rejects(() => closePosition({ symbol: 'X', _deps: foreign }), (e) => e.code === 'NOT_PAPER_PROVIDER');
+    const paperDeps = contextDeps(PAPER_CONNECTED);
+    await assert.rejects(() => closePosition({ symbol: 'X', qty: 0, _deps: paperDeps }), /qty must be positive/);
+    await assert.rejects(() => closePosition({ symbol: 'X', qty: -1, _deps: paperDeps }), /qty must be positive/);
     let expr = '';
     const deps = {
       evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
@@ -643,6 +646,26 @@ describe('paper mutation tools', () => {
     const res = await switchAccount({ account_id: '15372380', _deps: deps });
     assert.equal(res.account_id, '15372380');
     assert.match(expr, /setCurrentAccount/);
+    assert.match(expr, /tvRequirePaperBroker/);
+  });
+
+  it('switchAccount fails when active account does not match request', async () => {
+    const mismatch = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => ({ account_id: '999' }),
+    };
+    await assert.rejects(
+      () => switchAccount({ account_id: '15372380', _deps: mismatch }),
+      /account switch failed: active account is 999, expected 15372380/,
+    );
+    const unconfirmed = {
+      evaluate: async () => ({ desktop: true, ...PAPER_CONNECTED }),
+      evaluateAsync: async () => ({ account_id: null }),
+    };
+    await assert.rejects(
+      () => switchAccount({ account_id: '15372380', _deps: unconfirmed }),
+      /account switch unconfirmed for 15372380/,
+    );
   });
 });
 

--- a/tests/paper_discovery.test.js
+++ b/tests/paper_discovery.test.js
@@ -1,0 +1,77 @@
+/**
+ * Tests for the Paper Trading discovery probe (scripts/paper_discovery.js).
+ * Covers the report sanitizer (secret redaction) and a source audit that the
+ * injected probes never touch cookies or web storage.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { sanitizeForReport } from '../scripts/paper_discovery.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── sanitizeForReport() — secret redaction ──────────────────────────────
+
+describe('sanitizeForReport() — secret redaction', () => {
+  it('passes through primitives untouched', () => {
+    assert.equal(sanitizeForReport(42), 42);
+    assert.equal(sanitizeForReport(true), true);
+    assert.equal(sanitizeForReport(null), null);
+    assert.equal(sanitizeForReport('short string'), 'short string');
+  });
+
+  it('redacts values under secret-looking keys but keeps the key visible', () => {
+    const report = sanitizeForReport({
+      authToken: 'abc',
+      session_id: 'xyz',
+      Cookie: 'a=b',
+      password: 'hunter2',
+      dataName: 'trading-button',
+    });
+    assert.equal(report.authToken, '[REDACTED]');
+    assert.equal(report.session_id, '[REDACTED]');
+    assert.equal(report.Cookie, '[REDACTED]');
+    assert.equal(report.password, '[REDACTED]');
+    assert.equal(report.dataName, 'trading-button');
+  });
+
+  it('redacts token-like string values regardless of key name', () => {
+    const tokenLike = 'A'.repeat(20) + 'b1-_'.repeat(10);
+    const report = sanitizeForReport({ note: tokenLike });
+    assert.equal(report.note, '[REDACTED-TOKEN-LIKE]');
+  });
+
+  it('does not treat normal sentences as token-like', () => {
+    const sentence = 'Paper Trading is currently disconnected from the panel';
+    assert.equal(sanitizeForReport(sentence), sentence);
+  });
+
+  it('truncates overly long strings', () => {
+    const long = 'word '.repeat(100);
+    const result = sanitizeForReport(long);
+    assert.ok(result.length < long.length);
+    assert.ok(result.endsWith('…'));
+  });
+
+  it('recurses through nested objects and arrays', () => {
+    const report = sanitizeForReport({
+      services: [{ path: 'window.TradingViewApi._x', accessToken: 'zzz' }],
+    });
+    assert.equal(report.services[0].path, 'window.TradingViewApi._x');
+    assert.equal(report.services[0].accessToken, '[REDACTED]');
+  });
+});
+
+// ── Source audit — probes must never read secret material ───────────────
+
+describe('paper_discovery.js — source audit', () => {
+  const source = readFileSync(join(__dirname, '..', 'scripts', 'paper_discovery.js'), 'utf8');
+
+  for (const forbidden of ['document.cookie', 'localStorage', 'sessionStorage', 'indexedDB']) {
+    it(`never references ${forbidden}`, () => {
+      assert.ok(!source.includes(forbidden), `probe script must not access ${forbidden}`);
+    });
+  }
+});

--- a/tests/paper_discovery.test.js
+++ b/tests/paper_discovery.test.js
@@ -8,9 +8,13 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { sanitizeForReport } from '../scripts/paper_discovery.js';
+import { sanitizeForReport, MEMBER_INSPECTION_HELPERS } from '../scripts/paper_discovery.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function describeMembersIn(obj) {
+  return new Function('obj', `${MEMBER_INSPECTION_HELPERS}; return describeMembers(obj);`)(obj);
+}
 
 // ── sanitizeForReport() — secret redaction ──────────────────────────────
 
@@ -61,6 +65,71 @@ describe('sanitizeForReport() — secret redaction', () => {
     });
     assert.equal(report.services[0].path, 'window.TradingViewApi._x');
     assert.equal(report.services[0].accessToken, '[REDACTED]');
+  });
+
+  it('redacts email addresses embedded in strings', () => {
+    const report = sanitizeForReport({ label: 'Switch account (rapha@example.com)' });
+    assert.equal(report.label, 'Switch account ([REDACTED-EMAIL])');
+  });
+
+  it('redacts every email occurrence in a string', () => {
+    const result = sanitizeForReport('a@b.co then c.d@e-f.org');
+    assert.ok(!result.includes('@b.co'));
+    assert.ok(!result.includes('@e-f.org'));
+    assert.equal(result.match(/\[REDACTED-EMAIL\]/g).length, 2);
+  });
+});
+
+// ── describeMembers() — getter-safe runtime inspection ──────────────────
+
+describe('describeMembers() — injected inspection helper', () => {
+  it('never invokes accessor getters', () => {
+    let invoked = false;
+    const service = {};
+    Object.defineProperty(service, 'positions', {
+      get() { invoked = true; return []; },
+      enumerable: true,
+      configurable: true,
+    });
+    const members = describeMembersIn(service);
+    assert.equal(invoked, false);
+    assert.ok(members.accessors.includes('positions'));
+  });
+
+  it('survives getters that throw', () => {
+    const service = {};
+    Object.defineProperty(service, 'account', {
+      get() { throw new Error('getter executed'); },
+    });
+    const members = describeMembersIn(service);
+    assert.ok(members.accessors.includes('account'));
+  });
+
+  it('enumerates non-enumerable prototype methods of class instances', () => {
+    class FakeBrokerService {
+      getPositions() {}
+      placeOrder() {}
+    }
+    const members = describeMembersIn(new FakeBrokerService());
+    assert.ok(members.methods.includes('getPositions'));
+    assert.ok(members.methods.includes('placeOrder'));
+  });
+
+  it('enumerates inherited methods without duplicates', () => {
+    class BaseService { connect() {} }
+    class PaperService extends BaseService { connect() {} getOrders() {} }
+    const members = describeMembersIn(new PaperService());
+    assert.equal(members.methods.filter((m) => m === 'connect').length, 1);
+    assert.ok(members.methods.includes('getOrders'));
+  });
+
+  it('excludes constructor and classifies object-valued members', () => {
+    class Service {}
+    const instance = new Service();
+    instance.store = { positions: [] };
+    const members = describeMembersIn(instance);
+    assert.ok(!members.methods.includes('constructor'));
+    assert.ok(members.objects.includes('store'));
   });
 });
 


### PR DESCRIPTION
## Summary

Optional contribution: native **Paper Trading** support through the locally running TradingView Desktop app (CDP only). Broker id is hard-gated to Paper`; mutations fail closed for any other broker or anonymous session.

I read `CONTRIBUTING.md` carefully. Order execution for live/automated trading is out of scope here — this PR is offered as a **discretionary** addition for the maintainer to accept, trim, or close. No pressure either way.

## Why this may still fit

- Stays inside the local Desktop bridge (no TradingView servers, no external brokers, no bots/signal layers).
- Discovery was evidence-first (`docs/PAPER_TRADING_DISCOVERY.md`) before any mutation surface.
- Mutations require `safe_for_paper_mutation: true` (authenticated + connected + active broker id exactly `Paper`).
- Closest existing pattern is `replay_trade` (practice execution on Desktop), not a trading-bot framework.

If you would rather keep mutations out of mainline, I am happy to shrink this to **read-only** status/account/positions/orders (or close the PR). Just say the word.

## What changed

- Discovery kit + evidence doc (anonymous + authenticated captures on Desktop 3.3.0)
- `paper_*` MCP tools + matching `tv paper` CLI (status, panel, connect, accounts, positions, orders, place/cancel/modify, close, brackets)
- Fail-closed guards in host + in-page helpers (`src/core/paper.js`, `src/core/paper_cdp.js`)
- Offline unit coverage in `tests/paper.test.js` / `tests/paper_discovery.test.js`
- Docs: README / CLAUDE / server instructions; tool count → 97

## Validation

- `npm run lint` — 0 errors (4 pre-existing warnings unrelated to this change)
- `npm run test:unit` — paper suites green; full unit run on this branch
- Live smoke on TradingView Desktop **3.3.0** with authenticated Paper: status, account, positions, place+cancel limit (`--tif DAY`), brackets set/clear
- Use `TV_CDP_PORT` when multiple Desktop instances are present

## Scope note for review

Please treat merge as optional. If this conflicts with the project’s “no order execution” line even for native Paper, closing or requesting a read-only subset is completely fine — I will follow your call.
