### PR TITLE
fix: harden TradingView layout navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,28 @@ The key flag: `--remote-debugging-port=9222`
 ## Testing
 
 ```bash
-# Requires TradingView running with --remote-debugging-port=9222
+# Offline/unit release gate (does not require a live TradingView target)
 npm test
+
+# Focused PR1 transport/layout tests
+npm run test:focused
+
+# Opt-in bounded live canary. Requires the authenticated TradingView Desktop
+# chart target on localhost:9222 and opens (but never saves) three layouts.
+npm run test:layout-canary
+
+# Broad, state-mutating live tool suite; run separately and deliberately.
+npm run test:e2e
 ```
 
-29 tests covering: Pine Script static analysis, server-side compilation, and CLI routing.
+The layout canary opens `Analysis - Stock Database`, `Analysis - Peers`, and
+`Analysis - Against Index` sequentially. Each switch has one hard 20-second
+deadline and must verify layout identity and stable chart API/pane state. After
+the in-memory lightweight screenshot, a fresh read-only layout snapshot must
+still match the layout, every pane, and pane geometry; the canary exits nonzero
+on a timeout or false success. Optional
+`layout_switch` inputs `expected_pane_signature` and `expected_symbol` add
+fail-closed verification without changing callers that pass only `name`.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
+    "test": "npm run test:unit",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/connection.test.js tests/layout.test.js tests/pine_analyze.test.js tests/cli.test.js tests/replay.test.js tests/sanitization.test.js",
+    "test:focused": "node --test tests/connection.test.js tests/layout.test.js",
+    "test:layout-canary": "node scripts/layout_canary.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
+    "test:all": "npm run test:unit && npm run test:e2e",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/scripts/layout_canary.js
+++ b/scripts/layout_canary.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+import { getLayoutSnapshot, layoutIdentityMatches, layoutSwitch } from '../src/core/ui.js';
+import { getState } from '../src/core/chart.js';
+import { disconnect, reconnect } from '../src/connection.js';
+
+const LAYOUTS = [
+  'Analysis - Stock Database',
+  'Analysis - Peers',
+  'Analysis - Against Index',
+];
+const SWITCH_TIMEOUT_MS = 20000;
+const STEP_TIMEOUT_MS = 25000;
+const SCREENSHOT_TIMEOUT_MS = 10000;
+const SUITE_TIMEOUT_MS = 180000;
+
+function withDeadline(promise, timeoutMs, label) {
+  let timer;
+  return Promise.race([
+    Promise.resolve(promise),
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+function assertState(state, label) {
+  if (!state?.success || !state.symbol || !state.resolution) {
+    throw new Error(`${label} returned incomplete chart state`);
+  }
+}
+
+export function assertPostScreenshotSnapshot(name, switched, snapshot) {
+  const expected = {
+    id: switched.layout_id,
+    url_layout_id: switched.url_layout_id,
+    name: switched.layout,
+  };
+  const baseline = switched.observed || {};
+  if (!baseline.target_id || snapshot.target_id !== baseline.target_id) {
+    throw new Error(`${name} TradingView chart target changed after screenshot`);
+  }
+  if (!layoutIdentityMatches(expected, snapshot)) {
+    throw new Error(`${name} layout identity changed after screenshot`);
+  }
+  if (snapshot.pane_count !== baseline.pane_count) {
+    throw new Error(`${name} pane count changed after screenshot`);
+  }
+  if (snapshot.pane_signature !== baseline.pane_signature) {
+    throw new Error(`${name} pane signature changed after screenshot`);
+  }
+  if (snapshot.geometry_signature !== baseline.geometry_signature) {
+    throw new Error(`${name} pane geometry changed after screenshot`);
+  }
+  const baselinePanes = (baseline.panes || []).map(pane => [pane.symbol, pane.resolution]);
+  const currentPanes = (snapshot.panes || []).map(pane => [pane.symbol, pane.resolution]);
+  if (JSON.stringify(currentPanes) !== JSON.stringify(baselinePanes)) {
+    throw new Error(`${name} pane symbols or resolutions changed after screenshot`);
+  }
+  if (!snapshot.chart_api_ready || !snapshot.pane_geometry_valid
+      || !snapshot.symbols_valid || !snapshot.resolutions_valid
+      || snapshot.invalid_symbol || snapshot.loading
+      || snapshot.visible_modal || snapshot.blank_chart) {
+    throw new Error(`${name} snapshot was not stable after screenshot`);
+  }
+}
+
+async function lightweightScreenshotCheck(expectedTargetId) {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      const client = await withDeadline(
+        reconnect('layout_canary_screenshot', { expectedTargetId }),
+        STEP_TIMEOUT_MS,
+        'lightweight screenshot reconnect',
+      );
+      const result = await withDeadline(
+        client.Page.captureScreenshot({
+          format: 'jpeg',
+          quality: 25,
+          captureBeyondViewport: false,
+          fromSurface: true,
+        }),
+        SCREENSHOT_TIMEOUT_MS,
+        'lightweight screenshot',
+      );
+      const bytes = result?.data ? Buffer.from(result.data, 'base64').length : 0;
+      if (bytes < 1000) throw new Error(`lightweight screenshot was empty (${bytes} bytes)`);
+      return bytes;
+    } catch (err) {
+      if (attempt === 2) throw err;
+    }
+  }
+}
+
+async function checkLayout(name) {
+  const switched = await layoutSwitch({ name, timeout_ms: SWITCH_TIMEOUT_MS });
+  if (!switched?.success || !switched.verified) {
+    const reason = switched?.reason || 'false_success';
+    throw new Error(`${name} failed verification: ${reason}: ${switched?.error || 'layout switch was not verified'}`);
+  }
+  const expectedTargetId = switched.observed?.target_id;
+  if (!expectedTargetId) throw new Error(`${name} verified result did not retain a TradingView chart target`);
+
+  const beforeScreenshot = await withDeadline(getState(), 5000, `${name} state before screenshot`);
+  assertState(beforeScreenshot, `${name} state before screenshot`);
+  const screenshotBytes = await lightweightScreenshotCheck(expectedTargetId);
+  const afterScreenshot = await withDeadline(getState(), 5000, `${name} state after screenshot`);
+  assertState(afterScreenshot, `${name} state after screenshot`);
+  const postScreenshotSnapshot = await getLayoutSnapshot({ timeout_ms: 5000, expected_target_id: expectedTargetId });
+
+  if (beforeScreenshot.symbol !== afterScreenshot.symbol || beforeScreenshot.resolution !== afterScreenshot.resolution) {
+    throw new Error(`${name} chart state changed during screenshot check`);
+  }
+  assertPostScreenshotSnapshot(name, switched, postScreenshotSnapshot);
+
+  return {
+    layout: name,
+    verified: true,
+    source: switched.source,
+    pane_count: postScreenshotSnapshot.pane_count,
+    pane_signature: postScreenshotSnapshot.pane_signature,
+    geometry_signature: postScreenshotSnapshot.geometry_signature,
+    screenshot_bytes: screenshotBytes,
+    state_stable: true,
+  };
+}
+
+async function main() {
+  const suiteTimer = setTimeout(() => {
+    console.error(JSON.stringify({ success: false, reason: 'navigation_timeout', error: `Layout canary exceeded ${SUITE_TIMEOUT_MS}ms` }));
+    process.exit(1);
+  }, SUITE_TIMEOUT_MS);
+
+  try {
+    const checks = [];
+    for (const name of LAYOUTS) checks.push(await checkLayout(name));
+    console.log(JSON.stringify({ success: true, layout_count: checks.length, checks }, null, 2));
+  } catch (err) {
+    console.error(JSON.stringify({
+      success: false,
+      reason: err.reason || (/timed out/i.test(err.message) ? 'navigation_timeout' : 'canary_failed'),
+      error: err.message,
+    }, null, 2));
+    process.exitCode = 1;
+  } finally {
+    clearTimeout(suiteTimer);
+    await disconnect();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -3,6 +3,7 @@
  * Zero dependencies — uses only Node.js built-ins.
  */
 import { parseArgs } from 'node:util';
+import { disconnect } from '../connection.js';
 
 /** @type {Map<string, { description: string, options?: object, handler: Function, subcommands?: Map<string, object> }>} */
 const commands = new Map();
@@ -128,23 +129,43 @@ export async function run(argv) {
   }
 }
 
-async function execute(handler, values, positionals) {
+export async function execute(handler, values, positionals, {
+  disconnect: disconnectFn = disconnect,
+  log = console.log,
+} = {}) {
+  let result;
+  let handlerError;
+  let succeeded = false;
+
   try {
-    const result = await handler(values, positionals);
-    console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    result = await handler(values, positionals);
+    succeeded = true;
   } catch (err) {
-    handleError(err);
+    handlerError = err;
+  } finally {
+    try {
+      await disconnectFn();
+    } catch {
+      // Best-effort cleanup must not replace the handler result or error.
+    }
   }
+
+  if (!succeeded) return handleError(handlerError, false);
+
+  log(JSON.stringify(result, null, 2));
+  process.exitCode = result?.success === false ? 1 : 0;
 }
 
-function handleError(err) {
+function handleError(err, exitImmediately = true) {
   const message = err.message || String(err);
   // Connection failures get exit code 2
   if (/CDP|connection|ECONNREFUSED|not running/i.test(message)) {
     console.error(JSON.stringify({ success: false, error: message }, null, 2));
-    process.exit(2);
+    if (exitImmediately) process.exit(2);
+    process.exitCode = 2;
+    return;
   }
   console.error(JSON.stringify({ success: false, error: message }, null, 2));
-  process.exit(1);
+  if (exitImmediately) process.exit(1);
+  process.exitCode = 1;
 }

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,11 +1,23 @@
 import CDP from 'chrome-remote-interface';
 
-let client = null;
-let targetInfo = null;
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
-const MAX_RETRIES = 5;
-const BASE_DELAY = 500;
+
+const DEFAULT_TIMEOUTS = Object.freeze({
+  liveness: 1500,
+  evaluate: 10000,
+  discovery: 3000,
+  connect: 8000,
+  setup: 3000,
+  close: 500,
+});
+
+const RECOVERABLE_REASONS = new Set([
+  'cdp_timeout',
+  'execution_context_lost',
+  'navigation_invalidated',
+  'target_replaced',
+]);
 
 // Known direct API paths discovered via live probing (see PROBE_RESULTS.md)
 const KNOWN_PATHS = {
@@ -28,6 +40,15 @@ const KNOWN_PATHS = {
 
 export { KNOWN_PATHS };
 
+export class CdpError extends Error {
+  constructor(reason, message, options = {}) {
+    super(message, options.cause ? { cause: options.cause } : undefined);
+    this.name = 'CdpError';
+    this.reason = reason;
+    if (options.outcomeUnknown) this.outcome_unknown = true;
+  }
+}
+
 /**
  * Sanitize a string for safe interpolation into JavaScript code evaluated via CDP.
  * Uses JSON.stringify to produce a properly escaped JS string literal (with quotes).
@@ -47,97 +68,479 @@ export function requireFinite(value, name) {
   return n;
 }
 
-export async function getClient() {
-  if (client) {
-    try {
-      // Quick liveness check
-      await client.Runtime.evaluate({ expression: '1', returnByValue: true });
-      return client;
-    } catch {
-      client = null;
-      targetInfo = null;
-    }
+export function classifyCdpError(err) {
+  if (err?.reason) return err.reason;
+  const message = String(err?.message || err || '');
+  if (/timed out|timeout/i.test(message)) return 'cdp_timeout';
+  if (/execution context|context.*destroyed|cannot find context|contexts? cleared/i.test(message)) {
+    return 'execution_context_lost';
   }
-  return connect();
-}
-
-export async function connect() {
-  let lastError;
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    try {
-      const target = await findChartTarget();
-      if (!target) {
-        throw new Error('No TradingView chart target found. Is TradingView open with a chart?');
-      }
-      targetInfo = target;
-      client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
-
-      // Enable required domains
-      await client.Runtime.enable();
-      await client.Page.enable();
-      await client.DOM.enable();
-
-      return client;
-    } catch (err) {
-      lastError = err;
-      const delay = Math.min(BASE_DELAY * Math.pow(2, attempt), 30000);
-      await new Promise(r => setTimeout(r, delay));
-    }
+  if (/navigat|frame was detached|frame.*removed/i.test(message)) return 'navigation_invalidated';
+  if (/target.*(?:closed|detached|destroyed)|inspector.*detached|session.*closed|websocket.*(?:closed|not open)|socket.*closed|connection.*closed|not connected|no target with given id/i.test(message)) {
+    return 'target_replaced';
   }
-  throw new Error(`CDP connection failed after ${MAX_RETRIES} attempts: ${lastError?.message}`);
+  return 'cdp_command_failed';
 }
 
-async function findChartTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
-    || null;
-}
-
-export async function getTargetInfo() {
-  if (!targetInfo) {
-    await getClient();
-  }
-  return targetInfo;
-}
-
-export async function evaluate(expression, opts = {}) {
-  const c = await getClient();
-  const result = await c.Runtime.evaluate({
-    expression,
-    returnByValue: true,
-    awaitPromise: opts.awaitPromise ?? false,
-    ...opts,
+function toCdpError(err, label, options = {}) {
+  if (err instanceof CdpError) return err;
+  const reason = options.reason || classifyCdpError(err);
+  return new CdpError(reason, `${label} failed: ${err?.message || String(err)}`, {
+    cause: err,
+    outcomeUnknown: options.outcomeUnknown,
   });
-  if (result.exceptionDetails) {
-    const msg = result.exceptionDetails.exception?.description
-      || result.exceptionDetails.text
-      || 'Unknown evaluation error';
-    throw new Error(`JS evaluation error: ${msg}`);
-  }
-  return result.result?.value;
 }
 
-export async function evaluateAsync(expression) {
-  return evaluate(expression, { awaitPromise: true });
+function subscribeProtocolEvent(client, domain, event, handler) {
+  const eventMethod = client?.[domain]?.[event];
+  if (typeof eventMethod === 'function') {
+    try {
+      eventMethod.call(client[domain], handler);
+      return;
+    } catch {
+      // Fall through to EventEmitter-style subscription.
+    }
+  }
+  if (typeof client?.on === 'function') client.on(`${domain}.${event}`, handler);
 }
 
-export async function disconnect() {
-  if (client) {
-    try { await client.close(); } catch {}
-    client = null;
-    targetInfo = null;
+/**
+ * Create an isolated connection manager. Exported for deterministic offline tests;
+ * production callers use the singleton wrappers below.
+ */
+export function createConnectionManager({
+  cdp = CDP,
+  fetchImpl = globalThis.fetch,
+  host = CDP_HOST,
+  port = CDP_PORT,
+  timeouts = {},
+} = {}) {
+  const limits = { ...DEFAULT_TIMEOUTS, ...timeouts };
+  let cachedClient = null;
+  let cachedTargetInfo = null;
+  let connectPromise = null;
+  let connectPromiseGeneration = null;
+  let autoRecoveredClient = null;
+  let epoch = 0;
+  let teardownGeneration = 0;
+  const closingClients = new WeakSet();
+
+  function expectedTargetIdFrom(options) {
+    if (typeof options === 'string') return options || null;
+    const value = options?.expectedTargetId
+      ?? options?.preferredTargetId
+      ?? options?.expected_target_id
+      ?? options?.preferred_target_id;
+    return value == null || value === '' ? null : String(value);
   }
+
+  function isTradingViewChartTarget(target) {
+    return target?.type === 'page' && /tradingview\.com\/chart/i.test(target.url || '');
+  }
+
+  function assertExpectedTarget(expectedTargetId, label = 'CDP connection') {
+    if (!expectedTargetId || (cachedTargetInfo?.id != null && String(cachedTargetInfo.id) === expectedTargetId)) return;
+    throw new CdpError('target_replaced', `${label} could not retain the expected TradingView chart target`);
+  }
+
+  function withDeadline(promise, timeoutMs, label) {
+    const ms = Math.max(1, Number(timeoutMs) || 1);
+    let timer;
+    return Promise.race([
+      Promise.resolve(promise),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new CdpError('cdp_timeout', `${label} timed out after ${ms}ms`));
+        }, ms);
+      }),
+    ]).finally(() => clearTimeout(timer));
+  }
+
+  async function closeBounded(candidate) {
+    if (!candidate || typeof candidate.close !== 'function') return;
+    if ((typeof candidate === 'object' || typeof candidate === 'function') && closingClients.has(candidate)) return;
+    if (typeof candidate === 'object' || typeof candidate === 'function') closingClients.add(candidate);
+    try {
+      await withDeadline(Promise.resolve().then(() => candidate.close()), limits.close, 'CDP client close');
+    } catch {
+      // Best effort. Cache state is cleared before close is attempted.
+    }
+  }
+
+  async function invalidate(candidate = cachedClient) {
+    if (!candidate || cachedClient !== candidate) return false;
+    cachedClient = null;
+    cachedTargetInfo = null;
+    if (autoRecoveredClient === candidate) autoRecoveredClient = null;
+    epoch++;
+    await closeBounded(candidate);
+    return true;
+  }
+
+  async function findChartTarget(options = {}) {
+    const expectedTargetId = expectedTargetIdFrom(options);
+    let controller;
+    try { controller = new AbortController(); } catch { controller = null; }
+    const url = `http://${host}:${port}/json/list`;
+    let response;
+    try {
+      response = await withDeadline(
+        fetchImpl(url, controller ? { signal: controller.signal } : undefined),
+        limits.discovery,
+        'CDP target discovery',
+      );
+      if (typeof response?.ok === 'boolean' && !response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const targets = await withDeadline(response.json(), limits.discovery, 'CDP target list parsing');
+      if (expectedTargetId) {
+        const expected = targets.find(target => String(target?.id) === expectedTargetId);
+        if (!isTradingViewChartTarget(expected)) {
+          throw new CdpError('target_replaced', 'Expected TradingView chart target is no longer available');
+        }
+        return expected;
+      }
+      return targets.find(isTradingViewChartTarget)
+        || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
+        || null;
+    } catch (err) {
+      try { controller?.abort(); } catch {}
+      throw toCdpError(err, 'CDP target discovery');
+    }
+  }
+
+  function connectionClosedError(label = 'CDP operation') {
+    return new CdpError('connection_closed', `${label} was interrupted by explicit disconnect`);
+  }
+
+  function assertCurrentGeneration(operationGeneration, label) {
+    if (operationGeneration === teardownGeneration) return;
+    throw connectionClosedError(label);
+  }
+
+  function assertCurrentAttempt(attemptEpoch, attemptGeneration) {
+    assertCurrentGeneration(attemptGeneration, 'CDP connection attempt');
+    if (attemptEpoch === epoch) return;
+    throw new CdpError('target_replaced', 'CDP connection attempt was superseded');
+  }
+
+  function attachInvalidationHandlers(candidate, clientGeneration, candidateTargetId) {
+    const recover = (reason) => {
+      if (cachedClient !== candidate || clientGeneration !== teardownGeneration) return;
+      void (async () => {
+        const invalidated = await invalidate(candidate);
+        if (!invalidated) return;
+        try {
+          assertCurrentGeneration(clientGeneration, `CDP event recovery (${reason})`);
+          const recovered = await connectForGeneration(clientGeneration, { expectedTargetId: candidateTargetId });
+          if (cachedClient === recovered) autoRecoveredClient = recovered;
+        } catch { /* Next public call will retry discovery. */ }
+      })();
+    };
+
+    if (typeof candidate?.on === 'function') {
+      candidate.on('disconnect', () => recover('target_replaced'));
+      candidate.on('close', () => recover('target_replaced'));
+      candidate.on('error', () => recover('target_replaced'));
+    }
+    subscribeProtocolEvent(candidate, 'Runtime', 'executionContextsCleared', () => recover('execution_context_lost'));
+    subscribeProtocolEvent(candidate, 'Inspector', 'detached', () => recover('target_replaced'));
+    subscribeProtocolEvent(candidate, 'Target', 'detachedFromTarget', event => {
+      if (!event?.targetId || event.targetId === candidateTargetId) recover('target_replaced');
+    });
+    subscribeProtocolEvent(candidate, 'Target', 'targetDestroyed', event => {
+      if (!event?.targetId || event.targetId === candidateTargetId) recover('target_replaced');
+    });
+    subscribeProtocolEvent(candidate, 'Page', 'frameNavigated', event => {
+      if (!event?.frame?.parentId) recover('navigation_invalidated');
+    });
+  }
+
+  async function connectOnce(attemptEpoch, attemptGeneration, expectedTargetId) {
+    const target = await findChartTarget({ expectedTargetId });
+    assertCurrentAttempt(attemptEpoch, attemptGeneration);
+    if (!target) {
+      throw new CdpError('target_replaced', 'No TradingView chart target found. Is TradingView open with a chart?');
+    }
+
+    let candidate;
+    try {
+      const socketPromise = Promise.resolve().then(() => cdp({ host, port, target: target.id }));
+      try {
+        candidate = await withDeadline(socketPromise, limits.connect, 'CDP socket connection');
+      } catch (err) {
+        // Promise.race cannot cancel the underlying CDP connection. If its own
+        // deadline won, dispose a client that arrives after this attempt failed.
+        if (err instanceof CdpError && err.reason === 'cdp_timeout') {
+          void socketPromise.then(lateClient => closeBounded(lateClient), () => {});
+        }
+        throw err;
+      }
+      assertCurrentAttempt(attemptEpoch, attemptGeneration);
+      await withDeadline(candidate.Runtime.enable(), limits.setup, 'CDP Runtime.enable');
+      assertCurrentAttempt(attemptEpoch, attemptGeneration);
+      await withDeadline(candidate.Page.enable(), limits.setup, 'CDP Page.enable');
+      assertCurrentAttempt(attemptEpoch, attemptGeneration);
+      await withDeadline(candidate.DOM.enable(), limits.setup, 'CDP DOM.enable');
+      assertCurrentAttempt(attemptEpoch, attemptGeneration);
+    } catch (err) {
+      await closeBounded(candidate);
+      throw toCdpError(err, 'CDP connection');
+    }
+
+    cachedClient = candidate;
+    cachedTargetInfo = target;
+    attachInvalidationHandlers(candidate, attemptGeneration, String(target.id));
+    return candidate;
+  }
+
+  async function connectForGeneration(operationGeneration, options = {}) {
+    const expectedTargetId = expectedTargetIdFrom(options);
+    assertCurrentGeneration(operationGeneration, 'CDP connection');
+    if (cachedClient) {
+      assertExpectedTarget(expectedTargetId);
+      return cachedClient;
+    }
+    if (connectPromise && connectPromiseGeneration === operationGeneration) {
+      try {
+        const candidate = await withDeadline(connectPromise, limits.connect, 'CDP connection');
+        assertCurrentGeneration(operationGeneration, 'CDP connection');
+        assertExpectedTarget(expectedTargetId);
+        return candidate;
+      } catch (err) {
+        assertCurrentGeneration(operationGeneration, 'CDP connection');
+        throw toCdpError(err, 'CDP connection');
+      }
+    }
+
+    const attemptEpoch = ++epoch;
+    const pending = connectOnce(attemptEpoch, operationGeneration, expectedTargetId);
+    connectPromise = pending;
+    connectPromiseGeneration = operationGeneration;
+    try {
+      const candidate = await withDeadline(pending, limits.connect, 'CDP connection');
+      assertCurrentGeneration(operationGeneration, 'CDP connection');
+      assertExpectedTarget(expectedTargetId);
+      return candidate;
+    } catch (err) {
+      if (attemptEpoch === epoch) epoch++;
+      assertCurrentGeneration(operationGeneration, 'CDP connection');
+      throw toCdpError(err, 'CDP connection');
+    } finally {
+      if (connectPromise === pending) {
+        connectPromise = null;
+        connectPromiseGeneration = null;
+      }
+    }
+  }
+
+  async function connect(options = {}) {
+    const operationGeneration = teardownGeneration;
+    return connectForGeneration(operationGeneration, options);
+  }
+
+  async function reconnectForGeneration(reason, operationGeneration, options = {}) {
+    const expectedTargetId = expectedTargetIdFrom(options);
+    assertCurrentGeneration(operationGeneration, `CDP reconnect (${reason})`);
+    if (reason === 'layout_navigation' && cachedClient && autoRecoveredClient === cachedClient) {
+      assertExpectedTarget(expectedTargetId, `CDP reconnect (${reason})`);
+      const recovered = cachedClient;
+      autoRecoveredClient = null;
+      return recovered;
+    }
+    const previous = cachedClient;
+    if (previous) await invalidate(previous);
+    try {
+      assertCurrentGeneration(operationGeneration, `CDP reconnect (${reason})`);
+      return await connectForGeneration(operationGeneration, { expectedTargetId });
+    } catch (err) {
+      throw toCdpError(err, `CDP reconnect (${reason})`);
+    }
+  }
+
+  async function reconnect(reason = 'target_replaced', options = {}) {
+    if (reason && typeof reason === 'object') {
+      options = reason;
+      reason = 'target_replaced';
+    }
+    const operationGeneration = teardownGeneration;
+    return reconnectForGeneration(reason, operationGeneration, options);
+  }
+
+  async function getClientForGeneration(operationGeneration, options = {}) {
+    const requestedTargetId = expectedTargetIdFrom(options);
+    assertCurrentGeneration(operationGeneration, 'CDP getClient');
+    if (!cachedClient) return connectForGeneration(operationGeneration, { expectedTargetId: requestedTargetId });
+    assertExpectedTarget(requestedTargetId, 'CDP getClient');
+    const candidate = cachedClient;
+    const candidateTargetId = cachedTargetInfo?.id || requestedTargetId;
+    try {
+      await withDeadline(
+        candidate.Runtime.evaluate({ expression: '1', returnByValue: true }),
+        limits.liveness,
+        'CDP liveness Runtime.evaluate',
+      );
+      assertCurrentGeneration(operationGeneration, 'CDP getClient');
+      if (cachedClient !== candidate) {
+        throw new CdpError('target_replaced', 'CDP client changed during liveness check');
+      }
+      return candidate;
+    } catch (err) {
+      assertCurrentGeneration(operationGeneration, 'CDP getClient');
+      const failure = toCdpError(err, 'CDP liveness Runtime.evaluate');
+      await invalidate(candidate);
+      if (!RECOVERABLE_REASONS.has(failure.reason)) throw failure;
+      assertCurrentGeneration(operationGeneration, 'CDP getClient');
+      return connectForGeneration(operationGeneration, { expectedTargetId: candidateTargetId });
+    }
+  }
+
+  async function getClient(options = {}) {
+    const operationGeneration = teardownGeneration;
+    return getClientForGeneration(operationGeneration, options);
+  }
+
+  async function runEvaluation(candidate, expression, protocolOpts, timeoutMs) {
+    return withDeadline(
+      candidate.Runtime.evaluate({
+        ...protocolOpts,
+        expression,
+        returnByValue: protocolOpts.returnByValue ?? true,
+        awaitPromise: protocolOpts.awaitPromise ?? false,
+      }),
+      timeoutMs,
+      'CDP Runtime.evaluate',
+    );
+  }
+
+  async function evaluate(expression, opts = {}) {
+    const operationGeneration = teardownGeneration;
+    const {
+      timeoutMs = limits.evaluate,
+      retry = false,
+      expectedTargetId,
+      preferredTargetId,
+      expected_target_id,
+      preferred_target_id,
+      ...protocolOpts
+    } = opts;
+    const requestedTargetId = expectedTargetIdFrom({
+      expectedTargetId,
+      preferredTargetId,
+      expected_target_id,
+      preferred_target_id,
+    });
+    // These are manager-owned even if supplied through an object spread.
+    delete protocolOpts.retry;
+
+    let candidate = cachedClient || await connectForGeneration(operationGeneration, { expectedTargetId: requestedTargetId });
+    assertExpectedTarget(requestedTargetId, 'CDP Runtime.evaluate');
+    const candidateTargetId = cachedTargetInfo?.id || requestedTargetId;
+    assertCurrentGeneration(operationGeneration, 'CDP Runtime.evaluate');
+    let response;
+    try {
+      response = await runEvaluation(candidate, expression, protocolOpts, timeoutMs);
+      assertCurrentGeneration(operationGeneration, 'CDP Runtime.evaluate');
+    } catch (err) {
+      assertCurrentGeneration(operationGeneration, 'CDP Runtime.evaluate');
+      const failure = toCdpError(err, 'CDP Runtime.evaluate', { outcomeUnknown: !retry });
+      if (!RECOVERABLE_REASONS.has(failure.reason)) throw failure;
+
+      await invalidate(candidate);
+      assertCurrentGeneration(operationGeneration, 'CDP Runtime.evaluate recovery');
+      let reconnectFailure = null;
+      try {
+        candidate = await connectForGeneration(operationGeneration, { expectedTargetId: candidateTargetId }); // Exactly one bounded rediscovery/reconnect.
+      } catch (connectErr) {
+        assertCurrentGeneration(operationGeneration, 'CDP Runtime.evaluate recovery');
+        reconnectFailure = toCdpError(connectErr, 'CDP Runtime.evaluate reconnect');
+      }
+      if (!retry) {
+        const uncertain = new CdpError(failure.reason, failure.message, {
+          cause: failure,
+          outcomeUnknown: true,
+        });
+        uncertain.transport_reconnect_attempted = true;
+        uncertain.transport_reconnected = !reconnectFailure;
+        if (reconnectFailure) uncertain.reconnect_error = reconnectFailure.message;
+        throw uncertain;
+      }
+      if (reconnectFailure) throw reconnectFailure;
+
+      try {
+        response = await runEvaluation(candidate, expression, protocolOpts, timeoutMs);
+        assertCurrentGeneration(operationGeneration, 'CDP Runtime.evaluate retry');
+      } catch (retryErr) {
+        assertCurrentGeneration(operationGeneration, 'CDP Runtime.evaluate retry');
+        const retryFailure = toCdpError(retryErr, 'CDP Runtime.evaluate retry');
+        if (RECOVERABLE_REASONS.has(retryFailure.reason)) await invalidate(candidate);
+        throw retryFailure;
+      }
+    }
+
+    if (response.exceptionDetails) {
+      const message = response.exceptionDetails.exception?.description
+        || response.exceptionDetails.text
+        || 'Unknown evaluation error';
+      throw new CdpError('evaluation_failed', `JS evaluation error: ${message}`);
+    }
+    return response.result?.value;
+  }
+
+  async function evaluateAsync(expression, opts = {}) {
+    return evaluate(expression, { ...opts, awaitPromise: true });
+  }
+
+  async function getTargetInfo(options = {}) {
+    const expectedTargetId = expectedTargetIdFrom(options);
+    const operationGeneration = teardownGeneration;
+    if (!cachedTargetInfo) await getClientForGeneration(operationGeneration, { expectedTargetId });
+    assertCurrentGeneration(operationGeneration, 'CDP getTargetInfo');
+    assertExpectedTarget(expectedTargetId, 'CDP getTargetInfo');
+    return cachedTargetInfo;
+  }
+
+  async function disconnect() {
+    teardownGeneration++;
+    const candidate = cachedClient;
+    if (candidate) await invalidate(candidate);
+    else {
+      cachedTargetInfo = null;
+      epoch++;
+    }
+  }
+
+  return {
+    getClient,
+    connect,
+    reconnect,
+    getTargetInfo,
+    evaluate,
+    evaluateAsync,
+    disconnect,
+    invalidateClient: invalidate,
+    // Deliberately limited test visibility; no production caller should depend on it.
+    _debugState: () => ({ hasClient: !!cachedClient, targetInfo: cachedTargetInfo, epoch, teardownGeneration }),
+  };
 }
+
+const manager = createConnectionManager();
+
+export async function getClient(options) { return manager.getClient(options); }
+export async function connect(options) { return manager.connect(options); }
+export async function reconnect(reason, options) { return manager.reconnect(reason, options); }
+export async function getTargetInfo(options) { return manager.getTargetInfo(options); }
+export async function evaluate(expression, opts) { return manager.evaluate(expression, opts); }
+export async function evaluateAsync(expression, opts) { return manager.evaluateAsync(expression, opts); }
+export async function disconnect() { return manager.disconnect(); }
+export async function invalidateClient(candidate) { return manager.invalidateClient(candidate); }
 
 // --- Direct API path helpers ---
 // Each returns the STRING expression path after verifying it exists.
 // Callers use the returned string in their own evaluate() calls.
 
 async function verifyAndReturn(path, name) {
-  const exists = await evaluate(`typeof (${path}) !== 'undefined' && (${path}) !== null`);
+  const exists = await evaluate(`typeof (${path}) !== 'undefined' && (${path}) !== null`, { retry: true });
   if (!exists) {
     throw new Error(`${name} not available at ${path}`);
   }

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -33,7 +33,7 @@ export async function getState({ _deps } = {}) {
         studies: studies,
       };
     })()
-  `);
+  `, { retry: true });
   return { success: true, ...state };
 }
 
@@ -196,7 +196,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -207,7 +208,7 @@ export async function symbolInfo() {
         typespecs: info.typespecs, resolution: chart.resolution(), chart_type: chart.chartType()
       };
     })()
-  `);
+  `, { retry: true });
   return { success: true, ...result };
 }
 

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -27,7 +27,7 @@ export async function healthCheck() {
       }
       return result;
     })()
-  `);
+  `, { retry: true });
 
   return {
     success: true,
@@ -80,7 +80,7 @@ export async function discover() {
       } catch(e) { results.alertService = { available: false, error: e.message }; }
       return results;
     })()
-  `);
+  `, { retry: true });
 
   const available = Object.values(paths).filter(v => v.available).length;
   const total = Object.keys(paths).length;
@@ -154,7 +154,7 @@ export async function uiState() {
       } catch(e) { ui.replay = { error: e.message }; }
       return ui;
     })()
-  `);
+  `, { retry: true });
 
   return { success: true, ...state };
 }

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -1,7 +1,92 @@
 /**
  * Core UI automation logic.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { disconnect as disconnectClient, evaluate, evaluateAsync, getClient, getTargetInfo, reconnect as reconnectClient, safeString } from '../connection.js';
+
+const LAYOUT_SWITCH_TIMEOUT_MS = 20000;
+const LAYOUT_SNAPSHOT_TIMEOUT_MS = 5000;
+const LAYOUT_POLL_INTERVAL_MS = 250;
+const LAYOUT_STABLE_POLLS = 2;
+const NATIVE_STEP_TIMEOUT_MS = 2500;
+
+function resolveLayoutDeps(deps) {
+  return {
+    evaluate: deps?.evaluate || evaluate,
+    evaluateAsync: deps?.evaluateAsync || evaluateAsync,
+    getTargetInfo: deps?.getTargetInfo || getTargetInfo,
+    reconnect: deps?.reconnect || reconnectClient,
+    disconnect: deps?.disconnect || disconnectClient,
+    now: deps?.now || Date.now,
+    sleep: deps?.sleep || (ms => new Promise(resolve => setTimeout(resolve, ms))),
+  };
+}
+
+function layoutFailure(reason, error, details = {}) {
+  return { success: false, reason, error, verified: false, ...details };
+}
+
+function createLayoutDeadline(deps, timeoutMs) {
+  const expiresAt = deps.now() + timeoutMs;
+  let expired = false;
+
+  function navigationTimeout(label) {
+    const err = new Error(`${label} exceeded the overall layout deadline`);
+    err.reason = 'navigation_timeout';
+    return err;
+  }
+
+  function fence(label) {
+    if (!expired) {
+      expired = true;
+      // disconnect() advances the shared transport teardown generation before
+      // closing the client, fencing late evaluations/reconnects from this switch.
+      void Promise.resolve().then(() => deps.disconnect()).catch(() => {});
+    }
+    throw navigationTimeout(label);
+  }
+
+  async function run(label, operation) {
+    if (expired) throw navigationTimeout(label);
+    const remaining = Math.floor(expiresAt - deps.now());
+    if (remaining <= 0) return fence(label);
+
+    let timer;
+    try {
+      const result = await Promise.race([
+        Promise.resolve().then(() => operation(remaining)),
+        new Promise((_, reject) => {
+          timer = setTimeout(() => {
+            try { fence(label); } catch (err) { reject(err); }
+          }, remaining);
+        }),
+      ]);
+      if (deps.now() >= expiresAt) return fence(label);
+      return result;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  return {
+    expiresAt,
+    remaining: () => Math.max(0, Math.floor(expiresAt - deps.now())),
+    run,
+  };
+}
+
+function evaluateBeforeDeadline(deadline, deps, label, expression, options = {}) {
+  const targetOptions = deps.expectedTargetId ? { expectedTargetId: deps.expectedTargetId } : {};
+  return deadline.run(label, remaining => deps.evaluate(expression, { ...options, ...targetOptions, timeoutMs: remaining }));
+}
+
+function evaluateAsyncBeforeDeadline(deadline, deps, label, expression, options = {}) {
+  const targetOptions = deps.expectedTargetId ? { expectedTargetId: deps.expectedTargetId } : {};
+  return deadline.run(label, remaining => deps.evaluateAsync(expression, { ...options, ...targetOptions, timeoutMs: remaining }));
+}
+
+function sleepBeforeDeadline(deadline, deps, label, requestedMs) {
+  return deadline.run(label, remaining => deps.sleep(Math.min(requestedMs, remaining)));
+}
 
 export async function click({ by, value }) {
   const escaped = JSON.stringify(value);
@@ -101,63 +186,740 @@ export async function fullscreen() {
   return { success: true, action: 'fullscreen_toggled' };
 }
 
-export async function layoutList() {
-  const layouts = await evaluateAsync(`
+export async function layoutList({ _deps } = {}) {
+  const { evaluateAsync: evaluateLayoutAsync } = resolveLayoutDeps(_deps);
+  const layouts = await evaluateLayoutAsync(`
     new Promise(function(resolve) {
       try {
+        if (!window.TradingViewApi || typeof window.TradingViewApi.getSavedCharts !== 'function') {
+          resolve({layouts: [], source: 'internal_api', error: 'getSavedCharts unavailable'});
+          return;
+        }
         window.TradingViewApi.getSavedCharts(function(charts) {
           if (!charts || !Array.isArray(charts)) { resolve({layouts: [], source: 'internal_api', error: 'getSavedCharts returned no data'}); return; }
           var result = charts.map(function(c) { return { id: c.id || c.chartId || null, name: c.name || c.title || 'Untitled', symbol: c.symbol || null, resolution: c.resolution || null, modified: c.timestamp || c.modified || null }; });
           resolve({layouts: result, source: 'internal_api'});
         });
-        setTimeout(function() { resolve({layouts: [], source: 'internal_api', error: 'getSavedCharts timed out'}); }, 5000);
+        setTimeout(function() { resolve({layouts: [], source: 'internal_api', error: 'getSavedCharts timed out'}); }, 3000);
       } catch(e) { resolve({layouts: [], source: 'internal_api', error: e.message}); }
     })
-  `);
+  `, { retry: true });
   return { success: true, layout_count: layouts?.layouts?.length || 0, source: layouts?.source, layouts: layouts?.layouts || [], error: layouts?.error };
 }
 
-export async function layoutSwitch({ name }) {
-  const escaped = JSON.stringify(name);
-  const result = await evaluateAsync(`
+async function resolveInternalLayout(name, deps, deadline) {
+  return evaluateAsyncBeforeDeadline(deadline, deps, 'saved layout resolution', `
     new Promise(function(resolve) {
+      /* __TV_MCP_RESOLVE_LAYOUT__ */
       try {
-        var target = ${escaped};
-        if (/^\\d+$/.test(target)) { window.TradingViewApi.loadChartFromServer(target); resolve({success: true, method: 'loadChartFromServer', id: target, source: 'internal_api'}); return; }
-        window.TradingViewApi.getSavedCharts(function(charts) {
-          if (!charts || !Array.isArray(charts)) { resolve({success: false, error: 'getSavedCharts returned no data', source: 'internal_api'}); return; }
-          var match = null;
-          for (var i = 0; i < charts.length; i++) { var cname = charts[i].name || charts[i].title || ''; if (cname === target || cname.toLowerCase() === target.toLowerCase()) { match = charts[i]; break; } }
-          if (!match) { for (var j = 0; j < charts.length; j++) { var cn = (charts[j].name || charts[j].title || '').toLowerCase(); if (cn.indexOf(target.toLowerCase()) !== -1) { match = charts[j]; break; } } }
-          if (!match) { resolve({success: false, error: 'Layout "' + target + '" not found.', source: 'internal_api'}); return; }
-          var chartId = match.id || match.chartId;
-          window.TradingViewApi.loadChartFromServer(chartId);
-          resolve({success: true, method: 'loadChartFromServer', id: chartId, name: match.name || match.title, source: 'internal_api'});
+        var api = window.TradingViewApi;
+        if (!api || typeof api.getSavedCharts !== 'function' || typeof api.loadChartFromServer !== 'function') {
+          resolve({ status: 'unavailable', source: 'internal_api' });
+          return;
+        }
+        var target = ${safeString(name)};
+        var timer = setTimeout(function() { resolve({ status: 'unavailable', source: 'internal_api', error: 'getSavedCharts timed out' }); }, 3000);
+        api.getSavedCharts(function(charts) {
+          clearTimeout(timer);
+          if (!Array.isArray(charts)) { resolve({ status: 'unavailable', source: 'internal_api', error: 'getSavedCharts returned no data' }); return; }
+          function urlLayoutId(value) {
+            if (value == null) return '';
+            var url = String(value);
+            var match = url.match(/\\/chart\\/([^/?#]+)/i);
+            return match ? decodeURIComponent(match[1]) : url.replace(/^\\/+|\\/+$/g, '');
+          }
+          var normalized = charts.map(function(chart) {
+            var id = chart.id != null ? chart.id : chart.chartId != null ? chart.chartId : null;
+            return { id: id, url_layout_id: urlLayoutId(chart.url), name: String(chart.name || chart.title || 'Untitled') };
+          });
+          var exactId = normalized.filter(function(chart) { return String(chart.id == null ? '' : chart.id) === target || chart.url_layout_id === target; });
+          var exactName = normalized.filter(function(chart) { return chart.name === target; });
+          var insensitive = normalized.filter(function(chart) { return chart.name.toLowerCase() === target.toLowerCase(); });
+          var partial = normalized.filter(function(chart) { return chart.name.toLowerCase().indexOf(target.toLowerCase()) !== -1; });
+          var matches = exactId.length ? exactId : exactName.length ? exactName : insensitive.length ? insensitive : partial;
+          if (matches.length === 0) { resolve({ status: 'not_found', source: 'internal_api' }); return; }
+          if (matches.length > 1) { resolve({ status: 'ambiguous', source: 'internal_api', matches: matches.map(function(chart) { return chart.name; }) }); return; }
+          resolve({ status: 'resolved', source: 'internal_api', id: matches[0].id, url_layout_id: matches[0].url_layout_id || null, name: matches[0].name });
         });
-        setTimeout(function() { resolve({success: false, error: 'getSavedCharts timed out', source: 'internal_api'}); }, 5000);
-      } catch(e) { resolve({success: false, error: e.message, source: 'internal_api'}); }
+      } catch(e) { resolve({ status: 'unavailable', source: 'internal_api', error: e.message }); }
     })
-  `);
-  if (!result?.success) throw new Error(result?.error || 'Unknown error switching layout');
+  `, { retry: true });
+}
 
-  // Handle "unsaved changes" confirmation dialog
-  await new Promise(r => setTimeout(r, 500));
-  const dismissed = await evaluate(`
+async function initiateInternalLayout(layout, deps, deadline) {
+  return evaluateBeforeDeadline(deadline, deps, 'internal layout load', `
     (function() {
-      var btns = document.querySelectorAll('button');
-      for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (/open anyway|don't save|discard/i.test(text)) {
-          btns[i].click();
+      /* __TV_MCP_LOAD_LAYOUT__ */
+      var api = window.TradingViewApi;
+      if (!api || typeof api.loadChartFromServer !== 'function') return { initiated: false };
+      api.loadChartFromServer(${safeString(layout.id)});
+      return { initiated: true };
+    })()
+  `, { retry: false });
+}
+
+function layoutSnapshotExpression() {
+  return `
+    (function() {
+      /* __TV_MCP_LAYOUT_SNAPSHOT__ */
+      function unwrap(value) {
+        try { return value && typeof value.value === 'function' ? value.value() : value; }
+        catch(e) { return null; }
+      }
+      function visible(element) {
+        if (!element) return false;
+        var rect = element.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return false;
+        for (var node = element; node && node.nodeType === 1; node = node.parentElement) {
+          var style = window.getComputedStyle(node);
+          var opacity = parseFloat(style.opacity);
+          if (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse' || (!isNaN(opacity) && opacity <= 0)) return false;
+        }
+        return true;
+      }
+      function dialogContainer(element) {
+        if (!element || element.matches('button, [role="button"], a, input, select, textarea')) return false;
+        return element.getAttribute('role') === 'dialog'
+          || element.getAttribute('aria-modal') === 'true'
+          || /(^|[-_])(dialog|modal)([-_]|$)/i.test(element.getAttribute('data-name') || '');
+      }
+      function text(value) { return value == null ? '' : String(value).trim(); }
+      function elementValue(value) {
+        value = unwrap(value);
+        if (value && value.nodeType === 1) return value;
+        if (value && value[0] && value[0].nodeType === 1) return value[0];
+        return null;
+      }
+      function meaningfulSurface(element) {
+        if (!visible(element)) return false;
+        var rect = element.getBoundingClientRect();
+        return rect.width > 20 && rect.height > 20;
+      }
+      function paneSurfaceReady(element) {
+        if (!element) return false;
+        if (element.matches('[data-name="pane-canvas"], canvas') && meaningfulSurface(element)) return true;
+        var surfaces = element.querySelectorAll('[data-name="pane-canvas"], canvas');
+        for (var s = 0; s < surfaces.length; s++) {
+          if (meaningfulSurface(surfaces[s])) return true;
+        }
+        return false;
+      }
+      var api = window.TradingViewApi;
+      var collection = api && api._chartWidgetCollection;
+      var active = null;
+      try { active = api && api._activeChartWidgetWV && api._activeChartWidgetWV.value(); } catch(e) {}
+      var all = [];
+      try { all = collection && typeof collection.getAll === 'function' ? collection.getAll() : []; } catch(e) {}
+      var fallbackPaneContainers = Array.prototype.filter.call(
+        document.querySelectorAll('[data-name="chart-container"]'),
+        function(element) {
+          if (!visible(element)) return false;
+          return !element.querySelector('[data-name="chart-container"]');
+        }
+      );
+      var hasSafeFallback = fallbackPaneContainers.length === all.length;
+      var panes = [];
+      for (var i = 0; i < all.length; i++) {
+        try {
+          var widget = all[i];
+          var model = widget && typeof widget.model === 'function' ? widget.model() : null;
+          var series = model && typeof model.mainSeries === 'function' ? model.mainSeries() : null;
+          var symbol = series && typeof series.symbol === 'function' ? text(series.symbol()) : '';
+          var resolution = series && typeof series.interval === 'function' ? text(series.interval()) : '';
+          var element = elementValue(widget && widget._mainDiv) || (hasSafeFallback ? fallbackPaneContainers[i] : null);
+          var rect = element && typeof element.getBoundingClientRect === 'function' ? element.getBoundingClientRect() : null;
+          panes.push({
+            index: i,
+            symbol: symbol,
+            resolution: resolution,
+            surface_ready: paneSurfaceReady(element),
+            x: rect ? Math.round(rect.x) : 0,
+            y: rect ? Math.round(rect.y) : 0,
+            width: rect ? Math.round(rect.width) : 0,
+            height: rect ? Math.round(rect.height) : 0
+          });
+        } catch(e) { panes.push({ index: i, symbol: '', resolution: '', surface_ready: false, error: e.message, x: 0, y: 0, width: 0, height: 0 }); }
+      }
+      var layoutType = text(unwrap(collection && collection._layoutType));
+      var metaInfo = unwrap(collection && collection.metaInfo);
+      var layoutId = unwrap(metaInfo && metaInfo.id);
+      var layoutUid = text(unwrap(metaInfo && metaInfo.uid));
+      var layoutName = text(unwrap(metaInfo && metaInfo.name));
+      var nameCandidates = [api && api._savedChartName, api && api._chartName, collection && collection._layoutName];
+      for (var n = 0; n < nameCandidates.length && !layoutName; n++) layoutName = text(unwrap(nameCandidates[n]));
+      var layoutControl = document.querySelector('[data-name="save-load-menu"]') || document.querySelector('[aria-label="Manage layouts"]');
+      if (!layoutName && layoutControl) {
+        layoutName = text(layoutControl.getAttribute('data-layout-name'));
+        var controlText = text(layoutControl.textContent);
+        if (!layoutName && controlText && !/^(save|saved|manage layouts?)$/i.test(controlText)) layoutName = controlText;
+      }
+      var url = window.location.href;
+      var idMatch = url.match(/\\/chart\\/([^/?#]+)/i);
+      var invalidElements = document.querySelectorAll('[data-name*="invalid-symbol"], [class*="invalidSymbol"], [role="alert"]');
+      var invalidSymbol = false;
+      for (var j = 0; j < invalidElements.length; j++) {
+        if (visible(invalidElements[j]) && /invalid symbol|symbol not found|no data/i.test(text(invalidElements[j].textContent))) { invalidSymbol = true; break; }
+      }
+      var modal = null;
+      var dialogs = document.querySelectorAll('[role="dialog"], [aria-modal="true"], [data-name*="dialog"], [data-name*="modal"]');
+      for (var d = 0; d < dialogs.length; d++) { if (dialogContainer(dialogs[d]) && visible(dialogs[d])) { modal = dialogs[d]; break; } }
+      var loader = null;
+      var loaders = document.querySelectorAll('[data-name="loading"], [class*="loader"], [class*="loading"]');
+      for (var l = 0; l < loaders.length; l++) { if (visible(loaders[l])) { loader = loaders[l]; break; } }
+      var chartApiReady = !!(active && typeof active.symbol === 'function' && typeof active.resolution === 'function' && collection && all.length > 0);
+      var geometryValid = panes.length > 0 && panes.every(function(pane) { return pane.width > 20 && pane.height > 20; });
+      var symbolsValid = panes.length > 0 && panes.every(function(pane) { return pane.symbol && pane.symbol.toLowerCase() !== 'unknown'; });
+      var resolutionsValid = panes.length > 0 && panes.every(function(pane) { return !!pane.resolution; });
+      var paneSignature = layoutType + '|' + panes.map(function(pane) { return pane.resolution; }).join(',');
+      var geometrySignature = panes.map(function(pane) { return [pane.x, pane.y, pane.width, pane.height].join(':'); }).join('|');
+      return {
+        url: url,
+        url_layout_id: idMatch ? decodeURIComponent(idMatch[1]) : null,
+        layout_id: layoutId == null || layoutId === '' ? null : layoutId,
+        layout_name: layoutName || null,
+        layout_uid: layoutUid || null,
+        meta_info_available: !!metaInfo,
+        layout_type: layoutType || null,
+        chart_api_ready: chartApiReady,
+        pane_count: panes.length,
+        panes: panes,
+        pane_signature: paneSignature,
+        geometry_signature: geometrySignature,
+        pane_geometry_valid: geometryValid,
+        symbols_valid: symbolsValid,
+        resolutions_valid: resolutionsValid,
+        invalid_symbol: invalidSymbol,
+        visible_modal: !!modal,
+        loading: !!loader,
+        blank_chart: panes.some(function(pane) { return !pane.surface_ready; })
+      };
+    })()
+  `;
+}
+
+export function layoutIdentityMatches(expected, observed) {
+  const numericId = value => value != null && /^\d+$/.test(String(value)) ? String(value) : null;
+  const normalizedId = value => value == null || value === '' ? null : String(value).toLowerCase();
+  const expectedNumericId = numericId(expected?.id);
+  const observedNumericId = numericId(observed?.layout_id);
+  if (expectedNumericId && observedNumericId) return observedNumericId === expectedNumericId;
+
+  const expectedUid = normalizedId(expected?.url_layout_id || (!expectedNumericId ? expected?.id : null));
+  const observedUid = normalizedId(observed?.layout_uid);
+  if (expectedUid && observedUid) return observedUid === expectedUid;
+
+  const observedUrlId = normalizedId(observed?.url_layout_id);
+  if (expectedUid && observedUrlId) return observedUrlId === expectedUid;
+
+  // Once the requested layout has any authoritative identifier, a matching
+  // display name cannot compensate for that identifier disappearing.
+  if (expectedNumericId || expectedUid) return false;
+
+  return expected?.name != null
+    && observed?.layout_name != null
+    && String(observed.layout_name) === String(expected.name);
+}
+
+function symbolMatches(expected, actual) {
+  const wanted = String(expected || '').toUpperCase();
+  const found = String(actual || '').toUpperCase();
+  if (wanted.includes(':')) return found === wanted;
+  return found === wanted || found.split(':').pop() === wanted;
+}
+
+async function readLayoutSnapshot(deps, deadline, expectedTargetId = deps.expectedTargetId) {
+  const observed = await evaluateBeforeDeadline(
+    deadline,
+    deps,
+    'layout snapshot',
+    layoutSnapshotExpression(),
+    { retry: true },
+  );
+  const target = await deadline.run('layout target resolution', remaining => deps.getTargetInfo({
+    ...(expectedTargetId ? { expectedTargetId } : {}),
+    timeoutMs: remaining,
+  }));
+  observed.target_id = target?.id == null ? null : String(target.id);
+  return observed;
+}
+
+export async function getLayoutSnapshot({ timeout_ms, expected_target_id, expectedTargetId, _deps } = {}) {
+  const deps = resolveLayoutDeps(_deps);
+  deps.expectedTargetId = expectedTargetId || expected_target_id || null;
+  const timeout = Math.max(50, Number(timeout_ms) || LAYOUT_SNAPSHOT_TIMEOUT_MS);
+  const deadline = createLayoutDeadline(deps, timeout);
+  return readLayoutSnapshot(deps, deadline);
+}
+
+async function verifyLayout(expected, options, deps, deadline) {
+  let lastObserved = null;
+  let lastStableKey = null;
+  let stablePolls = 0;
+
+  while (deadline.remaining() > 0) {
+    try {
+      const observed = await readLayoutSnapshot(deps, deadline);
+      lastObserved = observed;
+
+      if (options.expectedTargetId && observed.target_id !== options.expectedTargetId) {
+        return layoutFailure('target_replaced', 'Layout verification moved to a different TradingView chart target', { observed });
+      }
+
+      const identityOk = layoutIdentityMatches(expected, observed);
+      const paneSignatureOk = !options.expected_pane_signature || observed.pane_signature === options.expected_pane_signature;
+      const symbolOk = !options.expected_symbol || observed.panes.every(pane => symbolMatches(options.expected_symbol, pane.symbol));
+      const apiStableCandidate = identityOk
+        && observed.chart_api_ready
+        && observed.pane_geometry_valid
+        && observed.symbols_valid
+        && observed.resolutions_valid
+        && !observed.invalid_symbol
+        && !observed.visible_modal
+        && !observed.loading
+        && !observed.blank_chart
+        && paneSignatureOk
+        && symbolOk;
+
+      if (apiStableCandidate) {
+        const stableKey = JSON.stringify({
+          target_id: observed.target_id,
+          url: observed.url,
+          layout_id: observed.layout_id,
+          layout_uid: observed.layout_uid,
+          url_layout_id: observed.url_layout_id,
+          layout_name: observed.layout_name,
+          pane_signature: observed.pane_signature,
+          geometry_signature: observed.geometry_signature,
+          symbols: observed.panes.map(pane => pane.symbol),
+        });
+        stablePolls = stableKey === lastStableKey ? stablePolls + 1 : 1;
+        lastStableKey = stableKey;
+        if (stablePolls >= LAYOUT_STABLE_POLLS) {
+          return { success: true, observed, stable_polls: stablePolls };
+        }
+      } else {
+        stablePolls = 0;
+        lastStableKey = null;
+      }
+    } catch (err) {
+      if (err?.reason === 'navigation_timeout') {
+        err.observed = lastObserved;
+        throw err;
+      }
+      if (err?.reason === 'target_replaced') {
+        return layoutFailure('target_replaced', err.message, {
+          observed: { error: err.message, reason: err.reason },
+        });
+      } else if (err?.reason === 'cdp_timeout' || err?.reason === 'execution_context_lost' || err?.reason === 'navigation_invalidated') {
+        lastObserved = { error: err.message, reason: err.reason };
+      } else {
+        return layoutFailure('chart_api_not_ready', err.message, { observed: lastObserved });
+      }
+    }
+    const remaining = deadline.remaining();
+    if (remaining > 0) {
+      try {
+        await sleepBeforeDeadline(deadline, deps, 'layout verification poll', Math.min(LAYOUT_POLL_INTERVAL_MS, remaining));
+      } catch (err) {
+        if (err?.reason === 'navigation_timeout') err.observed = lastObserved;
+        throw err;
+      }
+    }
+  }
+
+  // Expiry is a transport fence, not an opportunity to reinterpret the last
+  // observation as a different failure class.
+  await deadline.run('layout verification', () => Promise.resolve());
+
+  if (!lastObserved?.chart_api_ready) {
+    return layoutFailure('chart_api_not_ready', 'TradingView chart API did not become stable before the deadline', { observed: lastObserved });
+  }
+  if (options.expected_pane_signature && lastObserved.pane_signature !== options.expected_pane_signature) {
+    return layoutFailure('pane_signature_mismatch', `Expected pane signature ${options.expected_pane_signature}, observed ${lastObserved.pane_signature}`, { observed: lastObserved });
+  }
+  if (options.expected_symbol && !lastObserved.panes?.every(pane => symbolMatches(options.expected_symbol, pane.symbol))) {
+    return layoutFailure('symbol_mismatch', `Expected symbol ${options.expected_symbol} in every pane`, { observed: lastObserved });
+  }
+  return layoutFailure('navigation_timeout', `Layout ${expected.name || expected.id} did not reach verified postconditions before the deadline`, { observed: lastObserved });
+}
+
+async function dismissUnsavedDialog(deps, deadline, stopAt) {
+  while (deadline.remaining() > 0 && deps.now() < stopAt) {
+    const result = await evaluateBeforeDeadline(deadline, deps, 'unsaved dialog check', `
+      (function() {
+        /* __TV_MCP_UNSAVED_DIALOG__ */
+        function visible(element) {
+          if (!element) return false;
+          var r = element.getBoundingClientRect();
+          if (r.width <= 0 || r.height <= 0) return false;
+          for (var node = element; node && node.nodeType === 1; node = node.parentElement) {
+            var style = window.getComputedStyle(node);
+            var opacity = parseFloat(style.opacity);
+            if (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse' || (!isNaN(opacity) && opacity <= 0)) return false;
+          }
           return true;
         }
-      }
-      return false;
-    })()
-  `);
+        function dialogContainer(element) {
+          if (!element || element.matches('button, [role="button"], a, input, select, textarea')) return false;
+          return element.getAttribute('role') === 'dialog'
+            || element.getAttribute('aria-modal') === 'true'
+            || /(^|[-_])(dialog|modal)([-_]|$)/i.test(element.getAttribute('data-name') || '');
+        }
+        var dialogs = document.querySelectorAll('[role="dialog"], [aria-modal="true"], [data-name*="dialog"], [data-name*="modal"]');
+        for (var i = 0; i < dialogs.length; i++) {
+          if (!dialogContainer(dialogs[i]) || !visible(dialogs[i])) continue;
+          var buttons = dialogs[i].querySelectorAll('button, [role="button"]');
+          for (var j = 0; j < buttons.length; j++) {
+            var label = (buttons[j].textContent || '').trim();
+            if (/^(open anyway|don't save|discard)$/i.test(label)) { buttons[j].click(); return { dismissed: true }; }
+          }
+        }
+        return { dismissed: false };
+      })()
+    `, { retry: false });
+    if (result?.dismissed) return true;
+    const remaining = Math.min(deadline.remaining(), Math.max(0, stopAt - deps.now()));
+    if (remaining > 0) await sleepBeforeDeadline(deadline, deps, 'unsaved dialog poll', Math.min(150, remaining));
+  }
+  return false;
+}
 
-  if (dismissed) await new Promise(r => setTimeout(r, 1000));
-  return { success: true, layout: result.name || name, layout_id: result.id, source: result.source, action: 'switched', unsaved_dialog_dismissed: dismissed };
+async function nativeOpenLayout(name, deps, deadline) {
+  let menu;
+  try {
+    menu = await evaluateBeforeDeadline(deadline, deps, 'native layout menu', `
+      (function() {
+        /* __TV_MCP_NATIVE_OPEN_MENU__ */
+        function visible(element) { if (!element) return false; var r = element.getBoundingClientRect(); return r.width > 0 && r.height > 0; }
+        var controls = document.querySelectorAll('[data-name="save-load-menu"], [aria-label="Manage layouts"], [aria-label*="Manage layouts"]');
+        for (var i = 0; i < controls.length; i++) {
+          if (visible(controls[i])) { controls[i].click(); return { clicked: true }; }
+        }
+        return { clicked: false };
+      })()
+    `, { retry: false });
+  } catch (err) {
+    if (err?.reason === 'navigation_timeout') throw err;
+    return layoutFailure(err?.reason === 'target_replaced' ? 'target_replaced' : 'chart_api_not_ready', err.message, { source: 'native_ui' });
+  }
+  if (!menu?.clicked) return layoutFailure('chart_api_not_ready', 'Native Manage layouts control was not available', { source: 'native_ui', selection_initiated: false });
+
+  let actionOpened = false;
+  const actionDeadline = Math.min(deadline.expiresAt, deps.now() + NATIVE_STEP_TIMEOUT_MS);
+  while (deps.now() < actionDeadline && !actionOpened) {
+    const action = await evaluateBeforeDeadline(deadline, deps, 'native Open layout action', `
+      (function() {
+        /* __TV_MCP_NATIVE_OPEN_ACTION__ */
+        function visible(element) { if (!element) return false; var r = element.getBoundingClientRect(); return r.width > 0 && r.height > 0; }
+        function normalized(value) { return (value || '').trim().replace(/…/g, '...').replace(/\\s+/g, ' ').toLowerCase(); }
+        function openLayoutTitle(value) { var label = normalized(value); return label === 'open layout...' || label === 'open layout'; }
+        var items = document.querySelectorAll('button, [role="button"], [role="menuitem"], a, [role="row"]');
+        for (var i = 0; i < items.length; i++) {
+          var label = normalized(items[i].textContent || items[i].getAttribute('aria-label'));
+          var title = items[i].querySelector('[data-name="list-item-title"], [role="gridcell"]');
+          var titleMatches = title && openLayoutTitle(title.textContent || title.getAttribute('aria-label'));
+          var rowPrefixMatches = items[i].getAttribute('role') === 'row'
+            && (label.indexOf('open layout...') === 0 || label === 'open layout');
+          if (visible(items[i]) && (openLayoutTitle(label) || titleMatches || rowPrefixMatches)) { items[i].click(); return { clicked: true }; }
+        }
+        return { clicked: false };
+      })()
+    `, { retry: false });
+    actionOpened = !!action?.clicked;
+    if (!actionOpened) await sleepBeforeDeadline(deadline, deps, 'native Open layout action poll', Math.min(150, Math.max(0, actionDeadline - deps.now())));
+  }
+  if (!actionOpened) return layoutFailure('chart_api_not_ready', 'Native Open layout action was not available', { source: 'native_ui', selection_initiated: false });
+
+  const rowDeadline = Math.min(deadline.expiresAt, deps.now() + NATIVE_STEP_TIMEOUT_MS);
+  while (deps.now() < rowDeadline) {
+    let selected;
+    try {
+      selected = await evaluateBeforeDeadline(deadline, deps, 'native layout row selection', `
+        (function() {
+        /* __TV_MCP_NATIVE_SELECT_LAYOUT__ */
+        function visible(element) { if (!element) return false; var r = element.getBoundingClientRect(); return r.width > 0 && r.height > 0; }
+        function text(element) { return (element.textContent || '').trim().replace(/\\s+/g, ' '); }
+        var target = ${safeString(name)};
+        var dialog = document.querySelector('[role="dialog"][data-name="load-layout-dialog"]') || document.querySelector('[role="dialog"]');
+        var search = dialog && dialog.querySelector('[role="searchbox"][placeholder="Search"], input[type="search"], input[placeholder*="Search"]');
+        if (search && visible(search) && search.value !== target) {
+          var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+          setter.call(search, target);
+          search.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        var nodes = dialog ? dialog.querySelectorAll('[data-name="list-item-title"]') : [];
+        var matches = [];
+        for (var i = 0; i < nodes.length; i++) {
+          var row = nodes[i].closest('[data-name="load-chart-dialog-item"][data-role="list-item"], [data-name="load-chart-dialog-item"], [role="row"][data-role="list-item"]');
+          if (row && visible(row) && visible(nodes[i]) && text(nodes[i]).toLowerCase() === target.toLowerCase()) matches.push({ title: nodes[i], row: row });
+        }
+        if (matches.length > 1) return { selected: false, ambiguous: true };
+        if (matches.length === 0) return { selected: false };
+        var title = matches[0].title;
+        var item = matches[0].row;
+        var href = item.getAttribute('href') || '';
+        var id = item.getAttribute('data-chart-id') || item.getAttribute('data-layout-id') || '';
+        var currentUrl = new URL(window.location.href);
+        var safeUrl = null;
+        try { safeUrl = new URL(href, currentUrl.href); } catch(e) {}
+        var tradingViewOrigin = currentUrl.protocol === 'https:' && /(^|\\.)tradingview\\.com$/i.test(currentUrl.hostname);
+        var pathMatch = safeUrl && safeUrl.pathname.match(/^\\/chart\\/([A-Za-z0-9_-]+)\\/$/);
+        if (!tradingViewOrigin
+          || !safeUrl
+          || safeUrl.protocol !== 'https:'
+          || safeUrl.origin !== currentUrl.origin
+          || !pathMatch
+          || safeUrl.search
+          || safeUrl.hash) {
+          return { selected: false, unsafe_href: true };
+        }
+        var urlLayoutId = pathMatch[1];
+        window.location.assign(safeUrl.href);
+        return { selected: true, id: id || null, url_layout_id: urlLayoutId, name: text(title), direct_navigation: true };
+        })()
+      `, { retry: false });
+    } catch (err) {
+      if (err?.outcome_unknown) {
+        const uncertain = new Error(err.message, { cause: err });
+        uncertain.reason = err.reason;
+        uncertain.outcome_unknown = true;
+        uncertain.native_selection_outcome_unknown = true;
+        uncertain.selection_initiated = true;
+        uncertain.transport_reconnect_attempted = err.transport_reconnect_attempted;
+        uncertain.transport_reconnected = err.transport_reconnected;
+        uncertain.reconnect_error = err.reconnect_error;
+        throw uncertain;
+      }
+      if (err?.reason === 'navigation_timeout') {
+        err.selection_initiated = true;
+        throw err;
+      }
+      err.selection_initiated = true;
+      throw err;
+    }
+    if (selected?.ambiguous) return layoutFailure('layout_ambiguous', `Multiple native layout rows matched "${name}"`, { source: 'native_ui', selection_initiated: false });
+    if (selected?.unsafe_href) return layoutFailure('chart_api_not_ready', 'Native layout row had an unsafe or off-origin href', { source: 'native_ui', selection_initiated: false });
+    if (selected?.selected) return { success: true, source: 'native_ui', id: selected.id, url_layout_id: selected.url_layout_id, name: selected.name || name, selection_initiated: true };
+    await sleepBeforeDeadline(deadline, deps, 'native layout row poll', Math.min(200, Math.max(0, rowDeadline - deps.now())));
+  }
+  return layoutFailure('layout_not_found', `Layout "${name}" was not found in the native Open layout dialog`, { source: 'native_ui', selection_initiated: false });
+}
+
+export async function layoutSwitch({ name, expected_pane_signature, expected_symbol, timeout_ms, _deps }) {
+  const deps = resolveLayoutDeps(_deps);
+  const timeout = Math.max(50, Number(timeout_ms) || LAYOUT_SWITCH_TIMEOUT_MS);
+  const deadline = createLayoutDeadline(deps, timeout);
+  const options = { expected_pane_signature, expected_symbol, expectedTargetId: null };
+  let internal = null;
+  let dismissed = false;
+  let deadlineContext = {};
+
+  const reconnectForVerification = async () => {
+    try {
+      await deadline.run('layout navigation reconnect', remaining => deps.reconnect('layout_navigation', {
+        expectedTargetId: options.expectedTargetId,
+        timeoutMs: remaining,
+      }));
+      return null;
+    } catch (err) {
+      if (err?.reason === 'navigation_timeout') throw err;
+      return err;
+    }
+  };
+
+  const dismissBeforeVerification = async () => {
+    const stopAt = Math.min(deadline.expiresAt, deps.now() + 1500);
+    try {
+      dismissed = (await dismissUnsavedDialog(deps, deadline, stopAt)) || dismissed;
+    } catch (err) {
+      if (err?.reason === 'navigation_timeout') throw err;
+    }
+  };
+
+  const verifiedSuccess = (expected, verified, source, method, details = {}) => ({
+    success: true,
+    layout: expected.name,
+    layout_id: expected.id ?? verified.observed.layout_id ?? null,
+    url_layout_id: expected.url_layout_id || verified.observed.url_layout_id || verified.observed.layout_uid || null,
+    source,
+    method,
+    action: 'switched',
+    verified: true,
+    stable_polls: verified.stable_polls,
+    observed: verified.observed,
+    unsaved_dialog_dismissed: dismissed,
+    ...details,
+  });
+
+  try {
+    const originalTarget = await deadline.run('layout target capture', remaining => deps.getTargetInfo({ timeoutMs: remaining }));
+    const originalTargetId = originalTarget?.id == null ? null : String(originalTarget.id);
+    if (!originalTargetId) {
+      return layoutFailure('target_replaced', 'Could not capture the original TradingView chart target before layout mutation');
+    }
+    options.expectedTargetId = originalTargetId;
+    deps.expectedTargetId = originalTargetId;
+
+    // This internal call is identity resolution only. No saved chart is loaded.
+    try {
+      internal = await resolveInternalLayout(name, deps, deadline);
+    } catch (err) {
+      if (err?.reason === 'navigation_timeout') throw err;
+      internal = { status: 'unavailable', source: 'internal_api', error: err.message };
+    }
+
+    let native;
+    let nativeSelectionUnknown = null;
+    try {
+      native = await nativeOpenLayout(name, deps, deadline);
+    } catch (err) {
+      if (err?.reason === 'navigation_timeout') throw err;
+      if (err?.outcome_unknown && err?.native_selection_outcome_unknown) nativeSelectionUnknown = err;
+      else {
+        // Once the row-selection expression was sent, its outcome is treated as
+        // uncertain and no second layout mutation is permitted.
+        if (err?.selection_initiated) nativeSelectionUnknown = err;
+        else native = layoutFailure(err?.reason === 'target_replaced' ? 'target_replaced' : 'chart_api_not_ready', err.message, {
+          source: 'native_ui',
+          selection_initiated: false,
+        });
+      }
+    }
+
+    if (nativeSelectionUnknown || native?.success) {
+      const nativeNumericId = native?.id != null && /^\d+$/.test(String(native.id)) ? native.id : null;
+      const retainedInternalId = internal?.status === 'resolved' && /^\d+$/.test(String(internal.id)) ? internal.id : null;
+      const expected = native?.success ? {
+        id: nativeNumericId ?? retainedInternalId ?? native.id,
+        url_layout_id: native.url_layout_id || internal?.url_layout_id || null,
+        name: native.name || internal?.name || name,
+      } : internal?.status === 'resolved' ? {
+        id: internal.id,
+        url_layout_id: internal.url_layout_id,
+        name: internal.name,
+      } : { id: null, url_layout_id: null, name };
+
+      deadlineContext = {
+        source: 'native_ui',
+        fallback_used: false,
+        outcome_unknown: !!nativeSelectionUnknown,
+      };
+
+      const reconnectError = await reconnectForVerification();
+      await dismissBeforeVerification();
+      const verified = await verifyLayout(expected, options, deps, deadline);
+      if (verified.success) {
+        return verifiedSuccess(expected, verified, 'native_ui', 'open_layout_ui', {
+          fallback_used: false,
+          ...(nativeSelectionUnknown ? { outcome_unknown_recovered: true } : {}),
+        });
+      }
+      return layoutFailure(verified.reason, nativeSelectionUnknown
+        ? `Native layout selection outcome remained unknown: ${verified.error}`
+        : verified.error, {
+        layout: expected.name,
+        layout_id: expected.id,
+        url_layout_id: expected.url_layout_id,
+        source: 'native_ui',
+        fallback_used: false,
+        outcome_unknown: !!nativeSelectionUnknown,
+        verification_reason: verified.reason,
+        reconnect_error: reconnectError?.message,
+        observed: verified.observed,
+        unsaved_dialog_dismissed: dismissed,
+      });
+    }
+
+    // Native failed before any row selection/navigation. This is the sole point
+    // at which the internal mutation is allowed as a one-shot fallback.
+    if (internal?.status === 'ambiguous') {
+      return layoutFailure('layout_ambiguous', `Layout "${name}" matched multiple saved layouts`, {
+        layout: name,
+        matches: internal.matches,
+        source: 'internal_api',
+        fallback_used: false,
+        fallback_failure: native?.reason,
+      });
+    }
+    if (internal?.status !== 'resolved') {
+      return { ...native, layout: name, fallback_used: false };
+    }
+
+    let initiation = null;
+    let internalOutcomeUnknown = null;
+    try {
+      initiation = await initiateInternalLayout(internal, deps, deadline);
+    } catch (err) {
+      if (err?.reason === 'navigation_timeout') throw err;
+      internalOutcomeUnknown = err;
+    }
+
+    if (!internalOutcomeUnknown && !initiation?.initiated) {
+      return layoutFailure('chart_api_not_ready', 'Internal layout API did not initiate a load', {
+        layout: internal.name,
+        layout_id: internal.id,
+        url_layout_id: internal.url_layout_id,
+        source: 'internal_api',
+        fallback_used: true,
+        fallback_failure: native?.reason,
+      });
+    }
+
+    deadlineContext = {
+      source: 'internal_api',
+      fallback_used: true,
+      fallback_failure: native?.reason,
+      outcome_unknown: !!internalOutcomeUnknown,
+    };
+    const reconnectError = await reconnectForVerification();
+    await dismissBeforeVerification();
+    const verified = await verifyLayout(internal, options, deps, deadline);
+    if (verified.success) {
+      return verifiedSuccess(internal, verified, 'internal_api', 'loadChartFromServer', {
+        fallback_used: true,
+        fallback_failure: native?.reason,
+        ...(internalOutcomeUnknown ? { outcome_unknown_recovered: true } : {}),
+      });
+    }
+    return layoutFailure(verified.reason, internalOutcomeUnknown
+      ? `Internal layout load outcome remained unknown: ${verified.error}`
+      : verified.error, {
+      layout: internal.name,
+      layout_id: internal.id,
+      url_layout_id: internal.url_layout_id,
+      source: 'internal_api',
+      fallback_used: true,
+      fallback_failure: native?.reason,
+      outcome_unknown: !!internalOutcomeUnknown,
+      verification_reason: verified.reason,
+      reconnect_error: reconnectError?.message,
+      observed: verified.observed,
+      unsaved_dialog_dismissed: dismissed,
+    });
+  } catch (err) {
+    if (err?.reason === 'target_replaced') {
+      return layoutFailure('target_replaced', err.message, {
+        layout: internal?.name || name,
+        layout_id: internal?.status === 'resolved' ? internal.id : null,
+        url_layout_id: internal?.status === 'resolved' ? internal.url_layout_id : null,
+        source: deadlineContext.source || 'target_lineage',
+        fallback_used: deadlineContext.fallback_used || false,
+        fallback_failure: deadlineContext.fallback_failure,
+        outcome_unknown: deadlineContext.outcome_unknown || undefined,
+      });
+    }
+    if (err?.reason !== 'navigation_timeout') throw err;
+    return layoutFailure('navigation_timeout', err.message, {
+      layout: internal?.name || name,
+      layout_id: internal?.status === 'resolved' ? internal.id : null,
+      url_layout_id: internal?.status === 'resolved' ? internal.url_layout_id : null,
+      source: deadlineContext.source || 'deadline',
+      fallback_used: deadlineContext.fallback_used || false,
+      fallback_failure: deadlineContext.fallback_failure,
+      outcome_unknown: deadlineContext.outcome_unknown || undefined,
+      observed: err.observed,
+    });
+  }
 }
 
 export async function keyboard({ key, modifiers }) {

--- a/src/tools/ui.js
+++ b/src/tools/ui.js
@@ -29,11 +29,17 @@ export function registerUiTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('layout_switch', 'Switch to a saved chart layout by name or ID', {
+  server.tool('layout_switch', 'Switch to a saved chart layout by name or ID and verify the loaded chart state', {
     name: z.string().describe('Name or ID of the layout to switch to'),
-  }, async ({ name }) => {
-    try { return jsonResult(await core.layoutSwitch({ name })); }
-    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+    expected_pane_signature: z.string().optional().describe('Optional exact pane signature returned by a prior verified switch (for example: 4|1D,1D,1D,1D)'),
+    expected_symbol: z.string().optional().describe('Optional symbol that must be rendered in every chart pane'),
+  }, async ({ name, expected_pane_signature, expected_symbol }) => {
+    try {
+      const result = await core.layoutSwitch({ name, expected_pane_signature, expected_symbol });
+      return jsonResult(result, !result.success);
+    } catch (err) {
+      return jsonResult({ success: false, reason: err.reason || 'chart_api_not_ready', error: err.message }, true);
+    }
   });
 
   server.tool('ui_keyboard', 'Press keyboard keys or shortcuts (e.g., Enter, Escape, Alt+S, Ctrl+Z)', {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -11,6 +11,7 @@ import { execFileSync, execSync } from 'child_process';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { writeFileSync, unlinkSync } from 'fs';
+import { execute } from '../src/cli/router.js';
 
 function require_fs() { return { writeFileSync, unlinkSync }; }
 
@@ -146,5 +147,34 @@ describe('CLI — pine check (server compile)', () => {
     const result = JSON.parse(stdout);
     assert.equal(result.compiled, false);
     assert.ok(result.error_count > 0);
+  });
+});
+
+describe('CLI — structured result exit status', () => {
+  it('prints a failing result to stdout, exits 1, and disconnects gracefully', async () => {
+    const output = [];
+    let disconnectCount = 0;
+    const previousExitCode = process.exitCode;
+    try {
+      await execute(
+        async () => ({ success: false, reason: 'target_replaced', verified: false }),
+        {},
+        [],
+        {
+          disconnect: async () => { disconnectCount++; },
+          log: line => output.push(line),
+        },
+      );
+
+      assert.equal(process.exitCode, 1);
+      assert.equal(disconnectCount, 1);
+      assert.deepEqual(JSON.parse(output.join('\n')), {
+        success: false,
+        reason: 'target_replaced',
+        verified: false,
+      });
+    } finally {
+      process.exitCode = previousExitCode ?? 0;
+    }
   });
 });

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,0 +1,378 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createConnectionManager } from '../src/connection.js';
+import { symbolInfo } from '../src/core/chart.js';
+
+function makeClient(initialEvaluate) {
+  const protocolHandlers = new Map();
+  const clientHandlers = new Map();
+  let evaluateImpl = initialEvaluate;
+  let closeCount = 0;
+
+  const register = (domain, event) => (handler) => {
+    protocolHandlers.set(`${domain}.${event}`, handler);
+  };
+
+  const client = {
+    Runtime: {
+      enable: async () => {},
+      evaluate: (params) => evaluateImpl(params),
+      executionContextsCleared: register('Runtime', 'executionContextsCleared'),
+    },
+    Page: {
+      enable: async () => {},
+      frameNavigated: register('Page', 'frameNavigated'),
+    },
+    DOM: { enable: async () => {} },
+    Inspector: { detached: register('Inspector', 'detached') },
+    Target: {
+      detachedFromTarget: register('Target', 'detachedFromTarget'),
+      targetDestroyed: register('Target', 'targetDestroyed'),
+    },
+    on(event, handler) { clientHandlers.set(event, handler); },
+    async close() { closeCount++; },
+    setEvaluate(fn) { evaluateImpl = fn; },
+    emitProtocol(domain, event, payload = {}) {
+      protocolHandlers.get(`${domain}.${event}`)?.(payload);
+    },
+    emit(event, payload) { clientHandlers.get(event)?.(payload); },
+    get closeCount() { return closeCount; },
+  };
+  return client;
+}
+
+function makeManager(clients, overrides = {}, targetLists = null) {
+  let connectionCount = 0;
+  let discoveryCount = 0;
+  const connectedTargetIds = [];
+  const manager = createConnectionManager({
+    cdp: async ({ target }) => {
+      connectedTargetIds.push(target);
+      const next = clients[connectionCount++];
+      if (!next) throw new Error('unexpected extra CDP connection');
+      return next;
+    },
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        discoveryCount++;
+        const targets = targetLists?.[Math.min(discoveryCount - 1, targetLists.length - 1)];
+        return targets || [{ id: 'target-1', type: 'page', url: 'https://www.tradingview.com/chart/layout-1/' }];
+      },
+    }),
+    timeouts: {
+      liveness: 20,
+      evaluate: 20,
+      discovery: 50,
+      connect: 100,
+      setup: 50,
+      close: 20,
+      ...overrides,
+    },
+  });
+  return {
+    manager,
+    get connectionCount() { return connectionCount; },
+    get discoveryCount() { return discoveryCount; },
+    connectedTargetIds,
+  };
+}
+
+const never = () => new Promise(() => {});
+const value = (result) => Promise.resolve({ result: { value: result } });
+
+async function waitUntil(predicate, timeoutMs = 200) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  throw new Error('condition not reached before test deadline');
+}
+
+describe('connection deadlines and recovery', () => {
+  it('bounds an explicitly retryable Runtime.evaluate and resets the cached client after one retry', async () => {
+    const first = makeClient(never);
+    const second = makeClient(never);
+    const fixture = makeManager([first, second]);
+    const started = Date.now();
+
+    await assert.rejects(
+      () => fixture.manager.evaluate('window.neverResolves', { retry: true }),
+      err => err.reason === 'cdp_timeout' && /Runtime\.evaluate/.test(err.message),
+    );
+
+    assert.ok(Date.now() - started < 300, 'evaluation stayed inside its bounded deadline');
+    assert.equal(fixture.connectionCount, 2, 'initial connection plus exactly one reconnect');
+    assert.equal(first.closeCount, 1);
+    assert.equal(second.closeCount, 1);
+    assert.equal(fixture.manager._debugState().hasClient, false, 'failed retry was not cached');
+  });
+
+  it('reconnects exactly once after execution-context loss and retries the evaluation', async () => {
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const first = makeClient(async () => {
+      firstCalls++;
+      throw new Error('Execution context was destroyed, most likely because of a navigation.');
+    });
+    const second = makeClient(() => {
+      secondCalls++;
+      return value({ ready: true });
+    });
+    const fixture = makeManager([first, second]);
+
+    const result = await fixture.manager.evaluate('window.readOnlyState', { retry: true });
+
+    assert.deepEqual(result, { ready: true });
+    assert.equal(firstCalls, 1);
+    assert.equal(secondCalls, 1, 'explicit retry replayed the read exactly once');
+    assert.equal(fixture.connectionCount, 2);
+    assert.equal(first.closeCount, 1);
+    assert.equal(second.closeCount, 0);
+    assert.equal(fixture.manager._debugState().hasClient, true);
+  });
+
+  it('reconnects after a liveness Runtime.evaluate deadline', async () => {
+    const first = makeClient(() => value(1));
+    const second = makeClient(() => value(1));
+    const fixture = makeManager([first, second]);
+    await fixture.manager.connect();
+    first.setEvaluate(never);
+
+    const client = await fixture.manager.getClient();
+
+    assert.equal(client, second);
+    assert.equal(fixture.connectionCount, 2);
+    assert.equal(first.closeCount, 1);
+  });
+
+  it('defaults to reconnecting without replay when a mutating outcome is unknown', async () => {
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const first = makeClient(async () => {
+      firstCalls++;
+      throw new Error('Inspected target navigated or closed');
+    });
+    const second = makeClient(async () => {
+      secondCalls++;
+      return { result: { value: true } };
+    });
+    const fixture = makeManager([first, second]);
+
+    await assert.rejects(
+      () => fixture.manager.evaluate('window.startMutation()'),
+      err => err.reason === 'navigation_invalidated'
+        && err.outcome_unknown === true
+        && err.transport_reconnect_attempted === true
+        && err.transport_reconnected === true,
+    );
+
+    assert.equal(firstCalls, 1);
+    assert.equal(secondCalls, 0, 'uncertain mutation was not replayed');
+    assert.equal(fixture.connectionCount, 2, 'connection was reacquired once for verification callers');
+    assert.equal(fixture.manager._debugState().hasClient, true);
+  });
+
+  it('surfaces outcome_unknown even when transport reconnection also fails', async () => {
+    const first = makeClient(async () => {
+      throw new Error('Execution context was destroyed during navigation');
+    });
+    const fixture = makeManager([first]);
+
+    await assert.rejects(
+      () => fixture.manager.evaluate('window.startMutation()', { retry: false }),
+      err => err.reason === 'execution_context_lost'
+        && err.outcome_unknown === true
+        && err.transport_reconnect_attempted === true
+        && err.transport_reconnected === false
+        && /unexpected extra CDP connection/.test(err.reconnect_error),
+    );
+
+    assert.equal(fixture.connectionCount, 2, 'one reconnect was attempted without replay');
+    assert.equal(first.closeCount, 1);
+    assert.equal(fixture.manager._debugState().hasClient, false);
+  });
+
+  it('does not reconnect when disconnect fences a pending evaluation failure', async () => {
+    let rejectEvaluation;
+    let evaluationStarted = false;
+    const first = makeClient(() => {
+      evaluationStarted = true;
+      return new Promise((_, reject) => { rejectEvaluation = reject; });
+    });
+    const second = makeClient(() => value('later generation'));
+    const fixture = makeManager([first, second]);
+
+    const pending = fixture.manager.evaluate('window.pendingRead', { retry: true });
+    await waitUntil(() => evaluationStarted);
+    await fixture.manager.disconnect();
+    rejectEvaluation(new Error('Execution context was destroyed during navigation'));
+
+    await assert.rejects(
+      pending,
+      err => err.reason === 'connection_closed' && /explicit disconnect/.test(err.message),
+    );
+    assert.equal(fixture.connectionCount, 1, 'no connection was opened after explicit disconnect');
+    assert.equal(first.closeCount, 1);
+    assert.equal(second.closeCount, 0);
+    assert.equal(fixture.manager._debugState().hasClient, false);
+
+    const laterResult = await fixture.manager.evaluate('window.laterRead', { retry: true });
+    assert.equal(laterResult, 'later generation', 'an explicit later operation connected on the new generation');
+    assert.equal(fixture.connectionCount, 2);
+  });
+
+  it('closes a connect client that resolves after disconnect without publishing it', async () => {
+    let resolveSocket;
+    let socketStarted = false;
+    const lateClient = makeClient(() => value(1));
+    const manager = createConnectionManager({
+      cdp: () => {
+        socketStarted = true;
+        return new Promise(resolve => { resolveSocket = resolve; });
+      },
+      fetchImpl: async () => ({
+        ok: true,
+        json: async () => [{ id: 'disconnected-target', type: 'page', url: 'https://www.tradingview.com/chart/disconnected/' }],
+      }),
+      timeouts: { discovery: 100, connect: 100, setup: 100, close: 20 },
+    });
+
+    const pending = manager.connect();
+    await waitUntil(() => socketStarted);
+    await manager.disconnect();
+    resolveSocket(lateClient);
+
+    await assert.rejects(
+      pending,
+      err => err.reason === 'connection_closed' && /explicit disconnect/.test(err.message),
+    );
+    assert.equal(lateClient.closeCount, 1, 'late client was closed exactly once');
+    assert.equal(manager._debugState().hasClient, false, 'late client was never published');
+    assert.equal(manager._debugState().targetInfo, null);
+  });
+
+  it('closes a CDP client that resolves after the connect deadline without caching it', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    let resolveSocket;
+    let socketStarted = false;
+    const lateClient = makeClient(() => value(1));
+    const manager = createConnectionManager({
+      cdp: () => {
+        socketStarted = true;
+        return new Promise(resolve => { resolveSocket = resolve; });
+      },
+      fetchImpl: async () => ({
+        ok: true,
+        json: async () => [{ id: 'late-target', type: 'page', url: 'https://www.tradingview.com/chart/late/' }],
+      }),
+      timeouts: { discovery: 100, connect: 50, setup: 100, close: 20 },
+    });
+
+    const pending = manager.connect();
+    for (let i = 0; i < 100 && !socketStarted; i++) await Promise.resolve();
+    assert.equal(socketStarted, true);
+
+    t.mock.timers.tick(50);
+    await assert.rejects(pending, err => err.reason === 'cdp_timeout');
+    resolveSocket(lateClient);
+    for (let i = 0; i < 10 && lateClient.closeCount === 0; i++) await Promise.resolve();
+
+    assert.equal(lateClient.closeCount, 1, 'late client was closed exactly once');
+    assert.equal(manager._debugState().hasClient, false, 'late client was never published');
+    assert.equal(manager._debugState().targetInfo, null);
+  });
+
+  it('invalidates and reconnects once when the page navigation event fires', async () => {
+    const first = makeClient(() => value(1));
+    const second = makeClient(() => value(1));
+    const targetA = { id: 'target-A', type: 'page', url: 'https://www.tradingview.com/chart/a/' };
+    const targetB = { id: 'target-B', type: 'page', url: 'https://www.tradingview.com/chart/b/' };
+    const fixture = makeManager([first, second], {}, [
+      [targetB, targetA],
+      [targetB, targetA],
+    ]);
+    await fixture.manager.connect({ expectedTargetId: 'target-A' });
+
+    first.emitProtocol('Page', 'frameNavigated');
+    await waitUntil(() => fixture.connectionCount === 2 && fixture.manager._debugState().hasClient);
+    const recovered = await fixture.manager.reconnect('layout_navigation');
+
+    assert.equal(recovered, second);
+    assert.equal(first.closeCount, 1);
+    assert.equal(second.closeCount, 0);
+    assert.equal(fixture.connectionCount, 2, 'explicit layout recovery reused the event recovery');
+    assert.deepEqual(fixture.connectedTargetIds, ['target-A', 'target-A']);
+  });
+
+  it('pins event-driven recovery to the original target when multiple charts exist', async () => {
+    const first = makeClient(() => value(1));
+    const second = makeClient(() => value(1));
+    const targetA = { id: 'target-A', type: 'page', url: 'https://www.tradingview.com/chart/a/' };
+    const targetB = { id: 'target-B', type: 'page', url: 'https://www.tradingview.com/chart/b/' };
+    const fixture = makeManager([first, second], {}, [
+      [targetB, targetA],
+      [targetB, targetA],
+    ]);
+    await fixture.manager.connect({ expectedTargetId: 'target-A' });
+
+    first.emitProtocol('Runtime', 'executionContextsCleared');
+    await waitUntil(() => fixture.connectionCount === 2 && fixture.manager._debugState().hasClient);
+
+    assert.deepEqual(fixture.connectedTargetIds, ['target-A', 'target-A']);
+    assert.equal(fixture.manager._debugState().targetInfo.id, 'target-A');
+  });
+
+  it('fails closed when the pinned target disappears, while a later unpinned connect may select another chart', async () => {
+    const first = makeClient(() => value(1));
+    const second = makeClient(() => value(1));
+    const targetA = { id: 'target-A', type: 'page', url: 'https://www.tradingview.com/chart/a/' };
+    const targetB = { id: 'target-B', type: 'page', url: 'https://www.tradingview.com/chart/b/' };
+    const fixture = makeManager([first, second], {}, [
+      [targetA, targetB],
+      [targetB],
+      [targetB],
+    ]);
+    await fixture.manager.connect({ preferredTargetId: 'target-A' });
+
+    await assert.rejects(
+      () => fixture.manager.reconnect('layout_navigation', { expectedTargetId: 'target-A' }),
+      err => err.reason === 'target_replaced',
+    );
+    assert.deepEqual(fixture.connectedTargetIds, ['target-A'], 'replacement target was never connected during pinned recovery');
+    assert.equal(fixture.manager._debugState().hasClient, false);
+
+    await fixture.manager.connect();
+    assert.deepEqual(fixture.connectedTargetIds, ['target-A', 'target-B']);
+    assert.equal(fixture.manager._debugState().targetInfo.id, 'target-B');
+  });
+});
+
+describe('symbolInfo regression', () => {
+  it('uses the shared injected evaluator instead of an undefined evaluate binding', async () => {
+    const expected = {
+      symbol: 'AAPL',
+      full_name: 'NASDAQ:AAPL',
+      exchange: 'NASDAQ',
+      description: 'Apple Inc.',
+      type: 'stock',
+      pro_name: 'NASDAQ:AAPL',
+      typespecs: ['common'],
+      resolution: '1D',
+      chart_type: 1,
+    };
+    const calls = [];
+    const evaluate = async (expression, options) => {
+      calls.push({ expression, options });
+      return expected;
+    };
+
+    const result = await symbolInfo({ _deps: { evaluate } });
+
+    assert.deepEqual(result, { success: true, ...expected });
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].expression, /symbolExt\(\)/);
+    assert.deepEqual(calls[0].options, { retry: true });
+  });
+});

--- a/tests/layout.test.js
+++ b/tests/layout.test.js
@@ -1,0 +1,885 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getLayoutSnapshot, layoutIdentityMatches, layoutSwitch } from '../src/core/ui.js';
+import { assertPostScreenshotSnapshot } from '../scripts/layout_canary.js';
+
+function verifiedSnapshot(overrides = {}) {
+  return {
+    url: 'https://www.tradingview.com/chart/layout-id/',
+    target_id: 'stable-target',
+    url_layout_id: 'layout-id',
+    layout_id: null,
+    layout_name: 'Analysis - Stock Database',
+    layout_uid: 'layout-id',
+    meta_info_available: true,
+    layout_type: '2h',
+    chart_api_ready: true,
+    pane_count: 2,
+    panes: [
+      { index: 0, symbol: 'NASDAQ:AAPL', resolution: '1D', surface_ready: true, x: 0, y: 0, width: 600, height: 800 },
+      { index: 1, symbol: 'NASDAQ:AAPL', resolution: '1D', surface_ready: true, x: 600, y: 0, width: 600, height: 800 },
+    ],
+    pane_signature: '2h|1D,1D',
+    geometry_signature: '0:0:600:800|600:0:600:800',
+    pane_geometry_valid: true,
+    symbols_valid: true,
+    resolutions_valid: true,
+    invalid_symbol: false,
+    visible_modal: false,
+    loading: false,
+    blank_chart: false,
+    ...overrides,
+  };
+}
+
+function makeDeps({
+  internal = { status: 'resolved', source: 'internal_api', id: 'layout-id', url_layout_id: 'layout-id', name: 'Analysis - Stock Database' },
+  snapshots = [verifiedSnapshot()],
+  menu = { clicked: false },
+  action = { clicked: false },
+  selected = { selected: false },
+  selectError = null,
+  internalLoadError = null,
+  unsaved = { dismissed: true },
+  targetIds = ['stable-target'],
+} = {}) {
+  let currentTime = 0;
+  let snapshotIndex = 0;
+  let reconnectCount = 0;
+  let disconnectCount = 0;
+  let targetIndex = 0;
+  const calls = [];
+  const reconnectCalls = [];
+
+  function marker(expression) {
+    return [
+      '__TV_MCP_RESOLVE_LAYOUT__',
+      '__TV_MCP_LOAD_LAYOUT__',
+      '__TV_MCP_LAYOUT_SNAPSHOT__',
+      '__TV_MCP_UNSAVED_DIALOG__',
+      '__TV_MCP_NATIVE_OPEN_MENU__',
+      '__TV_MCP_NATIVE_OPEN_ACTION__',
+      '__TV_MCP_NATIVE_SELECT_LAYOUT__',
+    ].find(value => expression.includes(value));
+  }
+
+  const evaluate = async (expression, options) => {
+    const found = marker(expression);
+    calls.push({ marker: found, options, expression });
+    if (found === '__TV_MCP_LOAD_LAYOUT__') {
+      if (internalLoadError) throw internalLoadError;
+      return { initiated: true };
+    }
+    if (found === '__TV_MCP_LAYOUT_SNAPSHOT__') {
+      const snapshot = snapshots[Math.min(snapshotIndex, snapshots.length - 1)];
+      snapshotIndex++;
+      return structuredClone(snapshot);
+    }
+    if (found === '__TV_MCP_UNSAVED_DIALOG__') return unsaved;
+    if (found === '__TV_MCP_NATIVE_OPEN_MENU__') return menu;
+    if (found === '__TV_MCP_NATIVE_OPEN_ACTION__') return action;
+    if (found === '__TV_MCP_NATIVE_SELECT_LAYOUT__') {
+      if (selectError) throw selectError;
+      return selected;
+    }
+    throw new Error(`unexpected evaluate expression: ${found || expression.slice(0, 40)}`);
+  };
+
+  return {
+    _deps: {
+      evaluate,
+      evaluateAsync: async (expression, options) => {
+        calls.push({ marker: marker(expression), expression, options });
+        return internal;
+      },
+      getTargetInfo: async options => {
+        calls.push({ marker: 'targetInfo', options });
+        return { id: targetIds[Math.min(targetIndex++, targetIds.length - 1)] };
+      },
+      reconnect: async (reason, options) => {
+        reconnectCount++;
+        reconnectCalls.push({ reason, options });
+      },
+      disconnect: async () => { disconnectCount++; },
+      now: () => currentTime,
+      sleep: async ms => { currentTime += Math.max(1, ms); },
+    },
+    calls,
+    reconnectCalls,
+    get reconnectCount() { return reconnectCount; },
+    get disconnectCount() { return disconnectCount; },
+  };
+}
+
+describe('verified layout switching', () => {
+  it('keeps the numeric saved-chart id while verifying and reporting the URL short id', async () => {
+    const fixture = makeDeps({
+      internal: {
+        status: 'resolved',
+        source: 'internal_api',
+        id: 987654321,
+        url_layout_id: 'short-AbC12',
+        name: 'Analysis - Stock Database',
+      },
+      snapshots: [verifiedSnapshot({
+        url: 'https://www.tradingview.com/chart/short-AbC12/',
+        url_layout_id: 'short-AbC12',
+        layout_id: 987654321,
+        layout_uid: 'short-AbC12',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.layout_id, 987654321);
+    assert.equal(result.url_layout_id, 'short-AbC12');
+    assert.equal(result.observed.layout_id, 987654321);
+    assert.equal(result.observed.layout_uid, 'short-AbC12');
+    assert.equal(result.observed.url_layout_id, 'short-AbC12');
+    const resolveExpression = fixture.calls.find(call => call.marker === '__TV_MCP_RESOLVE_LAYOUT__').expression;
+    const loadExpression = fixture.calls.find(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').expression;
+    assert.match(resolveExpression, /url_layout_id: urlLayoutId\(chart\.url\)/);
+    assert.match(loadExpression, /loadChartFromServer\("987654321"\)/);
+    assert.doesNotMatch(loadExpression, /short-AbC12/);
+    const snapshotExpression = fixture.calls.find(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').expression;
+    assert.match(snapshotExpression, /collection && collection\.metaInfo/);
+    assert.match(snapshotExpression, /layoutId = unwrap\(metaInfo && metaInfo\.id\)/);
+    assert.match(snapshotExpression, /layoutName = text\(unwrap\(metaInfo && metaInfo\.name\)\)/);
+    assert.match(snapshotExpression, /layoutUid = text\(unwrap\(metaInfo && metaInfo\.uid\)\)/);
+    assert.match(snapshotExpression, /element\.querySelectorAll\('\[data-name="pane-canvas"\], canvas'\)/);
+    assert.match(snapshotExpression, /elementValue\(widget && widget\._mainDiv\)/);
+    assert.match(snapshotExpression, /hasSafeFallback = fallbackPaneContainers\.length === all\.length/);
+    assert.match(snapshotExpression, /surface_ready: paneSurfaceReady\(element\)/);
+    assert.match(snapshotExpression, /blank_chart: panes\.some\(function\(pane\) \{ return !pane\.surface_ready; \}\)/);
+    assert.doesNotMatch(snapshotExpression, /paneCanvases\.length < panes\.length/);
+    assert.deepEqual(fixture.calls.find(call => call.marker === '__TV_MCP_RESOLVE_LAYOUT__').options, { retry: true, expectedTargetId: 'stable-target', timeoutMs: 1000 });
+    assert.deepEqual(fixture.calls.find(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').options, { retry: true, expectedTargetId: 'stable-target', timeoutMs: 1000 });
+  });
+
+  it('cannot verify a mutation initiated on target A using a stable snapshot from target B', async () => {
+    const fixture = makeDeps({ targetIds: ['target-A', 'target-B'] });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'target_replaced');
+    assert.equal(result.observed.target_id, 'target-B');
+    const mutation = fixture.calls.find(call => call.marker === '__TV_MCP_LOAD_LAYOUT__');
+    assert.equal(mutation.options.expectedTargetId, 'target-A');
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 1);
+    assert.deepEqual(fixture.reconnectCalls[0], {
+      reason: 'layout_navigation',
+      options: { expectedTargetId: 'target-A', timeoutMs: 1000 },
+    });
+    assert.ok(
+      fixture.calls.findIndex(call => call.marker === 'targetInfo')
+        < fixture.calls.findIndex(call => call.marker === '__TV_MCP_LOAD_LAYOUT__'),
+      'the target was captured before the mutation',
+    );
+  });
+
+  it('accepts the observed numeric metaInfo id when the URL identity is stale', async () => {
+    const fixture = makeDeps({
+      internal: {
+        status: 'resolved',
+        source: 'internal_api',
+        id: 987654321,
+        url_layout_id: 'expected-short-id',
+        name: 'Analysis - Stock Database',
+      },
+      snapshots: [verifiedSnapshot({
+        url: 'https://www.tradingview.com/chart/stale-short-id/',
+        url_layout_id: 'stale-short-id',
+        layout_id: 987654321,
+        layout_uid: 'stale-short-id',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.observed.layout_id, 987654321);
+  });
+
+  it('uses the UID when expected numeric identity exists but observed numeric identity is unavailable', async () => {
+    const fixture = makeDeps({
+      internal: {
+        status: 'resolved',
+        source: 'internal_api',
+        id: 987654321,
+        url_layout_id: 'expected-short-id',
+        name: 'Analysis - Stock Database',
+      },
+      snapshots: [verifiedSnapshot({
+        url_layout_id: 'stale-url-id',
+        layout_id: null,
+        layout_uid: 'expected-short-id',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.observed.layout_id, null);
+    assert.equal(result.observed.layout_uid, 'expected-short-id');
+  });
+
+  it('fails closed on a numeric metaInfo mismatch even when UID and URL both match', async () => {
+    const fixture = makeDeps({
+      internal: {
+        status: 'resolved',
+        source: 'internal_api',
+        id: 987654321,
+        url_layout_id: 'expected-short-id',
+        name: 'Analysis - Stock Database',
+      },
+      snapshots: [verifiedSnapshot({
+        url: 'https://www.tradingview.com/chart/expected-short-id/',
+        url_layout_id: 'expected-short-id',
+        layout_id: 111111111,
+        layout_uid: 'expected-short-id',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 200,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'navigation_timeout');
+    assert.equal(result.layout_id, 987654321);
+    assert.equal(result.url_layout_id, 'expected-short-id');
+    assert.equal(fixture.disconnectCount, 1);
+  });
+
+  it('fails when an initiated internal layout load never verifies', async () => {
+    const fixture = makeDeps({
+      snapshots: [verifiedSnapshot({
+        url: 'https://www.tradingview.com/chart/old-layout/',
+        url_layout_id: 'old-layout',
+        layout_uid: 'old-layout',
+        layout_name: 'Old Layout',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 200,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'navigation_timeout');
+    assert.equal(result.verified, false);
+    assert.ok(fixture.calls.some(call => call.marker === '__TV_MCP_LOAD_LAYOUT__'));
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_MENU__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_ACTION__').length, 0);
+    assert.equal(fixture.reconnectCount, 1);
+  });
+
+  it('uses the internal fallback when the native Open action is unavailable before selection', async () => {
+    const fixture = makeDeps({ menu: { clicked: true }, action: { clicked: false } });
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 4000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.source, 'internal_api');
+    assert.equal(result.fallback_used, true);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__').length, 0);
+  });
+
+  it('uses the internal fallback when the native row is unavailable before selection', async () => {
+    const fixture = makeDeps({ menu: { clicked: true }, action: { clicked: true }, selected: { selected: false } });
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 4000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.source, 'internal_api');
+    assert.equal(result.fallback_used, true);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 1);
+    assert.ok(fixture.calls.some(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__'));
+  });
+
+  it('uses the native Open layout route first when the internal API is unavailable', async () => {
+    const fixture = makeDeps({
+      internal: { status: 'unavailable', source: 'internal_api' },
+      menu: { clicked: true },
+      action: { clicked: true },
+      selected: { selected: true, id: '24681012', url_layout_id: 'native-short-id', name: 'Analysis - Stock Database' },
+      snapshots: [verifiedSnapshot({
+        url: 'https://www.tradingview.com/chart/native-short-id/',
+        url_layout_id: 'native-short-id',
+        layout_id: 24681012,
+        layout_uid: 'native-short-id',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.verified, true);
+    assert.equal(result.source, 'native_ui');
+    assert.equal(result.method, 'open_layout_ui');
+    assert.equal(result.fallback_used, false);
+    assert.equal(result.layout_id, '24681012');
+    assert.equal(result.url_layout_id, 'native-short-id');
+    assert.equal(fixture.reconnectCount, 1);
+    assert.ok(fixture.calls.some(call => call.marker === '__TV_MCP_NATIVE_OPEN_MENU__'));
+    assert.ok(fixture.calls.some(call => call.marker === '__TV_MCP_NATIVE_OPEN_ACTION__'));
+    assert.ok(fixture.calls.some(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__'));
+    const actionExpression = fixture.calls.find(call => call.marker === '__TV_MCP_NATIVE_OPEN_ACTION__').expression;
+    assert.match(actionExpression, /a, \[role="row"\]/);
+    assert.match(actionExpression, /\[role="gridcell"\]/);
+    assert.match(actionExpression, /label\.indexOf\('open layout\.\.\.'\) === 0/);
+    const selectExpression = fixture.calls.find(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__').expression;
+    assert.match(selectExpression, /\[role="dialog"\]\[data-name="load-layout-dialog"\]/);
+    assert.match(selectExpression, /\[role="searchbox"\]\[placeholder="Search"\]/);
+    assert.match(selectExpression, /querySelectorAll\('\[data-name="list-item-title"\]'\)/);
+    assert.match(selectExpression, /text\(nodes\[i\]\)\.toLowerCase\(\) === target\.toLowerCase\(\)/);
+    assert.match(selectExpression, /visible\(nodes\[i\]\)/);
+    assert.match(selectExpression, /closest\('\[data-name="load-chart-dialog-item"\]\[data-role="list-item"\]/);
+    assert.match(selectExpression, /var href = item\.getAttribute\('href'\)/);
+    assert.match(selectExpression, /new URL\(href, currentUrl\.href\)/);
+    assert.ok(selectExpression.includes(String.raw`currentUrl.protocol === 'https:' && /(^|\.)tradingview\.com$/i.test(currentUrl.hostname)`));
+    assert.match(selectExpression, /\|\| !safeUrl/);
+    assert.match(selectExpression, /safeUrl\.protocol !== 'https:'/);
+    assert.match(selectExpression, /safeUrl\.origin !== currentUrl\.origin/);
+    assert.ok(selectExpression.includes(String.raw`safeUrl.pathname.match(/^\/chart\/([A-Za-z0-9_-]+)\/$/)`));
+    assert.match(selectExpression, /safeUrl\.search/);
+    assert.match(selectExpression, /safeUrl\.hash/);
+    assert.match(selectExpression, /return \{ selected: false, unsafe_href: true \}/);
+    assert.match(selectExpression, /var urlLayoutId = pathMatch\[1\]/);
+    assert.match(selectExpression, /window\.location\.assign\(safeUrl\.href\)/);
+    assert.doesNotMatch(selectExpression, /item\.click\(\)/);
+    assert.equal((selectExpression.match(/window\.location\.assign\(/g) || []).length, 1);
+    const navigationPrimitives = selectExpression.match(/window\.location\.(?:assign|replace)\(|window\.location\.href\s*=|window\.open\(|item\.click\(/g) || [];
+    assert.equal(navigationPrimitives.length, 1);
+    assert.match(selectExpression, /url_layout_id: urlLayoutId/);
+    assert.match(selectExpression, /id: id \|\| null/);
+    assert.match(selectExpression, /name: text\(title\)/);
+    assert.deepEqual(fixture.calls.find(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__').options, { retry: false, expectedTargetId: 'stable-target', timeoutMs: 1000 });
+  });
+
+  it('fails closed when the exact native row has an unsafe or off-origin href', async () => {
+    const fixture = makeDeps({
+      internal: { status: 'unavailable', source: 'internal_api' },
+      menu: { clicked: true },
+      action: { clicked: true },
+      selected: { selected: false, unsafe_href: true },
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'chart_api_not_ready');
+    assert.match(result.error, /unsafe or off-origin href/);
+    assert.equal(result.source, 'native_ui');
+    assert.equal(result.fallback_used, false);
+    assert.equal(fixture.reconnectCount, 0);
+    assert.ok(!fixture.calls.some(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__'));
+  });
+
+  it('verifies a native selection outcome_unknown after reconnect without replaying any mutation', async () => {
+    const selectError = Object.assign(new Error('target navigated during native selection'), {
+      reason: 'navigation_invalidated',
+      outcome_unknown: true,
+    });
+    const fixture = makeDeps({
+      internal: { status: 'resolved', source: 'internal_api', id: 24681012, url_layout_id: 'native-short-id', name: 'Analysis - Stock Database' },
+      menu: { clicked: true },
+      action: { clicked: true },
+      selectError,
+      snapshots: [verifiedSnapshot({
+        layout_id: 24681012,
+        layout_uid: 'native-short-id',
+        url_layout_id: 'native-short-id',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.verified, true);
+    assert.equal(result.outcome_unknown_recovered, true);
+    assert.equal(result.layout_id, 24681012);
+    assert.equal(fixture.reconnectCount, 1);
+    for (const marker of [
+      '__TV_MCP_NATIVE_OPEN_MENU__',
+      '__TV_MCP_NATIVE_OPEN_ACTION__',
+      '__TV_MCP_NATIVE_SELECT_LAYOUT__',
+    ]) {
+      assert.equal(fixture.calls.filter(call => call.marker === marker).length, 1, `${marker} was not replayed`);
+    }
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').length, 2);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 0);
+  });
+
+  it('fails closed after an unverifiable native selection outcome_unknown without replaying selection', async () => {
+    const selectError = Object.assign(new Error('target navigated during native selection'), {
+      reason: 'navigation_invalidated',
+      outcome_unknown: true,
+    });
+    const fixture = makeDeps({
+      internal: { status: 'resolved', source: 'internal_api', id: 24681012, url_layout_id: 'native-short-id', name: 'Analysis - Stock Database' },
+      menu: { clicked: true },
+      action: { clicked: true },
+      selectError,
+      snapshots: [verifiedSnapshot({
+        url_layout_id: 'different-layout',
+        layout_id: 11223344,
+        layout_uid: 'different-layout',
+        layout_name: 'Different Layout',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 700,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'navigation_timeout');
+    assert.equal(result.outcome_unknown, true);
+    assert.equal(fixture.reconnectCount, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_MENU__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_ACTION__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 0);
+  });
+
+  it('verifies an internal outcome_unknown using the remaining deadline without native replay', async () => {
+    const internalLoadError = Object.assign(new Error('target navigated during internal layout load'), {
+      reason: 'navigation_invalidated',
+      outcome_unknown: true,
+    });
+    const fixture = makeDeps({ internalLoadError });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.source, 'internal_api');
+    assert.equal(result.method, 'loadChartFromServer');
+    assert.equal(result.outcome_unknown_recovered, true);
+    assert.equal(result.fallback_used, true);
+    assert.equal(fixture.reconnectCount, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_MENU__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_ACTION__').length, 0);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__').length, 0);
+  });
+
+  it('fails closed after an unverifiable internal outcome_unknown without native replay', async () => {
+    const internalLoadError = Object.assign(new Error('target navigated during internal layout load'), {
+      reason: 'navigation_invalidated',
+      outcome_unknown: true,
+    });
+    const fixture = makeDeps({
+      internalLoadError,
+      snapshots: [verifiedSnapshot({
+        url: 'https://www.tradingview.com/chart/different-layout/',
+        url_layout_id: 'different-layout',
+        layout_name: 'Different Layout',
+        layout_uid: 'different-layout',
+      })],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 700,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'navigation_timeout');
+    assert.equal(result.outcome_unknown, true);
+    assert.equal(result.source, 'internal_api');
+    assert.equal(result.fallback_used, true);
+    assert.equal(fixture.reconnectCount, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').length, 3, 'verification used the full remaining deadline');
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_MENU__').length, 1);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_ACTION__').length, 0);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__').length, 0);
+  });
+
+  it('retains the internal numeric id after a verified native fallback row without one', async () => {
+    const oldSnapshot = verifiedSnapshot({
+      url: 'https://www.tradingview.com/chart/old-short-id/',
+      url_layout_id: 'old-short-id',
+      layout_id: 11223344,
+      layout_uid: 'old-short-id',
+      layout_name: 'Old Layout',
+    });
+    const switchedSnapshot = verifiedSnapshot({
+      url: 'https://www.tradingview.com/chart/native-short-id/',
+      url_layout_id: 'native-short-id',
+      layout_id: 91305550,
+      layout_uid: 'native-short-id',
+    });
+    const fixture = makeDeps({
+      internal: {
+        status: 'resolved',
+        source: 'internal_api',
+        id: 91305550,
+        url_layout_id: 'native-short-id',
+        name: 'Analysis - Stock Database',
+      },
+      menu: { clicked: true },
+      action: { clicked: true },
+      selected: { selected: true, id: 'native-short-id', url_layout_id: 'native-short-id', name: 'Analysis - Stock Database' },
+      snapshots: [oldSnapshot, oldSnapshot, oldSnapshot, oldSnapshot, oldSnapshot, switchedSnapshot, switchedSnapshot],
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 3000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.source, 'native_ui');
+    assert.equal(result.fallback_used, false);
+    assert.equal(result.layout_id, 91305550);
+    assert.equal(result.url_layout_id, 'native-short-id');
+    assert.equal(result.observed.layout_id, 91305550);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LOAD_LAYOUT__').length, 0);
+  });
+
+  it('does not treat ordinary dialog-named buttons as modal containers and waits for a real modal to close', async () => {
+    const fixture = makeDeps({
+      snapshots: [
+        verifiedSnapshot({ visible_modal: true }),
+        verifiedSnapshot(),
+        verifiedSnapshot(),
+      ],
+      unsaved: { dismissed: false },
+    });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 4000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').length, 3);
+    for (const marker of ['__TV_MCP_LAYOUT_SNAPSHOT__', '__TV_MCP_UNSAVED_DIALOG__']) {
+      const expression = fixture.calls.find(call => call.marker === marker).expression;
+      assert.match(expression, /dialogContainer\(dialogs\[/);
+      assert.match(expression, /element\.matches\('button, \[role="button"\], a, input, select, textarea'\)/);
+      assert.match(expression, /style\.display === 'none'/);
+      assert.match(expression, /style\.visibility === 'hidden'/);
+      assert.match(expression, /opacity <= 0/);
+    }
+  });
+
+  it('fails closed on the wrong optional pane signature', async () => {
+    const fixture = makeDeps();
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      expected_pane_signature: '4|1D,1D,1D,1D',
+      timeout_ms: 500,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'navigation_timeout');
+    assert.equal(fixture.disconnectCount, 1);
+    assert.equal(result.fallback_used, true);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_NATIVE_OPEN_MENU__').length, 1);
+  });
+
+  it('fails closed on the wrong optional symbol', async () => {
+    const fixture = makeDeps();
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      expected_symbol: 'MSFT',
+      timeout_ms: 500,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'navigation_timeout');
+  });
+
+  it('returns layout_not_found when neither route resolves the requested layout', async () => {
+    const fixture = makeDeps({
+      internal: { status: 'not_found', source: 'internal_api' },
+      menu: { clicked: true },
+      action: { clicked: true },
+      selected: { selected: false },
+    });
+
+    const result = await layoutSwitch({
+      name: 'Does Not Exist',
+      timeout_ms: 4000,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'layout_not_found');
+  });
+
+  it('requires consecutive stable postcondition polls before internal success', async () => {
+    const unstable = verifiedSnapshot({ geometry_signature: '0:0:500:800|500:0:700:800' });
+    const stable = verifiedSnapshot();
+    const fixture = makeDeps({ snapshots: [unstable, stable, stable] });
+
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 1500,
+      _deps: fixture._deps,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.verified, true);
+    assert.equal(result.source, 'internal_api');
+    assert.equal(result.stable_polls, 2);
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').length, 3);
+  });
+
+  it('fences a hanging operation at the hard overall deadline', async () => {
+    let disconnectCount = 0;
+    const result = await layoutSwitch({
+      name: 'Analysis - Stock Database',
+      timeout_ms: 50,
+      _deps: {
+        getTargetInfo: async () => ({ id: 'target-A' }),
+        evaluateAsync: async () => new Promise(() => {}),
+        disconnect: async () => { disconnectCount++; },
+      },
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.reason, 'navigation_timeout');
+    assert.equal(disconnectCount, 1);
+  });
+
+  it('returns a bounded read-only authoritative snapshot', async () => {
+    const fixture = makeDeps();
+    const snapshot = await getLayoutSnapshot({ timeout_ms: 750, _deps: fixture._deps });
+
+    assert.equal(snapshot.layout_name, 'Analysis - Stock Database');
+    assert.equal(snapshot.target_id, 'stable-target');
+    assert.equal(fixture.calls.filter(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').length, 1);
+    assert.deepEqual(fixture.calls.find(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').options, {
+      retry: true,
+      timeoutMs: 750,
+    });
+    assert.ok(!fixture.calls.some(call => call.marker === '__TV_MCP_LOAD_LAYOUT__'));
+    assert.ok(!fixture.calls.some(call => call.marker === '__TV_MCP_NATIVE_SELECT_LAYOUT__'));
+  });
+
+  it('associates render surfaces with their own pane instead of using a global canvas count', async () => {
+    function element({ tag = 'div', dataName = '', rect = { x: 0, y: 0, width: 600, height: 800 }, children = [] } = {}) {
+      const node = {
+        nodeType: 1,
+        tagName: tag.toUpperCase(),
+        parentElement: null,
+        children,
+        getBoundingClientRect: () => rect,
+        getAttribute: name => name === 'data-name' ? dataName : null,
+        matches(selector) {
+          return selector.split(',').some(part => {
+            const value = part.trim();
+            return (value === 'canvas' && tag === 'canvas')
+              || (value === '[data-name="pane-canvas"]' && dataName === 'pane-canvas')
+              || (value === '[data-name="chart-container"]' && dataName === 'chart-container');
+          });
+        },
+        querySelectorAll(selector) {
+          const found = [];
+          function visit(child) {
+            if (child.matches(selector)) found.push(child);
+            child.children.forEach(visit);
+          }
+          children.forEach(visit);
+          return found;
+        },
+        querySelector(selector) { return this.querySelectorAll(selector)[0] || null; },
+      };
+      children.forEach(child => { child.parentElement = node; });
+      return node;
+    }
+
+    const firstPane = element({ children: [element({ tag: 'canvas' }), element({ tag: 'canvas' })] });
+    const blankPane = element({ rect: { x: 600, y: 0, width: 600, height: 800 } });
+    const unrelatedCanvas = element({ tag: 'canvas' });
+    const series = { symbol: () => 'NASDAQ:AAPL', interval: () => '1D' };
+    const widgets = [firstPane, blankPane].map(_mainDiv => ({
+      _mainDiv,
+      model: () => ({ mainSeries: () => series }),
+    }));
+    const collection = {
+      getAll: () => widgets,
+      _layoutType: '2h',
+      metaInfo: { uid: 'layout-id', name: 'Analysis - Stock Database' },
+    };
+    const window = {
+      TradingViewApi: {
+        _chartWidgetCollection: collection,
+        _activeChartWidgetWV: { value: () => ({ symbol() {}, resolution() {} }) },
+      },
+      location: { href: 'https://www.tradingview.com/chart/layout-id/' },
+      getComputedStyle: () => ({ display: 'block', visibility: 'visible', opacity: '1' }),
+    };
+    const document = {
+      querySelector: () => null,
+      querySelectorAll(selector) {
+        if (selector === '[data-name="chart-container"]') return [];
+        if (selector === '[data-name="pane-canvas"], canvas') return [
+          ...firstPane.children,
+          unrelatedCanvas,
+        ];
+        return [];
+      },
+    };
+
+    const fixture = makeDeps();
+    await getLayoutSnapshot({ timeout_ms: 750, _deps: fixture._deps });
+    const expression = fixture.calls.find(call => call.marker === '__TV_MCP_LAYOUT_SNAPSHOT__').expression;
+    const snapshot = Function('window', 'document', `return (${expression});`)(window, document);
+
+    assert.deepEqual(snapshot.panes.map(pane => pane.surface_ready), [true, false]);
+    assert.equal(snapshot.blank_chart, true);
+  });
+});
+
+describe('layout identity matching', () => {
+  it('allows an exact name only when the expected layout has no authoritative identifier', () => {
+    assert.equal(layoutIdentityMatches(
+      { name: 'Analysis - Stock Database' },
+      { layout_name: 'Analysis - Stock Database' },
+    ), true);
+  });
+
+  it('fails closed when an expected numeric identifier disappears even if the name matches', () => {
+    assert.equal(layoutIdentityMatches(
+      { id: 987654321, name: 'Analysis - Stock Database' },
+      { layout_id: null, layout_uid: null, url_layout_id: null, layout_name: 'Analysis - Stock Database' },
+    ), false);
+  });
+
+  it('fails closed when an expected URL identifier disappears even if the name matches', () => {
+    assert.equal(layoutIdentityMatches(
+      { url_layout_id: 'short-AbC12', name: 'Analysis - Stock Database' },
+      { layout_id: null, layout_uid: null, url_layout_id: null, layout_name: 'Analysis - Stock Database' },
+    ), false);
+  });
+
+  it('treats observed numeric IDs as authoritative when both numeric IDs exist', () => {
+    assert.equal(layoutIdentityMatches(
+      { id: 987654321, url_layout_id: 'short-AbC12', name: 'Analysis - Stock Database' },
+      { layout_id: 111111111, layout_uid: 'short-AbC12', url_layout_id: 'short-AbC12', layout_name: 'Analysis - Stock Database' },
+    ), false);
+  });
+});
+
+describe('post-screenshot layout canary verification', () => {
+  function switched(snapshot = verifiedSnapshot()) {
+    return {
+      layout: 'Analysis - Stock Database',
+      layout_id: snapshot.layout_id,
+      url_layout_id: snapshot.url_layout_id,
+      observed: snapshot,
+    };
+  }
+
+  it('fails when a non-active pane changes', () => {
+    const baseline = verifiedSnapshot();
+    const changed = structuredClone(baseline);
+    changed.panes[1].symbol = 'NASDAQ:MSFT';
+    assert.throws(
+      () => assertPostScreenshotSnapshot('database', switched(baseline), changed),
+      /pane symbols or resolutions changed/,
+    );
+  });
+
+  it('fails when the layout identity changes', () => {
+    const baseline = verifiedSnapshot();
+    const changed = verifiedSnapshot({
+      url_layout_id: 'other-layout',
+      layout_uid: 'other-layout',
+      layout_name: 'Other Layout',
+    });
+    assert.throws(
+      () => assertPostScreenshotSnapshot('database', switched(baseline), changed),
+      /layout identity changed/,
+    );
+  });
+
+  it('fails when pane geometry changes', () => {
+    const baseline = verifiedSnapshot();
+    const changed = verifiedSnapshot({ geometry_signature: '0:0:500:800|500:0:700:800' });
+    assert.throws(
+      () => assertPostScreenshotSnapshot('database', switched(baseline), changed),
+      /pane geometry changed/,
+    );
+  });
+
+  it('fails when one pane is blank after the screenshot', () => {
+    const baseline = verifiedSnapshot();
+    const changed = structuredClone(baseline);
+    changed.panes[1].surface_ready = false;
+    changed.blank_chart = true;
+    assert.throws(
+      () => assertPostScreenshotSnapshot('database', switched(baseline), changed),
+      /snapshot was not stable/,
+    );
+  });
+
+  it('fails when the fresh post-screenshot snapshot comes from another target', () => {
+    const baseline = verifiedSnapshot({ target_id: 'target-A' });
+    const changed = verifiedSnapshot({ target_id: 'target-B' });
+    assert.throws(
+      () => assertPostScreenshotSnapshot('database', switched(baseline), changed),
+      /chart target changed/,
+    );
+  });
+});

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Summary
- bound CDP discovery/connect/evaluate operations and fence late/stale clients
- prevent replay of uncertain mutations while allowing one bounded retry for explicit read-only evaluations
- pin recovery and verification to the original TradingView target
- replace false-positive layout switching with verified native navigation plus fail-closed internal fallback
- fix `symbolInfo` evaluator regression and graceful CLI cleanup/exit status
- add deterministic connection/layout regressions and a live three-layout canary

## Verification
- `npm test`: **179/179 passed**
- `npm run test:layout-canary`: **3/3 layouts passed**
  - Analysis - Stock Database
  - Analysis - Peers
  - Analysis - Against Index
- independent blocking review: **0 HIGH / 0 MEDIUM**
- restored TradingView to **Analysis - Stock Database / NASDAQ:ARW / 1D**

## Safety
- no mutation replay after uncertain outcomes
- authoritative IDs and CDP target lineage fail closed
- fresh post-screenshot verification checks all panes, geometry, render surfaces, loading/modal/invalid state
- pre-existing local `package-lock.json` change was preserved and excluded from this PR
