### PR TITLE
Fix stale tab tracking when the user switches tabs outside of tab_switch

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -55,13 +55,123 @@ export async function getClient() {
     try {
       // Quick liveness check
       await client.Runtime.evaluate({ expression: '1', returnByValue: true });
-      return client;
     } catch {
       client = null;
       targetInfo = null;
+      return connect();
     }
+
+    // Liveness alone isn't enough: with multiple chart tabs open, the cached
+    // target can still be a live but backgrounded tab (stale state/screenshots)
+    // if the user switched tabs outside of tab_switch. TradingView Desktop's
+    // custom tab bar doesn't drive document.visibilityState/hasFocus() per tab
+    // (every tab reports hidden/unfocused regardless of which is on screen —
+    // confirmed by direct probing), so visibility APIs can't tell us which tab
+    // is actually shown. Compare layout names instead: read which tab is
+    // .active in the shell's tab bar, and if that differs from what the cached
+    // target itself is displaying, find and follow the matching one.
+    try {
+      const shellActiveName = await getShellActiveLayoutName();
+      if (shellActiveName) {
+        const cachedName = await readLayoutName(client);
+        if (cachedName && cachedName === shellActiveName) return client;
+
+        const match = await findTargetByLayoutName(shellActiveName);
+        if (match && match.id !== targetInfo?.id) {
+          return reconnectTo(match.id);
+        }
+      }
+    } catch {
+      // Best-effort — fall through and keep using the cached client rather
+      // than breaking a previously-working connection over this.
+    }
+    return client;
   }
   return connect();
+}
+
+// Reads the layout name TradingView itself is currently rendering in the
+// save/load toolbar button, e.g. "Daily Set Up - Crypto". The primary
+// selector targets today's (hashed, build-specific) class name; the fallback
+// scans buttons for the "<name>Save" pattern that button renders as, so a
+// TradingView UI update that changes the hash doesn't silently break this.
+const READ_LAYOUT_NAME_EXPR = `
+  (function() {
+    var el = document.querySelector('span[class*="text-OjWQ1m5F"]');
+    if (el && el.textContent.trim()) return el.textContent.trim();
+    var btns = document.querySelectorAll('button');
+    for (var i = 0; i < btns.length; i++) {
+      var t = (btns[i].textContent || '').trim();
+      if (/Save$/.test(t) && t.length > 4) return t.replace(/Save$/, '').trim();
+    }
+    return null;
+  })()
+`;
+
+async function readLayoutName(cdpClient) {
+  const { result } = await cdpClient.Runtime.evaluate({ expression: READ_LAYOUT_NAME_EXPR, returnByValue: true });
+  return result?.value || null;
+}
+
+/**
+ * Read the layout name of whichever tab is .active in the Electron shell's
+ * tab bar (the top tab strip, not the chart page itself).
+ */
+async function getShellActiveLayoutName() {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const shells = targets.filter(t => t.type === 'page' && /\/window\/index\.html/i.test(t.url || ''));
+
+  for (const s of shells) {
+    let c;
+    try {
+      c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: s.id });
+      const probe = await c.Runtime.evaluate({
+        expression: `!!document.querySelector('.tabs-container .tab')`, returnByValue: true,
+      });
+      if (!probe.result?.value) continue;
+
+      const { result } = await c.Runtime.evaluate({
+        expression: `
+          (function() {
+            var active = document.querySelector('.tabs-container .tab.active');
+            if (!active) return null;
+            var nameEl = active.querySelector('[class*="layout-name"]');
+            var text = nameEl ? nameEl.textContent : '';
+            return text.replace(/^\\s*\\/\\s*/, '').trim() || null;
+          })()
+        `,
+        returnByValue: true,
+      });
+      if (result?.value) return result.value;
+    } catch {
+      // This target wasn't the shell (or closed mid-probe) — try the next one.
+    } finally {
+      try { if (c) await c.close(); } catch { /* already gone */ }
+    }
+  }
+  return null;
+}
+
+/** Find the open chart tab whose own rendered layout name matches `name`. */
+async function findTargetByLayoutName(name) {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const chartTargets = targets.filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url));
+
+  for (const t of chartTargets) {
+    let c;
+    try {
+      c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: t.id });
+      const layoutName = await readLayoutName(c);
+      if (layoutName === name) return t;
+    } catch {
+      // Target may have closed mid-probe or not be ready yet — skip it.
+    } finally {
+      try { if (c) await c.close(); } catch { /* already gone */ }
+    }
+  }
+  return null;
 }
 
 export async function connect(targetId = null) {
@@ -110,8 +220,21 @@ export async function reconnectTo(targetId) {
 async function findChartTarget() {
   const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
-  return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
+  const chartTargets = targets.filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url));
+
+  if (chartTargets.length > 1) {
+    try {
+      const shellActiveName = await getShellActiveLayoutName();
+      if (shellActiveName) {
+        const match = await findTargetByLayoutName(shellActiveName);
+        if (match) return match;
+      }
+    } catch {
+      // Fall through to "just pick the first one" below.
+    }
+  }
+
+  return chartTargets[0]
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
     || null;
 }
@@ -123,9 +246,13 @@ async function findTargetById(id) {
 }
 
 export async function getTargetInfo() {
-  if (!targetInfo) {
-    await getClient();
-  }
+  // Always run getClient(), not just when nothing is cached yet — it's the
+  // one that re-checks whether the cached target is still the tab actually
+  // on screen and follows the user if it isn't. Skipping that check here
+  // left tv_health_check reporting a stale target after a tab switch even
+  // though evaluate()-based tools (which always call getClient()) had
+  // already followed it correctly.
+  await getClient();
   return targetInfo;
 }
 


### PR DESCRIPTION
## Problem

With multiple TradingView chart tabs open, `getClient()` stayed glued to whichever tab it first connected to. If the user manually clicked a different tab in the TradingView Desktop UI — without going through the `tab_switch` MCP tool — every subsequent `evaluate()`-based read (`chart_get_state`, `pane_list`, `capture_screenshot`, etc.) kept silently returning stale data from the backgrounded tab.

This is a different gap from #37/#319/#320, which fixed `tab_switch`/`layout_switch` themselves (the explicit tool call path, now sticky via `reconnectTo`). This PR fixes the *ambient* path: `getClient()` had no staleness check at all beyond a liveness probe, so it never noticed when the user changed tabs by hand.

## Root cause

The obvious fix is checking `document.visibilityState` per tab. It doesn't work here: TradingView Desktop's custom tab bar doesn't drive that API at all — **every open tab reports `hidden`, `document.hasFocus()` returns `false` on every one, regardless of which tab is actually on screen.** Confirmed by probing all open chart targets directly:

```
Geh9sjrX -> hidden|false
YdNtUWja -> hidden|false
G8MevtNU -> hidden|false
... (every tab, same result)
```

## Fix

Compare layout names instead of visibility:
1. Read which tab is `.active` in the Electron shell's own tab bar DOM (`.tabs-container .tab.active`) — this *is* reliably maintained, confirmed by direct probing.
2. Compare that name against what the cached chart tab is itself rendering in its own toolbar (the layout name shown next to the Save button).
3. On mismatch, search open chart targets for the one whose own rendered layout name matches the shell's active tab, and reconnect to it.

Also fixed `getTargetInfo()` (used by `tv_health_check`), which only called `getClient()` when nothing was cached yet — skipping the freshness check entirely once a target existed, so it kept reporting a stale target even after `evaluate()`-based tools had already followed a switch correctly.

Selector for the layout-name read has a fallback chain (primary hashed class, then a text-pattern scan for `"<name>Save"` button text) so a TradingView UI rebuild that changes the class hash doesn't silently break this again.

## Verification

- `npm run lint` — clean
- `npm run test:unit` — 152/152 passing
- Live-verified against TradingView Desktop (macOS, v3.3.0, Electron 38.2.2) across repeated real tab switches:
  - Standalone run of the actual `connection.js` module (bypassing the MCP layer) correctly picked the just-clicked tab out of two open ones.
  - Through the live MCP tool connection: opened two tabs (Daily Set Up - Crypto, RV - Crypto), clicked between them twice, `tv_health_check` correctly followed each switch both times (confirmed via `target_url`/`chart_symbol`/`chart_resolution` matching the clicked tab).

## Scope check

Single file (`src/connection.js`), no new dependencies, no data storage/export, no trading/order logic — stays within the bridge's stated scope per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)