### PR TITLE
ci: make the high-severity audit gate blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,7 @@ jobs:
         run: npm run test:unit
 
       - name: Audit (high severity)
+        # Blocking on purpose. A high-severity advisory can appear against a
+        # lockfile nobody touched, so an advisory-only step is never seen.
+        # --audit-level=high keeps moderate and low findings non-blocking.
         run: npm audit --audit-level=high
-        continue-on-error: true


### PR DESCRIPTION
## Problem

The audit step is configured so it can never fail:

```yaml
      - name: Audit (high severity)
        run: npm audit --audit-level=high
        continue-on-error: true
```

`continue-on-error: true` means high-severity advisories are printed and the run
goes green anyway. The gate is installed but disabled, which is indistinguishable
from not having one — except that it looks like coverage.

## This is live on the current tree

Against `package-lock.json` at `c05b8f5`:

```
npm audit --package-lock-only --audit-level=high
→ exit 1
```

Seven advisories, four high — `brace-expansion`, `fast-uri`, `ip-address`,
`js-yaml` — and **five of the seven reach production dependencies**, not just
devDependencies. Every CI run has been green the whole time.

## Change

Remove the one line. `--audit-level=high` is untouched, so moderate and low
findings remain non-blocking.

## This PR cannot be green on its own

The base lockfile fails today, so CI here will be red until a lockfile refresh
lands first. **#445 clears all of them** — I verified it directly:

```
git fetch origin refs/pull/445/head
npm audit --package-lock-only --audit-level=high
→ exit 0
```

So the merge order is #445, then this. The red run on this PR is the gate doing
its job, not a defect in the change. If you'd rather see it green before merging,
say so and I'll rebase it on #445.

## Tradeoff, stated plainly

With this in place, an advisory published against a lockfile nobody touched will
turn unrelated PRs red until someone refreshes it. That is the intended behavior
and it is exactly how the current drift would have surfaced — but on a repo with
this many open PRs it is a real cost, so it should be a deliberate choice rather
than a surprise.

If blocking every pull request is too aggressive, the alternative shape is to
keep `pull_request` advisory and make the gate blocking on `push` plus a
scheduled run. That still catches drift without gating contributors. I'm happy to
switch to that instead — this PR takes the simpler position because the smallest
change that fixes the stated problem seemed like the right default.

## Verification

- `npm audit --package-lock-only --audit-level=high` on `c05b8f5` → exit 1 (would now fail CI)
- same against `refs/pull/445/head` → exit 0 (would pass)
- workflow file: no tabs, 6 steps preserved, only the audit step touched
- no source, test, or dependency changes — CI configuration only
