### PR TITLE
Add clean-room Cup-and-Handle pattern watch

### DIFF
--- a/cup-and-handle/README.md
+++ b/cup-and-handle/README.md
@@ -50,7 +50,7 @@ NONE
   -> HANDLE_READY
   -> BREAKOUT_CONFIRMED
 
-Any confirmed pattern can instead become INVALIDATED or EXPIRED.
+Any active pattern can instead become INVALIDATED or EXPIRED.
 ```
 
 Anchor timestamps describe where the geometry is drawn. Detection timestamps
@@ -70,7 +70,9 @@ encoded in the configuration identity carried by detector events.
 - `analysis/live-qa-v0.json` — source-bound historical 0.1.0 TradingView
   runtime-matrix, screenshot-hash, and cleanup receipt; superseded after the
   independent review found lifecycle defects.
-- `analysis/verification-0.1.1.json` — current source hashes, regression checks,
+- `analysis/verification-0.1.1.json` — historical verification receipt for the
+  first review-corrected build.
+- `analysis/verification-0.1.2.json` — current source hashes, regression checks,
   TradingView compile-only result, and exact remaining verification boundary.
 - `cup-and-handle.pine` — TradingView overlay and alert surface.
 - `../tests/cup_handle_core.test.js` — geometry, lifecycle, and causality tests.
@@ -115,16 +117,32 @@ were re-verified unchanged. Independent review then found lifecycle defects in
 that exact build, so its matrix is retained as historical integration evidence,
 not as acceptance evidence for the current source.
 
-Version 0.1.1 fixes the reproduced post-breakout re-arming, stale provisional,
-pre-handle upside-escape, and late historical-right-rim paths. The exact 0.1.1
+Version 0.1.2 fixes the reproduced post-breakout re-arming, stale provisional,
+pre-handle upside-escape, and late historical-right-rim paths, including the
+same late-right-rim rule in the JavaScript reference detector. The exact 0.1.2
 Pine source passes TradingView's server compiler with zero errors and warnings,
-the local analyzer reports zero issues, and all 35 focused tests pass. It has
+the local analyzer reports zero issues, all 36 focused tests pass, and all 188
+repository unit tests pass with two platform-specific skips. It has
 not yet been applied to a live chart.
 
 The historical matrix proves basic integration and runtime behavior, not signal
 quality for the current source.
 No alert was activated, no replay-vs-live Pine trace was produced, and the
 Pine/JavaScript implementations do not yet have per-bar parity evidence. This
-therefore remains a calibration draft until the 0.1.1 source receives a fresh
+therefore remains a calibration draft until the 0.1.2 source receives a fresh
 chart runtime check and representative good, early, late, and rejected
 formations are labeled against a frozen acceptance set.
+
+## Calibration review set
+
+The first stock tranche now contains 12 local, blind review cards: four each
+for 4H, 1D, and 1W. Every chart stops on the bar where the candidate became
+knowable; later bars, detector stage, score, and anchors are hidden. Candidate
+metadata stores hashes and timestamps but no OHLC arrays.
+
+The cards and append-only label events remain under the gitignored
+`screenshots/cup-handle-calibration-v1/stock-batch-01/` directory. They are not
+part of the public pull request because this repository forbids committing or
+redistributing market data and personal watchlist configurations. The 12-card
+crypto tranche remains separate until its source can be frozen under the same
+lookahead and local-only rules.

--- a/cup-and-handle/README.md
+++ b/cup-and-handle/README.md
@@ -1,0 +1,130 @@
+# Cup-and-Handle Pattern Watch
+
+This directory contains an original, clean-room Cup-and-Handle detector for
+TradingView. It is informed by TradingView's public pattern documentation, not
+by copied, extracted, or reverse-engineered proprietary source code.
+
+## First-slice scope
+
+- Bullish Cup-and-Handle only.
+- Native `4H`, `1D`, and `1W` charts.
+- Closed-bar, causal calculations.
+- A pure JavaScript reference detector plus a Pine v6 overlay.
+- Machine-readable lifecycle stages and transition alerts.
+- One chart symbol at a time. Watchlist scanners come later.
+
+The detector is an attention tool named **Pattern Watch**. It is not a trading
+strategy, a buy signal, or a claim that a pattern predicts returns.
+
+## Public TradingView behavior used as a specification
+
+TradingView publicly documents these Cup-and-Handle behaviors:
+
+- Search the most recent 600 bars.
+- Use 5-left/5-right pivots for the structural points.
+- Require a cup at least 20 bars wide.
+- Place the cup low near the horizontal center.
+- Keep the two rims approximately level.
+- Limit handle rollback relative to cup height.
+- Do not allow the handle to outlive the cup.
+- Support in-progress patterns.
+- Confirm breakout from a close above the handle line.
+- Prefer an awaiting pattern, then the more U-shaped cup, when patterns overlap.
+- Leave the optional prior-trend rollback check disabled by default.
+
+Source: <https://www.tradingview.com/support/solutions/43000732556-chart-pattern-cup-and-handle/>
+
+TradingView does not publish its source or exact formulas for center tolerance,
+U-shape quality, plateau handling, default deviations, or provisional handle
+selection. Our definitions for those items are explicit in
+`analysis/frozen-v0-cup-handle.json` and are intended to be calibrated from
+human-reviewed chart labels.
+
+## Lifecycle
+
+```text
+NONE
+  -> CUP_FORMING
+  -> RIM_APPROACH
+  -> HANDLE_FORMING
+  -> HANDLE_READY
+  -> BREAKOUT_CONFIRMED
+
+Any confirmed pattern can instead become INVALIDATED or EXPIRED.
+```
+
+Anchor timestamps describe where the geometry is drawn. Detection timestamps
+identify both the open and close of the bar on which the information became
+knowable. A 5/5 pivot is never used until five later closed bars exist.
+
+Provisional alerts share a `family_id` based on the left rim and cup bottom.
+Once the right rim confirms, the final `pattern_id` also contains point 3, so a
+different confirmed right rim is a new pattern. Every runtime threshold is
+encoded in the configuration identity carried by detector events.
+
+## Files
+
+- `analysis/cup-handle-core.mjs` — deterministic reference implementation.
+- `analysis/frozen-v0-cup-handle.json` — public rules, tunable defaults, and
+  explicit non-goals.
+- `analysis/live-qa-v0.json` — source-bound historical 0.1.0 TradingView
+  runtime-matrix, screenshot-hash, and cleanup receipt; superseded after the
+  independent review found lifecycle defects.
+- `analysis/verification-0.1.1.json` — current source hashes, regression checks,
+  TradingView compile-only result, and exact remaining verification boundary.
+- `cup-and-handle.pine` — TradingView overlay and alert surface.
+- `../tests/cup_handle_core.test.js` — geometry, lifecycle, and causality tests.
+- `../tests/cup_handle_pine_contract.test.js` — static Pine safety contract.
+
+## Alert choices
+
+TradingView exposes six conditions after the indicator is added to a chart:
+
+- **Forming Watch** — early `CUP_FORMING` or `RIM_APPROACH` heads-up.
+- **Confirmed Cup / Handle Forming** — a causal right rim exists and the handle
+  is still developing.
+- **Handle Ready** — the handle pivot exists and price has not yet broken out.
+- **Breakout Confirmed** — a closed bar crossed above the handle line.
+- **Invalidated or Expired** — the active setup failed or aged out.
+- **Any Lifecycle Event** — one combined event stream.
+
+The first two are the useful attention alerts for the initial calibration.
+Each transition fires once per pattern on a closed chart-timeframe bar. The
+dynamic `alert()` payload includes the symbol, timeframe, stage, pattern IDs,
+pivot, invalidation level, quality, version, and full runtime configuration.
+
+Unlike TradingView's documented overlap preference, V0 follows one active
+pattern family per chart and does not queue overlapping families. A newer setup
+can therefore be missed while another valid setup is active. The broad
+candidate generator for calibration cards must not inherit that
+restriction. V0 follows the documented default of leaving the optional prior-
+trend rollback gate disabled; the human-labeled examples can tell us whether a
+stricter gate would make the alerts more useful.
+
+## Local verification
+
+```sh
+npm run test:cup-handle
+node src/cli/index.js pine analyze --file "cup-and-handle/cup-and-handle.pine"
+```
+
+The 0.1.0 Pine source completed a live seven-case matrix on AAPL and BTC across
+4H, 1D, and 1W, plus a 1M fail-closed check. The disposable study, cloud script,
+and chart tab were removed afterward; the original chart and alert definitions
+were re-verified unchanged. Independent review then found lifecycle defects in
+that exact build, so its matrix is retained as historical integration evidence,
+not as acceptance evidence for the current source.
+
+Version 0.1.1 fixes the reproduced post-breakout re-arming, stale provisional,
+pre-handle upside-escape, and late historical-right-rim paths. The exact 0.1.1
+Pine source passes TradingView's server compiler with zero errors and warnings,
+the local analyzer reports zero issues, and all 35 focused tests pass. It has
+not yet been applied to a live chart.
+
+The historical matrix proves basic integration and runtime behavior, not signal
+quality for the current source.
+No alert was activated, no replay-vs-live Pine trace was produced, and the
+Pine/JavaScript implementations do not yet have per-bar parity evidence. This
+therefore remains a calibration draft until the 0.1.1 source receives a fresh
+chart runtime check and representative good, early, late, and rejected
+formations are labeled against a frozen acceptance set.

--- a/cup-and-handle/analysis/cup-handle-core.mjs
+++ b/cup-and-handle/analysis/cup-handle-core.mjs
@@ -1,0 +1,954 @@
+const ACTIVE_STAGE_ORDER = Object.freeze({
+  NONE: 0,
+  CUP_FORMING: 1,
+  RIM_APPROACH: 2,
+  HANDLE_FORMING: 3,
+  HANDLE_READY: 4,
+  BREAKOUT_CONFIRMED: 5,
+});
+
+const TERMINAL_STAGES = new Set(['BREAKOUT_CONFIRMED', 'INVALIDATED', 'EXPIRED']);
+
+const CONFIG_SIGNATURE_FIELDS = Object.freeze([
+  ['lb', 'lookback_bars'],
+  ['pl', 'pivot_left_bars'],
+  ['pr', 'pivot_right_bars'],
+  ['cmin', 'minimum_cup_bars'],
+  ['cmax', 'maximum_cup_bars'],
+  ['center', 'center_tolerance_fraction_of_half_width'],
+  ['rim', 'rim_deviation_fraction_of_cup_height'],
+  ['dmin', 'minimum_cup_depth_fraction_of_rim'],
+  ['dmax', 'maximum_cup_depth_fraction_of_rim'],
+  ['ushape', 'minimum_u_shape_score'],
+  ['bottom', 'bottom_width_target_fraction'],
+  ['forming', 'forming_recovery_fraction'],
+  ['approach', 'rim_approach_recovery_fraction'],
+  ['handle', 'maximum_handle_rollback_fraction_of_cup_height'],
+  ['hmin', 'minimum_handle_bars'],
+  ['pivots', 'maximum_pivots_per_kind'],
+  ['trend', 'prior_trend_gate_enabled'],
+]);
+
+export const STAGES = Object.freeze([
+  'NONE',
+  'CUP_FORMING',
+  'RIM_APPROACH',
+  'HANDLE_FORMING',
+  'HANDLE_READY',
+  'BREAKOUT_CONFIRMED',
+  'INVALIDATED',
+  'EXPIRED',
+]);
+
+export const DEFAULT_CONFIG = Object.freeze({
+  config_id: 'ch-v0-default',
+  detector_version: '0.1.1-cleanroom',
+  lookback_bars: 600,
+  pivot_left_bars: 5,
+  pivot_right_bars: 5,
+  minimum_cup_bars: 20,
+  maximum_cup_bars: 240,
+  center_tolerance_fraction_of_half_width: 0.35,
+  rim_deviation_fraction_of_cup_height: 0.15,
+  minimum_cup_depth_fraction_of_rim: 0.08,
+  maximum_cup_depth_fraction_of_rim: 0.5,
+  minimum_u_shape_score: 0.5,
+  bottom_width_target_fraction: 0.12,
+  forming_recovery_fraction: 0.65,
+  rim_approach_recovery_fraction: 0.85,
+  maximum_handle_rollback_fraction_of_cup_height: 0.4,
+  minimum_handle_bars: 3,
+  prior_trend_gate_enabled: false,
+  maximum_pivots_per_kind: 64,
+});
+
+function finiteNumber(value, name) {
+  if (!Number.isFinite(value)) throw new TypeError(`${name} must be a finite number`);
+  return value;
+}
+
+function integer(value, name, minimum = 0) {
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new TypeError(`${name} must be an integer >= ${minimum}`);
+  }
+  return value;
+}
+
+function fraction(value, name, { inclusiveZero = false } = {}) {
+  const lowerOkay = inclusiveZero ? value >= 0 : value > 0;
+  if (!Number.isFinite(value) || !lowerOkay || value > 1) {
+    throw new TypeError(`${name} must be ${inclusiveZero ? 'between 0 and 1' : '> 0 and <= 1'}`);
+  }
+  return value;
+}
+
+export function validateConfig(overrides = {}) {
+  if (overrides === null || typeof overrides !== 'object' || Array.isArray(overrides)) {
+    throw new TypeError('config must be an object');
+  }
+  const config = { ...DEFAULT_CONFIG, ...overrides };
+  integer(config.lookback_bars, 'lookback_bars', 20);
+  integer(config.pivot_left_bars, 'pivot_left_bars', 1);
+  integer(config.pivot_right_bars, 'pivot_right_bars', 1);
+  integer(config.minimum_cup_bars, 'minimum_cup_bars', 2);
+  integer(config.maximum_cup_bars, 'maximum_cup_bars', config.minimum_cup_bars);
+  integer(config.minimum_handle_bars, 'minimum_handle_bars', 1);
+  integer(config.maximum_pivots_per_kind, 'maximum_pivots_per_kind', 8);
+  if (config.maximum_cup_bars >= config.lookback_bars) {
+    throw new RangeError('maximum_cup_bars must be below lookback_bars');
+  }
+  fraction(config.center_tolerance_fraction_of_half_width, 'center_tolerance_fraction_of_half_width');
+  fraction(config.rim_deviation_fraction_of_cup_height, 'rim_deviation_fraction_of_cup_height');
+  fraction(config.minimum_cup_depth_fraction_of_rim, 'minimum_cup_depth_fraction_of_rim');
+  fraction(config.maximum_cup_depth_fraction_of_rim, 'maximum_cup_depth_fraction_of_rim');
+  fraction(config.minimum_u_shape_score, 'minimum_u_shape_score', { inclusiveZero: true });
+  fraction(config.bottom_width_target_fraction, 'bottom_width_target_fraction');
+  fraction(config.forming_recovery_fraction, 'forming_recovery_fraction');
+  fraction(config.rim_approach_recovery_fraction, 'rim_approach_recovery_fraction');
+  fraction(
+    config.maximum_handle_rollback_fraction_of_cup_height,
+    'maximum_handle_rollback_fraction_of_cup_height',
+  );
+  if (config.minimum_cup_depth_fraction_of_rim >= config.maximum_cup_depth_fraction_of_rim) {
+    throw new RangeError('minimum cup depth must be below maximum cup depth');
+  }
+  if (config.forming_recovery_fraction >= config.rim_approach_recovery_fraction) {
+    throw new RangeError('forming recovery must be below rim-approach recovery');
+  }
+  if (typeof config.config_id !== 'string' || !config.config_id.trim()) {
+    throw new TypeError('config_id must be a non-empty string');
+  }
+  if (typeof config.detector_version !== 'string' || !config.detector_version.trim()) {
+    throw new TypeError('detector_version must be a non-empty string');
+  }
+  if (typeof config.prior_trend_gate_enabled !== 'boolean') {
+    throw new TypeError('prior_trend_gate_enabled must be boolean');
+  }
+  if (config.prior_trend_gate_enabled) {
+    throw new RangeError('prior_trend_gate_enabled is not implemented in clean-room v0');
+  }
+  const baseConfigId = config.config_id.split('|settings:')[0];
+  const signature = CONFIG_SIGNATURE_FIELDS
+    .map(([label, key]) => `${label}=${String(config[key])}`)
+    .join(',');
+  config.config_id = `${baseConfigId}|settings:${signature}`;
+  return Object.freeze(config);
+}
+
+export function normalizeTimeframe(value) {
+  const normalized = String(value ?? '').trim().toUpperCase();
+  const aliases = new Map([
+    ['240', '4H'],
+    ['4H', '4H'],
+    ['D', '1D'],
+    ['1D', '1D'],
+    ['W', '1W'],
+    ['1W', '1W'],
+  ]);
+  const timeframe = aliases.get(normalized);
+  if (!timeframe) throw new RangeError('timeframe must be 4H, 1D, or 1W');
+  return timeframe;
+}
+
+export function normalizeBars(rows) {
+  if (!Array.isArray(rows)) throw new TypeError('bars must be an array');
+  const bars = [];
+  let previousTime = -Infinity;
+  let sawIncompleteBar = false;
+  for (let sourceIndex = 0; sourceIndex < rows.length; sourceIndex += 1) {
+    const row = rows[sourceIndex];
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+      throw new TypeError(`bar ${sourceIndex} must be an object`);
+    }
+    if (row.complete_bar === false) {
+      sawIncompleteBar = true;
+      continue;
+    }
+    if (sawIncompleteBar) {
+      throw new RangeError('incomplete bars are only allowed as a terminal suffix');
+    }
+    const time = finiteNumber(row.time, `bar ${sourceIndex} time`);
+    const timeClose = row.time_close === undefined || row.time_close === null
+      ? null
+      : finiteNumber(row.time_close, `bar ${sourceIndex} time_close`);
+    const open = finiteNumber(row.open, `bar ${sourceIndex} open`);
+    const high = finiteNumber(row.high, `bar ${sourceIndex} high`);
+    const low = finiteNumber(row.low, `bar ${sourceIndex} low`);
+    const close = finiteNumber(row.close, `bar ${sourceIndex} close`);
+    if (time <= previousTime) {
+      throw new RangeError(`bars must have unique, strictly increasing times; failed at source index ${sourceIndex}`);
+    }
+    if (timeClose !== null && timeClose <= time) {
+      throw new RangeError(`bar ${sourceIndex} time_close must be after time`);
+    }
+    if (high < Math.max(open, close, low) || low > Math.min(open, close, high)) {
+      throw new RangeError(`bar ${sourceIndex} has invalid OHLC bounds`);
+    }
+    bars.push({
+      index: bars.length,
+      time,
+      time_close: timeClose,
+      open,
+      high,
+      low,
+      close,
+      volume: Number.isFinite(row.volume) ? row.volume : null,
+    });
+    previousTime = time;
+  }
+  return bars;
+}
+
+function isPivotHigh(bars, index, left, right) {
+  const price = bars[index].high;
+  for (let offset = 1; offset <= left; offset += 1) {
+    if (bars[index - offset].high > price) return false;
+  }
+  // Equal highs on the right suppress this point, selecting the rightmost point
+  // of a plateau deterministically.
+  for (let offset = 1; offset <= right; offset += 1) {
+    if (bars[index + offset].high >= price) return false;
+  }
+  return true;
+}
+
+function isPivotLow(bars, index, left, right) {
+  const price = bars[index].low;
+  for (let offset = 1; offset <= left; offset += 1) {
+    if (bars[index - offset].low < price) return false;
+  }
+  for (let offset = 1; offset <= right; offset += 1) {
+    if (bars[index + offset].low <= price) return false;
+  }
+  return true;
+}
+
+export function findConfirmedPivots(rows, configOverrides = {}) {
+  const config = validateConfig(configOverrides);
+  const bars = rows.length > 0 && Number.isInteger(rows[0]?.index) ? rows : normalizeBars(rows);
+  const highs = [];
+  const lows = [];
+  const left = config.pivot_left_bars;
+  const right = config.pivot_right_bars;
+  for (let index = left; index + right < bars.length; index += 1) {
+    const confirmedIndex = index + right;
+    if (isPivotHigh(bars, index, left, right)) {
+      highs.push({
+        kind: 'high',
+        index,
+        time: bars[index].time,
+        price: bars[index].high,
+        confirmed_index: confirmedIndex,
+        confirmed_time: bars[confirmedIndex].time,
+      });
+    }
+    if (isPivotLow(bars, index, left, right)) {
+      lows.push({
+        kind: 'low',
+        index,
+        time: bars[index].time,
+        price: bars[index].low,
+        confirmed_index: confirmedIndex,
+        confirmed_time: bars[confirmedIndex].time,
+      });
+    }
+  }
+  return { highs, lows };
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function minimumLow(bars, startIndex, endIndex) {
+  if (startIndex > endIndex) return null;
+  let value = Infinity;
+  for (let index = startIndex; index <= endIndex; index += 1) {
+    value = Math.min(value, bars[index].low);
+  }
+  return Number.isFinite(value) ? value : null;
+}
+
+function lineValue(pointA, pointB, index) {
+  const span = pointB.index - pointA.index;
+  if (span <= 0) return pointB.price;
+  return pointA.price + ((pointB.price - pointA.price) * (index - pointA.index)) / span;
+}
+
+export function computeUShapeScore(bars, p1, p2, p3, configOverrides = {}) {
+  const config = validateConfig(configOverrides);
+  return computeUShapeScoreWithConfig(bars, p1, p2, p3, config);
+}
+
+function computeUShapeScoreWithConfig(bars, p1, p2, p3, config) {
+  const width = p3.index - p1.index;
+  const rim = (p1.price + p3.price) / 2;
+  const cupHeight = rim - p2.price;
+  if (width <= 0 || cupHeight <= 0) return 0;
+  let absoluteError = 0;
+  let samples = 0;
+  let bottomSamples = 0;
+  for (let index = p1.index; index <= p3.index; index += 1) {
+    const x = (index - p1.index) / width;
+    const idealDepth = 1 - (2 * x - 1) ** 2;
+    const bar = bars[index];
+    const representativePrice = (bar.high + bar.low + bar.close) / 3;
+    const observedDepth = clamp((rim - representativePrice) / cupHeight, -0.25, 1.25);
+    absoluteError += Math.abs(observedDepth - idealDepth);
+    samples += 1;
+    if (observedDepth >= 0.75) bottomSamples += 1;
+  }
+  const fitScore = clamp(1 - absoluteError / Math.max(samples, 1), 0, 1);
+  const bottomWidthFraction = bottomSamples / Math.max(samples, 1);
+  const bottomWidthScore = clamp(bottomWidthFraction / config.bottom_width_target_fraction, 0, 1);
+  return clamp(0.8 * fitScore + 0.2 * bottomWidthScore, 0, 1);
+}
+
+function chooseBottomPivot(lows, p1, p3, config) {
+  const midpoint = (p1.index + p3.index) / 2;
+  const halfWidth = (p3.index - p1.index) / 2;
+  const eligible = lows.filter((pivot) => (
+    pivot.index > p1.index
+    && pivot.index < p3.index
+    && Math.abs(pivot.index - midpoint) / halfWidth
+      <= config.center_tolerance_fraction_of_half_width
+  ));
+  eligible.sort((a, b) => a.price - b.price || a.index - b.index);
+  return eligible[0] ?? null;
+}
+
+function cupMetrics(bars, p1, p2, p3, config, { provisional = false } = {}) {
+  const cupWidth = p3.index - p1.index;
+  const leftWidth = p2.index - p1.index;
+  const rightWidth = p3.index - p2.index;
+  const rim = (p1.price + p3.price) / 2;
+  const cupHeight = rim - p2.price;
+  const centerError = Math.abs(p2.index - (p1.index + p3.index) / 2) / (cupWidth / 2);
+  const depthFraction = cupHeight / Math.max(Math.abs(rim), Number.EPSILON);
+  const rimError = Math.abs(p1.price - p3.price) / Math.max(cupHeight, Number.EPSILON);
+  const symmetryScore = clamp(1 - Math.abs(leftWidth - rightWidth) / Math.max(cupWidth, 1), 0, 1);
+  const uShapeScore = computeUShapeScoreWithConfig(bars, p1, p2, p3, config);
+  const rejectionReasons = [];
+  if (cupWidth < config.minimum_cup_bars) rejectionReasons.push('CUP_TOO_SHORT');
+  if (cupWidth > config.maximum_cup_bars) rejectionReasons.push('CUP_TOO_LONG');
+  if (leftWidth <= 0 || rightWidth <= 0) rejectionReasons.push('BOTTOM_OUTSIDE_CUP');
+  if (centerError > config.center_tolerance_fraction_of_half_width) {
+    rejectionReasons.push('BOTTOM_OFF_CENTER');
+  }
+  if (!(cupHeight > 0)) rejectionReasons.push('NONPOSITIVE_CUP_HEIGHT');
+  if (rimError > config.rim_deviation_fraction_of_cup_height) {
+    rejectionReasons.push('RIMS_MISALIGNED');
+  }
+  if (depthFraction < config.minimum_cup_depth_fraction_of_rim) {
+    rejectionReasons.push('CUP_TOO_SHALLOW');
+  }
+  if (depthFraction > config.maximum_cup_depth_fraction_of_rim) {
+    rejectionReasons.push('CUP_TOO_DEEP');
+  }
+  if (uShapeScore < config.minimum_u_shape_score) rejectionReasons.push('NOT_U_SHAPED');
+
+  const rimScore = clamp(1 - rimError / config.rim_deviation_fraction_of_cup_height, 0, 1);
+  const centerScore = clamp(
+    1 - centerError / config.center_tolerance_fraction_of_half_width,
+    0,
+    1,
+  );
+  const depthMidpoint = (
+    config.minimum_cup_depth_fraction_of_rim + config.maximum_cup_depth_fraction_of_rim
+  ) / 2;
+  const depthHalfRange = (
+    config.maximum_cup_depth_fraction_of_rim - config.minimum_cup_depth_fraction_of_rim
+  ) / 2;
+  const depthScore = clamp(1 - Math.abs(depthFraction - depthMidpoint) / depthHalfRange, 0, 1);
+  const qualityScore = Math.round(100 * (
+    0.4 * uShapeScore
+    + 0.2 * rimScore
+    + 0.15 * centerScore
+    + 0.15 * symmetryScore
+    + 0.1 * depthScore
+  ));
+  return {
+    valid: rejectionReasons.length === 0,
+    provisional,
+    cup_width_bars: cupWidth,
+    left_width_bars: leftWidth,
+    right_width_bars: rightWidth,
+    rim,
+    cup_height: cupHeight,
+    depth_fraction: depthFraction,
+    rim_error: rimError,
+    center_error: centerError,
+    symmetry_score: symmetryScore,
+    u_shape_score: uShapeScore,
+    quality_score: qualityScore,
+    rejection_reasons: rejectionReasons,
+  };
+}
+
+function identityPart(value) {
+  return String(value).replaceAll('|', '_');
+}
+
+function familyId(symbol, timeframe, p1, p2, config) {
+  return [
+    config.detector_version,
+    config.config_id,
+    identityPart(symbol),
+    timeframe,
+    p1.time,
+    p2.time,
+  ].join('|');
+}
+
+function provisionalPatternId(patternFamilyId) {
+  return `${patternFamilyId}|p3=pending`;
+}
+
+function confirmedPatternId(patternFamilyId, p3) {
+  return `${patternFamilyId}|p3=${p3.time}`;
+}
+
+function eventId(patternId, stage, detectionTime, config) {
+  return [patternId, stage, detectionTime, config.config_id].join('|');
+}
+
+function anchor(pivot) {
+  if (!pivot) return null;
+  return {
+    index: pivot.index,
+    time: pivot.time,
+    price: pivot.price,
+    confirmed_index: pivot.confirmed_index ?? null,
+    confirmed_time: pivot.confirmed_time ?? null,
+  };
+}
+
+function activeRank(stage) {
+  return ACTIVE_STAGE_ORDER[stage] ?? -1;
+}
+
+function compareCandidates(a, b) {
+  const stageDifference = activeRank(b.stage) - activeRank(a.stage);
+  if (stageDifference !== 0) return stageDifference;
+  if (b.quality_score !== a.quality_score) return b.quality_score - a.quality_score;
+  if (b.anchors.left_rim.time !== a.anchors.left_rim.time) {
+    return b.anchors.left_rim.time - a.anchors.left_rim.time;
+  }
+  return a.pattern_id.localeCompare(b.pattern_id);
+}
+
+function confirmedCandidatesAt({ bars, pivots, barIndex, symbol, timeframe, config, locks }) {
+  const cutoff = Math.max(0, barIndex - config.lookback_bars + 1);
+  const highs = pivots.highs
+    .filter((pivot) => pivot.confirmed_index <= barIndex && pivot.index >= cutoff)
+    .slice(-config.maximum_pivots_per_kind);
+  const lows = pivots.lows
+    .filter((pivot) => pivot.confirmed_index <= barIndex && pivot.index >= cutoff)
+    .slice(-config.maximum_pivots_per_kind);
+  const candidates = [];
+
+  for (let rightIndex = 0; rightIndex < highs.length; rightIndex += 1) {
+    const p3 = highs[rightIndex];
+    for (let leftIndex = 0; leftIndex < rightIndex; leftIndex += 1) {
+      const p1 = highs[leftIndex];
+      const width = p3.index - p1.index;
+      if (width < config.minimum_cup_bars || width > config.maximum_cup_bars) continue;
+      const p2 = chooseBottomPivot(lows, p1, p3, config);
+      if (!p2) continue;
+      const metrics = cupMetrics(bars, p1, p2, p3, config);
+      if (!metrics.valid) continue;
+      const patternFamilyId = familyId(symbol, timeframe, p1, p2, config);
+      const patternId = confirmedPatternId(patternFamilyId, p3);
+      const locked = locks.get(patternId);
+      if (locked && locked.p3.index !== p3.index) continue;
+      const handle = deriveHandleState({
+        bars,
+        pivots,
+        barIndex,
+        p3,
+        metrics,
+        config,
+        lockedP4: locked?.p4 ?? null,
+      });
+      candidates.push({
+        schema_version: 'cup-handle-observation-v0',
+        detector_version: config.detector_version,
+        config_id: config.config_id,
+        symbol,
+        timeframe,
+        pattern_id: patternId,
+        family_id: patternFamilyId,
+        stage: handle.stage,
+        provisional: false,
+        detection_index: barIndex,
+        detection_bar_open_time: bars[barIndex].time,
+        detection_bar_close_time: bars[barIndex].time_close,
+        first_known_index: Math.max(p1.confirmed_index, p2.confirmed_index, p3.confirmed_index),
+        first_known_time: bars[Math.max(p1.confirmed_index, p2.confirmed_index, p3.confirmed_index)].time,
+        quality_score: metrics.quality_score,
+        reasons: handle.reasons,
+        anchors: {
+          left_rim: anchor(p1),
+          cup_bottom: anchor(p2),
+          right_rim: anchor(p3),
+          handle: anchor(handle.p4),
+          breakout: handle.breakout_anchor,
+        },
+        levels: {
+          rim: metrics.rim,
+          pivot: handle.handle_line,
+          invalidation: handle.invalidation_level,
+          target: handle.target_level,
+        },
+        metrics: {
+          cup_width_bars: metrics.cup_width_bars,
+          cup_height: metrics.cup_height,
+          depth_fraction: metrics.depth_fraction,
+          rim_error: metrics.rim_error,
+          center_error: metrics.center_error,
+          symmetry_score: metrics.symmetry_score,
+          u_shape_score: metrics.u_shape_score,
+          handle_age_bars: handle.handle_age_bars,
+          handle_rollback_fraction: handle.handle_rollback_fraction,
+        },
+        already_broken_when_discovered: handle.already_broken_when_discovered,
+        _p1: p1,
+        _p2: p2,
+        _p3: p3,
+        _p4: handle.p4,
+      });
+    }
+  }
+  return candidates;
+}
+
+function deriveHandleState({ bars, pivots, barIndex, p3, metrics, config, lockedP4 }) {
+  const handleAge = barIndex - p3.index;
+  const handleLow = minimumLow(bars, p3.index + 1, barIndex);
+  const rollback = handleLow === null
+    ? 0
+    : (p3.price - handleLow) / Math.max(metrics.cup_height, Number.EPSILON);
+  const invalidationLevel = p3.price
+    - metrics.cup_height * config.maximum_handle_rollback_fraction_of_cup_height;
+  if (handleAge > metrics.cup_width_bars) {
+    return {
+      stage: 'EXPIRED',
+      reasons: ['HANDLE_OUTLIVED_CUP'],
+      p4: lockedP4,
+      handle_age_bars: handleAge,
+      handle_rollback_fraction: rollback,
+      invalidation_level: invalidationLevel,
+      handle_line: null,
+      target_level: null,
+      breakout_anchor: null,
+      already_broken_when_discovered: false,
+    };
+  }
+  if (handleLow !== null && handleLow < invalidationLevel) {
+    return {
+      stage: 'INVALIDATED',
+      reasons: ['HANDLE_ROLLBACK_EXCEEDED'],
+      p4: lockedP4,
+      handle_age_bars: handleAge,
+      handle_rollback_fraction: rollback,
+      invalidation_level: invalidationLevel,
+      handle_line: null,
+      target_level: null,
+      breakout_anchor: null,
+      already_broken_when_discovered: false,
+    };
+  }
+
+  let p4 = lockedP4;
+  if (!p4) {
+    const handleHighs = pivots.highs.filter((pivot) => (
+      pivot.confirmed_index <= barIndex
+      && pivot.index - p3.index >= config.minimum_handle_bars
+      && pivot.price <= p3.price
+      && pivot.index <= barIndex
+    ));
+    for (let index = handleHighs.length - 1; index >= 0; index -= 1) {
+      const candidate = handleHighs[index];
+      const beforeLow = minimumLow(bars, p3.index + 1, candidate.index);
+      const afterLow = minimumLow(bars, candidate.index + 1, barIndex);
+      if (beforeLow !== null && afterLow !== null && beforeLow > afterLow) {
+        p4 = candidate;
+        break;
+      }
+    }
+  }
+
+  if (!p4 && barIndex > p3.index && bars[barIndex].close > p3.price) {
+    return {
+      stage: 'INVALIDATED',
+      reasons: ['PRE_HANDLE_UPSIDE_ESCAPE'],
+      p4: null,
+      handle_age_bars: handleAge,
+      handle_rollback_fraction: rollback,
+      invalidation_level: invalidationLevel,
+      handle_line: null,
+      target_level: null,
+      breakout_anchor: null,
+      already_broken_when_discovered: false,
+    };
+  }
+
+  if (!p4 || handleAge < config.minimum_handle_bars) {
+    return {
+      stage: 'HANDLE_FORMING',
+      reasons: ['CONFIRMED_CUP', 'HANDLE_NOT_READY'],
+      p4: null,
+      handle_age_bars: handleAge,
+      handle_rollback_fraction: rollback,
+      invalidation_level: invalidationLevel,
+      handle_line: null,
+      target_level: null,
+      breakout_anchor: null,
+      already_broken_when_discovered: false,
+    };
+  }
+
+  const currentLine = lineValue(p3, p4, barIndex);
+  const previousLine = lineValue(p3, p4, Math.max(p4.index, barIndex - 1));
+  const currentAbove = bars[barIndex].close > currentLine;
+  const previousAbove = barIndex > p4.index && bars[barIndex - 1].close > previousLine;
+  const breakout = currentAbove && (!previousAbove || barIndex === p4.confirmed_index);
+  return {
+    stage: breakout ? 'BREAKOUT_CONFIRMED' : 'HANDLE_READY',
+    reasons: breakout ? ['CLOSE_ABOVE_HANDLE_LINE'] : ['HANDLE_GEOMETRY_READY'],
+    p4,
+    handle_age_bars: handleAge,
+    handle_rollback_fraction: rollback,
+    invalidation_level: invalidationLevel,
+    handle_line: currentLine,
+    target_level: currentLine + metrics.cup_height,
+    breakout_anchor: breakout
+      ? { index: barIndex, time: bars[barIndex].time, price: bars[barIndex].close }
+      : null,
+    already_broken_when_discovered: breakout && barIndex === p4.confirmed_index,
+  };
+}
+
+function approachCandidatesAt({ bars, pivots, barIndex, symbol, timeframe, config, confirmedIds }) {
+  const cutoff = Math.max(0, barIndex - config.lookback_bars + 1);
+  const highs = pivots.highs
+    .filter((pivot) => pivot.confirmed_index <= barIndex && pivot.index >= cutoff)
+    .slice(-config.maximum_pivots_per_kind);
+  const lows = pivots.lows
+    .filter((pivot) => pivot.confirmed_index <= barIndex && pivot.index >= cutoff)
+    .slice(-config.maximum_pivots_per_kind);
+  const candidates = [];
+  const provisionalP3 = {
+    kind: 'provisional_high',
+    index: barIndex,
+    time: bars[barIndex].time,
+    price: bars[barIndex].high,
+    confirmed_index: null,
+    confirmed_time: null,
+  };
+
+  for (const p1 of highs) {
+    const width = barIndex - p1.index;
+    if (width < config.minimum_cup_bars || width > config.maximum_cup_bars) continue;
+    const p2 = chooseBottomPivot(lows, p1, provisionalP3, config);
+    if (!p2) continue;
+    const metrics = cupMetrics(bars, p1, p2, provisionalP3, config, { provisional: true });
+    const heightFromLeftRim = p1.price - p2.price;
+    if (!(heightFromLeftRim > 0)) continue;
+    const recovery = (provisionalP3.price - p2.price) / heightFromLeftRim;
+    const permittedOvershoot = heightFromLeftRim * config.rim_deviation_fraction_of_cup_height;
+    if (provisionalP3.price > p1.price + permittedOvershoot) continue;
+    const structuralRejections = metrics.rejection_reasons.filter((reason) => reason !== 'RIMS_MISALIGNED');
+    if (structuralRejections.length > 0 || recovery < config.forming_recovery_fraction) continue;
+    const patternFamilyId = familyId(symbol, timeframe, p1, p2, config);
+    const patternId = provisionalPatternId(patternFamilyId);
+    if (confirmedIds.has(patternFamilyId)) continue;
+    const stage = recovery >= config.rim_approach_recovery_fraction
+      ? 'RIM_APPROACH'
+      : 'CUP_FORMING';
+    candidates.push({
+      schema_version: 'cup-handle-observation-v0',
+      detector_version: config.detector_version,
+      config_id: config.config_id,
+      symbol,
+      timeframe,
+      pattern_id: patternId,
+      family_id: patternFamilyId,
+      stage,
+      provisional: true,
+      detection_index: barIndex,
+      detection_bar_open_time: bars[barIndex].time,
+      detection_bar_close_time: bars[barIndex].time_close,
+      first_known_index: Math.max(p1.confirmed_index, p2.confirmed_index),
+      first_known_time: bars[Math.max(p1.confirmed_index, p2.confirmed_index)].time,
+      quality_score: metrics.quality_score,
+      reasons: stage === 'RIM_APPROACH'
+        ? ['RIGHT_SIDE_NEAR_LEFT_RIM']
+        : ['RIGHT_SIDE_RECOVERING'],
+      anchors: {
+        left_rim: anchor(p1),
+        cup_bottom: anchor(p2),
+        right_rim: anchor(provisionalP3),
+        handle: null,
+        breakout: null,
+      },
+      levels: {
+        rim: p1.price,
+        pivot: p1.price,
+        invalidation: null,
+        target: null,
+      },
+      metrics: {
+        cup_width_bars: metrics.cup_width_bars,
+        cup_height: heightFromLeftRim,
+        depth_fraction: metrics.depth_fraction,
+        rim_error: metrics.rim_error,
+        center_error: metrics.center_error,
+        symmetry_score: metrics.symmetry_score,
+        u_shape_score: metrics.u_shape_score,
+        right_side_recovery_fraction: recovery,
+        handle_age_bars: 0,
+        handle_rollback_fraction: 0,
+      },
+      already_broken_when_discovered: false,
+      _p1: p1,
+      _p2: p2,
+      _p3: null,
+      _p4: null,
+    });
+  }
+  return candidates;
+}
+
+function publicObservation(pattern) {
+  if (!pattern) return null;
+  const {
+    _p1,
+    _p2,
+    _p3,
+    _p4,
+    ...observation
+  } = pattern;
+  return observation;
+}
+
+export function detectCupAndHandle({
+  bars: rows,
+  symbol,
+  timeframe,
+  config: configOverrides = {},
+}) {
+  if (typeof symbol !== 'string' || !symbol.trim()) {
+    throw new TypeError('symbol must be a non-empty exchange-qualified string');
+  }
+  const normalizedTimeframe = normalizeTimeframe(timeframe);
+  const config = validateConfig(configOverrides);
+  const bars = normalizeBars(rows);
+  const pivots = findConfirmedPivots(bars, config);
+  const minimumHistory = config.pivot_left_bars
+    + config.minimum_cup_bars
+    + config.pivot_right_bars
+    + 1;
+  const transitions = [];
+  const latestById = new Map();
+  const stageById = new Map();
+  const locks = new Map();
+  const completedFamilyIds = new Set();
+  let activePatternId = null;
+
+  for (let barIndex = 0; barIndex < bars.length; barIndex += 1) {
+    if (barIndex + 1 < minimumHistory) continue;
+    const confirmed = confirmedCandidatesAt({
+      bars,
+      pivots,
+      barIndex,
+      symbol: symbol.trim(),
+      timeframe: normalizedTimeframe,
+      config,
+      locks,
+    });
+    const confirmedIds = new Set(
+      confirmed
+        .filter((candidate) => !TERMINAL_STAGES.has(candidate.stage))
+        .map((candidate) => candidate.family_id),
+    );
+    const approaches = approachCandidatesAt({
+      bars,
+      pivots,
+      barIndex,
+      symbol: symbol.trim(),
+      timeframe: normalizedTimeframe,
+      config,
+      confirmedIds,
+    });
+    const allCandidates = [...confirmed, ...approaches]
+      .filter((candidate) => !completedFamilyIds.has(candidate.family_id));
+    let selected = activePatternId
+      ? allCandidates.find((candidate) => candidate.pattern_id === activePatternId)
+      : null;
+    if (!selected && activePatternId) {
+      const activeObservation = latestById.get(activePatternId);
+      if (activeObservation?.provisional) {
+        selected = allCandidates
+          .filter((candidate) => candidate.family_id === activeObservation.family_id)
+          .sort(compareCandidates)[0] ?? null;
+      }
+    }
+    if (activePatternId && !selected) {
+      const previousObservation = latestById.get(activePatternId);
+      const previousStage = stageById.get(activePatternId) ?? 'NONE';
+      const terminalStage = 'INVALIDATED';
+      const transition = {
+        schema_version: 'cup-handle-transition-v0',
+        detector_version: config.detector_version,
+        config_id: config.config_id,
+        event_id: eventId(activePatternId, terminalStage, bars[barIndex].time, config),
+        pattern_id: activePatternId,
+        family_id: previousObservation?.family_id ?? null,
+        symbol: symbol.trim(),
+        timeframe: normalizedTimeframe,
+        from_stage: previousStage,
+        to_stage: terminalStage,
+        detection_index: barIndex,
+        detection_bar_open_time: bars[barIndex].time,
+        detection_bar_close_time: bars[barIndex].time_close,
+        provisional: previousObservation?.provisional ?? true,
+        pivot: previousObservation?.levels.pivot ?? null,
+        invalidation: previousObservation?.levels.invalidation ?? null,
+        quality_score: previousObservation?.quality_score ?? null,
+        already_broken_when_discovered: false,
+        anchors: previousObservation?.anchors ?? null,
+      };
+      transitions.push(transition);
+      stageById.set(activePatternId, terminalStage);
+      latestById.set(activePatternId, {
+        ...previousObservation,
+        stage: terminalStage,
+        reasons: ['ACTIVE_GEOMETRY_NO_LONGER_VALID'],
+        detection_index: barIndex,
+        detection_bar_open_time: bars[barIndex].time,
+        detection_bar_close_time: bars[barIndex].time_close,
+        last_transition: transition,
+      });
+      activePatternId = null;
+      continue;
+    }
+    if (!selected) {
+      selected = allCandidates
+        .filter((candidate) => (
+          !TERMINAL_STAGES.has(candidate.stage)
+          && !TERMINAL_STAGES.has(stageById.get(candidate.pattern_id))
+        ))
+        .sort(compareCandidates)[0] ?? null;
+    }
+    if (!selected) {
+      activePatternId = null;
+      continue;
+    }
+
+    const activeObservation = activePatternId ? latestById.get(activePatternId) : null;
+    const isPromotion = Boolean(
+      activeObservation?.provisional
+      && !selected.provisional
+      && activeObservation.family_id === selected.family_id,
+    );
+    const previousStage = isPromotion
+      ? activeObservation.stage
+      : stageById.get(selected.pattern_id) ?? 'NONE';
+    const previousObservation = isPromotion
+      ? activeObservation
+      : latestById.get(selected.pattern_id) ?? null;
+    if (isPromotion) {
+      stageById.set(activePatternId, 'EXPIRED');
+      latestById.delete(activePatternId);
+    }
+    const isTerminal = TERMINAL_STAGES.has(selected.stage);
+    const progressed = isTerminal
+      ? !TERMINAL_STAGES.has(previousStage)
+      : activeRank(selected.stage) > activeRank(previousStage);
+
+    if (!isTerminal && activeRank(selected.stage) < activeRank(previousStage)) {
+      selected = {
+        ...selected,
+        stage: previousStage,
+        anchors: previousObservation?.anchors ?? selected.anchors,
+        levels: { ...selected.levels, ...previousObservation?.levels },
+      };
+    }
+
+    if (selected._p3 && !locks.has(selected.pattern_id)) {
+      locks.set(selected.pattern_id, { p3: selected._p3, p4: null });
+    }
+    if (selected._p4) {
+      const locked = locks.get(selected.pattern_id) ?? { p3: selected._p3, p4: null };
+      if (!locked.p4) locks.set(selected.pattern_id, { ...locked, p4: selected._p4 });
+    }
+
+    if (progressed) {
+      const transition = {
+        schema_version: 'cup-handle-transition-v0',
+        detector_version: config.detector_version,
+        config_id: config.config_id,
+        event_id: eventId(selected.pattern_id, selected.stage, bars[barIndex].time, config),
+        pattern_id: selected.pattern_id,
+        family_id: selected.family_id,
+        symbol: symbol.trim(),
+        timeframe: normalizedTimeframe,
+        from_stage: previousStage,
+        to_stage: selected.stage,
+        detection_index: barIndex,
+        detection_bar_open_time: bars[barIndex].time,
+        detection_bar_close_time: bars[barIndex].time_close,
+        provisional: selected.provisional,
+        pivot: selected.levels.pivot,
+        invalidation: selected.levels.invalidation,
+        quality_score: selected.quality_score,
+        already_broken_when_discovered: selected.already_broken_when_discovered,
+        anchors: selected.anchors,
+      };
+      transitions.push(transition);
+      stageById.set(selected.pattern_id, selected.stage);
+      if (selected.stage === 'BREAKOUT_CONFIRMED') {
+        completedFamilyIds.add(selected.family_id);
+      }
+      selected = { ...selected, last_transition: transition };
+    } else if (previousStage !== 'NONE') {
+      selected = { ...selected, stage: previousStage };
+    }
+    if (!previousObservation) {
+      selected = {
+        ...selected,
+        first_seen_index: barIndex,
+        first_seen_time: bars[barIndex].time,
+      };
+    } else {
+      selected = {
+        ...selected,
+        first_seen_index: previousObservation.first_seen_index,
+        first_seen_time: previousObservation.first_seen_time,
+      };
+    }
+    latestById.set(selected.pattern_id, selected);
+    activePatternId = isTerminal ? null : selected.pattern_id;
+  }
+
+  const patterns = [...latestById.values()]
+    .map(publicObservation)
+    .sort((a, b) => a.first_seen_time - b.first_seen_time || a.pattern_id.localeCompare(b.pattern_id));
+  const currentPattern = activePatternId ? publicObservation(latestById.get(activePatternId)) : null;
+  return {
+    schema_version: 'cup-handle-detection-result-v0',
+    detector_version: config.detector_version,
+    config_id: config.config_id,
+    symbol: symbol.trim(),
+    timeframe: normalizedTimeframe,
+    closed_bars: bars.length,
+    pivots: {
+      highs: pivots.highs.map(anchor),
+      lows: pivots.lows.map(anchor),
+    },
+    patterns,
+    transitions,
+    current_pattern: currentPattern,
+  };
+}

--- a/cup-and-handle/analysis/cup-handle-core.mjs
+++ b/cup-and-handle/analysis/cup-handle-core.mjs
@@ -42,7 +42,7 @@ export const STAGES = Object.freeze([
 
 export const DEFAULT_CONFIG = Object.freeze({
   config_id: 'ch-v0-default',
-  detector_version: '0.1.1-cleanroom',
+  detector_version: '0.1.2-cleanroom',
   lookback_bars: 600,
   pivot_left_bars: 5,
   pivot_right_bars: 5,
@@ -767,10 +767,15 @@ export function detectCupAndHandle({
       config,
       locks,
     });
-    const confirmedIds = new Set(
-      confirmed
-        .filter((candidate) => !TERMINAL_STAGES.has(candidate.stage))
-        .map((candidate) => candidate.family_id),
+    // Pine only discovers a right rim on the bar where its pivot becomes
+    // knowable. Keep the reference detector on that same causal boundary:
+    // historical right rims remain available for an already-active confirmed
+    // pattern, but they cannot start or promote a different pattern later.
+    const newlyConfirmed = confirmed.filter(
+      (candidate) => candidate._p3?.confirmed_index === barIndex,
+    );
+    const newlyConfirmedFamilyIds = new Set(
+      newlyConfirmed.map((candidate) => candidate.family_id),
     );
     const approaches = approachCandidatesAt({
       bars,
@@ -779,7 +784,7 @@ export function detectCupAndHandle({
       symbol: symbol.trim(),
       timeframe: normalizedTimeframe,
       config,
-      confirmedIds,
+      confirmedIds: newlyConfirmedFamilyIds,
     });
     const allCandidates = [...confirmed, ...approaches]
       .filter((candidate) => !completedFamilyIds.has(candidate.family_id));
@@ -789,7 +794,7 @@ export function detectCupAndHandle({
     if (!selected && activePatternId) {
       const activeObservation = latestById.get(activePatternId);
       if (activeObservation?.provisional) {
-        selected = allCandidates
+        selected = newlyConfirmed
           .filter((candidate) => candidate.family_id === activeObservation.family_id)
           .sort(compareCandidates)[0] ?? null;
       }
@@ -834,7 +839,8 @@ export function detectCupAndHandle({
       continue;
     }
     if (!selected) {
-      selected = allCandidates
+      selected = [...newlyConfirmed, ...approaches]
+        .filter((candidate) => !completedFamilyIds.has(candidate.family_id))
         .filter((candidate) => (
           !TERMINAL_STAGES.has(candidate.stage)
           && !TERMINAL_STAGES.has(stageById.get(candidate.pattern_id))

--- a/cup-and-handle/analysis/frozen-v0-cup-handle.json
+++ b/cup-and-handle/analysis/frozen-v0-cup-handle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "cup-handle-contract-v0",
-  "detector_version": "0.1.1-cleanroom",
+  "detector_version": "0.1.2-cleanroom",
   "status": "draft_calibration",
   "name": "Cup-and-Handle Pattern Watch",
   "purpose": "Causal attention signal for a forming bullish Cup-and-Handle pattern; not a trade recommendation.",

--- a/cup-and-handle/analysis/frozen-v0-cup-handle.json
+++ b/cup-and-handle/analysis/frozen-v0-cup-handle.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "cup-handle-contract-v0",
+  "detector_version": "0.1.1-cleanroom",
+  "status": "draft_calibration",
+  "name": "Cup-and-Handle Pattern Watch",
+  "purpose": "Causal attention signal for a forming bullish Cup-and-Handle pattern; not a trade recommendation.",
+  "supported_timeframes": ["4H", "1D", "1W"],
+  "documented_tradingview_rules": {
+    "source": "https://www.tradingview.com/support/solutions/43000732556-chart-pattern-cup-and-handle/",
+    "lookback_bars": 600,
+    "pivot_left_bars": 5,
+    "pivot_right_bars": 5,
+    "minimum_cup_bars": 20,
+    "bottom_is_lowest_pivot_near_center": true,
+    "approximately_level_rims": true,
+    "handle_rollback_is_limited_relative_to_cup_height": true,
+    "handle_cannot_outlive_cup": true,
+    "supports_in_progress_patterns": true,
+    "breakout_uses_close_above_handle_line": true,
+    "overlapping_patterns_prefer_awaiting_then_best_u_shape": true,
+    "prior_trend_check_is_optional_and_disabled_by_default": true
+  },
+  "explicit_cleanroom_defaults": {
+    "maximum_cup_bars": 240,
+    "center_tolerance_fraction_of_half_width": 0.35,
+    "rim_deviation_fraction_of_cup_height": 0.15,
+    "minimum_cup_depth_fraction_of_rim": 0.08,
+    "maximum_cup_depth_fraction_of_rim": 0.5,
+    "minimum_u_shape_score": 0.5,
+    "bottom_width_target_fraction": 0.12,
+    "forming_recovery_fraction": 0.65,
+    "rim_approach_recovery_fraction": 0.85,
+    "maximum_handle_rollback_fraction_of_cup_height": 0.4,
+    "minimum_handle_bars": 3,
+    "pre_handle_close_above_right_rim_invalidates": true,
+    "completed_breakout_family_cannot_rearm": true,
+    "prior_trend_gate_enabled": false,
+    "equal_price_pivot_plateau_policy": "rightmost"
+  },
+  "lifecycle": [
+    "NONE",
+    "CUP_FORMING",
+    "RIM_APPROACH",
+    "HANDLE_FORMING",
+    "HANDLE_READY",
+    "BREAKOUT_CONFIRMED",
+    "INVALIDATED",
+    "EXPIRED"
+  ],
+  "causality": {
+    "closed_bars_only": true,
+    "pivot_detection_is_not_backdated": true,
+    "anchors_lock_after_first_confirmed_pattern_transition": true,
+    "one_event_per_pattern_stage": true,
+    "historical_anchor_time_is_distinct_from_detection_time": true,
+    "event_reports_detection_bar_open_and_close_times": true,
+    "live_bar_drawings_use_last_closed_values": true,
+    "promoted_provisional_identity_is_retired": true
+  },
+  "identity": {
+    "family_id_anchors": ["left_rim", "cup_bottom"],
+    "provisional_pattern_id_uses_pending_right_rim": true,
+    "confirmed_pattern_id_adds_right_rim": true,
+    "configuration_id_encodes_all_runtime_thresholds": true
+  },
+  "non_goals": [
+    "Reproduce TradingView's undisclosed implementation exactly",
+    "Automated trading or order placement",
+    "Claim predictive efficacy",
+    "Scan or alert on off-watchlist symbols automatically",
+    "Watchlist scanner implementation in the first slice",
+    "Track or queue more than one overlapping active pattern family per chart",
+    "Monthly support before 4H/1D/1W calibration",
+    "Target-reached outcome tracking in the first slice"
+  ]
+}

--- a/cup-and-handle/analysis/live-qa-v0.json
+++ b/cup-and-handle/analysis/live-qa-v0.json
@@ -1,0 +1,200 @@
+{
+  "schema_version": "cup-handle-live-qa-v1",
+  "run_id": "20260810171712",
+  "tested_at_utc": "2026-08-10T17:17:12Z",
+  "status": "superseded_after_parallel_grill",
+  "detector_version": "0.1.0-cleanroom",
+  "source": {
+    "pine_path": "cup-and-handle/cup-and-handle.pine",
+    "pine_sha256": "a610542464758b5c3a9831eb31c364c1acd20a62469eabd80d91f403c47965b5",
+    "reference_path": "cup-and-handle/analysis/cup-handle-core.mjs",
+    "reference_sha256": "32a4f94443bccafcbbf968b0301c8cb4f8c8cab211c106a77faef8c81df61c81"
+  },
+  "compile": {
+    "tradingview_server_compile": "passed",
+    "errors": 0,
+    "warnings": 0
+  },
+  "runtime_matrix": {
+    "result": "passed",
+    "invariants_checked_per_case": [
+      "exact temporary script identity and version",
+      "study completed and settled to the current main-series bar",
+      "two identical machine reads on the same closed bar",
+      "valid lifecycle code and transition coherence",
+      "stage-specific anchor, level, and drawing-count coherence",
+      "chart-only screenshot captured on the same bar"
+    ],
+    "cases": [
+      {
+        "id": "aapl-4h",
+        "requested_symbol": "NASDAQ:AAPL",
+        "resolved_chart_symbol": "BATS:AAPL",
+        "timeframe": "4H",
+        "supported": true,
+        "stage_code": 3,
+        "stage": "HANDLE_FORMING",
+        "quality": 64,
+        "rim": 276.54,
+        "invalidation": 262.52,
+        "line_count": 2,
+        "repeat_read_equal": true,
+        "screenshot": {
+          "path": "screenshots/cup-handle-live-qa-20260810171712/aapl-4h.png",
+          "sha256": "4f027e1e233e88e70802d9bbd7f8133fbe8aa73f601a1bea2ef52b1465a1150a",
+          "size_bytes": 142316,
+          "width": 1144,
+          "height": 1082
+        }
+      },
+      {
+        "id": "aapl-1d",
+        "requested_symbol": "NASDAQ:AAPL",
+        "resolved_chart_symbol": "BATS:AAPL",
+        "timeframe": "1D",
+        "supported": true,
+        "stage_code": 0,
+        "stage": "NONE",
+        "line_count": 0,
+        "repeat_read_equal": true,
+        "screenshot": {
+          "path": "screenshots/cup-handle-live-qa-20260810171712/aapl-1d.png",
+          "sha256": "e5a5ca44559b474529131d23e2658a4e4e8ec28e6546929ab67dea17c4dde6fc",
+          "size_bytes": 137931,
+          "width": 1144,
+          "height": 1082
+        }
+      },
+      {
+        "id": "aapl-1w",
+        "requested_symbol": "NASDAQ:AAPL",
+        "resolved_chart_symbol": "BATS:AAPL",
+        "timeframe": "1W",
+        "supported": true,
+        "stage_code": 0,
+        "stage": "NONE",
+        "line_count": 0,
+        "repeat_read_equal": true,
+        "screenshot": {
+          "path": "screenshots/cup-handle-live-qa-20260810171712/aapl-1w.png",
+          "sha256": "c2af55ebda077056012f72fb3d7f2f02b6bd8d25a295db0f0ccc7161b6b29ada",
+          "size_bytes": 124722,
+          "width": 1144,
+          "height": 1082
+        }
+      },
+      {
+        "id": "btc-4h",
+        "requested_symbol": "BITSTAMP:BTCUSD",
+        "resolved_chart_symbol": "BITSTAMP:BTCUSD",
+        "timeframe": "4H",
+        "supported": true,
+        "stage_code": 3,
+        "stage": "HANDLE_FORMING",
+        "quality": 70,
+        "rim": 64831,
+        "invalidation": 62080,
+        "line_count": 2,
+        "repeat_read_equal": true,
+        "screenshot": {
+          "path": "screenshots/cup-handle-live-qa-20260810171712/btc-4h.png",
+          "sha256": "d70660c97c0a3eb652fb330387eded0ac5b64bc0485312119a34e92ec8d4b746",
+          "size_bytes": 138717,
+          "width": 1144,
+          "height": 1082
+        }
+      },
+      {
+        "id": "btc-1d",
+        "requested_symbol": "BITSTAMP:BTCUSD",
+        "resolved_chart_symbol": "BITSTAMP:BTCUSD",
+        "timeframe": "1D",
+        "supported": true,
+        "stage_code": 0,
+        "stage": "NONE",
+        "line_count": 0,
+        "repeat_read_equal": true,
+        "screenshot": {
+          "path": "screenshots/cup-handle-live-qa-20260810171712/btc-1d.png",
+          "sha256": "061fdace392d79e2f37439c5c651e5f7895a3151470b1c4d76dc54f9b78811c3",
+          "size_bytes": 175253,
+          "width": 1144,
+          "height": 1082
+        }
+      },
+      {
+        "id": "btc-1w",
+        "requested_symbol": "BITSTAMP:BTCUSD",
+        "resolved_chart_symbol": "BITSTAMP:BTCUSD",
+        "timeframe": "1W",
+        "supported": true,
+        "stage_code": 0,
+        "stage": "NONE",
+        "line_count": 0,
+        "repeat_read_equal": true,
+        "screenshot": {
+          "path": "screenshots/cup-handle-live-qa-20260810171712/btc-1w.png",
+          "sha256": "cbb049c9a92fcb6f587c07cef0076113c41fbf3f40fda3c1fbce5ddb622564bf",
+          "size_bytes": 182080,
+          "width": 1144,
+          "height": 1082
+        }
+      },
+      {
+        "id": "aapl-1m-negative",
+        "requested_symbol": "NASDAQ:AAPL",
+        "resolved_chart_symbol": "BATS:AAPL",
+        "timeframe": "1M",
+        "supported": false,
+        "stage_code": 0,
+        "stage": "NONE",
+        "line_count": 0,
+        "exact_timeframe_warning_count": 1,
+        "repeat_read_equal": true,
+        "screenshot": {
+          "path": "screenshots/cup-handle-live-qa-20260810171712/aapl-1m-negative.png",
+          "sha256": "57df0a35e64fb21830f209070746b2c7e17f6ee422f9843600a91cafbf742134",
+          "size_bytes": 141122,
+          "width": 1144,
+          "height": 1082
+        }
+      }
+    ]
+  },
+  "visual_review": {
+    "result": "completed_with_context_noise",
+    "checked_images": 7,
+    "observed": [
+      "Cup-and-Handle transition labels and geometry rendered on live stock and crypto charts",
+      "the monthly negative control rendered the intended unsupported-timeframe warning",
+      "no blank chart or obvious Pine runtime-error overlay was visible"
+    ],
+    "limitation": "The disposable chart inherited the user's existing studies, so the screenshots are useful runtime evidence but are visually cluttered and do not independently prove that every historical label is a desirable pattern."
+  },
+  "cleanup": {
+    "result": "verified",
+    "temporary_study_references_after": 0,
+    "temporary_cloud_script_matches_after": 0,
+    "temporary_cloud_source_access_after": false,
+    "temporary_chart_targets_after": 0,
+    "temporary_shell_tabs_after": 0,
+    "original_chart_restored": true,
+    "original_alert_definitions_unchanged": true,
+    "cup_handle_alerts_created": 0
+  },
+  "claims_not_established": [
+    "Pine and JavaScript per-bar behavioral parity",
+    "replay-verified non-repainting behavior in TradingView",
+    "pattern precision or recall against human visual judgment",
+    "alert-delivery behavior",
+    "predictive or trading performance",
+    "monthly detection",
+    "watchlist or broader-market scanning"
+  ],
+  "artifact_note": "The screenshots and private recovery receipt are local, gitignored runtime evidence. Their content hashes are preserved here; no TradingView script identifier or account identity is recorded in this durable receipt.",
+  "superseded_by": {
+    "detector_version": "0.1.1-cleanroom",
+    "verification_receipt": "cup-and-handle/analysis/verification-0.1.1.json",
+    "reason": "Independent review reproduced post-breakout family re-arming, stale promoted provisional state, pre-handle upside escape, and late historical-right-rim resurrection in 0.1.0. The 0.1.1 build corrects those paths, so this live matrix is integration evidence for the earlier source only and must not be represented as exact-source runtime proof for 0.1.1."
+  }
+}

--- a/cup-and-handle/analysis/verification-0.1.1.json
+++ b/cup-and-handle/analysis/verification-0.1.1.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "cup-handle-verification-v1",
+  "verified_at_utc": "2026-08-10T17:44:58Z",
+  "detector_version": "0.1.1-cleanroom",
+  "source": {
+    "pine_path": "cup-and-handle/cup-and-handle.pine",
+    "pine_sha256": "bf594e19e26f825431e8408162f449224c69cc4f19d3549191d1bcccb26cd2ff",
+    "reference_path": "cup-and-handle/analysis/cup-handle-core.mjs",
+    "reference_sha256": "87bfe4c06ea9ffc4d13a42dbe3b48dff8c2d20e11aca05fcbccc29e3cf2eb3b3"
+  },
+  "checks": {
+    "focused_tests": {
+      "command": "npm run test:cup-handle",
+      "passed": 35,
+      "failed": 0
+    },
+    "repository_unit_tests": {
+      "command": "npm run test:unit",
+      "passed": 187,
+      "skipped": 2,
+      "failed": 0
+    },
+    "eslint": {
+      "command": "npx eslint cup-and-handle/analysis/cup-handle-core.mjs tests/cup_handle_core.test.js tests/cup_handle_pine_contract.test.js",
+      "errors": 0,
+      "warnings": 0
+    },
+    "local_pine_analysis": {
+      "command": "node src/cli/index.js pine analyze --file cup-and-handle/cup-and-handle.pine",
+      "issue_count": 0
+    },
+    "tradingview_server_compile": {
+      "method": "server API compile-only; source was not saved or added to a chart",
+      "compiled": true,
+      "errors": 0,
+      "warnings": 0
+    },
+    "json_validation": "passed",
+    "git_diff_check": "passed"
+  },
+  "parallel_grill_fixes": [
+    {
+      "failure": "A completed cup family could re-arm immediately after breakout under a different right-rim pattern ID.",
+      "resolution": "A breakout now retires the entire left-rim/bottom family; the provisional identity is retired when the cup promotes.",
+      "regression_covered": true
+    },
+    {
+      "failure": "A confirmed cup could remain HANDLE_FORMING after price closed above the right rim without ever producing a handle pivot.",
+      "resolution": "A pre-handle close above the right rim now invalidates the setup after giving a newly confirmed handle pivot first chance to lock.",
+      "regression_covered": true
+    },
+    {
+      "failure": "A historical right rim could be resurrected late as HANDLE_FORMING without reconstructing its already-known handle lifecycle.",
+      "resolution": "Historical right rims are no longer queued or resurrected; V0 explicitly tracks one active family at a time.",
+      "regression_covered": "static Pine contract plus documented V0 boundary"
+    }
+  ],
+  "historical_live_evidence": {
+    "receipt": "cup-and-handle/analysis/live-qa-v0.json",
+    "version": "0.1.0-cleanroom",
+    "status": "superseded for exact-source runtime proof",
+    "still_relevant_to": [
+      "TradingView integration and cleanup path",
+      "4H/1D/1W timeframe gating",
+      "stock and crypto chart rendering",
+      "1M fail-closed warning"
+    ]
+  },
+  "not_verified_for_0_1_1": [
+    "chart-applied runtime matrix",
+    "TradingView replay behavior",
+    "alert creation or delivery",
+    "Pine/JavaScript per-bar parity",
+    "human-approved signal precision or recall"
+  ]
+}

--- a/cup-and-handle/analysis/verification-0.1.2.json
+++ b/cup-and-handle/analysis/verification-0.1.2.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": "cup-handle-verification-v1",
+  "verified_at_utc": "2026-08-10T19:17:11Z",
+  "detector_version": "0.1.2-cleanroom",
+  "source": {
+    "pine_path": "cup-and-handle/cup-and-handle.pine",
+    "pine_sha256": "27381b36ac02b554e4dffccaa79ef902a8df4009d530fe9079607cb0ef8cbb85",
+    "reference_path": "cup-and-handle/analysis/cup-handle-core.mjs",
+    "reference_sha256": "892811d1128b4acdbe06ce82d5353d41a6f59686c1bfa52a04f539b9c5b0b83a",
+    "contract_path": "cup-and-handle/analysis/frozen-v0-cup-handle.json",
+    "contract_sha256": "6658c496110e1a64d36288231ce38c7f198dafb98df9058b23bdfaefe6db773b"
+  },
+  "checks": {
+    "focused_tests": {
+      "command": "npm run test:cup-handle",
+      "passed": 36,
+      "failed": 0
+    },
+    "repository_unit_tests": {
+      "command": "npm run test:unit",
+      "passed": 188,
+      "skipped": 2,
+      "failed": 0
+    },
+    "eslint": {
+      "command": "npx eslint cup-and-handle/analysis/cup-handle-core.mjs tests/cup_handle_core.test.js tests/cup_handle_pine_contract.test.js",
+      "errors": 0,
+      "warnings": 0
+    },
+    "local_pine_analysis": {
+      "command": "node src/cli/index.js pine analyze --file cup-and-handle/cup-and-handle.pine",
+      "issue_count": 0
+    },
+    "tradingview_server_compile": {
+      "method": "pine_check compile-only; source was not injected, saved, or added to a chart",
+      "compiled": true,
+      "errors": 0,
+      "warnings": 0
+    },
+    "post_compile_live_state": {
+      "chart_symbol": "FX_IDC:XAGUSD",
+      "study_count": 7,
+      "cup_handle_study_count": 0,
+      "alert_count": 40,
+      "cup_handle_alert_count": 0
+    },
+    "git_diff_check": "passed"
+  },
+  "incremental_grill_fixes": [
+    {
+      "failure": "The JavaScript reference could start a confirmed pattern from a right-rim pivot that had become knowable on an earlier bar, contradicting the Pine detector's no-historical-resurrection rule.",
+      "resolution": "Only right rims whose pivot confirms on the current bar can start or promote a pattern; historical right rims remain available only to update the exact active confirmed pattern.",
+      "regression_covered": true
+    },
+    {
+      "failure": "Changing detector behavior without changing its version would make old and new event identities indistinguishable.",
+      "resolution": "The Pine, JavaScript, and frozen contract identity was advanced from 0.1.1-cleanroom to 0.1.2-cleanroom.",
+      "regression_covered": true
+    }
+  ],
+  "calibration_batch": {
+    "status": "awaiting_human_labels",
+    "scope": "12 local stock cards; four each on 4H, 1D, and 1W",
+    "local_manifest_path": "screenshots/cup-handle-calibration-v1/stock-batch-01/manifest.json",
+    "local_manifest_sha256": "bf7c9706e6438ac1d2f5b10a06955dc5040e87184d10ec33d86eba1e7b4aa75b",
+    "candidate_metadata_sha256": "51c785bcd0a5372b0aec969c8fd377c87bb0a15180dd034867d202edae43d660",
+    "label_event_log_sha256": "b41a6c00ca032f2039f7256cb3b1d0f68f3c6e94956d845e2b76c6341f0cf8e2",
+    "future_bars_hidden": true,
+    "visible_detector_annotations": false,
+    "raw_ohlcv_persisted_in_metadata": false,
+    "deterministic_regeneration": "byte-identical manifest, candidates, label log, and 12 SVG cards",
+    "tracked_or_pushed": false,
+    "crypto_half_batch_status": "not_started; requires a separately frozen source"
+  },
+  "historical_live_evidence": {
+    "receipt": "cup-and-handle/analysis/live-qa-v0.json",
+    "version": "0.1.0-cleanroom",
+    "status": "superseded for exact-source runtime proof",
+    "still_relevant_to": [
+      "TradingView integration and cleanup path",
+      "4H/1D/1W timeframe gating",
+      "stock and crypto chart rendering",
+      "1M fail-closed warning"
+    ]
+  },
+  "not_verified_for_0_1_2": [
+    "chart-applied runtime matrix",
+    "TradingView replay behavior",
+    "alert creation or delivery",
+    "Pine/JavaScript per-bar parity",
+    "human-approved signal precision or recall",
+    "crypto calibration cards"
+  ]
+}

--- a/cup-and-handle/cup-and-handle.pine
+++ b/cup-and-handle/cup-and-handle.pine
@@ -11,7 +11,7 @@ indicator(
 // documentation is used as a behavioral specification; no protected or
 // proprietary source code was copied or extracted.
 
-string VERSION = "0.1.1-cleanroom"
+string VERSION = "0.1.2-cleanroom"
 string CONFIG_BASE_ID = "ch-v0-default"
 
 string GROUP_STRUCTURE = "Documented structure"

--- a/cup-and-handle/cup-and-handle.pine
+++ b/cup-and-handle/cup-and-handle.pine
@@ -1,0 +1,613 @@
+//@version=6
+indicator(
+     "Cup-and-Handle Pattern Watch [Clean-room V0]",
+     shorttitle = "CH Pattern Watch V0",
+     overlay = true,
+     max_bars_back = 650,
+     max_lines_count = 20,
+     max_labels_count = 100)
+
+// Original clean-room implementation. TradingView's public Cup-and-Handle
+// documentation is used as a behavioral specification; no protected or
+// proprietary source code was copied or extracted.
+
+string VERSION = "0.1.1-cleanroom"
+string CONFIG_BASE_ID = "ch-v0-default"
+
+string GROUP_STRUCTURE = "Documented structure"
+int lookbackBars = input.int(600, "Search bars", minval = 100, maxval = 600, group = GROUP_STRUCTURE)
+int pivotLeft = input.int(5, "Pivot bars left", minval = 1, maxval = 10, group = GROUP_STRUCTURE)
+int pivotRight = input.int(5, "Pivot bars right", minval = 1, maxval = 10, group = GROUP_STRUCTURE)
+int minimumCupBars = input.int(20, "Minimum cup bars", minval = 10, maxval = 100, group = GROUP_STRUCTURE)
+int maximumCupBars = input.int(240, "Maximum cup bars", minval = 20, maxval = 500, group = GROUP_STRUCTURE)
+
+string GROUP_CALIBRATION = "Clean-room calibration defaults"
+float centerTolerance = input.float(35.0, "Bottom center tolerance (% half-width)", minval = 5, maxval = 100, step = 1, group = GROUP_CALIBRATION) / 100
+float rimDeviation = input.float(15.0, "Permissible rim deviation (% cup height)", minval = 1, maxval = 50, step = 1, group = GROUP_CALIBRATION) / 100
+float minimumDepth = input.float(8.0, "Minimum cup depth (% rim)", minval = 1, maxval = 40, step = 1, group = GROUP_CALIBRATION) / 100
+float maximumDepth = input.float(50.0, "Maximum cup depth (% rim)", minval = 10, maxval = 80, step = 1, group = GROUP_CALIBRATION) / 100
+float minimumUScore = input.float(50.0, "Minimum U-shape score", minval = 0, maxval = 100, step = 1, group = GROUP_CALIBRATION) / 100
+float bottomWidthTarget = input.float(12.0, "Bottom-width target (% cup bars)", minval = 2, maxval = 40, step = 1, group = GROUP_CALIBRATION) / 100
+float formingRecovery = input.float(65.0, "Cup-forming recovery", minval = 40, maxval = 90, step = 1, group = GROUP_CALIBRATION) / 100
+float rimApproachRecovery = input.float(85.0, "Rim-approach recovery", minval = 60, maxval = 100, step = 1, group = GROUP_CALIBRATION) / 100
+float handleMaxRollback = input.float(40.0, "Handle maximum rollback (% cup height)", minval = 10, maxval = 80, step = 1, group = GROUP_CALIBRATION) / 100
+int minimumHandleBars = input.int(3, "Minimum handle bars", minval = 1, maxval = 20, group = GROUP_CALIBRATION)
+
+string runtimeConfigId = CONFIG_BASE_ID + "|settings:lb=" + str.tostring(lookbackBars) + ",pl=" + str.tostring(pivotLeft) + ",pr=" + str.tostring(pivotRight) + ",cmin=" + str.tostring(minimumCupBars) + ",cmax=" + str.tostring(maximumCupBars) + ",center=" + str.tostring(centerTolerance) + ",rim=" + str.tostring(rimDeviation) + ",dmin=" + str.tostring(minimumDepth) + ",dmax=" + str.tostring(maximumDepth) + ",ushape=" + str.tostring(minimumUScore) + ",bottom=" + str.tostring(bottomWidthTarget) + ",forming=" + str.tostring(formingRecovery) + ",approach=" + str.tostring(rimApproachRecovery) + ",handle=" + str.tostring(handleMaxRollback) + ",hmin=" + str.tostring(minimumHandleBars) + ",pivots=64,trend=false"
+
+string GROUP_DISPLAY = "Display and events"
+bool showGeometry = input.bool(true, "Show current geometry", group = GROUP_DISPLAY)
+bool showTransitionLabels = input.bool(true, "Show transition labels", group = GROUP_DISPLAY)
+bool enableDynamicAlerts = input.bool(true, "Enable dynamic alert() payload", group = GROUP_DISPLAY)
+
+int STAGE_NONE = 0
+int STAGE_CUP_FORMING = 1
+int STAGE_RIM_APPROACH = 2
+int STAGE_HANDLE_FORMING = 3
+int STAGE_HANDLE_READY = 4
+int STAGE_BREAKOUT = 5
+int STAGE_INVALIDATED = -1
+int STAGE_EXPIRED = -2
+
+bool supportedTimeframe = timeframe.period == "240" or timeframe.period == "4H" or timeframe.period == "D" or timeframe.period == "1D" or timeframe.period == "W" or timeframe.period == "1W"
+string profileTimeframe = timeframe.period == "240" or timeframe.period == "4H" ? "4H" : timeframe.period == "D" or timeframe.period == "1D" ? "1D" : timeframe.period == "W" or timeframe.period == "1W" ? "1W" : "UNSUPPORTED"
+
+if barstate.isfirst
+    if maximumCupBars < minimumCupBars
+        runtime.error("Maximum cup bars must be greater than or equal to minimum cup bars")
+    if minimumDepth >= maximumDepth
+        runtime.error("Minimum cup depth must be below maximum cup depth")
+    if formingRecovery >= rimApproachRecovery
+        runtime.error("Cup-forming recovery must be below rim-approach recovery")
+    if maximumCupBars >= lookbackBars
+        runtime.error("Maximum cup bars must be below search bars")
+
+f_stageName(int stage) =>
+    switch stage
+        STAGE_CUP_FORMING => "CUP_FORMING"
+        STAGE_RIM_APPROACH => "RIM_APPROACH"
+        STAGE_HANDLE_FORMING => "HANDLE_FORMING"
+        STAGE_HANDLE_READY => "HANDLE_READY"
+        STAGE_BREAKOUT => "BREAKOUT_CONFIRMED"
+        STAGE_INVALIDATED => "INVALIDATED"
+        STAGE_EXPIRED => "EXPIRED"
+        => "NONE"
+
+f_isPivotHigh() =>
+    bool valid = bar_index >= pivotLeft + pivotRight
+    float candidate = high[pivotRight]
+    if valid
+        for offset = 1 to pivotLeft
+            if high[pivotRight + offset] > candidate
+                valid := false
+        for offset = 1 to pivotRight
+            // Suppress equal highs to the right, selecting the rightmost point
+            // of an equal-price plateau deterministically.
+            if high[pivotRight - offset] >= candidate
+                valid := false
+    valid
+
+f_isPivotLow() =>
+    bool valid = bar_index >= pivotLeft + pivotRight
+    float candidate = low[pivotRight]
+    if valid
+        for offset = 1 to pivotLeft
+            if low[pivotRight + offset] < candidate
+                valid := false
+        for offset = 1 to pivotRight
+            if low[pivotRight - offset] <= candidate
+                valid := false
+    valid
+
+f_pushPivot(array<int> indices, array<int> times, array<float> prices, array<int> confirmationIndices, int pivotIndex, int pivotTime, float pivotPrice, int confirmationIndex) =>
+    array.push(indices, pivotIndex)
+    array.push(times, pivotTime)
+    array.push(prices, pivotPrice)
+    array.push(confirmationIndices, confirmationIndex)
+    while array.size(indices) > 64
+        array.shift(indices)
+        array.shift(times)
+        array.shift(prices)
+        array.shift(confirmationIndices)
+
+f_prunePivots(array<int> indices, array<int> times, array<float> prices, array<int> confirmationIndices) =>
+    while array.size(indices) > 0 and bar_index - array.get(indices, 0) >= lookbackBars
+        array.shift(indices)
+        array.shift(times)
+        array.shift(prices)
+        array.shift(confirmationIndices)
+
+f_minLowBetween(int startIndex, int endIndex) =>
+    float result = na
+    if startIndex <= endIndex
+        for absoluteIndex = startIndex to endIndex
+            int offset = bar_index - absoluteIndex
+            if offset >= 0 and offset <= lookbackBars
+                result := na(result) ? low[offset] : math.min(result, low[offset])
+    result
+
+f_lineValue(int firstIndex, float firstPrice, int secondIndex, float secondPrice, int targetIndex) =>
+    int span = secondIndex - firstIndex
+    span <= 0 ? secondPrice : firstPrice + (secondPrice - firstPrice) * (targetIndex - firstIndex) / span
+
+f_uShapeScore(int p1Index, float p1Price, int p2Index, float p2Price, int p3Index, float p3Price) =>
+    int width = p3Index - p1Index
+    float rim = (p1Price + p3Price) / 2
+    float cupHeight = rim - p2Price
+    float absoluteError = 0.0
+    int samples = 0
+    int bottomSamples = 0
+    if width > 0 and cupHeight > 0
+        for absoluteIndex = p1Index to p3Index
+            int offset = bar_index - absoluteIndex
+            if offset >= 0 and offset <= lookbackBars
+                float x = (absoluteIndex - p1Index) / width
+                float idealDepth = 1 - math.pow(2 * x - 1, 2)
+                float representativePrice = (high[offset] + low[offset] + close[offset]) / 3
+                float observedDepth = math.max(-0.25, math.min(1.25, (rim - representativePrice) / cupHeight))
+                absoluteError += math.abs(observedDepth - idealDepth)
+                samples += 1
+                if observedDepth >= 0.75
+                    bottomSamples += 1
+    float fitScore = samples > 0 ? math.max(0.0, math.min(1.0, 1 - absoluteError / samples)) : 0.0
+    float bottomFraction = samples > 0 ? bottomSamples / samples : 0.0
+    float bottomScore = math.max(0.0, math.min(1.0, bottomFraction / bottomWidthTarget))
+    math.max(0.0, math.min(1.0, 0.8 * fitScore + 0.2 * bottomScore))
+
+f_cupMetrics(int p1Index, float p1Price, int p2Index, float p2Price, int p3Index, float p3Price, bool requireRimAlignment) =>
+    int width = p3Index - p1Index
+    int leftWidth = p2Index - p1Index
+    int rightWidth = p3Index - p2Index
+    float rim = (p1Price + p3Price) / 2
+    float cupHeight = rim - p2Price
+    float centerError = width > 0 ? math.abs(p2Index - (p1Index + p3Index) / 2.0) / (width / 2.0) : 10.0
+    float depthFraction = cupHeight > 0 and rim != 0 ? cupHeight / math.abs(rim) : 10.0
+    float rimError = cupHeight > 0 ? math.abs(p1Price - p3Price) / cupHeight : 10.0
+    float symmetryScore = width > 0 ? math.max(0.0, math.min(1.0, 1 - math.abs(leftWidth - rightWidth) / width)) : 0.0
+    bool cheapGeometryValid = width >= minimumCupBars and width <= maximumCupBars and leftWidth > 0 and rightWidth > 0 and centerError <= centerTolerance and cupHeight > 0 and depthFraction >= minimumDepth and depthFraction <= maximumDepth and (not requireRimAlignment or rimError <= rimDeviation)
+    float uScore = cheapGeometryValid ? f_uShapeScore(p1Index, p1Price, p2Index, p2Price, p3Index, p3Price) : 0.0
+    bool valid = cheapGeometryValid and uScore >= minimumUScore
+    float rimScore = math.max(0.0, math.min(1.0, 1 - rimError / rimDeviation))
+    float centerScore = math.max(0.0, math.min(1.0, 1 - centerError / centerTolerance))
+    float depthMidpoint = (minimumDepth + maximumDepth) / 2
+    float depthHalfRange = (maximumDepth - minimumDepth) / 2
+    float depthScore = math.max(0.0, math.min(1.0, 1 - math.abs(depthFraction - depthMidpoint) / depthHalfRange))
+    float quality = math.round(100 * (0.4 * uScore + 0.2 * rimScore + 0.15 * centerScore + 0.15 * symmetryScore + 0.1 * depthScore))
+    [valid, quality, rim, cupHeight, rimError, centerError, symmetryScore, uScore, depthFraction]
+
+f_findBottom(array<int> lowIndices, array<int> lowTimes, array<float> lowPrices, int p1Index, int p3Index) =>
+    int bestPosition = na
+    int bestIndex = na
+    int bestTime = na
+    float bestPrice = na
+    float midpoint = (p1Index + p3Index) / 2.0
+    float halfWidth = (p3Index - p1Index) / 2.0
+    int count = array.size(lowIndices)
+    if count > 0 and halfWidth > 0
+        for position = 0 to count - 1
+            int candidateIndex = array.get(lowIndices, position)
+            float candidatePrice = array.get(lowPrices, position)
+            bool centered = candidateIndex > p1Index and candidateIndex < p3Index and math.abs(candidateIndex - midpoint) / halfWidth <= centerTolerance
+            if centered and (na(bestPrice) or candidatePrice < bestPrice or candidatePrice == bestPrice and candidateIndex < bestIndex)
+                bestPosition := position
+                bestIndex := candidateIndex
+                bestTime := array.get(lowTimes, position)
+                bestPrice := candidatePrice
+    [bestPosition, bestIndex, bestTime, bestPrice]
+
+f_familyId(string symbolId, string timeframeId, int p1Time, int p2Time) =>
+    str.format("{0}|{1}|{2}|{3}|{4}|{5}", VERSION, runtimeConfigId, symbolId, timeframeId, p1Time, p2Time)
+
+f_provisionalPatternId(string familyId) =>
+    familyId + "|p3=pending"
+
+f_confirmedPatternId(string familyId, int p3Time) =>
+    familyId + "|p3=" + str.tostring(p3Time)
+
+f_wasFinished(array<string> finishedIds, string patternId) =>
+    array.includes(finishedIds, patternId)
+
+f_markFinished(array<string> finishedIds, string patternId) =>
+    if patternId != "" and not array.includes(finishedIds, patternId)
+        array.push(finishedIds, patternId)
+        while array.size(finishedIds) > 256
+            array.shift(finishedIds)
+
+var array<int> pivotHighIndices = array.new_int()
+var array<int> pivotHighTimes = array.new_int()
+var array<float> pivotHighPrices = array.new_float()
+var array<int> pivotHighConfirmationIndices = array.new_int()
+var array<int> pivotLowIndices = array.new_int()
+var array<int> pivotLowTimes = array.new_int()
+var array<float> pivotLowPrices = array.new_float()
+var array<int> pivotLowConfirmationIndices = array.new_int()
+var array<string> finishedPatternIds = array.new_string()
+var array<string> completedFamilyIds = array.new_string()
+
+bool newPivotHigh = false
+bool newPivotLow = false
+int newPivotHighIndex = na
+int newPivotHighTime = na
+float newPivotHighPrice = na
+bool withinExecutionWindow = bar_index >= math.max(0, last_bar_index - lookbackBars - pivotLeft - pivotRight)
+
+if supportedTimeframe and barstate.isconfirmed and withinExecutionWindow and bar_index >= pivotLeft + pivotRight
+    newPivotHigh := f_isPivotHigh()
+    newPivotLow := f_isPivotLow()
+    if newPivotHigh
+        newPivotHighIndex := bar_index - pivotRight
+        newPivotHighTime := time[pivotRight]
+        newPivotHighPrice := high[pivotRight]
+        f_pushPivot(pivotHighIndices, pivotHighTimes, pivotHighPrices, pivotHighConfirmationIndices, newPivotHighIndex, newPivotHighTime, newPivotHighPrice, bar_index)
+    if newPivotLow
+        f_pushPivot(pivotLowIndices, pivotLowTimes, pivotLowPrices, pivotLowConfirmationIndices, bar_index - pivotRight, time[pivotRight], low[pivotRight], bar_index)
+    f_prunePivots(pivotHighIndices, pivotHighTimes, pivotHighPrices, pivotHighConfirmationIndices)
+    f_prunePivots(pivotLowIndices, pivotLowTimes, pivotLowPrices, pivotLowConfirmationIndices)
+
+var string activeFamilyId = ""
+var string activePatternId = ""
+var int activeStage = STAGE_NONE
+var int activeP1Index = na
+var int activeP1Time = na
+var float activeP1Price = na
+var int activeP2Index = na
+var int activeP2Time = na
+var float activeP2Price = na
+var int activeP3Index = na
+var int activeP3Time = na
+var float activeP3Price = na
+var int activeP4Index = na
+var int activeP4Time = na
+var float activeP4Price = na
+var float activeRim = na
+var float activeCupHeight = na
+var float activeQuality = na
+var float activePivot = na
+var float activeInvalidation = na
+var bool activeAlreadyBrokenWhenDiscovered = false
+var int lastTransitionIndex = na
+
+bool activeIsTerminal = activeStage == STAGE_BREAKOUT or activeStage < STAGE_NONE
+if activeIsTerminal and not na(lastTransitionIndex) and bar_index > lastTransitionIndex
+    activeFamilyId := ""
+    activePatternId := ""
+    activeStage := STAGE_NONE
+    activeP1Index := na
+    activeP1Time := na
+    activeP1Price := na
+    activeP2Index := na
+    activeP2Time := na
+    activeP2Price := na
+    activeP3Index := na
+    activeP3Time := na
+    activeP3Price := na
+    activeP4Index := na
+    activeP4Time := na
+    activeP4Price := na
+    activeRim := na
+    activeCupHeight := na
+    activeQuality := na
+    activePivot := na
+    activeInvalidation := na
+    activeAlreadyBrokenWhenDiscovered := false
+
+int stageBeforeCalculation = activeStage
+
+// Promote an existing in-progress family when its right-rim pivot becomes
+// knowable. The original p1/p2 anchors and family ID remain locked.
+if supportedTimeframe and barstate.isconfirmed and (activeStage == STAGE_CUP_FORMING or activeStage == STAGE_RIM_APPROACH) and newPivotHigh and newPivotHighIndex > activeP2Index
+    [promoteValid, promoteQuality, promoteRim, promoteHeight, promoteRimError, promoteCenterError, promoteSymmetry, promoteU, promoteDepth] = f_cupMetrics(activeP1Index, activeP1Price, activeP2Index, activeP2Price, newPivotHighIndex, newPivotHighPrice, true)
+    if promoteValid
+        f_markFinished(finishedPatternIds, activePatternId)
+        activePatternId := f_confirmedPatternId(activeFamilyId, newPivotHighTime)
+        activeP3Index := newPivotHighIndex
+        activeP3Time := newPivotHighTime
+        activeP3Price := newPivotHighPrice
+        activeRim := promoteRim
+        activeCupHeight := promoteHeight
+        activeQuality := promoteQuality
+        activeInvalidation := activeP3Price - activeCupHeight * handleMaxRollback
+        activeStage := STAGE_HANDLE_FORMING
+
+// When no family is active, evaluate the newly confirmed P3 immediately.
+// Historical P3s are not queued: V0 intentionally tracks one active family.
+if supportedTimeframe and barstate.isconfirmed and activeStage == STAGE_NONE and newPivotHigh
+    bool foundConfirmed = false
+    float bestConfirmedQuality = -1.0
+    int bestP1Index = na
+    int bestP1Time = na
+    float bestP1Price = na
+    int bestP2Index = na
+    int bestP2Time = na
+    float bestP2Price = na
+    int bestP3Index = na
+    int bestP3Time = na
+    float bestP3Price = na
+    float bestRim = na
+    float bestHeight = na
+    int highCount = array.size(pivotHighIndices)
+    if highCount > 1
+        int p3StartPosition = highCount - 1
+        for p3Position = p3StartPosition to highCount - 1
+            int p3Index = array.get(pivotHighIndices, p3Position)
+            int p3Time = array.get(pivotHighTimes, p3Position)
+            float p3Price = array.get(pivotHighPrices, p3Position)
+            bool eligibleP3 = p3Index == newPivotHighIndex
+            if eligibleP3 and p3Position > 0
+                for highPosition = 0 to p3Position - 1
+                    int p1Index = array.get(pivotHighIndices, highPosition)
+                    int width = p3Index - p1Index
+                    if width >= minimumCupBars and width <= maximumCupBars
+                        int p1Time = array.get(pivotHighTimes, highPosition)
+                        float p1Price = array.get(pivotHighPrices, highPosition)
+                        [bottomPosition, p2Index, p2Time, p2Price] = f_findBottom(pivotLowIndices, pivotLowTimes, pivotLowPrices, p1Index, p3Index)
+                        if not na(bottomPosition)
+                            [candidateValid, candidateQuality, candidateRim, candidateHeight, candidateRimError, candidateCenterError, candidateSymmetry, candidateU, candidateDepth] = f_cupMetrics(p1Index, p1Price, p2Index, p2Price, p3Index, p3Price, true)
+                            string candidateFamilyId = f_familyId(syminfo.tickerid, profileTimeframe, p1Time, p2Time)
+                            string candidatePatternId = f_confirmedPatternId(candidateFamilyId, p3Time)
+                            int candidateHandleAge = bar_index - p3Index
+                            float candidateHandleLow = f_minLowBetween(p3Index + 1, bar_index)
+                            float candidateInvalidation = p3Price - candidateHeight * handleMaxRollback
+                            bool candidateActionable = candidateHandleAge <= width and (na(candidateHandleLow) or candidateHandleLow >= candidateInvalidation)
+                            bool betterCandidate = not foundConfirmed or candidateQuality > bestConfirmedQuality or candidateQuality == bestConfirmedQuality and p1Index > bestP1Index or candidateQuality == bestConfirmedQuality and p1Index == bestP1Index and p3Index > bestP3Index
+                            if candidateValid and candidateActionable and not f_wasFinished(finishedPatternIds, candidatePatternId) and not f_wasFinished(completedFamilyIds, candidateFamilyId) and betterCandidate
+                                foundConfirmed := true
+                                bestConfirmedQuality := candidateQuality
+                                bestP1Index := p1Index
+                                bestP1Time := p1Time
+                                bestP1Price := p1Price
+                                bestP2Index := p2Index
+                                bestP2Time := p2Time
+                                bestP2Price := p2Price
+                                bestP3Index := p3Index
+                                bestP3Time := p3Time
+                                bestP3Price := p3Price
+                                bestRim := candidateRim
+                                bestHeight := candidateHeight
+    if foundConfirmed
+        activeP1Index := bestP1Index
+        activeP1Time := bestP1Time
+        activeP1Price := bestP1Price
+        activeP2Index := bestP2Index
+        activeP2Time := bestP2Time
+        activeP2Price := bestP2Price
+        activeP3Index := bestP3Index
+        activeP3Time := bestP3Time
+        activeP3Price := bestP3Price
+        activeFamilyId := f_familyId(syminfo.tickerid, profileTimeframe, activeP1Time, activeP2Time)
+        activePatternId := f_confirmedPatternId(activeFamilyId, activeP3Time)
+        activeRim := bestRim
+        activeCupHeight := bestHeight
+        activeQuality := bestConfirmedQuality
+        activePivot := bestRim
+        activeInvalidation := activeP3Price - activeCupHeight * handleMaxRollback
+        activeStage := STAGE_HANDLE_FORMING
+
+if supportedTimeframe and barstate.isconfirmed and activeStage == STAGE_NONE
+    bool foundApproach = false
+    float bestApproachQuality = -1.0
+    int approachStage = STAGE_NONE
+    int approachP1Index = na
+    int approachP1Time = na
+    float approachP1Price = na
+    int approachP2Index = na
+    int approachP2Time = na
+    float approachP2Price = na
+    float approachRim = na
+    float approachHeight = na
+    int highCount = array.size(pivotHighIndices)
+    if highCount > 0
+        for highPosition = 0 to highCount - 1
+            int p1Index = array.get(pivotHighIndices, highPosition)
+            int width = bar_index - p1Index
+            if width >= minimumCupBars and width <= maximumCupBars
+                int p1Time = array.get(pivotHighTimes, highPosition)
+                float p1Price = array.get(pivotHighPrices, highPosition)
+                [bottomPosition, p2Index, p2Time, p2Price] = f_findBottom(pivotLowIndices, pivotLowTimes, pivotLowPrices, p1Index, bar_index)
+                if not na(bottomPosition)
+                    float leftHeight = p1Price - p2Price
+                    float recovery = leftHeight > 0 ? (high - p2Price) / leftHeight : 0.0
+                    bool noOvershoot = leftHeight > 0 and high <= p1Price + leftHeight * rimDeviation
+                    int candidateStage = recovery >= rimApproachRecovery ? STAGE_RIM_APPROACH : recovery >= formingRecovery ? STAGE_CUP_FORMING : STAGE_NONE
+                    if noOvershoot and candidateStage != STAGE_NONE
+                        [candidateValid, candidateQuality, candidateRim, candidateHeight, candidateRimError, candidateCenterError, candidateSymmetry, candidateU, candidateDepth] = f_cupMetrics(p1Index, p1Price, p2Index, p2Price, bar_index, high, false)
+                        string candidateFamilyId = f_familyId(syminfo.tickerid, profileTimeframe, p1Time, p2Time)
+                        string candidatePatternId = f_provisionalPatternId(candidateFamilyId)
+                        if candidateValid and not f_wasFinished(finishedPatternIds, candidatePatternId) and not f_wasFinished(completedFamilyIds, candidateFamilyId) and (not foundApproach or candidateStage > approachStage or candidateStage == approachStage and candidateQuality > bestApproachQuality or candidateStage == approachStage and candidateQuality == bestApproachQuality and p1Index > approachP1Index)
+                            foundApproach := true
+                            bestApproachQuality := candidateQuality
+                            approachStage := candidateStage
+                            approachP1Index := p1Index
+                            approachP1Time := p1Time
+                            approachP1Price := p1Price
+                            approachP2Index := p2Index
+                            approachP2Time := p2Time
+                            approachP2Price := p2Price
+                            approachRim := p1Price
+                            approachHeight := leftHeight
+    if foundApproach
+        activeP1Index := approachP1Index
+        activeP1Time := approachP1Time
+        activeP1Price := approachP1Price
+        activeP2Index := approachP2Index
+        activeP2Time := approachP2Time
+        activeP2Price := approachP2Price
+        activeP3Index := na
+        activeP3Time := na
+        activeP3Price := na
+        activeFamilyId := f_familyId(syminfo.tickerid, profileTimeframe, activeP1Time, activeP2Time)
+        activePatternId := f_provisionalPatternId(activeFamilyId)
+        activeRim := approachRim
+        activeCupHeight := approachHeight
+        activeQuality := math.min(100, bestApproachQuality)
+        activePivot := approachRim
+        activeStage := approachStage
+
+if supportedTimeframe and barstate.isconfirmed and (activeStage == STAGE_CUP_FORMING or activeStage == STAGE_RIM_APPROACH)
+    int activeAge = bar_index - activeP1Index
+    float recovery = activeCupHeight > 0 ? (high - activeP2Price) / activeCupHeight : 0.0
+    bool noOvershoot = activeCupHeight > 0 and high <= activeP1Price + activeCupHeight * rimDeviation
+    [stillValid, refreshedQuality, refreshedRim, refreshedHeight, refreshedRimError, refreshedCenterError, refreshedSymmetry, refreshedU, refreshedDepth] = f_cupMetrics(activeP1Index, activeP1Price, activeP2Index, activeP2Price, bar_index, high, false)
+    bool bottomSuperseded = false
+    if newPivotLow and array.size(pivotLowIndices) > 0
+        int newestLowPosition = array.size(pivotLowIndices) - 1
+        int newestLowIndex = array.get(pivotLowIndices, newestLowPosition)
+        float newestLowPrice = array.get(pivotLowPrices, newestLowPosition)
+        bottomSuperseded := newestLowIndex > activeP2Index and newestLowPrice < activeP2Price
+    if activeAge > maximumCupBars
+        activeStage := STAGE_EXPIRED
+    else if not stillValid or not noOvershoot or recovery < formingRecovery or bottomSuperseded
+        activeStage := STAGE_INVALIDATED
+    else if activeStage == STAGE_CUP_FORMING and recovery >= rimApproachRecovery
+        activeStage := STAGE_RIM_APPROACH
+    if activeStage == STAGE_CUP_FORMING or activeStage == STAGE_RIM_APPROACH
+        activeQuality := refreshedQuality
+
+if supportedTimeframe and barstate.isconfirmed and (activeStage == STAGE_HANDLE_FORMING or activeStage == STAGE_HANDLE_READY)
+    int cupWidth = activeP3Index - activeP1Index
+    int handleAge = bar_index - activeP3Index
+    float handleLow = f_minLowBetween(activeP3Index + 1, bar_index)
+    activeInvalidation := activeP3Price - activeCupHeight * handleMaxRollback
+    if handleAge > cupWidth
+        activeStage := STAGE_EXPIRED
+    else if not na(handleLow) and handleLow < activeInvalidation
+        activeStage := STAGE_INVALIDATED
+    else
+        bool p4JustLocked = false
+        if na(activeP4Index) and newPivotHigh and newPivotHighIndex - activeP3Index >= minimumHandleBars and newPivotHighPrice <= activeP3Price
+            float beforeLow = f_minLowBetween(activeP3Index + 1, newPivotHighIndex)
+            float afterLow = f_minLowBetween(newPivotHighIndex + 1, bar_index)
+            if not na(beforeLow) and not na(afterLow) and beforeLow > afterLow
+                activeP4Index := newPivotHighIndex
+                activeP4Time := newPivotHighTime
+                activeP4Price := newPivotHighPrice
+                p4JustLocked := true
+        if not na(activeP4Index)
+            activePivot := f_lineValue(activeP3Index, activeP3Price, activeP4Index, activeP4Price, bar_index)
+            float previousPivot = f_lineValue(activeP3Index, activeP3Price, activeP4Index, activeP4Price, math.max(activeP4Index, bar_index - 1))
+            bool closeAbove = close > activePivot
+            bool previousAbove = bar_index > activeP4Index and close[1] > previousPivot
+            if activeStage < STAGE_BREAKOUT and closeAbove and (not previousAbove or p4JustLocked)
+                activeAlreadyBrokenWhenDiscovered := p4JustLocked
+                activeStage := STAGE_BREAKOUT
+            else if activeStage < STAGE_HANDLE_READY
+                activeStage := STAGE_HANDLE_READY
+        else
+            activePivot := na
+            if bar_index > activeP3Index and close > activeP3Price
+                activeStage := STAGE_INVALIDATED
+
+bool transitionOccurred = barstate.isconfirmed and activeStage != STAGE_NONE and activeStage != stageBeforeCalculation
+int transitionStage = transitionOccurred ? activeStage : STAGE_NONE
+if transitionOccurred
+    lastTransitionIndex := bar_index
+    if transitionStage == STAGE_BREAKOUT
+        f_markFinished(completedFamilyIds, activeFamilyId)
+    if transitionStage == STAGE_BREAKOUT or transitionStage < STAGE_NONE
+        f_markFinished(finishedPatternIds, activePatternId)
+
+string transitionName = f_stageName(transitionStage)
+color stageColor = activeStage == STAGE_CUP_FORMING ? color.aqua : activeStage == STAGE_RIM_APPROACH ? color.blue : activeStage == STAGE_HANDLE_FORMING ? color.orange : activeStage == STAGE_HANDLE_READY ? color.yellow : activeStage == STAGE_BREAKOUT ? color.lime : activeStage < STAGE_NONE ? color.red : color.gray
+
+if transitionOccurred and showTransitionLabels
+    label.new(bar_index, high, transitionName, style = label.style_label_down, color = stageColor, textcolor = color.black, size = size.tiny)
+
+string dynamicMessage = "Cup-and-Handle Pattern Watch | symbol=" + syminfo.tickerid + " | timeframe=" + profileTimeframe + " | stage=" + transitionName + " | family_id=" + activeFamilyId + " | pattern_id=" + activePatternId + " | bar_open_time=" + str.tostring(time) + " | bar_close_time=" + str.tostring(time_close) + " | pivot=" + str.tostring(activePivot) + " | invalidation=" + str.tostring(activeInvalidation) + " | quality=" + str.tostring(activeQuality) + " | already_broken_when_discovered=" + (activeAlreadyBrokenWhenDiscovered ? "true" : "false") + " | version=" + VERSION + " | config=" + runtimeConfigId
+if transitionOccurred and enableDynamicAlerts
+    alert(dynamicMessage, alert.freq_once_per_bar_close)
+
+bool formingWatchEvent = transitionOccurred and (transitionStage == STAGE_CUP_FORMING or transitionStage == STAGE_RIM_APPROACH)
+bool handleFormingEvent = transitionOccurred and transitionStage == STAGE_HANDLE_FORMING
+bool handleReadyEvent = transitionOccurred and transitionStage == STAGE_HANDLE_READY
+bool breakoutEvent = transitionOccurred and transitionStage == STAGE_BREAKOUT
+bool invalidatedEvent = transitionOccurred and (transitionStage == STAGE_INVALIDATED or transitionStage == STAGE_EXPIRED)
+
+alertcondition(formingWatchEvent, "Cup-and-Handle Forming Watch", "Cup-and-Handle is forming on {{ticker}} {{interval}}. Stage {{plot(\"CH Transition Stage\")}}. Inspect the chart; this is not a trade recommendation.")
+alertcondition(handleFormingEvent, "Cup-and-Handle Confirmed Cup / Handle Forming", "A causal cup is confirmed and its handle is forming on {{ticker}} {{interval}}. Inspect the chart.")
+alertcondition(handleReadyEvent, "Cup-and-Handle Handle Ready", "Cup-and-Handle is breakout-ready on {{ticker}} {{interval}}. Pivot {{plot(\"CH Pivot\")}} | Invalidation {{plot(\"CH Invalidation\")}}.")
+alertcondition(breakoutEvent, "Cup-and-Handle Breakout Confirmed", "Cup-and-Handle closed above its handle line on {{ticker}} {{interval}}. Pivot {{plot(\"CH Pivot\")}} | Already broken when discovered {{plot(\"CH Already Broken When Discovered\")}}.")
+alertcondition(invalidatedEvent, "Cup-and-Handle Invalidated or Expired", "Cup-and-Handle was invalidated or expired on {{ticker}} {{interval}}. Stage {{plot(\"CH Transition Stage\")}}.")
+alertcondition(transitionOccurred, "Any Cup-and-Handle Lifecycle Event", "Cup-and-Handle lifecycle event on {{ticker}} {{interval}}. Stage {{plot(\"CH Transition Stage\")}}.")
+
+plot(activeStage, "CH Stage Code", display = display.data_window)
+plot(transitionOccurred ? transitionStage : na, "CH Transition Stage", display = display.data_window)
+plot(activeQuality, "CH Quality Score", display = display.data_window)
+plot(activePivot, "CH Pivot", display = display.data_window)
+plot(activeInvalidation, "CH Invalidation", display = display.data_window)
+plot(activeRim, "CH Rim", display = display.data_window)
+plot(activeCupHeight, "CH Cup Height", display = display.data_window)
+plot(activeStage == STAGE_CUP_FORMING or activeStage == STAGE_RIM_APPROACH ? 1 : 0, "CH Provisional", display = display.data_window)
+plot(activeP1Time, "CH Left Rim Time", display = display.data_window)
+plot(activeP2Time, "CH Bottom Time", display = display.data_window)
+plot(activeP3Time, "CH Right Rim Time", display = display.data_window)
+plot(activeP4Time, "CH Handle Time", display = display.data_window)
+plot(activeAlreadyBrokenWhenDiscovered ? 1 : 0, "CH Already Broken When Discovered", display = display.data_window)
+
+var line cupLeftLine = na
+var line cupRightLine = na
+var line handleTrendLine = na
+var line pivotGuideLine = na
+
+if barstate.islast
+    bool hasPattern = activeStage != STAGE_NONE and not na(activeP1Index) and not na(activeP2Index)
+    if showGeometry and hasPattern
+        int lastClosedIndex = barstate.isconfirmed ? bar_index : bar_index - 1
+        float lastClosedHigh = barstate.isconfirmed ? high : high[1]
+        int displayP3Index = na(activeP3Index) ? lastClosedIndex : activeP3Index
+        float displayP3Price = na(activeP3Price) ? lastClosedHigh : activeP3Price
+        if na(cupLeftLine)
+            cupLeftLine := line.new(activeP1Index, activeP1Price, activeP2Index, activeP2Price, xloc = xloc.bar_index, color = stageColor, width = 2)
+        else
+            line.set_xy1(cupLeftLine, activeP1Index, activeP1Price)
+            line.set_xy2(cupLeftLine, activeP2Index, activeP2Price)
+            line.set_color(cupLeftLine, stageColor)
+        if na(cupRightLine)
+            cupRightLine := line.new(activeP2Index, activeP2Price, displayP3Index, displayP3Price, xloc = xloc.bar_index, color = stageColor, width = 2)
+        else
+            line.set_xy1(cupRightLine, activeP2Index, activeP2Price)
+            line.set_xy2(cupRightLine, displayP3Index, displayP3Price)
+            line.set_color(cupRightLine, stageColor)
+        if not na(activeP4Index)
+            float displayPivot = f_lineValue(activeP3Index, activeP3Price, activeP4Index, activeP4Price, lastClosedIndex)
+            if na(handleTrendLine)
+                handleTrendLine := line.new(activeP3Index, activeP3Price, lastClosedIndex, displayPivot, xloc = xloc.bar_index, color = color.yellow, width = 2)
+            else
+                line.set_xy1(handleTrendLine, activeP3Index, activeP3Price)
+                line.set_xy2(handleTrendLine, lastClosedIndex, displayPivot)
+                line.set_color(handleTrendLine, color.yellow)
+            if na(pivotGuideLine)
+                pivotGuideLine := line.new(lastClosedIndex - 1, displayPivot, lastClosedIndex, displayPivot, xloc = xloc.bar_index, extend = extend.right, color = color.new(color.yellow, 50), style = line.style_dotted)
+            else
+                line.set_xy1(pivotGuideLine, lastClosedIndex - 1, displayPivot)
+                line.set_xy2(pivotGuideLine, lastClosedIndex, displayPivot)
+        else
+            if not na(handleTrendLine)
+                line.delete(handleTrendLine)
+                handleTrendLine := na
+            if not na(pivotGuideLine)
+                line.delete(pivotGuideLine)
+                pivotGuideLine := na
+    else
+        if not na(cupLeftLine)
+            line.delete(cupLeftLine)
+            cupLeftLine := na
+        if not na(cupRightLine)
+            line.delete(cupRightLine)
+            cupRightLine := na
+        if not na(handleTrendLine)
+            line.delete(handleTrendLine)
+            handleTrendLine := na
+        if not na(pivotGuideLine)
+            line.delete(pivotGuideLine)
+            pivotGuideLine := na
+
+var label timeframeWarning = na
+if barstate.islast
+    if not supportedTimeframe
+        if na(timeframeWarning)
+            timeframeWarning := label.new(bar_index, high, "Cup-and-Handle V0 supports native 4H, 1D, and 1W charts", style = label.style_label_down, color = color.red, textcolor = color.white)
+        else
+            label.set_xy(timeframeWarning, bar_index, high)
+    else if not na(timeframeWarning)
+        label.delete(timeframeWarning)
+        timeframeWarning := na

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/cup_handle_core.test.js tests/cup_handle_pine_contract.test.js",
+    "test:cup-handle": "node --test tests/cup_handle_core.test.js tests/cup_handle_pine_contract.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/cup_handle_core.test.js tests/cup_handle_pine_contract.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/tests/cup_handle_core.test.js
+++ b/tests/cup_handle_core.test.js
@@ -1,0 +1,376 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  DEFAULT_CONFIG,
+  detectCupAndHandle,
+  findConfirmedPivots,
+  normalizeBars,
+  normalizeTimeframe,
+  validateConfig,
+} from '../cup-and-handle/analysis/cup-handle-core.mjs';
+
+const STEP = 14_400_000;
+
+function makeBar(index, close, overrides = {}) {
+  return {
+    time: 1_700_000_000_000 + index * STEP,
+    time_close: 1_700_000_000_000 + (index + 1) * STEP,
+    open: overrides.open ?? close,
+    high: overrides.high ?? close + 0.4,
+    low: overrides.low ?? close - 0.4,
+    close: overrides.close ?? close,
+    volume: overrides.volume ?? 1_000_000,
+  };
+}
+
+function makeValidPattern({
+  scale = 1,
+  breakout = true,
+  wickOnlyBreakout = false,
+  invalidateHandle = false,
+} = {}) {
+  const closes = [];
+  for (let index = 0; index < 10; index += 1) closes.push(92 + index * 0.8);
+  for (let index = 10; index <= 50; index += 1) {
+    const x = (index - 10) / 40;
+    closes.push(100 - 25 * (1 - (2 * x - 1) ** 2));
+  }
+  closes.push(
+    97, 95, 93, 94, 95, 96, 97, 98,
+    96, 94, invalidateHandle ? 84 : 91, 93, 95, 95.5,
+    breakout ? 99 : 95,
+    breakout ? 101 : 94.8,
+    breakout ? 102 : 94.6,
+    breakout ? 103 : 94.4,
+  );
+  return closes.map((unscaledClose, index) => {
+    const close = unscaledClose * scale;
+    const overrides = {};
+    if (wickOnlyBreakout && index === 65) {
+      overrides.high = 101 * scale;
+      overrides.close = 96 * scale;
+    }
+    if (invalidateHandle && index === 61) overrides.low = 83.5 * scale;
+    return makeBar(index, close, {
+      ...overrides,
+      high: overrides.high ?? close + 0.4 * scale,
+      low: overrides.low ?? close - 0.4 * scale,
+    });
+  });
+}
+
+function detect(bars, overrides = {}) {
+  return detectCupAndHandle({
+    bars,
+    symbol: 'NASDAQ:TEST',
+    timeframe: '4H',
+    config: overrides,
+  });
+}
+
+describe('Cup-and-Handle clean-room configuration', () => {
+  it('freezes TradingView-documented structural defaults separately from tunable rules', () => {
+    assert.equal(DEFAULT_CONFIG.lookback_bars, 600);
+    assert.equal(DEFAULT_CONFIG.pivot_left_bars, 5);
+    assert.equal(DEFAULT_CONFIG.pivot_right_bars, 5);
+    assert.equal(DEFAULT_CONFIG.minimum_cup_bars, 20);
+    assert.equal(DEFAULT_CONFIG.prior_trend_gate_enabled, false);
+    assert.equal(DEFAULT_CONFIG.detector_version, '0.1.1-cleanroom');
+  });
+
+  it('normalizes only the approved first-slice timeframes', () => {
+    assert.equal(normalizeTimeframe('240'), '4H');
+    assert.equal(normalizeTimeframe('D'), '1D');
+    assert.equal(normalizeTimeframe('1W'), '1W');
+    assert.throws(() => normalizeTimeframe('1M'), /4H, 1D, or 1W/);
+  });
+
+  it('rejects contradictory or malformed threshold contracts', () => {
+    assert.throws(
+      () => validateConfig({ forming_recovery_fraction: 0.9 }),
+      /forming recovery must be below rim-approach recovery/,
+    );
+    assert.throws(
+      () => validateConfig({ minimum_cup_bars: 40, maximum_cup_bars: 20 }),
+      /maximum_cup_bars/,
+    );
+    assert.throws(
+      () => validateConfig({ lookback_bars: 100, maximum_cup_bars: 100 }),
+      /maximum_cup_bars must be below lookback_bars/,
+    );
+    assert.throws(
+      () => validateConfig({ prior_trend_gate_enabled: true }),
+      /not implemented/,
+    );
+    assert.notEqual(
+      validateConfig().config_id,
+      validateConfig({ minimum_handle_bars: 4 }).config_id,
+    );
+  });
+});
+
+describe('Closed-bar normalization and causal 5/5 pivots', () => {
+  it('drops an explicitly incomplete tail but rejects duplicate or unordered bars', () => {
+    const rows = makeValidPattern().slice(0, 20);
+    const incomplete = { ...rows.at(-1), time: rows.at(-1).time + STEP, complete_bar: false };
+    assert.equal(normalizeBars([...rows, incomplete]).length, rows.length);
+    assert.throws(
+      () => normalizeBars([rows[0], { ...rows[1], complete_bar: false }, rows[2]]),
+      /terminal suffix/,
+    );
+    assert.throws(() => normalizeBars([...rows, { ...rows.at(-1) }]), /strictly increasing/);
+    assert.throws(() => normalizeBars([rows[1], rows[0]]), /strictly increasing/);
+  });
+
+  it('records a pivot at its anchor bar but makes it available five bars later', () => {
+    const bars = normalizeBars(makeValidPattern());
+    const pivots = findConfirmedPivots(bars);
+    const leftRim = pivots.highs.find((pivot) => pivot.index === 10);
+    const bottom = pivots.lows.find((pivot) => pivot.index === 30);
+    const rightRim = pivots.highs.find((pivot) => pivot.index === 50);
+    assert.equal(leftRim.confirmed_index, 15);
+    assert.equal(bottom.confirmed_index, 35);
+    assert.equal(rightRim.confirmed_index, 55);
+  });
+
+  it('preserves explicit close time separately from the bar-open identity', () => {
+    const [bar] = normalizeBars([makeBar(0, 100)]);
+    assert.equal(bar.time_close - bar.time, STEP);
+    assert.throws(
+      () => normalizeBars([{ ...makeBar(0, 100), time_close: makeBar(0, 100).time }]),
+      /time_close must be after time/,
+    );
+  });
+
+  it('uses the rightmost member of an equal-price pivot plateau', () => {
+    const rows = Array.from({ length: 20 }, (_, index) => makeBar(index, 90));
+    rows[8] = makeBar(8, 100, { high: 101 });
+    rows[9] = makeBar(9, 100, { high: 101 });
+    for (let index = 10; index < 15; index += 1) rows[index] = makeBar(index, 95 - index / 10);
+    const pivots = findConfirmedPivots(normalizeBars(rows));
+    assert.equal(pivots.highs.some((pivot) => pivot.index === 8), false);
+    assert.equal(pivots.highs.some((pivot) => pivot.index === 9), true);
+  });
+});
+
+describe('Cup-and-Handle lifecycle', () => {
+  it('progresses once through forming, rim, handle, ready, and close-confirmed breakout', () => {
+    const result = detect(makeValidPattern());
+    const breakout = result.transitions.find(
+      (transition) => transition.to_stage === 'BREAKOUT_CONFIRMED',
+    );
+    const lifecycle = result.transitions.filter((transition) => (
+      transition.family_id === breakout.family_id
+      && (transition.provisional || transition.pattern_id === breakout.pattern_id)
+    ));
+    const stages = lifecycle.map((transition) => transition.to_stage);
+    assert.deepEqual(stages, [
+      'CUP_FORMING',
+      'RIM_APPROACH',
+      'HANDLE_FORMING',
+      'HANDLE_READY',
+      'BREAKOUT_CONFIRMED',
+    ]);
+    assert.equal(new Set(lifecycle.map((transition) => transition.event_id)).size, stages.length);
+    assert.equal(new Set(lifecycle.map((transition) => transition.family_id)).size, 1);
+    assert.equal(new Set(lifecycle.map((transition) => transition.pattern_id)).size, 2);
+    assert.match(breakout.pattern_id, /\|p3=\d+$/);
+    assert.equal(breakout.detection_bar_close_time - breakout.detection_bar_open_time, STEP);
+    const completed = result.patterns.find((pattern) => pattern.stage === 'BREAKOUT_CONFIRMED');
+    assert.equal(completed.provisional, false);
+    assert.equal(completed.anchors.left_rim.index, 10);
+    assert.equal(completed.anchors.cup_bottom.index, 30);
+    assert.equal(completed.anchors.right_rim.index, 50);
+    assert.equal(completed.anchors.handle.index, 58);
+    assert.equal(completed.anchors.breakout.index, 65);
+  });
+
+  it('does not claim the confirmed cup before the right-rim pivot becomes knowable', () => {
+    const bars = makeValidPattern();
+    const beforeConfirmation = detect(bars.slice(0, 55));
+    const atConfirmation = detect(bars.slice(0, 56));
+    assert.equal(
+      beforeConfirmation.transitions.some((transition) => transition.to_stage === 'HANDLE_FORMING'),
+      false,
+    );
+    const handleEvent = atConfirmation.transitions.find(
+      (transition) => transition.to_stage === 'HANDLE_FORMING',
+    );
+    assert.equal(handleEvent.detection_index, 55);
+  });
+
+  it('requires a close above the handle line, not merely a wick', () => {
+    const result = detect(makeValidPattern({ breakout: false, wickOnlyBreakout: true }));
+    assert.equal(
+      result.transitions.some((transition) => transition.to_stage === 'BREAKOUT_CONFIRMED'),
+      false,
+    );
+    assert.equal(result.current_pattern.stage, 'HANDLE_READY');
+  });
+
+  it('invalidates when the handle rollback crosses its configured floor', () => {
+    const result = detect(makeValidPattern({ breakout: false, invalidateHandle: true }));
+    const invalidation = result.transitions.find(
+      (transition) => transition.to_stage === 'INVALIDATED' && !transition.provisional,
+    );
+    assert.ok(invalidation);
+    assert.notEqual(result.current_pattern?.pattern_id, invalidation.pattern_id);
+  });
+
+  it('invalidates an upside escape that occurs before any handle pivot exists', () => {
+    const bars = makeValidPattern().slice(0, 56);
+    for (let index = 56; index < 70; index += 1) {
+      bars.push(makeBar(index, 101 + (index - 56) * 0.5));
+    }
+    const result = detect(bars);
+    const handleStart = result.transitions.find(
+      (transition) => transition.to_stage === 'HANDLE_FORMING',
+    );
+    const invalidation = result.transitions.find((transition) => (
+      transition.pattern_id === handleStart.pattern_id
+      && transition.to_stage === 'INVALIDATED'
+    ));
+    assert.ok(invalidation);
+    const escaped = result.patterns.find(
+      (pattern) => pattern.pattern_id === handleStart.pattern_id,
+    );
+    assert.deepEqual(escaped.reasons, ['PRE_HANDLE_UPSIDE_ESCAPE']);
+    assert.ok(bars[invalidation.detection_index].close > escaped.anchors.right_rim.price);
+  });
+
+  it('emits an explicit terminal event when provisional geometry collapses', () => {
+    const bars = makeValidPattern().slice(0, 50);
+    bars.push(makeBar(50, 60, { high: 61, low: 59 }));
+    const result = detect(bars);
+    assert.deepEqual(
+      result.transitions.map((transition) => transition.to_stage),
+      ['CUP_FORMING', 'RIM_APPROACH', 'INVALIDATED'],
+    );
+    const invalidation = result.transitions.at(-1);
+    assert.equal(invalidation.from_stage, 'RIM_APPROACH');
+    assert.equal(invalidation.provisional, true);
+    assert.equal(invalidation.anchors.left_rim.index, 10);
+    assert.equal(result.current_pattern, null);
+  });
+
+  it('treats a confirmed breakout as terminal and never later expires the same family', () => {
+    const bars = makeValidPattern();
+    const nextIndex = bars.length;
+    for (let index = nextIndex; index < nextIndex + 60; index += 1) {
+      bars.push(makeBar(index, 101 + Math.sin(index) * 0.2));
+    }
+    const result = detect(bars);
+    const breakout = result.transitions.find(
+      (transition) => transition.to_stage === 'BREAKOUT_CONFIRMED',
+    );
+    const terminalStages = result.transitions
+      .filter((transition) => transition.pattern_id === breakout.pattern_id)
+      .filter((transition) => (
+        transition.to_stage === 'BREAKOUT_CONFIRMED'
+        || transition.to_stage === 'INVALIDATED'
+        || transition.to_stage === 'EXPIRED'
+      ))
+      .map((transition) => transition.to_stage);
+    assert.deepEqual(terminalStages, ['BREAKOUT_CONFIRMED']);
+    assert.notEqual(result.current_pattern?.pattern_id, breakout.pattern_id);
+  });
+
+  it('does not re-arm a completed cup family after its confirmed breakout', () => {
+    const result = detect(makeValidPattern());
+    const breakout = result.transitions.find(
+      (transition) => transition.to_stage === 'BREAKOUT_CONFIRMED',
+    );
+    const sameFamilyAfterBreakout = result.transitions.filter((transition) => (
+      transition.family_id === breakout.family_id
+      && transition.detection_index > breakout.detection_index
+    ));
+    assert.deepEqual(sameFamilyAfterBreakout, []);
+  });
+
+  it('retires the provisional record when its family promotes to a confirmed cup', () => {
+    const result = detect(makeValidPattern());
+    const breakout = result.transitions.find(
+      (transition) => transition.to_stage === 'BREAKOUT_CONFIRMED',
+    );
+    assert.equal(
+      result.patterns.some((pattern) => (
+        pattern.family_id === breakout.family_id && pattern.provisional
+      )),
+      false,
+    );
+  });
+
+  it('rejects a confirmed cup one bar inside the documented 20-bar minimum', () => {
+    const bars = makeValidPattern();
+    // Raising the minimum to 41 makes the otherwise valid 40-bar cup the exact
+    // one-bar-inside boundary twin.
+    const result = detect(bars, { minimum_cup_bars: 41 });
+    assert.equal(
+      result.patterns.some((pattern) => (
+        pattern.anchors.left_rim?.index === 10
+        && pattern.anchors.right_rim?.index === 50
+      )),
+      false,
+    );
+  });
+
+  it('is price-scale invariant for stages and normalized geometry', () => {
+    const base = detect(makeValidPattern());
+    const scaled = detect(makeValidPattern({ scale: 100 }));
+    assert.deepEqual(
+      scaled.transitions.map((transition) => transition.to_stage),
+      base.transitions.map((transition) => transition.to_stage),
+    );
+    const baseCompleted = base.patterns.find((pattern) => pattern.stage === 'BREAKOUT_CONFIRMED');
+    const scaledCompleted = scaled.patterns.find((pattern) => pattern.stage === 'BREAKOUT_CONFIRMED');
+    assert.equal(scaledCompleted.quality_score, baseCompleted.quality_score);
+    assert.ok(
+      Math.abs(
+        scaledCompleted.metrics.rim_error - baseCompleted.metrics.rim_error,
+      ) < 1e-12,
+    );
+  });
+});
+
+describe('Non-repainting invariants', () => {
+  it('matches every transition on the same closed prefix', () => {
+    const bars = makeValidPattern();
+    const full = detect(bars);
+    for (const length of [48, 50, 56, 64, 66]) {
+      const prefix = detect(bars.slice(0, length));
+      const cutoffTime = bars[length - 1].time;
+      assert.deepEqual(
+        full.transitions.filter(
+          (transition) => transition.detection_bar_open_time <= cutoffTime,
+        ),
+        prefix.transitions,
+        `prefix length ${length}`,
+      );
+    }
+  });
+
+  it('future mutations cannot alter already-known anchors, IDs, or transitions', () => {
+    const bars = makeValidPattern();
+    const cutoffLength = 64;
+    const original = detect(bars.slice(0, cutoffLength));
+    const mutated = bars.map((bar, index) => (
+      index < cutoffLength
+        ? bar
+        : makeBar(index, 40 + index, { high: 200 + index, low: 20 })
+    ));
+    const mutatedResult = detect(mutated);
+    const cutoffTime = bars[cutoffLength - 1].time;
+    assert.deepEqual(
+      mutatedResult.transitions.filter(
+        (transition) => transition.detection_bar_open_time <= cutoffTime,
+      ),
+      original.transitions,
+    );
+  });
+
+  it('recalculation is byte-deterministic', () => {
+    const bars = makeValidPattern();
+    assert.equal(JSON.stringify(detect(bars)), JSON.stringify(detect(bars)));
+  });
+});

--- a/tests/cup_handle_core.test.js
+++ b/tests/cup_handle_core.test.js
@@ -69,6 +69,26 @@ function detect(bars, overrides = {}) {
   });
 }
 
+function makeDeterministicRandomWalk(seed, length = 500) {
+  let state = seed >>> 0;
+  const random = () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+  let previousClose = 100;
+  return Array.from({ length }, (_, index) => {
+    const open = previousClose;
+    const close = Math.max(5, open + (random() - 0.49) * 6);
+    const spread = 0.2 + random() * 2;
+    previousClose = close;
+    return makeBar(index, close, {
+      open,
+      high: Math.max(open, close) + spread,
+      low: Math.max(0.1, Math.min(open, close) - spread),
+    });
+  });
+}
+
 describe('Cup-and-Handle clean-room configuration', () => {
   it('freezes TradingView-documented structural defaults separately from tunable rules', () => {
     assert.equal(DEFAULT_CONFIG.lookback_bars, 600);
@@ -76,7 +96,7 @@ describe('Cup-and-Handle clean-room configuration', () => {
     assert.equal(DEFAULT_CONFIG.pivot_right_bars, 5);
     assert.equal(DEFAULT_CONFIG.minimum_cup_bars, 20);
     assert.equal(DEFAULT_CONFIG.prior_trend_gate_enabled, false);
-    assert.equal(DEFAULT_CONFIG.detector_version, '0.1.1-cleanroom');
+    assert.equal(DEFAULT_CONFIG.detector_version, '0.1.2-cleanroom');
   });
 
   it('normalizes only the approved first-slice timeframes', () => {
@@ -286,6 +306,20 @@ describe('Cup-and-Handle lifecycle', () => {
       && transition.detection_index > breakout.detection_index
     ));
     assert.deepEqual(sameFamilyAfterBreakout, []);
+  });
+
+  it('never starts a confirmed pattern from a right rim that was knowable on an earlier bar', () => {
+    const result = detect(makeDeterministicRandomWalk(1), {
+      minimum_u_shape_score: 0.2,
+      center_tolerance_fraction_of_half_width: 0.8,
+      rim_deviation_fraction_of_cup_height: 0.5,
+    });
+    const lateConfirmedStarts = result.transitions.filter((transition) => (
+      transition.to_stage === 'HANDLE_FORMING'
+      && transition.from_stage === 'NONE'
+      && transition.anchors?.right_rim?.confirmed_index < transition.detection_index
+    ));
+    assert.deepEqual(lateConfirmedStarts, []);
   });
 
   it('retires the provisional record when its family promotes to a confirmed cup', () => {

--- a/tests/cup_handle_pine_contract.test.js
+++ b/tests/cup_handle_pine_contract.test.js
@@ -28,10 +28,10 @@ describe('Cup-and-Handle Pine clean-room contract', () => {
   it('is an original Pine v6 indicator carrying the frozen detector identity', () => {
     assert.match(pine, /^\/\/@version=6/m);
     assert.match(pine, /indicator\(\s*\n\s*"Cup-and-Handle Pattern Watch \[Clean-room V0\]"/);
-    assert.match(pine, /string VERSION = "0\.1\.1-cleanroom"/);
+    assert.match(pine, /string VERSION = "0\.1\.2-cleanroom"/);
     assert.match(pine, /string CONFIG_BASE_ID = "ch-v0-default"/);
     assert.match(pine, /string runtimeConfigId = CONFIG_BASE_ID \+ "\|settings:/);
-    assert.equal(contract.detector_version, '0.1.1-cleanroom');
+    assert.equal(contract.detector_version, '0.1.2-cleanroom');
     assert.equal(contract.status, 'draft_calibration');
     assert.match(pine, /no protected or\s*\n\/\/ proprietary source code was copied or extracted/i);
   });

--- a/tests/cup_handle_pine_contract.test.js
+++ b/tests/cup_handle_pine_contract.test.js
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PINE_PATH = join(ROOT, 'cup-and-handle', 'cup-and-handle.pine');
+const CONTRACT_PATH = join(
+  ROOT,
+  'cup-and-handle',
+  'analysis',
+  'frozen-v0-cup-handle.json',
+);
+const pine = readFileSync(PINE_PATH, 'utf8');
+const contract = JSON.parse(readFileSync(CONTRACT_PATH, 'utf8'));
+
+const ALERT_TITLES = [
+  'Cup-and-Handle Forming Watch',
+  'Cup-and-Handle Confirmed Cup / Handle Forming',
+  'Cup-and-Handle Handle Ready',
+  'Cup-and-Handle Breakout Confirmed',
+  'Cup-and-Handle Invalidated or Expired',
+  'Any Cup-and-Handle Lifecycle Event',
+];
+
+describe('Cup-and-Handle Pine clean-room contract', () => {
+  it('is an original Pine v6 indicator carrying the frozen detector identity', () => {
+    assert.match(pine, /^\/\/@version=6/m);
+    assert.match(pine, /indicator\(\s*\n\s*"Cup-and-Handle Pattern Watch \[Clean-room V0\]"/);
+    assert.match(pine, /string VERSION = "0\.1\.1-cleanroom"/);
+    assert.match(pine, /string CONFIG_BASE_ID = "ch-v0-default"/);
+    assert.match(pine, /string runtimeConfigId = CONFIG_BASE_ID \+ "\|settings:/);
+    assert.equal(contract.detector_version, '0.1.1-cleanroom');
+    assert.equal(contract.status, 'draft_calibration');
+    assert.match(pine, /no protected or\s*\n\/\/ proprietary source code was copied or extracted/i);
+  });
+
+  it('freezes the publicly documented 600-bar, 5\/5-pivot, 20-bar baseline', () => {
+    assert.match(pine, /input\.int\(600, "Search bars"/);
+    assert.match(pine, /input\.int\(5, "Pivot bars left"/);
+    assert.match(pine, /input\.int\(5, "Pivot bars right"/);
+    assert.match(pine, /input\.int\(20, "Minimum cup bars"/);
+    assert.equal(contract.documented_tradingview_rules.lookback_bars, 600);
+    assert.equal(contract.documented_tradingview_rules.pivot_left_bars, 5);
+    assert.equal(contract.documented_tradingview_rules.pivot_right_bars, 5);
+    assert.equal(contract.documented_tradingview_rules.minimum_cup_bars, 20);
+  });
+
+  it('supports only native 4H, 1D, and 1W in the first slice', () => {
+    assert.match(pine, /timeframe\.period == "240"/);
+    assert.match(pine, /timeframe\.period == "1D"/);
+    assert.match(pine, /timeframe\.period == "1W"/);
+    assert.match(pine, /supports native 4H, 1D, and 1W charts/);
+    assert.deepEqual(contract.supported_timeframes, ['4H', '1D', '1W']);
+  });
+
+  it('gates transitions to confirmed bars and never requests future data', () => {
+    assert.match(pine, /supportedTimeframe and barstate\.isconfirmed/);
+    assert.match(pine, /alert\.freq_once_per_bar_close/);
+    assert.doesNotMatch(pine, /\brequest\./);
+    assert.doesNotMatch(pine, /barmerge\.lookahead_on/);
+    assert.doesNotMatch(pine, /plot\([^\n]*\boffset\s*=/);
+    assert.doesNotMatch(pine, /\bta\.pivothigh\s*\(/);
+    assert.doesNotMatch(pine, /\bta\.pivotlow\s*\(/);
+    assert.equal(contract.causality.closed_bars_only, true);
+    assert.equal(contract.causality.pivot_detection_is_not_backdated, true);
+  });
+
+  it('is non-trading and does not contain a multi-symbol scanner', () => {
+    assert.doesNotMatch(pine, /\bstrategy\s*\(/);
+    assert.doesNotMatch(pine, /\bstrategy\./);
+    assert.doesNotMatch(pine, /input\.symbol\s*\(/);
+    assert.doesNotMatch(pine, /request\.security\s*\(/);
+    assert.ok(contract.non_goals.includes('Automated trading or order placement'));
+    assert.ok(contract.non_goals.includes('Watchlist scanner implementation in the first slice'));
+  });
+
+  it('exposes the complete lifecycle through stable machine plots', () => {
+    for (const stage of contract.lifecycle) assert.match(pine, new RegExp(stage));
+    for (const title of [
+      'CH Stage Code',
+      'CH Transition Stage',
+      'CH Quality Score',
+      'CH Pivot',
+      'CH Invalidation',
+      'CH Rim',
+      'CH Cup Height',
+      'CH Provisional',
+      'CH Left Rim Time',
+      'CH Bottom Time',
+      'CH Right Rim Time',
+      'CH Handle Time',
+      'CH Already Broken When Discovered',
+    ]) {
+      assert.match(pine, new RegExp(`plot\\([^\\n]+"${title}"`), title);
+    }
+  });
+
+  it('defines one alert condition per useful transition plus one combined condition', () => {
+    const observedTitles = [...pine.matchAll(/alertcondition\([^\n]+?"([^"]+)"/g)]
+      .map((match) => match[1]);
+    assert.deepEqual(observedTitles, ALERT_TITLES);
+    assert.match(pine, /family_id=" \+ activeFamilyId/);
+    assert.match(pine, /pattern_id=" \+ activePatternId/);
+    assert.match(pine, /bar_open_time=" \+ str\.tostring\(time\)/);
+    assert.match(pine, /bar_close_time=" \+ str\.tostring\(time_close\)/);
+    assert.match(pine, /config=" \+ runtimeConfigId/);
+  });
+
+  it('uses provisional family identity and adds point 3 to confirmed pattern IDs', () => {
+    assert.match(pine, /f_familyId\(/);
+    assert.match(pine, /f_provisionalPatternId\(/);
+    assert.match(pine, /f_confirmedPatternId\(string familyId, int p3Time\)/);
+    assert.match(pine, /familyId \+ "\|p3=" \+ str\.tostring\(p3Time\)/);
+  });
+
+  it('keeps last-bar drawings on confirmed data', () => {
+    assert.match(pine, /lastClosedIndex = barstate\.isconfirmed \? bar_index : bar_index - 1/);
+    assert.match(pine, /lastClosedHigh = barstate\.isconfirmed \? high : high\[1\]/);
+    assert.doesNotMatch(pine, /displayP3Price = na\(activeP3Price\) \? high : activeP3Price/);
+  });
+
+  it('terminates failed provisional geometry without resurrecting historical right rims', () => {
+    assert.match(pine, /else if not stillValid or not noOvershoot or recovery < formingRecovery or bottomSuperseded/);
+    assert.match(pine, /activeStage := STAGE_INVALIDATED/);
+    assert.match(pine, /activeStage == STAGE_NONE and newPivotHigh/);
+    assert.doesNotMatch(pine, /terminalResetThisBar/);
+    assert.match(pine, /for p3Position = p3StartPosition to highCount - 1/);
+    assert.match(pine, /candidateActionable = candidateHandleAge <= width/);
+  });
+
+  it('invalidates an upside escape before the handle pivot becomes knowable', () => {
+    assert.match(pine, /if bar_index > activeP3Index and close > activeP3Price/);
+    assert.match(pine, /activeStage := STAGE_INVALIDATED/);
+  });
+
+  it('limits historical execution to the documented rolling search window', () => {
+    assert.match(pine, /withinExecutionWindow = bar_index >= math\.max\(0, last_bar_index - lookbackBars - pivotLeft - pivotRight\)/);
+    assert.match(pine, /barstate\.isconfirmed and withinExecutionWindow/);
+  });
+
+  it('deduplicates terminal patterns so an old cup cannot immediately alert again', () => {
+    assert.match(pine, /var array<string> finishedPatternIds = array\.new_string\(\)/);
+    assert.match(pine, /var array<string> completedFamilyIds = array\.new_string\(\)/);
+    assert.match(pine, /f_wasFinished\(finishedPatternIds, candidatePatternId\)/);
+    assert.match(pine, /f_wasFinished\(completedFamilyIds, candidateFamilyId\)/);
+    assert.match(pine, /f_markFinished\(finishedPatternIds, activePatternId\)\s*\n\s*activePatternId := f_confirmedPatternId/);
+    assert.match(pine, /transitionStage == STAGE_BREAKOUT\s*\n\s*f_markFinished\(completedFamilyIds, activeFamilyId\)/);
+    assert.match(pine, /f_markFinished\(finishedPatternIds, activePatternId\)/);
+    assert.match(pine, /activeStage == STAGE_BREAKOUT or activeStage < STAGE_NONE/);
+  });
+
+  it('stays comfortably below TradingView plot-resource limits', () => {
+    const plotCalls = [...pine.matchAll(/^plot\(/gm)].length;
+    const plotshapeCalls = [...pine.matchAll(/^plotshape\(/gm)].length;
+    const alertConditions = [...pine.matchAll(/^alertcondition\(/gm)].length;
+    const estimatedPlotResources = plotCalls + plotshapeCalls + alertConditions;
+    assert.equal(plotCalls, 13);
+    assert.equal(alertConditions, ALERT_TITLES.length);
+    assert.ok(
+      estimatedPlotResources <= 32,
+      `expected a small first-slice surface; observed ${estimatedPlotResources} plot resources`,
+    );
+  });
+});


### PR DESCRIPTION
## Goal

Add an original, clean-room TradingView Cup-and-Handle attention indicator for bullish formations on native 4H, 1D, and 1W charts, with closed-bar lifecycle alerts that can later be calibrated from human-reviewed stock and crypto examples.

## What changed

- Added a Pine v6 overlay with forming, rim-approach, handle-forming, handle-ready, breakout, invalidation, and expiry stages.
- Added stable machine-readable plots, six alert conditions, dynamic payloads, causal 5/5 pivots, geometry drawings, and a 1M fail-closed warning.
- Added a deterministic JavaScript reference detector and a frozen v0 behavior/configuration contract.
- Added 36 focused lifecycle, geometry, causality, deduplication, and Pine-contract regressions.
- Added source-bound verification receipts and a usage/limitation README.
- Added focused tests to the repository unit and all-test scripts.

No TradingView proprietary source was copied or extracted. Public behavior is sourced from [TradingView's Cup-and-Handle documentation](https://www.tradingview.com/support/solutions/43000732556-chart-pattern-cup-and-handle/); undisclosed rules are explicit clean-room defaults.

## Why

This is the first one-chart detector slice needed before building a watchlist scanner. It emits early attention events without presenting them as buy signals or performance claims.

Three independent adversarial reviews and three later incremental review passes reproduced lifecycle/reference failures in the initial drafts. Version 0.1.2 now:

- retires a whole cup family after confirmed breakout, preventing immediate re-arming under another right rim;
- retires the provisional identity when the cup promotes;
- invalidates price escaping above the right rim before any handle pivot exists;
- does not resurrect historical right rims at a misleading late lifecycle stage; and
- applies that same no-historical-resurrection boundary in the JavaScript reference detector.

The paired identity advanced to `0.1.2-cleanroom`, so events from the corrected detector cannot be confused with 0.1.1 events.

## Verification

- `npm run test:cup-handle` — 36 passed, 0 failed.
- `npm run test:unit` — 188 passed, 2 platform-specific skipped, 0 failed.
- `npx eslint cup-and-handle/analysis/cup-handle-core.mjs tests/cup_handle_core.test.js tests/cup_handle_pine_contract.test.js` — 0 errors/warnings.
- `node src/cli/index.js pine analyze --file cup-and-handle/cup-and-handle.pine` — 0 issues.
- TradingView `pine_check` compile-only for Pine SHA-256 `27381b36ac02b554e4dffccaa79ef902a8df4009d530fe9079607cb0ef8cbb85` — compiled, 0 errors, 0 warnings; source was not injected, saved, or applied.
- Post-compile read-only state: 7 existing chart studies, 0 Cup-and-Handle studies; 40 alerts, 0 Cup-and-Handle alerts.
- JSON validation and `git diff --check` passed.
- A local 12-card stock calibration tranche was regenerated byte-identically and is awaiting human labels. Its SVGs, market-data display, label log, generator, and any watchlist context are gitignored and were not pushed.
- The prior 0.1.0 build completed a reversible seven-case live matrix on AAPL/BTC across 4H/1D/1W plus a 1M negative control; its exact source was superseded after review, so it remains historical integration/cleanup evidence only.

## Not verified

- The exact 0.1.2 source has not been added to a live chart.
- No TradingView alert was created or delivered.
- No replay-vs-live trace or per-bar Pine/JavaScript parity run was performed.
- Human signal-quality labels, precision, recall, and predictive value remain open.
- The 12-card crypto calibration tranche still needs a separately frozen source.
- Monthly detection and multi-symbol scanning are intentionally out of scope.

## Residual risks

- V0 tracks one active family per chart and does not queue overlapping families; a newer overlap can be missed.
- The optional prior-trend rollback gate follows TradingView's documented default and remains disabled pending human calibration.
- This is a calibration draft, not a production signal or trading recommendation.
- `CONTRIBUTING.md` currently says personal indicators belong in a fork or separate repository. This draft should not be merged upstream unless the maintainers explicitly accept it as an exception.

## Handoff / clean state

The branch contains only the ten intended source, test, documentation, and receipt files. The tracked worktree is clean. No Cup-and-Handle cloud script, chart study, or alert is live. Calibration cards and metadata remain local, ignored, and unpublished.
