### PR TITLE
fix(pine): stop pine_new/pine_smart_compile silently overwriting the open script

### DIFF
--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -565,10 +565,12 @@ export async function newScript({ type }) {
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
   const typeMap = { indicator: 'indicator', strategy: 'strategy', library: 'library' };
+  // Submenu labels carry their shortcut inline ("Indicator⌘ K, ⌘ I"), so anchor
+  // at the start only. "Built-in…" sits in the same submenu and must not match.
   const patterns = {
-    indicator: 'new blank indicator|new indicator',
-    strategy: 'new blank strategy|new strategy',
-    library: 'new blank library|new library',
+    indicator: '^indicator',
+    strategy: '^strategy',
+    library: '^library',
   };
   const wanted = patterns[type] || patterns.indicator;
 
@@ -583,10 +585,13 @@ export async function newScript({ type }) {
     (function() {
       var root = document.querySelector('${PINE_ROOT}');
       if (!root) return false;
-      // The script-name button is the dropdown holding Create new / Make a copy /
-      // Version history. Class suffixes are build-hashed, so match on the prefix.
-      var title = root.querySelector('button[class*="nameButton"]');
-      if (title && title.offsetParent !== null) { title.click(); return 'title-dropdown'; }
+      // The script-name control is the dropdown holding Create new / Make a copy /
+      // Version history. It is a DIV[role=button], NOT a <button>, so do not
+      // restrict by tag. Class suffixes are build-hashed; match on the prefix.
+      var title = Array.prototype.slice.call(
+        root.querySelectorAll('[class*="nameButton"]')
+      ).filter(function(e) { return e.offsetParent !== null; })[0];
+      if (title) { title.click(); return 'title-dropdown'; }
       var more = Array.prototype.slice.call(
         root.querySelectorAll('button[aria-label="More"], button[data-name*="menu"], button[aria-label*="menu" i]')
       ).filter(function(b) { return b.offsetParent !== null; });
@@ -604,28 +609,39 @@ export async function newScript({ type }) {
 
   await new Promise(r => setTimeout(r, 400));
 
-  // Click the "New blank <type>" item. Only ever click an item matching this
-  // regex — never anything else in that menu (it also contains destructive items).
-  const itemClicked = await evaluate(`
+  // "Create new" opens a submenu; the type lives one level down. Only ever click
+  // items matching these exact patterns — the same menu holds destructive entries.
+  const MENU_SEL = '[role="menuitem"], [class*="item-"], [class*="label-"]';
+  const clickMenuItem = (pattern) => evaluate(`
     (function() {
-      var re = new RegExp(${JSON.stringify(wanted)}, 'i');
-      var nodes = document.querySelectorAll('[role="menuitem"], [class*="item" i], [class*="label" i]');
+      var re = new RegExp(${JSON.stringify('PLACEHOLDER')}, 'i');
+      var nodes = document.querySelectorAll('${MENU_SEL}');
       for (var i = 0; i < nodes.length; i++) {
         var n = nodes[i];
         if (n.offsetParent === null) continue;
         var t = (n.textContent || '').trim();
-        if (t.length > 60) continue;
+        if (t.length > 40) continue;
         if (re.test(t)) { n.click(); return t; }
       }
       return null;
     })()
-  `);
+  `.replace(JSON.stringify('PLACEHOLDER'), JSON.stringify(pattern)));
+
+  const submenuOpened = await clickMenuItem('^create new$');
+  if (!submenuOpened) {
+    await evaluate(`(function(){ document.body.click(); return true; })()`);
+    throw new Error('Could not find "Create new" in the Pine Editor script menu. Refusing to fall back to overwriting the open script.');
+  }
+
+  await new Promise(r => setTimeout(r, 400));
+
+  const itemClicked = await clickMenuItem(wanted);
 
   if (!itemClicked) {
     // Close the menu so we do not leave the UI in a half-open state.
     await evaluate(`(function(){ document.body.click(); return true; })()`);
     throw new Error(
-      'Could not find a "New blank ' + type + '" item in the Pine Editor menu. ' +
+      'Could not find a "' + type + '" item in the Pine Editor "Create new" submenu. ' +
       'Refusing to fall back to overwriting the open script.'
     );
   }

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -5,6 +5,12 @@
  */
 import { evaluate, evaluateAsync, getClient } from '../connection.js';
 
+// Root of the Pine Editor panel. Used to scope DOM lookups so we never touch the
+// chart's own controls (notably the chart-layout Save button, which shares the
+// "saveButton" class prefix with Pine's). Other classes in this subtree are
+// build-hashed (e.g. editorWrapper-mImut1T6) and unsafe to match on.
+const PINE_ROOT = '.tv-script-widget';
+
 // ── Monaco finder (injected into TV page) ──
 const FIND_MONACO = `
   (function findMonacoEditor() {
@@ -426,7 +432,15 @@ export async function getConsole() {
   return { success: true, entries: entries || [], entry_count: entries?.length || 0 };
 }
 
-export async function smartCompile() {
+/**
+ * Compile / apply the current script to the chart.
+ *
+ * `allowSave` defaults to false and MUST stay that way: TradingView's Save
+ * button persists into the script slot the buffer is bound to, so an implicit
+ * Save here silently overwrites whichever saved script happens to be open.
+ * See upstream issue #395.
+ */
+export async function smartCompile({ allowSave = false } = {}) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
@@ -442,23 +456,38 @@ export async function smartCompile() {
 
   const buttonClicked = await evaluate(`
     (function() {
-      var btns = document.querySelectorAll('button');
-      var addBtn = null;
-      var updateBtn = null;
-      var saveBtn = null;
-      for (var i = 0; i < btns.length; i++) {
-        var text = btns[i].textContent.trim();
-        if (/save and add to chart/i.test(text)) {
-          btns[i].click();
-          return 'Save and add to chart';
-        }
-        if (!addBtn && /^add to chart$/i.test(text)) addBtn = btns[i];
-        if (!updateBtn && /^update on chart$/i.test(text)) updateBtn = btns[i];
-        if (!saveBtn && btns[i].className.indexOf('saveButton') !== -1 && btns[i].offsetParent !== null) saveBtn = btns[i];
+      var allowSave = ${allowSave ? 'true' : 'false'};
+      // TradingView Desktop 3.x renders these as icon-only buttons, so matching on
+      // textContent alone finds nothing. Fold in aria-label/title/data-name/class
+      // so "Add to chart" is still detected and we never fall through to Save.
+      function label(b) {
+        return (
+          (b.textContent || '') + ' ' +
+          (b.getAttribute('aria-label') || '') + ' ' +
+          (b.getAttribute('title') || '') + ' ' +
+          (b.getAttribute('data-name') || '')
+        ).trim();
       }
+      var btns = document.querySelectorAll('button');
+      var addBtn = null, updateBtn = null, saveAndAddBtn = null, saveBtn = null;
+      for (var i = 0; i < btns.length; i++) {
+        var b = btns[i];
+        if (b.offsetParent === null) continue;
+        var t = label(b);
+        var cls = (typeof b.className === 'string') ? b.className : '';
+        if (/save and add to chart/i.test(t)) { if (!saveAndAddBtn) saveAndAddBtn = b; continue; }
+        if (!addBtn && (/add to chart/i.test(t) || cls.indexOf('addToChart') !== -1 || cls.indexOf('applyToChart') !== -1)) addBtn = b;
+        if (!updateBtn && (/update on chart/i.test(t) || cls.indexOf('updateOnChart') !== -1)) updateBtn = b;
+        // Scope Save to the Pine Editor panel: the chart-layout save button also
+        // carries a "saveButton" class and must never be clicked here.
+        if (!saveBtn && cls.indexOf('saveButton') !== -1 && b.closest('${PINE_ROOT}')) saveBtn = b;
+      }
+      // Non-destructive actions first, always.
       if (addBtn) { addBtn.click(); return 'Add to chart'; }
       if (updateBtn) { updateBtn.click(); return 'Update on chart'; }
-      if (saveBtn) { saveBtn.click(); return 'Pine Save'; }
+      if (allowSave && saveAndAddBtn) { saveAndAddBtn.click(); return 'Save and add to chart'; }
+      if (allowSave && saveBtn) { saveBtn.click(); return 'Pine Save'; }
+      // Deliberately NOT falling back to Save when allowSave is false.
       return null;
     })()
   `);
@@ -505,33 +534,126 @@ export async function smartCompile() {
   };
 }
 
+/**
+ * Reads the Pine Editor's binding state: which saved script the buffer is
+ * currently attached to. Used to prove a new script was really created rather
+ * than the open script being silently overwritten.
+ */
+const READ_BINDING = `
+  (function() {
+    var out = { title: null, saveState: null };
+    var root = document.querySelector('${PINE_ROOT}');
+    if (!root) return out;
+    var titleEl = root.querySelector('button[class*="nameButton"]');
+    if (titleEl) out.title = titleEl.textContent.trim();
+    // A bound script shows a version stamp like "8 ∙ Today, 03:02"; an unsaved
+    // one shows "Unsaved version". Separator glyph varies (· / ∙ / •),
+    // so match "digits + any non-alphanumeric separator" rather than a literal.
+    var els = root.querySelectorAll('button,div,span');
+    for (var i = 0; i < els.length; i++) {
+      var t = els[i].textContent;
+      if (!t) continue;
+      t = t.trim();
+      if (/^unsaved/i.test(t) || /^[0-9]+\\s*[^0-9A-Za-z\\s]/.test(t)) { out.saveState = t; break; }
+    }
+    return out;
+  })()
+`;
+
 export async function newScript({ type }) {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
   const typeMap = { indicator: 'indicator', strategy: 'strategy', library: 'library' };
-  const templates = {
-    indicator: '//@version=6\nindicator("My script")\nplot(close)',
-    strategy: '//@version=6\nstrategy("My strategy", overlay=true)\n',
-    library: '//@version=6\n// @description TODO: add library description here\nlibrary("MyLibrary")\n',
+  const patterns = {
+    indicator: 'new blank indicator|new indicator',
+    strategy: 'new blank strategy|new strategy',
+    library: 'new blank library|new library',
   };
+  const wanted = patterns[type] || patterns.indicator;
 
-  const template = templates[type] || templates.indicator;
+  const before = await evaluate(READ_BINDING);
 
-  // Simply set the source to a new template — this is the most reliable approach
-  const escaped = JSON.stringify(template);
-  const set = await evaluate(`
+  // Per TradingView docs, "Create new -> indicator/strategy/library" lives in the
+  // script-NAME dropdown (the script title in the Pine Editor header). Older/other
+  // builds surface it under the "..." (More) button, so try the title first and
+  // fall back to More. Both are scoped to the Pine Editor subtree so we never hit
+  // the chart toolbar's own "More" button.
+  const menuOpened = await evaluate(`
     (function() {
-      var m = ${FIND_MONACO};
-      if (!m) return false;
-      m.editor.setValue(${escaped});
-      return true;
+      var root = document.querySelector('${PINE_ROOT}');
+      if (!root) return false;
+      // The script-name button is the dropdown holding Create new / Make a copy /
+      // Version history. Class suffixes are build-hashed, so match on the prefix.
+      var title = root.querySelector('button[class*="nameButton"]');
+      if (title && title.offsetParent !== null) { title.click(); return 'title-dropdown'; }
+      var more = Array.prototype.slice.call(
+        root.querySelectorAll('button[aria-label="More"], button[data-name*="menu"], button[aria-label*="menu" i]')
+      ).filter(function(b) { return b.offsetParent !== null; });
+      if (more[0]) { more[0].click(); return 'more-button'; }
+      return false;
     })()
   `);
 
-  if (!set) throw new Error('Monaco editor not found. Ensure Pine Editor is open.');
+  if (!menuOpened) {
+    throw new Error(
+      'Could not open the Pine Editor script menu (looked for the script-name dropdown, then "More") ' +
+      `inside ${PINE_ROOT}. Refusing to fall back to overwriting the open script.`
+    );
+  }
 
-  return { success: true, type, action: 'new_script_created', template: typeMap[type] };
+  await new Promise(r => setTimeout(r, 400));
+
+  // Click the "New blank <type>" item. Only ever click an item matching this
+  // regex — never anything else in that menu (it also contains destructive items).
+  const itemClicked = await evaluate(`
+    (function() {
+      var re = new RegExp(${JSON.stringify(wanted)}, 'i');
+      var nodes = document.querySelectorAll('[role="menuitem"], [class*="item" i], [class*="label" i]');
+      for (var i = 0; i < nodes.length; i++) {
+        var n = nodes[i];
+        if (n.offsetParent === null) continue;
+        var t = (n.textContent || '').trim();
+        if (t.length > 60) continue;
+        if (re.test(t)) { n.click(); return t; }
+      }
+      return null;
+    })()
+  `);
+
+  if (!itemClicked) {
+    // Close the menu so we do not leave the UI in a half-open state.
+    await evaluate(`(function(){ document.body.click(); return true; })()`);
+    throw new Error(
+      'Could not find a "New blank ' + type + '" item in the Pine Editor menu. ' +
+      'Refusing to fall back to overwriting the open script.'
+    );
+  }
+
+  await new Promise(r => setTimeout(r, 900));
+
+  const after = await evaluate(READ_BINDING);
+
+  // A genuinely new script is unsaved and carries no version stamp. If the buffer
+  // is still bound to the previously open script, fail loudly — a later save
+  // would otherwise overwrite the user's script.
+  const stillBound = after?.saveState && /^\d+\s*·/.test(after.saveState);
+  if (stillBound) {
+    throw new Error(
+      'Pine Editor still reports a saved script ("' + after.saveState + '") after requesting a new script. ' +
+      'Aborting: saving now would overwrite the open script.'
+    );
+  }
+
+  return {
+    success: true,
+    type,
+    action: 'new_script_created',
+    template: typeMap[type],
+    menu_item: itemClicked,
+    binding_before: before,
+    binding_after: after,
+  };
 }
 
 export async function openScript({ name }) {

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -35,12 +35,14 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_smart_compile', 'Intelligent compile: detects button, compiles, checks errors, reports study changes', {}, async () => {
-    try { return jsonResult(await core.smartCompile()); }
+  server.tool('pine_smart_compile', 'Intelligent compile: detects button, compiles, checks errors, reports study changes. Does NOT save by default.', {
+    allow_save: z.boolean().optional().describe('Allow clicking Save if no non-destructive compile button is found. DANGEROUS: Save persists into the script slot the editor is bound to and will overwrite that saved script. Default false.'),
+  }, async ({ allow_save }) => {
+    try { return jsonResult(await core.smartCompile({ allowSave: allow_save === true })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_new', 'Create a new blank Pine Script', {
+  server.tool('pine_new', 'Create a genuinely new, unsaved Pine Script via the editor menu. Throws rather than overwriting the currently open script.', {
     type: z.enum(['indicator', 'strategy', 'library']).describe('Type of script to create'),
   }, async ({ type }) => {
     try { return jsonResult(await core.newScript({ type })); }


### PR DESCRIPTION
Fixes #395. Related: #352, #158.

## Problem

`pine_new` → `pine_set_source` → `pine_smart_compile` overwrites whichever saved script happens to be open in the Pine Editor. I lost a script to this today; #395 reports the same thing ("a 312-line saved strategy replaced by a 13-line probe script"). Two separate defects combine:

### 1. `smartCompile()` falls through to Save

```js
if (!addBtn && /^add to chart$/i.test(text)) addBtn = btns[i];
...
if (!saveBtn && btns[i].className.indexOf('saveButton') !== -1 ...) saveBtn = btns[i];
```

`addBtn`/`updateBtn` are matched on `textContent`, but TradingView Desktop 3.x renders them **icon-only** — `textContent` is empty, so neither matches. `saveBtn` is matched on **className**, which always matches. So every compile clicked Save, persisting the buffer into the bound script slot.

Verified live against TradingView Desktop 3.3.0 by running both matchers against the real DOM:

```
OLD_would_click: "Pine Save (DESTRUCTIVE)"
NEW_would_click: "Add to chart"
addBtn_label:    "Add to chart"   <- via aria-label; textContent is ""
```

The accessible name is on `aria-label`, not `textContent`. That is the whole bug.

### 2. `newScript()` never created a script

```js
// Simply set the source to a new template — this is the most reliable approach
m.editor.setValue(template);
return { success: true, type, action: 'new_script_created', ... };
```

It only replaced the buffer text, leaving it bound to the previously open script, then reported `new_script_created`. Combined with (1), the next compile wrote the new source over the user's existing script.

## Fix

**`smartCompile({ allowSave = false })`**
- Fold `aria-label` / `title` / `data-name` / `class` into the button match so the non-destructive buttons are found again on icon-only builds.
- Gate every Save path behind explicit opt-in (`allow_save`, default `false`). With no non-destructive button available it now falls through to Ctrl+Enter rather than Save.
- Scope the Save lookup to the Pine Editor panel — the **chart layout's** save button also carries the `saveButton` class prefix and was reachable from the old selector (confirmed: it resolved to `"UnnamedSave All changes saved"`).

**`newScript({ type })`**
- Drives the script-name dropdown's documented **Create new → indicator/strategy/library** ([TradingView docs](https://www.tradingview.com/support/solutions/43000711497-how-to-create-new-script/)), falling back to the "More" menu.
- Re-reads the editor's binding afterwards; if it still shows a saved version stamp, it **throws** instead of returning success.
- Only ever clicks a menu item matching the `new blank <type>` pattern — that menu also holds destructive items.
- There is no longer any code path where `newScript` mutates the open script's contents. It fails loudly instead.

DOM lookups are anchored to `.tv-script-widget`; sibling classes in that subtree are build-hashed (`editorWrapper-mImut1T6`, `container-FgScb_09`) and unsafe to match on.

## Compatibility

`allow_save` is optional and defaults to false, so this is a behaviour change for anyone who relied on `pine_smart_compile` implicitly saving. That seems clearly right given the failure mode, but happy to add a `pine_compile_and_save` alias instead if you'd prefer to keep the old default reachable.

## Testing

- `node --check` on both files; module imports clean.
- Both matchers exercised against a live TradingView Desktop 3.3.0 session via CDP (results above).
- The `newScript` menu selectors were validated read-only against the live DOM (`button[class*="nameButton"]` resolves to the script-name dropdown; `button[class*="saveButton"]` scoped to `.tv-script-widget` correctly excludes the chart-layout button).

I could not exercise the full `newScript` click-through end-to-end without risking another live script, so the menu-item click path is verified by selector resolution rather than a completed run. Worth a second pair of eyes there.