### PR TITLE
fix: use fileURLToPath instead of URL.pathname for filesystem paths

### DIFF
--- a/scripts/pine_pull.js
+++ b/scripts/pine_pull.js
@@ -2,6 +2,7 @@
 // Pull current Pine Script source from TradingView editor → scripts/current.pine
 import CDP from 'chrome-remote-interface';
 import { writeFileSync } from 'fs';
+import { fileURLToPath } from 'node:url';
 
 const targets = await (await fetch('http://localhost:9222/json/list')).json();
 const t = targets.find(t => t.url?.includes('tradingview.com'));
@@ -16,7 +17,7 @@ const src = (await c.Runtime.evaluate({
 
 if (!src) { console.error('Could not read Pine editor'); await c.close(); process.exit(1); }
 
-const outPath = new URL('../scripts/current.pine', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const outPath = fileURLToPath(new URL('../scripts/current.pine', import.meta.url));
 writeFileSync(outPath, src);
 console.log(`Pulled ${src.split('\n').length} lines → scripts/current.pine`);
 await c.close();

--- a/scripts/pine_push.js
+++ b/scripts/pine_push.js
@@ -2,8 +2,9 @@
 // Push scripts/current.pine → TradingView editor, then compile
 import CDP from 'chrome-remote-interface';
 import { readFileSync } from 'fs';
+import { fileURLToPath } from 'node:url';
 
-const srcPath = new URL('../scripts/current.pine', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const srcPath = fileURLToPath(new URL('../scripts/current.pine', import.meta.url));
 const src = readFileSync(srcPath, 'utf-8');
 
 const targets = await (await fetch('http://localhost:9222/json/list')).json();

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
`new URL(...).pathname` returns `/C:/Users/...` on Windows — the leading slash makes `fs` resolve it against the cwd (`C:\C:\Users\...`) and throw ENOENT.

This made the source-audit test in `tests/sanitization.test.js` pass when run standalone but fail under `npm run test:unit`, which read as flakiness rather than a real bug.

`scripts/pine_pull.js` and `scripts/pine_push.js` hit the same problem and worked around it with a `.replace(/^\/([A-Z]:)/, '$1')` hack that only handled uppercase drive letters and left percent-encoding intact (a path containing a space would still break). Both now use `fileURLToPath` as well.

Other `import.meta.url` uses in the repo were already correct: `src/core/{batch,capture,update}.js` and `tests/cli.test.js` use `fileURLToPath`, and the remaining `readFileSync(new URL(...))` calls pass a `URL` object directly, which `fs` accepts.

## Testing

`npm run test:unit` on Windows: 157 pass, 2 fail. The sanitization suite is fully green.

The two remaining failures are the `pine check` server-compile tests in `tests/cli.test.js`, which need a live TradingView Desktop on CDP port 9222. They are environmental and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)