### PR TITLE
Fix Pine editor selection, compilation, and logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/pine_editor.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/pine_editor.test.js tests/pine_actions.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/pine_editor.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/pine_editor.test.js tests/pine_actions.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/pine_editor.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/pine_editor.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -136,8 +136,17 @@ export async function uiState() {
       ui.bottom_panel = { open: !!(bottom && bottom.offsetHeight > 50), height: bottom ? bottom.offsetHeight : 0 };
       var right = document.querySelector('[class*="layout__area--right"]');
       ui.right_panel = { open: !!(right && right.offsetWidth > 50), width: right ? right.offsetWidth : 0 };
-      var monacoEl = document.querySelector('.monaco-editor.pine-editor-monaco');
-      ui.pine_editor = { open: !!monacoEl, width: monacoEl ? monacoEl.offsetWidth : 0, height: monacoEl ? monacoEl.offsetHeight : 0 };
+      var monacoEls = document.querySelectorAll('.monaco-editor.pine-editor-monaco');
+      var monacoEl = Array.from(monacoEls).find(function(el) {
+        var rect = el.getBoundingClientRect();
+        return el.isConnected && el.offsetParent !== null && rect.width > 0 && rect.height > 0;
+      });
+      ui.pine_editor = {
+        open: !!monacoEl,
+        width: monacoEl ? monacoEl.offsetWidth : 0,
+        height: monacoEl ? monacoEl.offsetHeight : 0,
+        instance_count: monacoEls.length,
+      };
       var stratPanel = document.querySelector('[data-name="backtesting"]') || document.querySelector('[class*="strategyReport"]');
       ui.strategy_tester = { open: !!(stratPanel && stratPanel.offsetParent) };
       var widgetbar = document.querySelector('[data-name="widgetbar-wrap"]');

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -5,6 +5,8 @@
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
+let lastCompiledStudyIds = [];
+
 // ── Monaco finder (injected into TV page) ──
 export const FIND_MONACO = `
   (function findMonacoEditor() {
@@ -151,6 +153,64 @@ export const READ_PINE_CONSOLE = `
   })()
 `;
 
+export const READ_PINE_STUDY_LOGS = `
+  (function readPineStudyLogs(preferredStudyIds) {
+    var chart;
+    try {
+      chart = window.TradingViewApi._activeChartWidgetWV.value();
+    } catch (e) {
+      return { available: false, entries: [] };
+    }
+    if (!chart || !chart._chartWidget) return { available: false, entries: [] };
+
+    var model = chart._chartWidget.model().model();
+    var sources = typeof model.dataSources === 'function' ? model.dataSources() : [];
+    var entries = [];
+    var available = false;
+    for (var i = 0; i < sources.length; i++) {
+      var source = sources[i];
+      if (typeof source.logs !== 'function' || typeof source.logLevelMask !== 'function') continue;
+
+      var id;
+      try { id = String(typeof source.id === 'function' ? source.id() : source.id); }
+      catch (e) { continue; }
+      var mask = source.logLevelMask() || {};
+      var selected = preferredStudyIds.indexOf(id) !== -1 || mask.error || mask.warning || mask.info;
+      if (!selected) continue;
+      available = true;
+
+      var title = '';
+      try { title = String(typeof source.title === 'function' ? source.title() : source.title || ''); }
+      catch (e) {}
+      var logs = source.logs();
+      var values = logs && typeof logs.values === 'function' ? Array.from(logs.values()) : [];
+      for (var l = 0; l < values.length; l++) {
+        var item = values[l] || {};
+        var level = Number(item.level);
+        var type = level === 1 ? 'error' : level === 2 ? 'warning' : 'info';
+        var time = Number(item.time);
+        entries.push({
+          timestamp: Number.isFinite(time) ? new Date(time).toISOString() : null,
+          type: type,
+          level: Number.isFinite(level) ? level : null,
+          message: String(item.message || ''),
+          bar_time: Number.isFinite(Number(item.barTime)) ? Number(item.barTime) : null,
+          study_id: id,
+          study: title,
+          line: item.source && item.source.start ? item.source.start.line : null,
+          column: item.source && item.source.start ? item.source.start.column : null,
+          source: 'pine_logs',
+        });
+      }
+    }
+
+    entries.sort(function(a, b) {
+      return (a.bar_time || 0) - (b.bar_time || 0) || a.study_id.localeCompare(b.study_id);
+    });
+    return { available: available, entries: entries };
+  })
+`;
+
 async function clickPineActionButton() {
   const action = await evaluate(`
     (function() {
@@ -181,6 +241,34 @@ async function handleSaveBeforeAddDialog() {
     await new Promise(r => setTimeout(r, 100));
   }
   return false;
+}
+
+async function enablePineLogs(studyIds) {
+  if (!studyIds || studyIds.length === 0) return [];
+  return evaluate(`
+    (function() {
+      var chart;
+      try { chart = window.TradingViewApi._activeChartWidgetWV.value(); }
+      catch (e) { return []; }
+      if (!chart || !chart._chartWidget) return [];
+
+      var wanted = ${JSON.stringify(studyIds)};
+      var model = chart._chartWidget.model().model();
+      var sources = typeof model.dataSources === 'function' ? model.dataSources() : [];
+      var enabled = [];
+      for (var i = 0; i < sources.length; i++) {
+        var source = sources[i];
+        if (typeof source.setLogLevelMask !== 'function') continue;
+        var id;
+        try { id = String(typeof source.id === 'function' ? source.id() : source.id); }
+        catch (e) { continue; }
+        if (wanted.indexOf(id) === -1) continue;
+        source.setLogLevelMask({ error: true, warning: true, info: true });
+        enabled.push(id);
+      }
+      return enabled;
+    })()
+  `);
 }
 
 /**
@@ -508,6 +596,10 @@ export async function getConsole() {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
+  const studyResult = await evaluate(
+    `${READ_PINE_STUDY_LOGS}(${JSON.stringify(lastCompiledStudyIds)})`
+  );
+
   const consoleState = await evaluate(`
     (function() {
       var visible = function(element) {
@@ -528,14 +620,18 @@ export async function getConsole() {
   if (consoleState?.opened) await new Promise(r => setTimeout(r, 250));
 
   const result = await evaluate(READ_PINE_CONSOLE);
-  const entries = result?.entries || [];
+  const studyEntries = studyResult?.entries || [];
+  const consoleEntries = (result?.entries || []).map(entry => ({ ...entry, source: 'pine_console' }));
+  const entries = [...studyEntries, ...consoleEntries];
   return {
     success: true,
+    pine_logs_available: studyResult?.available || false,
+    pine_log_entry_count: studyEntries.length,
     console_available: result?.available || consoleState?.available || false,
     console_opened: consoleState?.opened || false,
     entries,
     entry_count: entries.length,
-    source: 'pine_console',
+    source: studyEntries.length > 0 ? 'pine_logs_and_console' : 'pine_console',
   };
 }
 
@@ -611,6 +707,9 @@ export async function smartCompile() {
   if (expectsNewStudy && studyAdded === false && !(errors?.length > 0)) {
     throw new Error('Add to chart control was clicked but no study was added.');
   }
+  if (studyIdsAdded && studyIdsAdded.length > 0) lastCompiledStudyIds = studyIdsAdded;
+  const pineLogsEnabledFor = await enablePineLogs(lastCompiledStudyIds);
+  if (pineLogsEnabledFor.length > 0) await new Promise(r => setTimeout(r, 250));
 
   return {
     success: true,
@@ -620,6 +719,7 @@ export async function smartCompile() {
     study_added: studyAdded,
     study_ids_added: studyIdsAdded || [],
     save_before_add_handled: saveBeforeAddHandled,
+    pine_logs_enabled_for: pineLogsEnabledFor,
   };
 }
 

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -57,6 +57,97 @@ export const FIND_MONACO = `
   })()
 `;
 
+// TradingView's Pine toolbar uses icon-only buttons in some layouts. The
+// action is then exposed through title/data-tooltip instead of textContent.
+export const FIND_PINE_ACTION_BUTTON = `
+  (function findPineActionButton() {
+    function isVisible(button) {
+      if (!button || !button.isConnected || button.offsetParent === null) return false;
+      var rect = button.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }
+
+    function labels(button) {
+      return [
+        button.textContent,
+        button.getAttribute('aria-label'),
+        button.getAttribute('title'),
+        button.getAttribute('data-tooltip'),
+      ].filter(Boolean).map(function(label) { return label.trim().replace(/\\s+/g, ' '); });
+    }
+
+    var buttons = Array.from(document.querySelectorAll('button')).filter(isVisible);
+    var actions = [
+      { name: 'Save and add to chart', pattern: /^save and add to chart$/i },
+      { name: 'Add to chart', pattern: /^add to chart$/i },
+      { name: 'Update on chart', pattern: /^update on chart$/i },
+    ];
+
+    for (var a = 0; a < actions.length; a++) {
+      for (var b = 0; b < buttons.length; b++) {
+        if (labels(buttons[b]).some(function(label) { return actions[a].pattern.test(label); })) {
+          return { button: buttons[b], action: actions[a].name };
+        }
+      }
+    }
+    return null;
+  })()
+`;
+
+export const READ_PINE_CONSOLE = `
+  (function readPineConsole() {
+    function isVisible(element) {
+      if (!element || !element.isConnected || element.offsetParent === null) return false;
+      var rect = element.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }
+
+    var wrappers = Array.from(document.querySelectorAll('[class*="consoleWrapper"]')).filter(isVisible);
+    var wrapper = wrappers.find(function(element) {
+      return /consoleWrapperOpen/.test(String(element.className));
+    }) || wrappers[0];
+    if (!wrapper) return { available: false, entries: [] };
+
+    var rows = wrapper.querySelectorAll('table[class*="messages"] tbody tr');
+    var entries = Array.from(rows).map(function(row) {
+      var cells = Array.from(row.querySelectorAll('td'));
+      var timestamp = null;
+      var messageCells = cells;
+      if (cells.length > 1 && /time/i.test(String(cells[0].className))) {
+        timestamp = cells[0].textContent.trim() || null;
+        messageCells = cells.slice(1);
+      }
+      var message = messageCells.map(function(cell) { return cell.textContent.trim(); }).filter(Boolean).join(' ');
+      if (!message && cells.length === 0) message = row.textContent.trim();
+
+      var signal = String(row.className) + ' ' + message;
+      var type = 'info';
+      if (/\\berror\\b/i.test(signal)) type = 'error';
+      else if (/\\bwarn(?:ing)?\\b/i.test(signal)) type = 'warning';
+      else if (/compil/i.test(message)) type = 'compile';
+      return { timestamp: timestamp, type: type, message: message };
+    }).filter(function(entry) { return entry.message; });
+
+    return { available: true, entries: entries };
+  })()
+`;
+
+async function clickPineActionButton() {
+  const action = await evaluate(`
+    (function() {
+      var match = ${FIND_PINE_ACTION_BUTTON};
+      if (!match) return null;
+      match.button.click();
+      return match.action;
+    })()
+  `);
+
+  if (!action) {
+    throw new Error('Could not find a visible Add to chart or Update on chart control.');
+  }
+  return action;
+}
+
 /**
  * Opens the Pine Editor panel and waits for Monaco to become available.
  * Returns true if editor is accessible, false on timeout.
@@ -307,38 +398,10 @@ export async function compile() {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
-  const clicked = await evaluate(`
-    (function() {
-      var btns = document.querySelectorAll('button');
-      var fallback = null;
-      var saveBtn = null;
-      for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (/save and add to chart/i.test(text)) {
-          btns[i].click();
-          return 'Save and add to chart';
-        }
-        if (!fallback && /^(Add to chart|Update on chart)/i.test(text)) {
-          fallback = btns[i];
-        }
-        if (!saveBtn && btns[i].className.indexOf('saveButton') !== -1 && btns[i].offsetParent !== null) {
-          saveBtn = btns[i];
-        }
-      }
-      if (fallback) { fallback.click(); return fallback.textContent.trim(); }
-      if (saveBtn) { saveBtn.click(); return 'Pine Save'; }
-      return null;
-    })()
-  `);
-
-  if (!clicked) {
-    const c = await getClient();
-    await c.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 2, key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 });
-    await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Enter', code: 'Enter' });
-  }
+  const clicked = await clickPineActionButton();
 
   await new Promise(r => setTimeout(r, 2000));
-  return { success: true, button_clicked: clicked || 'keyboard_shortcut', source: 'dom_fallback' };
+  return { success: true, button_clicked: clicked, source: 'pine_toolbar' };
 }
 
 export async function getErrors() {
@@ -402,50 +465,35 @@ export async function getConsole() {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
-  const entries = await evaluate(`
+  const consoleState = await evaluate(`
     (function() {
-      var results = [];
-      var rows = document.querySelectorAll('[class*="consoleRow"], [class*="log-"], [class*="consoleLine"]');
-      if (rows.length === 0) {
-        var bottomArea = document.querySelector('[class*="layout__area--bottom"]')
-          || document.querySelector('[class*="bottom-widgetbar-content"]');
-        if (bottomArea) {
-          rows = bottomArea.querySelectorAll('[class*="message"], [class*="log"], [class*="console"]');
-        }
+      var visible = function(element) {
+        if (!element || !element.isConnected || element.offsetParent === null) return false;
+        var rect = element.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      };
+      var openButton = Array.from(document.querySelectorAll('button[data-tooltip="Open console"]')).find(visible);
+      if (openButton) {
+        openButton.click();
+        return { available: true, opened: true };
       }
-      if (rows.length === 0) {
-        var pinePanel = document.querySelector('.pine-editor-container')
-          || document.querySelector('[class*="pine-editor"]')
-          || document.querySelector('[class*="layout__area--bottom"]');
-        if (pinePanel) {
-          var allSpans = pinePanel.querySelectorAll('span, div');
-          for (var s = 0; s < allSpans.length; s++) {
-            var txt = allSpans[s].textContent.trim();
-            if (/^\\d{2}:\\d{2}:\\d{2}/.test(txt) || /error|warning|info/i.test(allSpans[s].className)) {
-              rows = Array.from(rows || []);
-              rows.push(allSpans[s]);
-            }
-          }
-        }
-      }
-      for (var i = 0; i < rows.length; i++) {
-        var text = rows[i].textContent.trim();
-        if (!text) continue;
-        var ts = null;
-        var tsMatch = text.match(/^(\\d{4}-\\d{2}-\\d{2}\\s+)?\\d{2}:\\d{2}:\\d{2}/);
-        if (tsMatch) ts = tsMatch[0];
-        var type = 'info';
-        var cls = rows[i].className || '';
-        if (/error/i.test(cls) || /error/i.test(text.substring(0, 30))) type = 'error';
-        else if (/compil/i.test(text.substring(0, 40))) type = 'compile';
-        else if (/warn/i.test(cls)) type = 'warning';
-        results.push({ timestamp: ts, type: type, message: text });
-      }
-      return results;
+      var closeButton = Array.from(document.querySelectorAll('button[data-tooltip="Close console"]')).find(visible);
+      return { available: !!closeButton, opened: false };
     })()
   `);
 
-  return { success: true, entries: entries || [], entry_count: entries?.length || 0 };
+  if (consoleState?.opened) await new Promise(r => setTimeout(r, 250));
+
+  const result = await evaluate(READ_PINE_CONSOLE);
+  const entries = result?.entries || [];
+  return {
+    success: true,
+    console_available: result?.available || consoleState?.available || false,
+    console_opened: consoleState?.opened || false,
+    entries,
+    entry_count: entries.length,
+    source: 'pine_console',
+  };
 }
 
 export async function smartCompile() {
@@ -456,42 +504,34 @@ export async function smartCompile() {
     (function() {
       try {
         var chart = window.TradingViewApi._activeChartWidgetWV.value();
-        if (chart && typeof chart.getAllStudies === 'function') return chart.getAllStudies().length;
+        if (chart && typeof chart.getAllStudies === 'function') {
+          return chart.getAllStudies().map(function(study) { return String(study.id); });
+        }
       } catch(e) {}
       return null;
     })()
   `);
 
-  const buttonClicked = await evaluate(`
-    (function() {
-      var btns = document.querySelectorAll('button');
-      var addBtn = null;
-      var updateBtn = null;
-      var saveBtn = null;
-      for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (/save and add to chart/i.test(text)) {
-          btns[i].click();
-          return 'Save and add to chart';
-        }
-        if (!addBtn && /^add to chart$/i.test(text)) addBtn = btns[i];
-        if (!updateBtn && /^update on chart$/i.test(text)) updateBtn = btns[i];
-        if (!saveBtn && btns[i].className.indexOf('saveButton') !== -1 && btns[i].offsetParent !== null) saveBtn = btns[i];
-      }
-      if (addBtn) { addBtn.click(); return 'Add to chart'; }
-      if (updateBtn) { updateBtn.click(); return 'Update on chart'; }
-      if (saveBtn) { saveBtn.click(); return 'Pine Save'; }
-      return null;
-    })()
-  `);
-
-  if (!buttonClicked) {
-    const c = await getClient();
-    await c.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 2, key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 });
-    await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Enter', code: 'Enter' });
+  const buttonClicked = await clickPineActionButton();
+  const expectsNewStudy = /add to chart/i.test(buttonClicked);
+  if (expectsNewStudy) {
+    for (let i = 0; i < 40; i++) {
+      await new Promise(r => setTimeout(r, 250));
+      const added = await evaluate(`
+        (function() {
+          try {
+            var chart = window.TradingViewApi._activeChartWidgetWV.value();
+            if (!chart || typeof chart.getAllStudies !== 'function') return false;
+            var before = ${JSON.stringify(studiesBefore)};
+            return chart.getAllStudies().some(function(study) { return before.indexOf(String(study.id)) === -1; });
+          } catch(e) { return false; }
+        })()
+      `);
+      if (added) break;
+    }
+  } else {
+    await new Promise(r => setTimeout(r, 2500));
   }
-
-  await new Promise(r => setTimeout(r, 2500));
 
   const errors = await evaluate(`
     (function() {
@@ -510,20 +550,29 @@ export async function smartCompile() {
     (function() {
       try {
         var chart = window.TradingViewApi._activeChartWidgetWV.value();
-        if (chart && typeof chart.getAllStudies === 'function') return chart.getAllStudies().length;
+        if (chart && typeof chart.getAllStudies === 'function') {
+          return chart.getAllStudies().map(function(study) { return String(study.id); });
+        }
       } catch(e) {}
       return null;
     })()
   `);
 
-  const studyAdded = (studiesBefore !== null && studiesAfter !== null) ? studiesAfter > studiesBefore : null;
+  const studyIdsAdded = (studiesBefore !== null && studiesAfter !== null)
+    ? studiesAfter.filter(id => !studiesBefore.includes(id))
+    : null;
+  const studyAdded = studyIdsAdded === null ? null : studyIdsAdded.length > 0;
+  if (expectsNewStudy && studyAdded === false && !(errors?.length > 0)) {
+    throw new Error('Add to chart control was clicked but no study was added.');
+  }
 
   return {
     success: true,
-    button_clicked: buttonClicked || 'keyboard_shortcut',
+    button_clicked: buttonClicked,
     has_errors: errors?.length > 0,
     errors: errors || [],
     study_added: studyAdded,
+    study_ids_added: studyIdsAdded || [],
   };
 }
 

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -94,6 +94,25 @@ export const FIND_PINE_ACTION_BUTTON = `
   })()
 `;
 
+export const FIND_SAVE_BEFORE_ADD_BUTTON = `
+  (function findSaveBeforeAddButton() {
+    function isVisible(element) {
+      if (!element || !element.isConnected || element.offsetParent === null) return false;
+      var rect = element.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }
+
+    var dialogs = Array.from(document.querySelectorAll('[data-name="confirm-dialog"]')).filter(isVisible);
+    var dialog = dialogs.find(function(element) {
+      return element.textContent.toLowerCase().includes('save this script before adding?');
+    });
+    if (!dialog) return null;
+
+    var button = dialog.querySelector('button[data-qa-id="yes-btn"], button[name="yes"]');
+    return isVisible(button) ? button : null;
+  })()
+`;
+
 export const READ_PINE_CONSOLE = `
   (function readPineConsole() {
     function isVisible(element) {
@@ -146,6 +165,22 @@ async function clickPineActionButton() {
     throw new Error('Could not find a visible Add to chart or Update on chart control.');
   }
   return action;
+}
+
+async function handleSaveBeforeAddDialog() {
+  for (let i = 0; i < 20; i++) {
+    const handled = await evaluate(`
+      (function() {
+        var button = ${FIND_SAVE_BEFORE_ADD_BUTTON};
+        if (!button) return false;
+        button.click();
+        return true;
+      })()
+    `);
+    if (handled) return true;
+    await new Promise(r => setTimeout(r, 100));
+  }
+  return false;
 }
 
 /**
@@ -399,9 +434,17 @@ export async function compile() {
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
   const clicked = await clickPineActionButton();
+  const saveBeforeAddHandled = /add to chart/i.test(clicked)
+    ? await handleSaveBeforeAddDialog()
+    : false;
 
   await new Promise(r => setTimeout(r, 2000));
-  return { success: true, button_clicked: clicked, source: 'pine_toolbar' };
+  return {
+    success: true,
+    button_clicked: clicked,
+    save_before_add_handled: saveBeforeAddHandled,
+    source: 'pine_toolbar',
+  };
 }
 
 export async function getErrors() {
@@ -514,6 +557,9 @@ export async function smartCompile() {
 
   const buttonClicked = await clickPineActionButton();
   const expectsNewStudy = /add to chart/i.test(buttonClicked);
+  const saveBeforeAddHandled = expectsNewStudy
+    ? await handleSaveBeforeAddDialog()
+    : false;
   if (expectsNewStudy) {
     for (let i = 0; i < 40; i++) {
       await new Promise(r => setTimeout(r, 250));
@@ -573,6 +619,7 @@ export async function smartCompile() {
     errors: errors || [],
     study_added: studyAdded,
     study_ids_added: studyIdsAdded || [],
+    save_before_add_handled: saveBeforeAddHandled,
   };
 }
 

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -6,30 +6,52 @@
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
 // ── Monaco finder (injected into TV page) ──
-const FIND_MONACO = `
+export const FIND_MONACO = `
   (function findMonacoEditor() {
-    var container = document.querySelector('.monaco-editor.pine-editor-monaco');
-    if (!container) return null;
-    var el = container;
-    var fiberKey;
-    for (var i = 0; i < 20; i++) {
-      if (!el) break;
-      fiberKey = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); });
-      if (fiberKey) break;
-      el = el.parentElement;
-    }
-    if (!fiberKey) return null;
-    var current = el[fiberKey];
-    for (var d = 0; d < 15; d++) {
-      if (!current) break;
-      if (current.memoizedProps && current.memoizedProps.value && current.memoizedProps.value.monacoEnv) {
-        var env = current.memoizedProps.value.monacoEnv;
-        if (env.editor && typeof env.editor.getEditors === 'function') {
-          var editors = env.editor.getEditors();
-          if (editors.length > 0) return { editor: editors[0], env: env };
-        }
+    var containers = Array.from(document.querySelectorAll('.monaco-editor.pine-editor-monaco'));
+    var visible = containers.filter(function(container) {
+      var rect = container.getBoundingClientRect();
+      return container.isConnected && container.offsetParent !== null && rect.width > 0 && rect.height > 0;
+    });
+
+    for (var c = 0; c < visible.length; c++) {
+      var container = visible[c];
+      var el = container;
+      var fiberKey;
+      for (var i = 0; i < 40; i++) {
+        if (!el) break;
+        fiberKey = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); });
+        if (fiberKey) break;
+        el = el.parentElement;
       }
-      current = current.return;
+      if (!fiberKey) continue;
+
+      var current = el[fiberKey];
+      for (var d = 0; d < 40; d++) {
+        if (!current) break;
+        if (current.memoizedProps && current.memoizedProps.value && current.memoizedProps.value.monacoEnv) {
+          var env = current.memoizedProps.value.monacoEnv;
+          if (env.editor && typeof env.editor.getEditors === 'function') {
+            var editors = env.editor.getEditors();
+            var matched = editors.find(function(editor) {
+              if (typeof editor.getDomNode !== 'function') return false;
+              var node = editor.getDomNode();
+              return node === container;
+            });
+            if (matched) return { editor: matched, env: env };
+
+            var active = editors.find(function(editor) {
+              if (typeof editor.getDomNode !== 'function') return false;
+              var node = editor.getDomNode();
+              if (!node || !node.isConnected || node.offsetParent === null) return false;
+              var rect = node.getBoundingClientRect();
+              return rect.width > 0 && rect.height > 0;
+            });
+            if (active) return { editor: active, env: env };
+          }
+        }
+        current = current.return;
+      }
     }
     return null;
   })()

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -174,15 +174,22 @@ export const READ_PINE_STUDY_LOGS = `
       var id;
       try { id = String(typeof source.id === 'function' ? source.id() : source.id); }
       catch (e) { continue; }
-      var mask = source.logLevelMask() || {};
-      var selected = preferredStudyIds.indexOf(id) !== -1 || mask.error || mask.warning || mask.info;
+      var preferred = preferredStudyIds.indexOf(id) !== -1;
+      var mask = {};
+      if (!preferred) {
+        try { mask = source.logLevelMask() || {}; }
+        catch (e) { continue; }
+      }
+      var selected = preferred || mask.error || mask.warning || mask.info;
       if (!selected) continue;
       available = true;
 
       var title = '';
       try { title = String(typeof source.title === 'function' ? source.title() : source.title || ''); }
       catch (e) {}
-      var logs = source.logs();
+      var logs;
+      try { logs = source.logs(); }
+      catch (e) { continue; }
       var values = logs && typeof logs.values === 'function' ? Array.from(logs.values()) : [];
       for (var l = 0; l < values.length; l++) {
         var item = values[l] || {};

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -41,20 +41,28 @@ export async function openPanel({ panel, action }) {
         var action = ${JSON.stringify(action)};
         var bottomArea = document.querySelector('[class*="layout__area--bottom"]');
         var isOpen = !!(bottomArea && bottomArea.offsetHeight > 50);
-        if (panel === 'pine-editor') { var monacoEl = document.querySelector('.monaco-editor.pine-editor-monaco'); isOpen = isOpen && !!monacoEl; }
+        if (panel === 'pine-editor') {
+          var monacoEls = document.querySelectorAll('.monaco-editor.pine-editor-monaco');
+          isOpen = Array.from(monacoEls).some(function(el) {
+            var rect = el.getBoundingClientRect();
+            return el.isConnected && el.offsetParent !== null && rect.width > 0 && rect.height > 0;
+          });
+        }
         if (panel === 'strategy-tester') { var stratPanel = document.querySelector('[data-name="backtesting"]') || document.querySelector('[class*="strategyReport"]'); isOpen = isOpen && !!(stratPanel && stratPanel.offsetParent); }
         var performed = 'none';
-        if (action === 'open' || (action === 'toggle' && !isOpen)) {
+        if ((action === 'open' && !isOpen) || (action === 'toggle' && !isOpen)) {
           if (panel === 'pine-editor') { if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab(); else if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); }
           else { if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); }
           performed = 'opened';
-        } else if (action === 'close' || (action === 'toggle' && isOpen)) {
+        } else if ((action === 'close' && isOpen) || (action === 'toggle' && isOpen)) {
           // hideWidget(name) was removed in newer TradingView builds; fall back to
           // close() (minimizes the bottom panel) and then hide() (hides the bar).
           if (typeof bwb.hideWidget === 'function') bwb.hideWidget(widgetName);
           else if (typeof bwb.close === 'function') bwb.close();
           else if (typeof bwb.hide === 'function') bwb.hide();
           performed = 'closed';
+        } else {
+          performed = isOpen ? 'already_open' : 'already_closed';
         }
         return { was_open: isOpen, performed: performed };
       })()

--- a/tests/pine_actions.test.js
+++ b/tests/pine_actions.test.js
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import vm from 'node:vm';
-import { FIND_PINE_ACTION_BUTTON, READ_PINE_CONSOLE } from '../src/core/pine.js';
+import {
+  FIND_PINE_ACTION_BUTTON,
+  FIND_SAVE_BEFORE_ADD_BUTTON,
+  READ_PINE_CONSOLE,
+} from '../src/core/pine.js';
 
 function element({ text = '', attributes = {}, visible = true, className = '', cells = [] } = {}) {
   return {
@@ -37,6 +41,24 @@ test('Pine action finder never treats the save icon as a compile control', () =>
   const context = { document: { querySelectorAll: () => [save] } };
 
   assert.equal(vm.runInNewContext(FIND_PINE_ACTION_BUTTON, context), null);
+});
+
+test('save-before-add finder selects only the affirmative button in the explicit confirmation', () => {
+  const yes = element({ text: 'Save', attributes: { 'data-qa-id': 'yes-btn' } });
+  const dialog = element({ text: 'Save this script before adding? Script with unsaved changes cannot be added.' });
+  dialog.querySelector = () => yes;
+  const context = { document: { querySelectorAll: () => [dialog] } };
+
+  assert.equal(vm.runInNewContext(FIND_SAVE_BEFORE_ADD_BUTTON, context), yes);
+});
+
+test('save-before-add finder ignores unrelated save dialogs', () => {
+  const save = element({ text: 'Save' });
+  const dialog = element({ text: 'Save chart layout' });
+  dialog.querySelector = () => save;
+  const context = { document: { querySelectorAll: () => [dialog] } };
+
+  assert.equal(vm.runInNewContext(FIND_SAVE_BEFORE_ADD_BUTTON, context), null);
 });
 
 test('Pine console reader returns only rows from the visible console table', () => {

--- a/tests/pine_actions.test.js
+++ b/tests/pine_actions.test.js
@@ -88,6 +88,11 @@ test('Pine console reader does not fall back to editor or dialog text', () => {
 });
 
 test('Pine study log reader returns structured logs for the compiled study', () => {
+  const brokenUnrelatedSource = {
+    id: () => 'broken-unrelated',
+    logLevelMask: () => { throw new Error('uninitialized internal value'); },
+    logs: () => { throw new Error('must not be called'); },
+  };
   const source = {
     id: () => 'study-1',
     title: () => 'MCP smoke',
@@ -107,7 +112,9 @@ test('Pine study log reader returns structured logs for the compiled study', () 
       TradingViewApi: {
         _activeChartWidgetWV: {
           value: () => ({
-            _chartWidget: { model: () => ({ model: () => ({ dataSources: () => [source] }) }) },
+            _chartWidget: {
+              model: () => ({ model: () => ({ dataSources: () => [brokenUnrelatedSource, source] }) }),
+            },
           }),
         },
       },

--- a/tests/pine_actions.test.js
+++ b/tests/pine_actions.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { FIND_PINE_ACTION_BUTTON, READ_PINE_CONSOLE } from '../src/core/pine.js';
+
+function element({ text = '', attributes = {}, visible = true, className = '', cells = [] } = {}) {
+  return {
+    textContent: text,
+    className,
+    isConnected: true,
+    offsetParent: visible ? {} : null,
+    clicked: false,
+    getAttribute(name) { return attributes[name] ?? null; },
+    getBoundingClientRect() { return { width: visible ? 34 : 0, height: visible ? 34 : 0 }; },
+    click() { this.clicked = true; },
+    querySelectorAll(selector) {
+      if (selector === 'td') return cells;
+      return [];
+    },
+  };
+}
+
+test('Pine action finder selects a visible icon-only Add to chart button', () => {
+  const hiddenAdd = element({ attributes: { title: 'Add to chart' }, visible: false });
+  const save = element({ className: 'saveButton-abc', attributes: { title: 'Save' } });
+  const add = element({ attributes: { title: 'Add to chart' } });
+  const context = { document: { querySelectorAll: () => [hiddenAdd, save, add] } };
+
+  const match = vm.runInNewContext(FIND_PINE_ACTION_BUTTON, context);
+
+  assert.equal(match.action, 'Add to chart');
+  assert.equal(match.button, add);
+});
+
+test('Pine action finder never treats the save icon as a compile control', () => {
+  const save = element({ className: 'saveButton-abc', attributes: { title: 'Save' } });
+  const context = { document: { querySelectorAll: () => [save] } };
+
+  assert.equal(vm.runInNewContext(FIND_PINE_ACTION_BUTTON, context), null);
+});
+
+test('Pine console reader returns only rows from the visible console table', () => {
+  const time = element({ text: '12:34:56 AM', className: 'time-abc' });
+  const log = element({ text: 'MCP_LOG_SMOKE|123.45' });
+  const row = element({ cells: [time, log] });
+  const wrapper = element({ className: 'consoleWrapper-abc consoleWrapperOpen-abc' });
+  wrapper.querySelectorAll = (selector) => selector === 'table[class*="messages"] tbody tr' ? [row] : [];
+  const context = { document: { querySelectorAll: () => [wrapper] } };
+
+  const result = vm.runInNewContext(READ_PINE_CONSOLE, context);
+
+  assert.equal(result.available, true);
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].timestamp, '12:34:56 AM');
+  assert.equal(result.entries[0].message, 'MCP_LOG_SMOKE|123.45');
+});
+
+test('Pine console reader does not fall back to editor or dialog text', () => {
+  const context = { document: { querySelectorAll: () => [] } };
+
+  const result = vm.runInNewContext(READ_PINE_CONSOLE, context);
+
+  assert.equal(result.available, false);
+  assert.equal(result.entries.length, 0);
+});

--- a/tests/pine_actions.test.js
+++ b/tests/pine_actions.test.js
@@ -5,6 +5,7 @@ import {
   FIND_PINE_ACTION_BUTTON,
   FIND_SAVE_BEFORE_ADD_BUTTON,
   READ_PINE_CONSOLE,
+  READ_PINE_STUDY_LOGS,
 } from '../src/core/pine.js';
 
 function element({ text = '', attributes = {}, visible = true, className = '', cells = [] } = {}) {
@@ -81,6 +82,66 @@ test('Pine console reader does not fall back to editor or dialog text', () => {
   const context = { document: { querySelectorAll: () => [] } };
 
   const result = vm.runInNewContext(READ_PINE_CONSOLE, context);
+
+  assert.equal(result.available, false);
+  assert.equal(result.entries.length, 0);
+});
+
+test('Pine study log reader returns structured logs for the compiled study', () => {
+  const source = {
+    id: () => 'study-1',
+    title: () => 'MCP smoke',
+    logLevelMask: () => ({ error: true, warning: true, info: true }),
+    logs: () => ({
+      values: () => [{
+        barTime: 1700000000000,
+        time: 1700000000000,
+        level: 4,
+        message: 'MCP_LOG_SMOKE|123.45',
+        source: { start: { line: 4, column: 5 } },
+      }],
+    }),
+  };
+  const context = {
+    window: {
+      TradingViewApi: {
+        _activeChartWidgetWV: {
+          value: () => ({
+            _chartWidget: { model: () => ({ model: () => ({ dataSources: () => [source] }) }) },
+          }),
+        },
+      },
+    },
+  };
+
+  const result = vm.runInNewContext(`${READ_PINE_STUDY_LOGS}(['study-1'])`, context);
+
+  assert.equal(result.available, true);
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].message, 'MCP_LOG_SMOKE|123.45');
+  assert.equal(result.entries[0].study_id, 'study-1');
+  assert.equal(result.entries[0].source, 'pine_logs');
+});
+
+test('Pine study log reader ignores unselected studies with logging disabled', () => {
+  const source = {
+    id: () => 'other-study',
+    logLevelMask: () => ({ error: false, warning: false, info: false }),
+    logs: () => ({ values: () => [{ message: 'must not leak' }] }),
+  };
+  const context = {
+    window: {
+      TradingViewApi: {
+        _activeChartWidgetWV: {
+          value: () => ({
+            _chartWidget: { model: () => ({ model: () => ({ dataSources: () => [source] }) }) },
+          }),
+        },
+      },
+    },
+  };
+
+  const result = vm.runInNewContext(`${READ_PINE_STUDY_LOGS}(['study-1'])`, context);
 
   assert.equal(result.available, false);
   assert.equal(result.entries.length, 0);

--- a/tests/pine_editor.test.js
+++ b/tests/pine_editor.test.js
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+
+import { FIND_MONACO } from '../src/core/pine.js';
+
+function domNode({ visible }) {
+  return {
+    isConnected: true,
+    offsetParent: visible ? {} : null,
+    parentElement: null,
+    getBoundingClientRect() {
+      return visible ? { width: 500, height: 700 } : { width: 0, height: 0 };
+    },
+  };
+}
+
+function attachFiber(container, env) {
+  const host = { parentElement: null };
+  host.__reactFiber$test = {
+    memoizedProps: {},
+    return: {
+      memoizedProps: { value: { monacoEnv: env } },
+      return: null,
+    },
+  };
+  container.parentElement = host;
+}
+
+describe('FIND_MONACO', () => {
+  it('selects the visible editor when TradingView leaves a stale instance first', () => {
+    const staleContainer = domNode({ visible: false });
+    const activeContainer = domNode({ visible: true });
+    const staleEditor = { getDomNode: () => staleContainer };
+    const activeEditor = { getDomNode: () => activeContainer };
+    const env = { editor: { getEditors: () => [staleEditor, activeEditor] } };
+    attachFiber(activeContainer, env);
+
+    const found = vm.runInNewContext(FIND_MONACO, {
+      document: {
+        querySelectorAll: () => [staleContainer, activeContainer],
+      },
+    });
+
+    assert.equal(found.editor, activeEditor);
+    assert.equal(found.env, env);
+  });
+
+  it('does not treat a hidden stale editor as ready', () => {
+    const staleContainer = domNode({ visible: false });
+    const staleEditor = { getDomNode: () => staleContainer };
+    const env = { editor: { getEditors: () => [staleEditor] } };
+    attachFiber(staleContainer, env);
+
+    const found = vm.runInNewContext(FIND_MONACO, {
+      document: {
+        querySelectorAll: () => [staleContainer],
+      },
+    });
+
+    assert.equal(found, null);
+  });
+});


### PR DESCRIPTION
## Summary
- select the visible Pine Monaco container instead of TradingView's stale hidden instance after a dialog reopen
- recognize icon-only Add/Update controls through title, aria-label, and data-tooltip rather than textContent alone
- never treat the Pine save icon as a compile action
- handle only the explicit "Save this script before adding?" confirmation and verify that Add actually creates a study
- enable and read structured log records from the compiled study's internal log API while keeping editor compile messages separate
- add focused unit regressions for stale Monaco selection, icon-only compile controls, save confirmation containment, strict console rows, structured study logs, and throwing unrelated data sources

## Root causes
TradingView can retain a hidden stale Monaco instance, renders the active Add control as an icon-only button, requires an explicit save-before-add confirmation for changed scripts, and stores Pine log output on the compiled study data source rather than in the Pine Editor's compile-message console. The bridge selected the stale editor, missed the icon-only Add control, clicked Save as a fallback, ignored the confirmation dialog, and scraped broad editor DOM text as console output.

## Verification
Per the configured development workflow, no local project tests, lint, builds, or E2E suites were run. Exact-head fork CI passed lint and unit tests on Node 20 and 22: https://github.com/jamie7893/tradingview-mcp/actions/runs/31962153013

A live harmless Pine v6 smoke indicator on TradingView Desktop then proved the exact head: Add to chart was selected, the save confirmation was handled, one study was created, two structured MCP_LOG_SMOKE records were returned, only the new study was removed, and the original 1,104-byte source plus the exact preexisting study set were restored. No alerts, orders, broker actions, or research economics were opened.