### PR TITLE
fix(core): 7 exported functions threw ReferenceError on every call

### DIFF
--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -115,7 +115,8 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   }
 }
 
-export async function getVisibleRange() {
+export async function getVisibleRange({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};
@@ -157,7 +158,8 @@ export async function setVisibleRange({ from, to, _deps }) {
   return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
 }
 
-export async function scrollToDate({ date }) {
+export async function scrollToDate({ date, _deps }) {
+  const { evaluate } = _resolve(_deps);
   let timestamp;
   if (/^\d+$/.test(date)) timestamp = Number(date);
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
@@ -196,7 +198,8 @@ export async function scrollToDate({ date }) {
   return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
 }
 
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
   const result = await evaluate(`
     (function() {
       var chart = ${CHART_API};

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -44,7 +44,8 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   return { success: true, shape, entity_id: result?.entity_id };
 }
 
-export async function listDrawings() {
+export async function listDrawings({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const shapes = await evaluate(`
     (function() {
@@ -56,7 +57,8 @@ export async function listDrawings() {
   return { success: true, count: shapes?.length || 0, shapes: shapes || [] };
 }
 
-export async function getProperties({ entity_id }) {
+export async function getProperties({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -85,7 +87,8 @@ export async function getProperties({ entity_id }) {
   return { success: true, ...result };
 }
 
-export async function removeOne({ entity_id }) {
+export async function removeOne({ entity_id, _deps }) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   const result = await evaluate(`
     (function() {
@@ -106,7 +109,8 @@ export async function removeOne({ entity_id }) {
   return { success: true, entity_id: result?.entity_id, removed: result?.removed, remaining_shapes: result?.remaining_shapes };
 }
 
-export async function clearAll() {
+export async function clearAll({ _deps } = {}) {
+  const { evaluate, getChartApi } = _resolve(_deps);
   const apiPath = await getChartApi();
   await evaluate(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };


### PR DESCRIPTION
## The bug

Seven exported functions call bare `evaluate` / `getChartApi`. Those identifiers don't exist in either module — both import them **aliased**:

```js
import { evaluate as _evaluate, getChartApi as _getChartApi, ... } from '../connection.js';
```

and reach them via `_resolve(_deps)`, as every other exported function in both files does. So these seven threw on entry, on every call:

```
listDrawings     ReferenceError: getChartApi is not defined
getProperties    ReferenceError: getChartApi is not defined
removeOne        ReferenceError: getChartApi is not defined
clearAll         ReferenceError: getChartApi is not defined
getVisibleRange  ReferenceError: evaluate is not defined
scrollToDate     ReferenceError: evaluate is not defined
symbolInfo       ReferenceError: evaluate is not defined
```

Reproduced by importing the pre-fix modules directly and calling each one. `getState`, which already resolved deps correctly, is unaffected — so this is specific to these seven rather than a module-loading problem.

This reaches the MCP surface: `draw_list`, `draw_get_properties`, `draw_remove_one`, `draw_clear`, `chart_get_visible_range`, `chart_scroll_to_date` and `symbol_info` all fail.

## The fix

Adds the missing `_deps` parameter and `_resolve(_deps)` line to each, matching the surrounding convention exactly:

```js
-export async function symbolInfo() {
+export async function symbolInfo({ _deps } = {}) {
+  const { evaluate } = _resolve(_deps);
```

Signatures use `({ _deps } = {})` where the function previously took no argument, so existing no-arg call sites are unchanged. 2 files, +14/−7, no dependency or API-surface changes.

## Verification

Against a live TradingView session, after the fix:

| Tool | Result |
|---|---|
| `symbol_info` | `CME_MINI:ES1!` — E-mini S&P 500 Futures, full metadata |
| `chart_get_visible_range` | real `visible_range` + `bars_range` timestamps |
| `draw_list` | `{ success: true, count: 0, shapes: [] }` |

`listDrawings` also verified to accept injected `_deps`, which was impossible before.

**Not exercised:** `removeOne` and `clearAll` are destructive, and `getProperties` needs an existing drawing (the chart had none). I also did not run the repo's own test suite — it drives the attached chart into Bar Replay, which is disruptive on a machine with a live session. Left to CI / maintainer judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)