### PR TITLE
fix(windows): use fileURLToPath instead of URL.pathname

### DIFF
--- a/scripts/pine_pull.js
+++ b/scripts/pine_pull.js
@@ -2,6 +2,7 @@
 // Pull current Pine Script source from TradingView editor → scripts/current.pine
 import CDP from 'chrome-remote-interface';
 import { writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 
 const targets = await (await fetch('http://localhost:9222/json/list')).json();
 const t = targets.find(t => t.url?.includes('tradingview.com'));
@@ -16,7 +17,7 @@ const src = (await c.Runtime.evaluate({
 
 if (!src) { console.error('Could not read Pine editor'); await c.close(); process.exit(1); }
 
-const outPath = new URL('../scripts/current.pine', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const outPath = fileURLToPath(new URL('../scripts/current.pine', import.meta.url));
 writeFileSync(outPath, src);
 console.log(`Pulled ${src.split('\n').length} lines → scripts/current.pine`);
 await c.close();

--- a/scripts/pine_push.js
+++ b/scripts/pine_push.js
@@ -2,8 +2,9 @@
 // Push scripts/current.pine → TradingView editor, then compile
 import CDP from 'chrome-remote-interface';
 import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 
-const srcPath = new URL('../scripts/current.pine', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const srcPath = fileURLToPath(new URL('../scripts/current.pine', import.meta.url));
 const src = readFileSync(srcPath, 'utf-8');
 
 const targets = await (await fetch('http://localhost:9222/json/list')).json();

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,9 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  // fileURLToPath, not .pathname: on Windows .pathname yields "/C:/..." (leading
+  // slash, percent-encoded spaces), which readdirSync resolves to "C:\C:\...".
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
URL.pathname on Windows returns a POSIX-style path with a leading slash and percent-encoded characters - "/C:/Program%20Files/..." - which is not a usable filesystem path. Three call sites relied on it.

tests/sanitization.test.js passed it straight to readdirSync, which resolved it against the drive root and threw:

  ENOENT: no such file or directory, scandir 'C:\C:\...\src\core\'

That throw happens while the describe callback is building the suite, so the per-file source-audit tests were never registered at all. On Windows the file reported 34 passing tests; with the path fixed it reports 68. The audit that checks every core module for unsafe interpolation was silently not running.

scripts/pine_pull.js and pine_push.js worked around the leading slash with .replace(/^\/([A-Z]:)/, '$1'), which strips the slash but leaves percent encoding intact, so both still broke on any checkout path containing a space.

fileURLToPath handles the drive letter, the separators, and the decoding, and is the documented way to convert a file: URL to a path.