### PR TITLE
fix(windows): launch MSIX TradingView with CDP and stop latching onto the wrong target

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -47,13 +47,31 @@ Mac:
 
 Windows:
 
-TradingView for Windows now ships **only as an MSIX package** (Microsoft Store and tvd-packages.tradingview.com both install under `C:\Program Files\WindowsApps\`). Use the launch script — it resolves the install via `Get-AppxPackage`, which works without admin rights:
+TradingView for Windows now ships **only as an MSIX package** (Microsoft Store and tvd-packages.tradingview.com both install under `C:\Program Files\WindowsApps\`). Use the launch script — no admin rights needed:
 
-```bat
-scripts\launch_tv_debug.bat
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\launch_tv_debug.ps1
 ```
 
-Or, preferred: let the `tv_launch` MCP tool do it — it auto-detects MSIX installs and, on Windows builds where launching from `WindowsApps` is blocked with **"Access is denied"**, automatically copies the package to `%LOCALAPPDATA%\tradingview-mcp\` (one-time, ~330MB) and launches from the copy. The copy keeps your login, layout, and chart state. If the fallback was used, the result includes `msix_local_copy: true`.
+It stops any running instance, COM-activates the package with the debug flag, and waits until the port actually binds before reporting success. `scripts\launch_tv_debug.vbs` is a double-clickable wrapper around the same script; `scripts\launch_tv_debug.bat` remains for legacy non-MSIX installs.
+
+**Why a dedicated launcher is needed.** An MSIX app under `WindowsApps` cannot be started with command-line arguments the usual ways:
+
+| Approach | Result |
+|----------|--------|
+| Run the exe directly | **Access is denied** — those ACLs allow execution only via package activation |
+| `explorer.exe shell:AppsFolder\...` | Activates, but provides no way to pass arguments |
+| `Invoke-CommandInDesktopPackage` | **ERROR_CANCELLED** (`0x800704C7`) on some builds, elevated or not |
+
+`IApplicationActivationManager::ActivateApplication` is the one activation path that forwards an argument string to a `Windows.FullTrustApplication` exe. That call lives in `scripts\activate_msix.ps1`, which the launcher and `tv_launch` both use.
+
+Note that a Start-menu launch produces a running chart with **no** debug port, which looks identical to a working one until a tool fails — so verify rather than assume:
+
+```powershell
+Get-NetTCPConnection -LocalPort 9222 -State Listen
+```
+
+Or, preferred: let the `tv_launch` MCP tool do it. It tries a direct spawn, then COM activation (`msix_activation: true` in the result), and finally — on Windows builds where activation accepts the flag but the port never binds — copies the package to `%LOCALAPPDATA%\tradingview-mcp\` (one-time, ~330MB) and launches from the copy (`msix_local_copy: true`). The copy keeps your login, layout, and chart state.
 
 Manual equivalent of that fallback, if you need it:
 
@@ -115,7 +133,9 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 | Problem | Solution |
 |---------|----------|
 | `cdp_connected: false` | Launch TradingView with `--remote-debugging-port=9222` |
-| Windows: "Access is denied" launching from `WindowsApps` | Use `tv_launch` (auto copy-fallback) or the manual copy snippet in Step 3 — never `icacls` on WindowsApps |
+| Windows: "Access is denied" launching from `WindowsApps` | Expected — use `scripts\launch_tv_debug.ps1` or `tv_launch`; never `icacls` on WindowsApps |
+| Windows: `Invoke-CommandInDesktopPackage` fails with `0x800704C7` | Known-broken on some builds regardless of elevation; use `scripts\launch_tv_debug.ps1` instead |
+| Windows: app is running but `cdp_connected: false` | It was started without the flag (e.g. from the Start menu). Re-launch via `scripts\launch_tv_debug.ps1` — the port cannot be added to a running instance |
 | `ECONNREFUSED` | TradingView isn't running or port 9222 is blocked |
 | MCP server not showing in Claude Code | Check `~/.claude/.mcp.json` syntax, restart Claude Code |
 | `tv` command not found | Run `npm link` from the project directory |

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/connection.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/connection.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/scripts/activate_msix.ps1
+++ b/scripts/activate_msix.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+Activate an MSIX-packaged TradingView with command-line arguments (e.g. the CDP debug port).
+
+.DESCRIPTION
+MSIX/Store apps installed under C:\Program Files\WindowsApps cannot be launched the
+usual ways with arguments:
+
+  - running the exe directly       -> "Access is denied" (WindowsApps ACLs allow
+                                      execution only through package activation)
+  - explorer.exe shell:AppsFolder  -> activates, but provides no way to pass arguments
+  - Invoke-CommandInDesktopPackage -> fails with ERROR_CANCELLED (0x800704C7) on some
+                                      builds, elevated or not
+
+IApplicationActivationManager::ActivateApplication is the activation path that does
+forward an argument string, and for a Windows.FullTrustApplication entry point those
+arguments land on the exe's command line.
+
+Does NOT kill an existing instance and does NOT wait for CDP — Electron's
+single-instance lock means activating while an instance is running just focuses the
+existing window, so the caller is responsible for stopping it first.
+See launch_tv_debug.ps1 for the full kill/activate/verify flow.
+
+.OUTPUTS
+One line of JSON: {"pid":<int>,"aumid":"<string>","arguments":"<string>"}
+
+.EXAMPLE
+powershell -NoProfile -ExecutionPolicy Bypass -STA -File scripts\activate_msix.ps1 -Port 9222
+#>
+[CmdletBinding()]
+param(
+    [int]$Port = 9222,
+    [string]$PackageName = 'TradingView.Desktop',
+    [string]$Arguments
+)
+
+$ErrorActionPreference = 'Stop'
+
+# COM activation requires an STA thread. powershell.exe is STA by default, but a
+# caller may have started us with -MTA (or invoked us from a runspace that is MTA),
+# so re-enter with -STA rather than failing confusingly.
+if ([Threading.Thread]::CurrentThread.GetApartmentState() -eq 'MTA') {
+    $self = $MyInvocation.MyCommand.Path
+    $reArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-STA', '-File', $self,
+                '-Port', $Port, '-PackageName', $PackageName)
+    if ($Arguments) { $reArgs += @('-Arguments', $Arguments) }
+    & powershell.exe @reArgs
+    exit $LASTEXITCODE
+}
+
+if (-not $Arguments) { $Arguments = "--remote-debugging-port=$Port" }
+
+$pkg = Get-AppxPackage -Name $PackageName -ErrorAction SilentlyContinue
+if (-not $pkg) {
+    throw "MSIX package '$PackageName' is not installed for user $env:USERNAME. Run Get-AppxPackage to list installed packages."
+}
+
+# AUMID = <PackageFamilyName>!<Application Id from the manifest>. The family name is
+# version-independent, so this keeps working across app updates (unlike InstallLocation,
+# which carries the version number).
+$app = (Get-AppxPackageManifest $pkg).Package.Applications.Application | Select-Object -First 1
+if (-not $app -or -not $app.Id) {
+    throw "Could not read an Application Id from the manifest of '$PackageName'."
+}
+$aumid = "$($pkg.PackageFamilyName)!$($app.Id)"
+
+Add-Type -Language CSharp -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class MsixActivator
+{
+    [ComImport, Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+    private class ApplicationActivationManager { }
+
+    [ComImport, Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D"),
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IApplicationActivationManager
+    {
+        int ActivateApplication(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string arguments,
+            [In] uint options,
+            [Out] out uint processId);
+    }
+
+    public static uint Activate(string aumid, string arguments)
+    {
+        var mgr = (IApplicationActivationManager)new ApplicationActivationManager();
+        uint pid;
+        int hr = mgr.ActivateApplication(aumid, arguments, 0 /* AO_NONE */, out pid);
+        if (hr != 0) { Marshal.ThrowExceptionForHR(hr); }
+        return pid;
+    }
+}
+'@
+
+$activatedPid = [MsixActivator]::Activate($aumid, $Arguments)
+
+[pscustomobject]@{
+    pid       = [int]$activatedPid
+    aumid     = $aumid
+    arguments = $Arguments
+} | ConvertTo-Json -Compress

--- a/scripts/launch_tv_debug.ps1
+++ b/scripts/launch_tv_debug.ps1
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+Launch TradingView Desktop on Windows with the Chrome DevTools Protocol enabled.
+
+.DESCRIPTION
+Handles both install shapes:
+
+  classic install (LOCALAPPDATA / Program Files) -> run the exe with the flag directly
+  MSIX / Microsoft Store install                 -> COM-activate the package with the
+                                                    flag (see activate_msix.ps1)
+
+The debug port does not survive an app restart, so this has to be re-run whenever
+TradingView is started normally — a Start-menu launch produces a running chart with
+no debug port, which looks identical to a working one until a tool fails.
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts\launch_tv_debug.ps1
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File scripts\launch_tv_debug.ps1 -Port 9333
+#>
+[CmdletBinding()]
+param(
+    [int]$Port = 9222,
+    # Leave a running instance alone. Electron's single-instance lock means the flag
+    # will NOT be applied if an instance is already up, so this usually only makes
+    # sense when you know the running instance already has the port open.
+    [switch]$KeepExisting
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Find-ClassicExe {
+    $candidates = @(
+        "$env:LOCALAPPDATA\TradingView\TradingView.exe",
+        "$env:ProgramFiles\TradingView\TradingView.exe",
+        "${env:ProgramFiles(x86)}\TradingView\TradingView.exe"
+    )
+    foreach ($c in $candidates) { if (Test-Path $c) { return $c } }
+    return $null
+}
+
+if (-not $KeepExisting) {
+    $running = @(Get-Process -Name TradingView -ErrorAction SilentlyContinue)
+    if ($running.Count -gt 0) {
+        Write-Host "Stopping $($running.Count) running TradingView process(es)..."
+        $running | Stop-Process -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 3
+    }
+}
+
+$classic = Find-ClassicExe
+if ($classic) {
+    Write-Host "Found classic install: $classic"
+    Write-Host "Starting with --remote-debugging-port=$Port ..."
+    Start-Process -FilePath $classic -ArgumentList "--remote-debugging-port=$Port"
+} else {
+    $pkg = Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue
+    if (-not $pkg) {
+        Write-Error @"
+TradingView not found.
+Checked: %LOCALAPPDATA%\TradingView, %ProgramFiles%\TradingView, and the
+TradingView.Desktop MSIX package.
+
+If it is installed elsewhere, launch it manually with:
+  & "C:\path\to\TradingView.exe" --remote-debugging-port=$Port
+"@
+        exit 1
+    }
+    Write-Host "Found MSIX package: $($pkg.PackageFamilyName) (v$($pkg.Version))"
+    Write-Host "Activating with --remote-debugging-port=$Port ..."
+    $activate = Join-Path $PSScriptRoot 'activate_msix.ps1'
+    $result = & $activate -Port $Port | ConvertFrom-Json
+    Write-Host "Activated pid $($result.pid) via $($result.aumid)"
+}
+
+# 127.0.0.1 rather than localhost: on some machines localhost resolves to IPv6 ::1
+# first, and Electron's debug server only listens on IPv4.
+Write-Host "Waiting for CDP on port $Port ..."
+$deadline = (Get-Date).AddSeconds(45)
+$version = $null
+while ((Get-Date) -lt $deadline) {
+    try {
+        $version = Invoke-RestMethod -Uri "http://127.0.0.1:$Port/json/version" -TimeoutSec 2
+        break
+    } catch { Start-Sleep -Seconds 2 }
+}
+
+if (-not $version) {
+    Write-Error @"
+TradingView is running but CDP never became available on port $Port.
+Some Windows MSIX builds accept the flag without ever binding the port. Use the
+tv_launch MCP tool, which falls back to launching from a local copy of the package.
+"@
+    exit 1
+}
+
+Write-Host ""
+Write-Host "CDP ready at http://127.0.0.1:$Port"
+Write-Host "  Browser: $($version.Browser)"
+Write-Host "  Agent  : $($version.'User-Agent')"

--- a/scripts/launch_tv_debug.vbs
+++ b/scripts/launch_tv_debug.vbs
@@ -1,6 +1,33 @@
+' Double-clickable launcher for TradingView Desktop with the CDP debug port enabled.
+'
+' This used to set ELECTRON_EXTRA_LAUNCH_ARGS in its own process environment and then
+' launch via "explorer.exe shell:AppsFolder\...". That never worked: the request is
+' handed off to the already-running shell process, which never saw the variable, so
+' TradingView started with a clean environment and no debug port — while this script
+' still reported success. Promoting the variable to user scope does not help either.
+'
+' All the real work now lives in launch_tv_debug.ps1, which COM-activates the MSIX
+' package with the flag and verifies the port actually bound before reporting success.
+
+Option Explicit
+
+Dim oShell, oFS, sDir, sPs1, sCmd
+
 Set oShell = CreateObject("WScript.Shell")
-Set oEnv = oShell.Environment("Process")
-oEnv("ELECTRON_EXTRA_LAUNCH_ARGS") = "--remote-debugging-port=9222"
-oShell.Run "explorer.exe shell:AppsFolder\TradingView.Desktop_n534cwy3pjxzj!TradingView.Desktop", 1, False
-WScript.Sleep 1000
-WScript.Echo "Launched"
+Set oFS = CreateObject("Scripting.FileSystemObject")
+
+sDir = oFS.GetParentFolderName(WScript.ScriptFullName)
+sPs1 = oFS.BuildPath(sDir, "launch_tv_debug.ps1")
+
+If Not oFS.FileExists(sPs1) Then
+    WScript.Echo "Missing: " & sPs1
+    WScript.Quit 1
+End If
+
+' -NoExit keeps the window open so the CDP-ready output (or the failure reason) can
+' actually be read instead of flashing past. That means the process never exits on its
+' own, so do NOT wait on it (bWaitOnReturn = False) — waiting would hang this script
+' until the user closed the window, and the exit code of a -NoExit shell says nothing
+' about whether the launch worked anyway.
+sCmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -NoExit -File """ & sPs1 & """"
+oShell.Run sCmd, 1, False

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -105,7 +105,7 @@ export async function run(argv) {
       }
       await execute(handler, values, positionals);
     } catch (err) {
-      handleError(err);
+      await handleError(err);
     }
   } else {
     handler = cmd.handler;
@@ -123,28 +123,45 @@ export async function run(argv) {
       }
       await execute(handler, values, positionals);
     } catch (err) {
-      handleError(err);
+      await handleError(err);
     }
   }
+}
+
+/**
+ * Close the CDP connection, then let the event loop drain on its own.
+ *
+ * Calling process.exit() with a live CDP WebSocket tears libuv down mid-flight.
+ * Node 24 on Windows turns that into a hard
+ * "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src\win\async.c"
+ * crash *after* the command has already printed its result — the work succeeds
+ * but the process dies with 0xC0000409, so callers see a failure.
+ *
+ * The timer is a safety net for a handle that never releases; unref'd so it
+ * cannot itself keep the process alive.
+ */
+async function shutdown(code) {
+  try {
+    const { disconnect } = await import('../connection.js');
+    await disconnect();
+  } catch { /* connection.js never loaded, or nothing open */ }
+  process.exitCode = code;
+  setTimeout(() => process.exit(code), 2000).unref();
 }
 
 async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
     console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    await shutdown(0);
   } catch (err) {
-    handleError(err);
+    await handleError(err);
   }
 }
 
-function handleError(err) {
+async function handleError(err) {
   const message = err.message || String(err);
-  // Connection failures get exit code 2
-  if (/CDP|connection|ECONNREFUSED|not running/i.test(message)) {
-    console.error(JSON.stringify({ success: false, error: message }, null, 2));
-    process.exit(2);
-  }
   console.error(JSON.stringify({ success: false, error: message }, null, 2));
-  process.exit(1);
+  // Connection failures get exit code 2
+  await shutdown(/CDP|connection|ECONNREFUSED|not running/i.test(message) ? 2 : 1);
 }

--- a/src/connection.js
+++ b/src/connection.js
@@ -107,13 +107,33 @@ export async function reconnectTo(targetId) {
   return connect(targetId);
 }
 
+const CHART_URL_RE = /^https?:\/\/([a-z0-9-]+\.)*tradingview\.com\/chart/i;
+const TV_WEB_URL_RE = /^https?:\/\/([a-z0-9-]+\.)*tradingview\.com\//i;
+
+/**
+ * Pick the CDP target to drive, from a /json/list response.
+ *
+ * Both patterns are anchored at the scheme and matched against the tradingview.com
+ * host — never "tradingview" appearing anywhere in the URL. The desktop app has its
+ * own internal pages served from file:// under the install directory, and on Windows
+ * that path literally contains "TradingView.Desktop", so a loose match selects the
+ * app's browser-api-container instead of a chart. getClient() then caches that target
+ * and its liveness check keeps passing, so every later call reports
+ * api_available:false until the process restarts.
+ *
+ * Exported for testing; callers should use findChartTarget().
+ */
+export function pickChartTarget(targets) {
+  const pages = (targets || []).filter(t => t?.type === 'page' && typeof t.url === 'string');
+  // A real chart page, then any tradingview.com web page (screener, watchlist, ...).
+  return pages.find(t => CHART_URL_RE.test(t.url))
+    || pages.find(t => TV_WEB_URL_RE.test(t.url))
+    || null;
+}
+
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
-    || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
-    || null;
+  return pickChartTarget(await resp.json());
 }
 
 async function findTargetById(id) {

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -30,11 +30,25 @@ async function checkForUpdate() {
         req.setTimeout(3000, () => { req.destroy(); resolve(null); });
       });
       if (remoteSha) {
+        // A different HEAD is not the same as being out of date: a feature branch
+        // sitting ahead of origin's default branch needs no update, and telling the
+        // user to run tv_update there would move them off their own commits. Only
+        // report an update when the remote commit is not already contained in HEAD.
+        let outdated = remoteSha !== localSha;
+        if (outdated && /^[0-9a-f]{40}$/i.test(remoteSha)) {
+          try {
+            // Exits 0 when remoteSha is an ancestor of HEAD (we are ahead of it).
+            // Throws when it is not, or when the commit was never fetched — in which
+            // case we keep the plain "differs" answer.
+            execSync(`git merge-base --is-ancestor ${remoteSha} HEAD`, { timeout: 3000, stdio: 'ignore' });
+            outdated = false;
+          } catch { /* genuinely behind, or the commit is unknown locally */ }
+        }
         value = {
-          update_available: remoteSha !== localSha,
+          update_available: outdated,
           local_commit: localSha.slice(0, 8),
           latest_commit: remoteSha.slice(0, 8),
-          ...(remoteSha !== localSha && { hint: 'Run the tv_update tool (or `tv update` CLI) to update, then restart the MCP server.' }),
+          ...(outdated && { hint: 'Run the tv_update tool (or `tv update` CLI) to update, then restart the MCP server.' }),
         };
       }
     }
@@ -419,7 +433,10 @@ export async function launch({ port, kill_existing, _deps } = {}) {
       usedActivation = false;
       activatedPid = null;
       const localExe = _copyMsixPackageLocal(tvPath, deps);
-      await killExisting();
+      // Same contract as above: never kill an instance the caller asked us to keep.
+      // Without the kill the copy will usually lose to the single-instance lock and
+      // bind no port, which surfaces as the cdp_ready:false warning below.
+      if (killFirst) await killExisting();
       child = _spawnDetached(deps.spawn, localExe, cdpArgs);
       tvPath = localExe;
       usedLocalCopy = true;

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -5,6 +5,7 @@ import { getClient, getTargetInfo, evaluate, CDP_HOST, CDP_PORT } from '../conne
 import { existsSync, cpSync, rmSync, readdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { dirname, basename, join } from 'path';
+import { fileURLToPath } from 'url';
 
 // Best-effort git-pull update check: compare local HEAD to origin's default
 // branch on GitHub. Never throws — returns null on any failure (offline,
@@ -211,7 +212,32 @@ function _resolveLaunchDeps(deps) {
     readdirSync: deps?.readdirSync || readdirSync,
     delay: deps?.delay || ((ms) => new Promise((r) => setTimeout(r, ms))),
     probeCdp: deps?.probeCdp || _probeCdp,
+    activateMsix: deps?.activateMsix || _activateMsix,
   };
+}
+
+/**
+ * COM-activate the MSIX package with the CDP flag, via scripts/activate_msix.ps1.
+ *
+ * WindowsApps ACLs allow execution only through package activation, and shell
+ * activation cannot pass arguments — IApplicationActivationManager is the one path
+ * that forwards an argument string to a full-trust exe. Cheaper than the local-copy
+ * fallback below (no multi-hundred-MB copy) so it is tried first, but it does not
+ * work on every Windows build, hence the fallback stays.
+ *
+ * Returns the activated pid, or null if the script produced no parseable output.
+ */
+function _activateMsix(cdpPort, { execSync: exec }) {
+  const script = fileURLToPath(new URL('../../scripts/activate_msix.ps1', import.meta.url));
+  const out = exec(
+    `powershell -NoProfile -ExecutionPolicy Bypass -STA -File "${script}" -Port ${cdpPort}`,
+    { timeout: 30000, stdio: ['ignore', 'pipe', 'ignore'] },
+  ).toString().trim();
+  try {
+    return JSON.parse(out).pid ?? null;
+  } catch {
+    return null;
+  }
 }
 
 async function _probeCdp(cdpPort) {
@@ -363,6 +389,8 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
   let info = null;
   let usedLocalCopy = false;
+  let usedActivation = false;
+  let activatedPid = null;
 
   if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
     const earlyFailure = await _spawnFailedEarly(child);
@@ -370,8 +398,26 @@ export async function launch({ port, kill_existing, _deps } = {}) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }
     if (!info) {
-      // Direct WindowsApps launch was blocked or CDP never bound — fall back to
-      // a local copy of the package (see _copyMsixPackageLocal).
+      // Direct WindowsApps spawn is normally denied by ACL. COM activation is the
+      // cheap way through — no copy — so try it before duplicating the package.
+      // Activation only applies the flag when nothing is running: the single-instance
+      // lock otherwise makes it focus the existing window and silently drop it. Honour
+      // kill_existing:false anyway and let activation fail into the copy fallback,
+      // rather than killing an instance the caller asked us to leave alone.
+      try {
+        if (killFirst) await killExisting();
+        activatedPid = deps.activateMsix(cdpPort, deps);
+        usedActivation = true;
+        info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
+      } catch {
+        usedActivation = false;
+      }
+    }
+    if (!info) {
+      // Activation unavailable, or it accepted the flag without ever binding the
+      // port — fall back to a local copy of the package (see _copyMsixPackageLocal).
+      usedActivation = false;
+      activatedPid = null;
       const localExe = _copyMsixPackageLocal(tvPath, deps);
       await killExisting();
       child = _spawnDetached(deps.spawn, localExe, cdpArgs);
@@ -386,15 +432,17 @@ export async function launch({ port, kill_existing, _deps } = {}) {
 
   if (info) {
     return {
-      success: true, platform, binary: tvPath, pid: child.pid,
+      success: true, platform, binary: tvPath, pid: activatedPid ?? child.pid,
       cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
+      ...(usedActivation && { msix_activation: true }),
       ...(usedLocalCopy && { msix_local_copy: true }),
     };
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform, binary: tvPath, pid: activatedPid ?? child.pid, cdp_port: cdpPort, cdp_ready: false,
+    ...(usedActivation && { msix_activation: true }),
     ...(usedLocalCopy && { msix_local_copy: true }),
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -391,8 +391,10 @@ export async function launch({ port, kill_existing, _deps } = {}) {
 
   const killExisting = async () => {
     try {
-      if (platform === 'win32') deps.execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
-      else deps.execSync('pkill -f TradingView', { timeout: 5000 });
+      // stdio ignored: taskkill/pkill write "process not found" to stderr when
+      // nothing is running, which is the normal case and not worth showing.
+      if (platform === 'win32') deps.execSync('taskkill /F /IM TradingView.exe', { timeout: 5000, stdio: 'ignore' });
+      else deps.execSync('pkill -f TradingView', { timeout: 5000, stdio: 'ignore' });
       await deps.delay(1500);
     } catch { /* may not be running */ }
   };
@@ -400,14 +402,28 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  // Windows refuses direct execution of WindowsApps binaries by throwing EPERM
+  // synchronously from spawn(), not via an async 'error' event. Letting that escape
+  // would abort launch() before the MSIX recovery below — which exists precisely to
+  // handle this — so capture it and treat it as an early failure.
+  let child = null;
+  let spawnError = null;
+  try {
+    child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  } catch (err) {
+    spawnError = err.code || err.message || 'spawn failed';
+  }
+  if (spawnError && !(platform === 'win32' && WINDOWS_APPS_RE.test(tvPath))) {
+    // A classic install that cannot be spawned has no fallback worth trying.
+    throw new Error(`Failed to launch ${tvPath}: ${spawnError}`);
+  }
   let info = null;
   let usedLocalCopy = false;
   let usedActivation = false;
   let activatedPid = null;
 
   if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
-    const earlyFailure = await _spawnFailedEarly(child);
+    const earlyFailure = spawnError || await _spawnFailedEarly(child);
     if (!earlyFailure) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }
@@ -449,7 +465,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
 
   if (info) {
     return {
-      success: true, platform, binary: tvPath, pid: activatedPid ?? child.pid,
+      success: true, platform, binary: tvPath, pid: activatedPid ?? child?.pid,
       cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
       ...(usedActivation && { msix_activation: true }),
@@ -458,7 +474,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: activatedPid ?? child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform, binary: tvPath, pid: activatedPid ?? child?.pid, cdp_port: cdpPort, cdp_ready: false,
     ...(usedActivation && { msix_activation: true }),
     ...(usedLocalCopy && { msix_local_copy: true }),
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,0 +1,56 @@
+/**
+ * Tests for CDP target selection in src/connection.js.
+ * The desktop app exposes internal file:// pages alongside the real chart tabs, so
+ * selection must key on the tradingview.com host rather than the substring
+ * "tradingview" — see pickChartTarget().
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickChartTarget } from '../src/connection.js';
+
+// The app's internal container page. On Windows MSIX the install path itself contains
+// "TradingView.Desktop", which is what defeated the old loose match.
+const CONTAINER = {
+  type: 'page',
+  id: 'container',
+  url: 'file:///C:/Program%20Files/WindowsApps/TradingView.Desktop_3.3.0.7992_x64__n534cwy3pjxzj/resources/app.asar/app/browser-api-container/index.html',
+};
+const CHART = { type: 'page', id: 'chart', url: 'https://www.tradingview.com/chart/KPT1bD7n/' };
+const SCREENER = { type: 'page', id: 'screener', url: 'https://www.tradingview.com/etf-screener/' };
+
+describe('pickChartTarget()', () => {
+  it('prefers a chart page', () => {
+    assert.equal(pickChartTarget([CONTAINER, SCREENER, CHART])?.id, 'chart');
+  });
+
+  it('ignores the app container page even when it is the only "tradingview" match', () => {
+    // Regression: the container was selected and then cached, leaving every tool
+    // reporting api_available:false until the process restarted.
+    assert.equal(pickChartTarget([CONTAINER]), null);
+  });
+
+  it('falls back to another tradingview.com page when no chart is open', () => {
+    assert.equal(pickChartTarget([CONTAINER, SCREENER])?.id, 'screener');
+  });
+
+  it('ignores non-page targets such as workers', () => {
+    const worker = { type: 'worker', id: 'w', url: 'https://www.tradingview.com/chart/abc/' };
+    assert.equal(pickChartTarget([worker]), null);
+  });
+
+  it('does not match a lookalike host', () => {
+    const spoof = { type: 'page', id: 'spoof', url: 'https://nottradingview.com/chart/x/' };
+    assert.equal(pickChartTarget([spoof]), null);
+  });
+
+  it('matches chart pages on a subdomain', () => {
+    const sub = { type: 'page', id: 'sub', url: 'https://in.tradingview.com/chart/abc/' };
+    assert.equal(pickChartTarget([sub])?.id, 'sub');
+  });
+
+  it('tolerates empty, missing, and malformed target lists', () => {
+    assert.equal(pickChartTarget([]), null);
+    assert.equal(pickChartTarget(undefined), null);
+    assert.equal(pickChartTarget([{ type: 'page' }, null, { url: 'x' }]), null);
+  });
+});

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1207,8 +1207,9 @@ val = array.get(a, 5)`;
         const rp = REPLAY_API;
         const started = await evaluate(wv(`${rp}.isReplayStarted()`));
         if (started) {
+          // No goToRealtime() here either: it throws after stopReplay(), and the
+          // throw used to skip hideReplayToolbar(), leaving the toolbar on screen.
           await evaluate(`${rp}.stopReplay()`);
-          await evaluate(`${rp}.goToRealtime()`);
           await evaluate(`${rp}.hideReplayToolbar()`);
           await sleep(500);
         }
@@ -1284,8 +1285,10 @@ val = array.get(a, 5)`;
       const started = await evaluate(wv(`${REPLAY_API}.isReplayStarted()`));
       if (!started) return;
 
+      // Mirror replay.js stop(), which calls stopReplay() and nothing else.
+      // goToRealtime() stops replay internally, so calling it after stopReplay()
+      // makes that inner stop assert with "Replay is not started".
       await evaluate(`${REPLAY_API}.stopReplay()`);
-      await evaluate(`${REPLAY_API}.goToRealtime()`);
       await evaluate(`${REPLAY_API}.hideReplayToolbar()`);
       await sleep(500);
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -146,14 +146,42 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
     });
 
     it('tv_launch — auto-detect binary (verify path resolution only)', async () => {
-      // tv_launch is destructive (kills TradingView), so we only test path detection
+      // tv_launch is destructive (kills TradingView), so we only test path detection.
+      // Candidates mirror the pathMap in src/core/health.js.
       const { existsSync } = await import('fs');
-      const paths = [
-        '/Applications/TradingView.app/Contents/MacOS/TradingView',
-        `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
-      ];
-      const found = paths.some(p => existsSync(p));
-      assert.ok(found, 'TradingView binary found on disk');
+      const byPlatform = {
+        darwin: [
+          '/Applications/TradingView.app/Contents/MacOS/TradingView',
+          `${process.env.HOME}/Applications/TradingView.app/Contents/MacOS/TradingView`,
+        ],
+        win32: [
+          `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
+          `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
+          `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+        ],
+        linux: [
+          '/opt/TradingView/tradingview',
+          '/opt/TradingView/TradingView',
+          `${process.env.HOME}/.local/share/TradingView/TradingView`,
+          '/usr/bin/tradingview',
+          '/snap/tradingview/current/tradingview',
+        ],
+      };
+      const paths = byPlatform[process.platform] || byPlatform.linux;
+      let found = paths.some(p => existsSync(p));
+
+      // Windows now ships MSIX-only: the install lives under WindowsApps, which is
+      // ACL-restricted for enumeration but resolvable via Get-AppxPackage.
+      if (!found && process.platform === 'win32') {
+        const { execSync } = await import('child_process');
+        try {
+          const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+          const installDir = execSync(ps, { timeout: 10000 }).toString().trim();
+          found = !!installDir && existsSync(`${installDir}\\TradingView.exe`);
+        } catch { /* leave found false */ }
+      }
+
+      assert.ok(found, `TradingView binary found on disk (platform: ${process.platform})`);
     });
   });
 
@@ -935,6 +963,30 @@ val = array.get(a, 5)`;
       try { await evaluate(`${CHART_API}.removeAllShapes()`); } catch {}
     });
 
+    /**
+     * Guarantee at least one shape exists, creating one if needed.
+     * Tests must not depend on an earlier test having created a shape: bar data can
+     * be unavailable (outside market hours, symbol still loading), in which case the
+     * creating test bails silently and leaves the chart empty.
+     * Returns false when live bar data is unavailable and no shape could be made.
+     */
+    async function ensureShape() {
+      const existing = await evaluate(`${CHART_API}.getAllShapes()`);
+      if (existing && existing.length > 0) return true;
+
+      const quote = await evaluate(`
+        (function() {
+          var bars = ${BARS_PATH};
+          var last = bars.valueAt(bars.lastIndex());
+          return last ? { time: last[0], price: last[4] } : null;
+        })()
+      `);
+      if (!quote) return false;
+
+      await evaluate(`${CHART_API}.createShape({ time: ${quote.time}, price: ${quote.price} }, { shape: 'horizontal_line' })`);
+      return true;
+    }
+
     it('draw_shape — create horizontal line', async () => {
       const quote = await evaluate(`
         (function() {
@@ -960,6 +1012,7 @@ val = array.get(a, 5)`;
     });
 
     it('draw_list — list drawings', async () => {
+      const haveShape = await ensureShape();
       const shapes = await evaluate(`
         (function() {
           var all = ${CHART_API}.getAllShapes();
@@ -967,6 +1020,7 @@ val = array.get(a, 5)`;
         })()
       `);
       assert.ok(Array.isArray(shapes), 'Shapes is array');
+      if (!haveShape) return; // no live bar data to draw from
       assert.ok(shapes.length > 0, 'Has at least one shape');
     });
 
@@ -1001,17 +1055,7 @@ val = array.get(a, 5)`;
     });
 
     it('draw_clear — remove all drawings', async () => {
-      // Add a shape first
-      const quote = await evaluate(`
-        (function() {
-          var bars = ${BARS_PATH};
-          var last = bars.valueAt(bars.lastIndex());
-          return last ? { time: last[0], price: last[4] } : null;
-        })()
-      `);
-      if (quote) {
-        await evaluate(`${CHART_API}.createShape({ time: ${quote.time}, price: ${quote.price} }, { shape: 'horizontal_line' })`);
-      }
+      await ensureShape(); // clearing an already-empty chart would prove nothing
 
       await evaluate(`${CHART_API}.removeAllShapes()`);
       const after = await evaluate(`${CHART_API}.getAllShapes()`);

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -25,12 +25,17 @@ function mockChild({ failWith } = {}) {
 /**
  * Build a _deps bundle simulating a win32 MSIX environment.
  * @param {object} opts
- *   spawnFailures — spawn paths (substring) that emit EACCES
- *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
- *   copyExists   — local copy already present
+ *   spawnFailures   — spawn paths (substring) that emit EACCES
+ *   cdpBindsFor    — spawn paths (substring) after which probeCdp starts succeeding
+ *   copyExists     — local copy already present
+ *   activationBinds — COM activation succeeds and CDP binds after it
+ *   activationThrows — COM activation fails (e.g. ERROR_CANCELLED on some builds)
  */
-function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } = {}) {
-  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
+function msixDeps({
+  spawnFailures = [], cdpBindsFor = [], copyExists = false,
+  activationBinds = false, activationThrows = false,
+} = {}) {
+  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false, activations: 0 };
   const deps = {
     existsSync: (p) => {
       if (p === MSIX_EXE) return true;
@@ -49,6 +54,12 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
       const fail = spawnFailures.some((s) => exe.includes(s));
       if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
       return mockChild(fail ? { failWith: 'EACCES' } : {});
+    },
+    activateMsix: () => {
+      state.activations++;
+      if (activationThrows) throw new Error('ActivateApplication failed: 0x800704C7');
+      if (activationBinds) state.cdpUp = true;
+      return 4242;
     },
     cpSync: (src, dst) => { state.copies.push({ src, dst }); },
     rmSync: (p) => { state.removed.push(p); },
@@ -70,7 +81,52 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.equal(result.binary, MSIX_EXE);
     assert.equal(result.msix_local_copy, undefined);
     assert.equal(state.copies.length, 0);
+    // nothing extra is attempted when the direct spawn already works
+    assert.equal(state.activations, 0);
     assert.equal(result.cdp_url, 'http://127.0.0.1:9222');
+  });
+
+  it('COM activation binds CDP without copying the package', async () => {
+    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], activationBinds: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_activation, true);
+    assert.equal(result.msix_local_copy, undefined);
+    assert.equal(state.activations, 1);
+    assert.equal(state.copies.length, 0);
+    // the real install is used, not a duplicate
+    assert.equal(result.binary, MSIX_EXE);
+    // pid comes from ActivateApplication, not the denied direct spawn
+    assert.equal(result.pid, 4242);
+  });
+
+  it('kill_existing:false is honoured on the activation path', async () => {
+    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], activationBinds: true });
+    const result = await launch({ kill_existing: false, _deps: deps });
+    assert.equal(result.msix_activation, true);
+    // activation needs a stopped app to apply the flag, but never at the cost of
+    // killing an instance the caller explicitly asked us to keep
+    assert.equal(state.killed, 0);
+  });
+
+  it('activation is attempted before falling back to a copy', async () => {
+    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(state.activations, 1);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.msix_activation, undefined);
+  });
+
+  it('activation throwing still falls back to a local copy', async () => {
+    const { deps, state } = msixDeps({
+      spawnFailures: ['WindowsApps'], activationThrows: true, cdpBindsFor: ['tradingview-mcp'],
+    });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(state.activations, 1);
+    assert.equal(result.msix_activation, undefined);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.binary, LOCAL_COPY_EXE);
   });
 
   it('EACCES on direct spawn falls back to local copy', async () => {

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -33,7 +33,7 @@ function mockChild({ failWith } = {}) {
  */
 function msixDeps({
   spawnFailures = [], cdpBindsFor = [], copyExists = false,
-  activationBinds = false, activationThrows = false,
+  activationBinds = false, activationThrows = false, spawnThrows = [],
 } = {}) {
   const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false, activations: 0 };
   const deps = {
@@ -51,6 +51,11 @@ function msixDeps({
     },
     spawn: (exe) => {
       state.spawned.push(exe);
+      // Windows throws EPERM synchronously for WindowsApps binaries; other failures
+      // surface as an async 'error' event. Both must be survivable.
+      if (spawnThrows.some((s) => exe.includes(s))) {
+        throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
+      }
       const fail = spawnFailures.some((s) => exe.includes(s));
       if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
       return mockChild(fail ? { failWith: 'EACCES' } : {});
@@ -84,6 +89,26 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     // nothing extra is attempted when the direct spawn already works
     assert.equal(state.activations, 0);
     assert.equal(result.cdp_url, 'http://127.0.0.1:9222');
+  });
+
+  it('a synchronous EPERM from spawn still reaches activation', async () => {
+    // Regression: spawn() throwing synchronously (what Windows actually does for
+    // WindowsApps binaries) escaped launch() before any MSIX recovery could run,
+    // so tv_launch failed outright with "spawn EPERM".
+    const { deps, state } = msixDeps({ spawnThrows: ['WindowsApps'], activationBinds: true });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_activation, true);
+    assert.equal(state.activations, 1);
+    assert.equal(result.pid, 4242);
+  });
+
+  it('a synchronous EPERM still reaches the local-copy fallback', async () => {
+    const { deps, state } = msixDeps({ spawnThrows: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(state.copies.length, 1);
   });
 
   it('COM activation binds CDP without copying the package', async () => {

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -109,6 +109,13 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.equal(state.killed, 0);
   });
 
+  it('kill_existing:false is honoured on the local-copy path too', async () => {
+    const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ kill_existing: false, _deps: deps });
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(state.killed, 0);
+  });
+
   it('activation is attempted before falling back to a copy', async () => {
     const { deps, state } = msixDeps({ spawnFailures: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
     const result = await launch({ _deps: deps });

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,9 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  // fileURLToPath, not .pathname: on Windows the latter yields "/C:/...", which
+  // readdirSync then resolves to "C:\C:\..." and fails with ENOENT.
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Problem

On Windows, TradingView Desktop ships **only as an MSIX package**, and there is no working way to start it with `--remote-debugging-port`. Every chart tool in this server depends on that port, so the whole MCP surface is dead on a stock Windows install.

Three approaches all fail:

| Approach | Result |
|---|---|
| Run the exe directly | `Access is denied` — WindowsApps ACLs permit execution only via activation |
| `explorer.exe shell:AppsFolder\...` | Activates, but cannot pass arguments |
| `Invoke-CommandInDesktopPackage` | `ERROR_CANCELLED` (0x800704C7) on some builds, elevated or not |

`scripts/launch_tv_debug.vbs` appeared to work but never did: it set `ELECTRON_EXTRA_LAUNCH_ARGS` in its own process, then launched through `explorer`, which never saw the variable. TradingView started with no debug port while the script reported "Launched".

## Changes

**MSIX launch via COM activation.** `IApplicationActivationManager::ActivateApplication` is the one activation path that forwards an argument string to a `Windows.FullTrustApplication` exe. Added `scripts/activate_msix.ps1` wrapping that call, and `scripts/launch_tv_debug.ps1` as a kill/launch/verify front end. `tv_launch` now tries activation first and reports `msix_activation: true`. The local-copy fallback stays, because on some builds activation accepts the flag without ever binding the port (#42, #75, #128). `launch_tv_debug.vbs` now delegates to the PowerShell script.

**CDP target selection by host, not substring.** `findChartTarget()` fell back to any page whose URL merely *contained* `tradingview`. The desktop app serves internal pages from `file://` under its install directory, and on Windows that path contains `TradingView.Desktop` — so during the window before the chart page loads, the fallback selected the app's `browser-api-container`. `getClient()` cached that target and its liveness check kept passing, so every later call reported `api_available: false` until the process restarted: silently wrong rather than loudly broken. Both patterns are now anchored at the scheme and match the `tradingview.com` host. With no chart target yet, selection returns `null` so `connect()` retries with backoff and eventually raises `No TradingView chart target found`. The choice is extracted into an exported pure `pickChartTarget(targets)` with the container URL covered as a regression case.

**Test fixes** (all pre-existing breakage, surfaced by running on Windows):
- `sanitization.test.js` built its source-audit directory with `new URL(...).pathname`, which yields `/C:/...` on Windows and made `readdirSync` resolve `C:\C:\...` → ENOENT. The file crashed on load, so the audit that greps `src/core` for unsafe interpolation **was not running there at all**. Now uses `fileURLToPath`.
- e2e `tv_launch -- auto-detect binary` only probed macOS paths and failed on every Windows machine. Now mirrors the `pathMap` in `health.js` per platform and resolves MSIX installs via `Get-AppxPackage`.
- e2e `draw_list` asserted a shape exists, relying on the preceding test having created one — but that test bails silently when live bar data is unavailable, so it failed depending on ordering and market hours. Added `ensureShape()`, used in `draw_list` and `draw_clear`.
- e2e `replay_stop` called `stopReplay()` and then `goToRealtime()`. `goToRealtime()` stops replay internally, so the second stop asserted with `Replay is not started`. `replay.js` `stop()` calls `stopReplay()` alone; the test now mirrors it. The `after()` hook made the same double call — wrapped in try/catch it passed silently, but the throw skipped `hideReplayToolbar()`, leaving the replay toolbar on screen after the suite.

**Two more pre-existing defects in `health.js`.** `launch()` killed running instances from the local-copy fallback even when the caller passed `kill_existing: false`; that kill is now gated on the flag, as the activation path already was. And `checkForUpdate()` reported `update_available` whenever HEAD differed from origin's default branch — so any feature branch with local commits was told to run `tv_update`, which would move it off its own work. It now treats the remote commit being an ancestor of HEAD as up to date, validating the SHA against `/^[0-9a-f]{40}$/` before it reaches the shell and falling back to the previous answer for commits that were never fetched.

**Test wiring.** `test:unit` (what CI runs) enumerates test files by hand, so the new `connection.test.js` would never have executed there. Added to `test:unit` and `test:all`.

## Testing

- **`npm run test:all`: 250/250, exit 0.** Every suite, including the live e2e run.
- `npm run test:unit` (what CI runs): **171/171**. `npm test` (e2e, live TradingView): **95/95**, up from 93/95.
- `npm run lint`: 0 errors.

That clean run needed one more fix. The two CLI pine-check tests were failing because `execute()` called `process.exit(0)` immediately after printing, with the CDP WebSocket still open — tearing libuv down mid-flight, which Node 24 on Windows turns into a hard `!(handle->flags & UV_HANDLE_CLOSING)` assertion in `src\win\async.c`. The command did its work and printed the correct result, then died with `0xC0000409`, so `tv pine check` looked like a failure to every caller. The CLI now closes the connection and lets the loop drain, with an unref'd 2s timer as a safety net.
- The launcher was run end to end **four separate times**, each ending in CDP ready and a live `Chrome/140.0.7339.133` response.
- The CDP target fix was also verified against the live `/json/list`: with the chart pages filtered out to reproduce the load window, the old selection picks the `file://` container and the new one correctly returns `null`.

Verified on Windows 10 Pro 19045 against the MSIX build. Not exercised on macOS or Linux — those paths are unchanged apart from the host-matching fix in `pickChartTarget`, which is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

