### PR TITLE
Add .env and .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 node_modules/
 screenshots/
+.env
 scripts/current.pine
 temp_*
 *.log
 discovery-log.json
 rules.json
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds `.env` and `.claude/settings.local.json` to `.gitignore` to prevent accidental commits of local secrets (Telegram bot tokens, API keys) and personal Claude Code permission settings.

## Test plan
- N/A (gitignore-only change, no code path affected)