### PR TITLE
docs(security): add MCP trust architecture threat model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,21 @@ This project connects to a locally running TradingView Desktop instance via Chro
 - Chrome DevTools Protocol security (report to Google/Chromium)
 - Claude Code or MCP SDK security (report to Anthropic)
 
+## MCP Trust Architecture
+
+This project is a local bridge, not a security boundary. The trust model is intentionally narrow: the user controls the machine, the MCP server executes locally, and TradingView Desktop is the only runtime target on `localhost:9222`.
+
+| Actor | Capability | Exposure | Mitigation | Residual limitation |
+|---|---|---|---|---|
+| Local user / operator | Can launch the server, pass CLI/MCP inputs, and edit the config | Can cause the bridge to read local chart state or issue UI actions in TradingView | Keep the bridge local-only; require explicit user setup; keep CDP on localhost | Any local user with machine access can still operate the bridge |
+| Prompted LLM / agent | Can supply arbitrary tool arguments and text payloads | Could attempt injection through evaluated strings or malformed inputs | Escape user strings with `safeString()`, validate numeric inputs, prefer narrow tool scopes | Model output can still be wrong, incomplete, or overly confident |
+| TradingView Desktop UI | Renders chart state, indicators, dialogs, and account/session content | MCP tools can observe and interact with whatever the UI exposes | Use explicit selectors, limit reads to visible UI, and verify results before acting | UI refactors can break selectors or change observed state without warning |
+| Network-local attacker | Can only reach the bridge if the operator exposes CDP beyond localhost | Could observe or interfere with CDP traffic if the port is misconfigured | Bind CDP to localhost and do not expose port 9222 to the network | If the port is exposed, CDP is not protected by this project |
+
 ## Best Practices for Users
 
 - Only run TradingView with `--remote-debugging-port=9222` on localhost
 - Do not expose port 9222 to your network or the internet
 - Do not pipe `tv stream` output to external services without reviewing the data
 - Keep your TradingView Desktop and Node.js installations up to date
+


### PR DESCRIPTION
## Summary

Adds a short, documentation-only threat model to SECURITY.md for the MCP trust boundary.

The new section clarifies:
- the local-only trust model,
- what each actor can and cannot do,
- the main exposure points,
- the mitigation already in place,
- the residual limitations that remain by design.

## What changed

- Added an MCP Trust Architecture section to SECURITY.md
- Included a compact threat-model table with:
  - actor
  - capability
  - exposure
  - mitigation
  - residual limitation

## Scope

Documentation only. No runtime code changes.

## Testing

Not applicable.