### PR TITLE
fix(windows): make MSIX/Store launches reach the local-copy fallback

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -22,7 +22,7 @@ REM Check MSIX / Windows Store installs.
 REM Get-AppxPackage resolves the install without elevation; enumerating
 REM %PROGRAMFILES%\WindowsApps with dir requires admin rights, so keep it as a fallback.
 if "%TV_EXE%"=="" (
-    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView.Desktop' -ErrorAction SilentlyContinue).InstallLocation" 2^>nul`) do (
+    for /f "usebackq tokens=*" %%i in (`powershell -NoProfile -Command "(Get-AppxPackage -Name '*TradingView*' -ErrorAction SilentlyContinue | Select-Object -First 1).InstallLocation" 2^>nul`) do (
         if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
     )
 )

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -318,7 +318,9 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      // Wildcard match: the Store listing publishes under a numeric-publisher name
+      // (e.g. 31178TradingViewInc.TradingView), not just TradingView.Desktop.
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'*TradingView*\' -ErrorAction SilentlyContinue | Select-Object -First 1).InstallLocation"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;
@@ -360,12 +362,27 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  const isWindowsApps = platform === 'win32' && WINDOWS_APPS_RE.test(tvPath);
+
+  // On some machines spawning out of WindowsApps raises EPERM synchronously
+  // rather than via an 'error' event, so the throw has to be caught here for
+  // the local-copy fallback below to be reachable at all.
+  let child = null;
+  let syncSpawnError = null;
+  try {
+    child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  } catch (err) {
+    if (!isWindowsApps) throw err;
+    syncSpawnError = err;
+  }
+
   let info = null;
   let usedLocalCopy = false;
 
-  if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
-    const earlyFailure = await _spawnFailedEarly(child);
+  if (isWindowsApps) {
+    const earlyFailure = syncSpawnError
+      ? (syncSpawnError.code || syncSpawnError.message)
+      : await _spawnFailedEarly(child);
     if (!earlyFailure) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }
@@ -386,7 +403,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
 
   if (info) {
     return {
-      success: true, platform, binary: tvPath, pid: child.pid,
+      success: true, platform, binary: tvPath, pid: child?.pid,
       cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
       browser: info.Browser, user_agent: info['User-Agent'],
       ...(usedLocalCopy && { msix_local_copy: true }),
@@ -394,7 +411,7 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   }
 
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
+    success: true, platform, binary: tvPath, pid: child?.pid, cdp_port: cdpPort, cdp_ready: false,
     ...(usedLocalCopy && { msix_local_copy: true }),
     warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
   };

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -26,11 +26,12 @@ function mockChild({ failWith } = {}) {
  * Build a _deps bundle simulating a win32 MSIX environment.
  * @param {object} opts
  *   spawnFailures — spawn paths (substring) that emit EACCES
+ *   syncThrowFor  — spawn paths (substring) where spawn throws synchronously
  *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
  *   copyExists   — local copy already present
  */
-function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } = {}) {
-  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
+function msixDeps({ spawnFailures = [], syncThrowFor = [], cdpBindsFor = [], copyExists = false } = {}) {
+  const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false, appxQueries: [] };
   const deps = {
     existsSync: (p) => {
       if (p === MSIX_EXE) return true;
@@ -39,6 +40,7 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
     },
     execSync: (cmd) => {
       if (cmd.includes('Get-AppxPackage')) {
+        state.appxQueries.push(cmd);
         return 'C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj\n';
       }
       if (cmd.includes('taskkill')) { state.killed++; return ''; }
@@ -46,6 +48,9 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
     },
     spawn: (exe) => {
       state.spawned.push(exe);
+      if (syncThrowFor.some((s) => exe.includes(s))) {
+        throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
+      }
       const fail = spawnFailures.some((s) => exe.includes(s));
       if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
       return mockChild(fail ? { failWith: 'EACCES' } : {});
@@ -86,6 +91,44 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.match(state.removed[0], /3\.0\.0\.7652/);
     // the CDP-less direct instance is killed before relaunching from the copy
     assert.ok(state.killed >= 2);
+  });
+
+  it('synchronous EPERM on direct spawn falls back to local copy', async () => {
+    // Some Windows builds reject the WindowsApps spawn by throwing from spawn()
+    // itself rather than emitting 'error', so the throw has to be caught for the
+    // fallback to run at all.
+    const { deps, state } = msixDeps({ syncThrowFor: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.binary, LOCAL_COPY_EXE);
+    assert.equal(result.pid, 12345);
+    assert.equal(state.copies.length, 1);
+    assert.match(state.spawned[0], /WindowsApps/);
+    assert.match(state.spawned[1], /tradingview-mcp/);
+  });
+
+  it('a synchronous spawn failure on a classic path still propagates', async () => {
+    // Only WindowsApps launches have a fallback; anything else should surface.
+    const classicExe = `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`;
+    const deps = {
+      existsSync: (p) => p === classicExe,
+      execSync: (cmd) => { if (cmd.includes('taskkill')) return ''; throw new Error(`unexpected: ${cmd}`); },
+      spawn: () => { throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' }); },
+      cpSync: () => { throw new Error('should not copy'); },
+      rmSync: () => {}, readdirSync: () => [],
+      delay: async () => {}, probeCdp: async () => null,
+    };
+    await assert.rejects(() => launch({ _deps: deps }), /EPERM/);
+  });
+
+  it('resolves the Store package by wildcard, not one hardcoded name', async () => {
+    // Store-published builds carry a numeric-publisher package name
+    // (e.g. 31178TradingViewInc.TradingView), so an exact-name lookup finds nothing.
+    const { deps, state } = msixDeps({ cdpBindsFor: ['WindowsApps'] });
+    await launch({ _deps: deps });
+    assert.equal(state.appxQueries.length, 1);
+    assert.match(state.appxQueries[0], /\*TradingView\*/);
   });
 
   it('CDP never binding on direct spawn falls back to local copy', async () => {


### PR DESCRIPTION
## Problem

`tv_launch` could never succeed against a TradingView Desktop installed from the Microsoft Store. Two separate Windows-only issues stack up, and the second one hides the fallback that was written to handle exactly this situation.

**1. The package lookup used one hardcoded name.**

`launch()` resolves Store installs with:

```
Get-AppxPackage -Name 'TradingView.Desktop'
```

The Store listing does not install under that name. It installs under a numeric-publisher name â€” on my machine `31178TradingViewInc.TradingView`, install location `C:\Program Files\WindowsApps\31178TradingViewInc.TradingView_3.3.0.0_x64__q4jpyh43s5mv6`. So the lookup returned an empty string, every other candidate path missed, `where TradingView.exe` found nothing, and `launch()` threw:

```
TradingView not found on win32. Searched: ...
```

`scripts/launch_tv_debug.bat` had the same hardcoded name.

**2. `spawn` from WindowsApps throws EPERM synchronously.**

With detection fixed, the direct launch fails like this:

```
Error: spawn EPERM
    at ChildProcess.spawn (node:internal/child_process:420:11)
    at spawn (node:child_process:796:9)
    at _spawnDetached (src/core/health.js:231:17)
    at Module.launch (src/core/health.js:365:15)
```

The existing MSIX handling assumes the failure arrives as an `'error'` event, which `_spawnFailedEarly` observes before falling back to `_copyMsixPackageLocal`. Here `spawn()` throws before returning, so the error escapes `launch()` entirely and the local-copy fallback â€” the code that already knows how to solve this â€” is never reached.

## Fix

- Match `*TradingView*` instead of the exact `TradingView.Desktop`, in both `src/core/health.js` and `scripts/launch_tv_debug.bat`.
- Wrap the first `_spawnDetached` call and route a synchronous throw into the same fallback that already handles the async `'error'` case. On a non-WindowsApps binary the throw still propagates, since no fallback applies there.

## Tests

Three cases added to `tests/launch.test.js`, and the `msixDeps` mock grew a `syncThrowFor` option:

- synchronous EPERM on the direct spawn falls back to the local copy
- a synchronous spawn failure on a classic install path still propagates
- the Appx lookup is a wildcard, not one hardcoded name

`node --test tests/launch.test.js` â†’ 10/10 pass.

Two suites fail on this machine both before and after this change, so they look unrelated: `tests/cli.test.js` (2 failures) and `tests/sanitization.test.js`, the latter because line 290 uses `new URL('../src/core/', import.meta.url).pathname`, which on Windows yields `/C:/...` with percent-encoding and produces `scandir 'C:\C:\Claude%20projects\...'`. Happy to send that as a separate PR if it's useful.

## Verified on

Windows 11, TradingView Desktop 3.3.0 (Store/MSIX build), Node 25.2.1. After the fix, `tv_launch` copies the package once and relaunches from it, CDP binds, and `tv_health_check` returns live chart state:

```json
{
  "success": true,
  "cdp_connected": true,
  "target_url": "https://www.tradingview.com/chart/",
  "chart_symbol": "BATS:AAPL",
  "chart_resolution": "D",
  "api_available": true
}
```
