### PR TITLE
fix(health): don't report a phantom update when local is ahead of origin

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -10,12 +10,41 @@ import { dirname, basename, join } from 'path';
 // branch on GitHub. Never throws — returns null on any failure (offline,
 // detached HEAD, not a git checkout) so it can't break the health check.
 let _updateCache = null;
+
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+
+/**
+ * Decide what origin's HEAD means relative to local HEAD.
+ *
+ * A raw SHA inequality is not enough. When local carries commits that aren't on
+ * origin, origin's HEAD is an *ancestor* of local HEAD — that is being ahead, not
+ * behind — yet inequality reports it as an available update and points the user at
+ * tv_update, which then refuses because it cannot fast-forward.
+ *
+ * `git` is injected so this is unit-testable, and must throw on a non-zero exit
+ * (execSync semantics). A remote commit that isn't in the local object DB makes
+ * merge-base throw, which falls through to "behind" — the safe default, since we
+ * cannot prove we already have it.
+ */
+export function classifyUpdate(localSha, remoteSha, git) {
+  if (remoteSha === localSha) return { behind: false, ahead: 0 };
+  // Network-sourced value heading into a shell command — never interpolate it raw.
+  if (!SHA_RE.test(remoteSha)) return { behind: false, ahead: 0 };
+  try {
+    git(`merge-base --is-ancestor ${remoteSha} HEAD`);
+    return { behind: false, ahead: Number(git(`rev-list --count ${remoteSha}..HEAD`)) || 0 };
+  } catch {
+    return { behind: true, ahead: 0 };
+  }
+}
+
 async function checkForUpdate() {
   if (_updateCache && (Date.now() - _updateCache.at) < 3600_000) return _updateCache.value;
   let value = null;
   try {
-    const localSha = execSync('git rev-parse HEAD', { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
-    const remoteUrl = execSync('git config --get remote.origin.url', { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    const git = (args) => execSync(`git ${args}`, { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    const localSha = git('rev-parse HEAD');
+    const remoteUrl = git('config --get remote.origin.url');
     const m = remoteUrl.match(/github\.com[:/](.+?)(?:\.git)?$/);
     if (localSha && m) {
       const repo = m[1];
@@ -29,11 +58,13 @@ async function checkForUpdate() {
         req.setTimeout(3000, () => { req.destroy(); resolve(null); });
       });
       if (remoteSha) {
+        const { behind, ahead } = classifyUpdate(localSha, remoteSha, git);
         value = {
-          update_available: remoteSha !== localSha,
+          update_available: behind,
           local_commit: localSha.slice(0, 8),
           latest_commit: remoteSha.slice(0, 8),
-          ...(remoteSha !== localSha && { hint: 'Run the tv_update tool (or `tv update` CLI) to update, then restart the MCP server.' }),
+          ...(ahead > 0 && { local_ahead: ahead }),
+          ...(behind && { hint: 'Run the tv_update tool (or `tv update` CLI) to update, then restart the MCP server.' }),
         };
       }
     }

--- a/tests/update.test.js
+++ b/tests/update.test.js
@@ -6,6 +6,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { update } from '../src/core/update.js';
+import { classifyUpdate } from '../src/core/health.js';
 
 const OLD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const NEW = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
@@ -123,5 +124,49 @@ describe('update() — update paths', () => {
     assert.equal(r.updated, true);
     assert.equal(r.deps_installed, false);
     assert.match(r.warning, /npm ci failed/);
+  });
+});
+
+// ── Update classification (health check) ─────────────────────────────────
+
+describe('classifyUpdate() — ahead vs behind', () => {
+  it('reports neither when the SHAs match, without shelling out', () => {
+    const calls = [];
+    const result = classifyUpdate(OLD, OLD, (args) => { calls.push(args); return ''; });
+    assert.deepEqual(result, { behind: false, ahead: 0 });
+    assert.equal(calls.length, 0, 'no git call is needed when the SHAs match');
+  });
+
+  // The regression: local main carrying unpushed commits means origin's HEAD is an
+  // ancestor of local HEAD. A raw SHA inequality called that an available update and
+  // sent the user to tv_update, which then refuses because it cannot fast-forward.
+  it('treats an ancestor remote as ahead, not as an available update', () => {
+    const git = (args) => {
+      if (args.startsWith('merge-base --is-ancestor')) return '';
+      if (args.startsWith('rev-list --count')) return '2';
+      throw new Error(`unexpected git call: ${args}`);
+    };
+    assert.deepEqual(classifyUpdate(NEW, OLD, git), { behind: false, ahead: 2 });
+  });
+
+  it('reports behind when the remote commit is not an ancestor', () => {
+    const git = (args) => {
+      if (args.startsWith('merge-base --is-ancestor')) throw new Error('exit status 1');
+      throw new Error(`unexpected git call: ${args}`);
+    };
+    assert.deepEqual(classifyUpdate(OLD, NEW, git), { behind: true, ahead: 0 });
+  });
+
+  it('reports behind when the remote commit is absent from the local object DB', () => {
+    const git = () => { throw new Error('fatal: Not a valid object name'); };
+    assert.deepEqual(classifyUpdate(OLD, NEW, git), { behind: true, ahead: 0 });
+  });
+
+  it('never passes a non-hex remote sha to git', () => {
+    const calls = [];
+    const git = (args) => { calls.push(args); return ''; };
+    const result = classifyUpdate(OLD, 'abc123 && echo pwned', git);
+    assert.deepEqual(result, { behind: false, ahead: 0 });
+    assert.equal(calls.length, 0, 'a malformed sha must never reach a shell command');
   });
 });


### PR DESCRIPTION
## Problem

`checkForUpdate()` decides whether an update exists with a raw inequality:

```js
update_available: remoteSha !== localSha,
```

That is true whenever the two commits differ **in either direction**. A checkout that
carries commits *not yet on origin* — a contributor mid-branch, or anyone running a local
patch while waiting on a PR — is **ahead**, not behind. Every `tv_health_check` then
reports an update that does not exist, and attaches:

> Run the tv_update tool (or `tv update` CLI) to update, then restart the MCP server.

Following that hint lands on `update()`'s own guard, which correctly refuses:

> Local main has 2 commit(s) not on origin — fast-forward is not possible.

So the health check recommends a command that its sibling in `src/core/update.js` is
designed to block. Both are behaving as written; they just disagree about what the SHA
difference means.

## Fix

Adds `classifyUpdate()`, which asks the question the inequality was standing in for: is
origin's commit an **ancestor** of local HEAD? If it is, we already contain it — we are
ahead, and there is nothing to pull. Only a remote commit genuinely absent from local
history counts as an update.

Also reports `local_ahead: N` so the state is legible instead of silently suppressed.

### Design notes

- **Missing object falls through to "behind."** If origin's commit isn't in the local
  object DB (never fetched, or diverged history), `merge-base` throws and we report
  behind. That is the safe direction: we cannot prove we already have it, so we don't
  claim to.
- **No `^{commit}` syntax.** `git cat-file -e <sha>^{commit}` would be the natural
  existence check, but `execSync` goes through `cmd.exe` on Windows, where `^` is the
  escape character. `merge-base --is-ancestor` already throws for both missing-object and
  not-an-ancestor, so the extra call was redundant anyway.
- **The remote SHA is validated as hex before it reaches a shell.** It arrives from the
  GitHub API and gets interpolated into a `git` command; a non-hex value now short-circuits
  and never reaches `execSync`.

The two existing `execSync` calls are folded into a small local `git()` helper, which is
also what makes the classifier injectable for tests.

## Interaction with #391

#391 fixes a **different** bug in this same function — those `git` calls inherit
`process.cwd()` instead of the repo root — by adding `cwd: REPO_ROOT` to each call site.
The two are complementary, not competing, but they will conflict textually since they
touch the same lines.

They compose cleanly in either order. This PR collapses both calls into one `git()`
helper, which is the natural single place for #391's `cwd`:

```js
const git = (args) => execSync(`git ${args}`, { cwd: REPO_ROOT, timeout: 3000, stdio: [...] });
```

If #391 merges first I'll rebase and move the `cwd` into the helper. Happy to sequence
whichever way suits you.

## Verification

Against a real checkout sitting 2 commits ahead of origin:

```
before:  { update_available: true,  local_commit: "1bd29585", latest_commit: "c05b8f57",
           hint: "Run the tv_update tool ..." }

after:   { update_available: false, local_commit: "1bd29585", latest_commit: "c05b8f57",
           local_ahead: 2 }
```

Also confirmed the up-to-date and genuinely-behind paths still report as before.

5 unit tests added to `tests/update.test.js` covering: SHAs match (and no git call is made),
ancestor remote → ahead, non-ancestor → behind, object missing from local DB → behind, and
non-hex SHA never reaching a shell command.

- `npm run lint` — 0 errors
- `npm run test:unit` — 128/130; the 2 failures are the pre-existing `pine check` cases
  that reach TradingView's server-compile endpoint, unrelated to this change and present
  on `c05b8f5` without it.


---

## CI verification

Upstream CI has never run on this PR. Like every external PR on this repo since 2026-07-24, its workflow run is held at `action_required` — 91 runs from 49 contributors are in the same state, and no fork PR has ever produced a green check on this repo (details in #474). So the change is not left unverified, I ran the identical workflow on my fork:

**https://github.com/L3G1T50/tradingview-mcp/actions/runs/32521718142** — `success`, both matrix legs:

- `lint-and-test (20.x)` — success
- `lint-and-test (22.x)` — success

That run executed `.github/workflows/ci.yml` at blob `1a5e337`, which is **byte-identical to the copy on `tradesdontlie:main`** (I compared the blob SHAs, not just the contents) — same workflow, unmodified, ubuntu-latest, lint + unit tests + audit.

The exact commit in this PR (`1bd2958`) is present in that tested tree.

**Caveat, stated plainly:** `86672de` carries this change alongside several other commits from my fork, so the run shows *"this change passes together with those,"* not per-PR isolation. Read it as supporting evidence rather than a substitute for CI running here.

