### PR TITLE
docs: fix stale tool count (78 -> 84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (84 MCP tools)
 
 ### Chart Reading
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -125,5 +125,5 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 ## What to Read Next
 
 - `CLAUDE.md` — Decision tree for which tool to use when (auto-loaded by Claude Code)
-- `README.md` — Full tool reference (78 MCP tools, 30 CLI commands)
+- `README.md` — Full tool reference (84 MCP tools, 30 CLI commands)
 - `RESEARCH.md` — Research context and open questions


### PR DESCRIPTION
## Summary
- README.md and SETUP_GUIDE.md still said "78 MCP tools" while every other doc (CLAUDE.md, RESEARCH.md) and `src/server.js` already say 84, and counting the actual `server.tool(...)` registrations in `src/` confirms 84.
- Updates both stale references to 84 for consistency.

## Test plan
- Docs-only change, no functional code touched.
- Verified tool count via `grep -rn "server.tool(" src | wc -l` -> 84.