### PR TITLE
Add optional MT5 live trading module via local Python bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TradingView MCP — Claude Instructions
 
-84 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+91 tools: 84 for reading and controlling a live TradingView Desktop chart via CDP (port 9222), plus 7 optional MT5 trading tools via a local Python bridge (port 8721).
 
 ## Decision Tree — Which Tool When
 
@@ -84,6 +84,18 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `tv_launch` → auto-detect and launch TradingView with CDP on Mac/Win/Linux
 - `tv_health_check` → verify connection is working
 
+### "Trade on MT5" (real order execution — separate from TradingView)
+Requires `scripts/mt5_bridge.py` running on the machine with the MT5 terminal (Windows + `pip install MetaTrader5`). This is a distinct system from the CDP-based TradingView tools above — it places real orders (demo or live, whichever account the bridge is logged into).
+
+1. `mt5_health_check` → verify the bridge + terminal are reachable
+2. `mt5_get_account` → balance, equity, margin, and **`is_demo`** — always check this before trading
+3. `mt5_get_positions` / `mt5_get_quote` → read current positions and prices
+4. `mt5_place_order` → place a market buy/sell order. **Requires `confirm: true`.** Never set this without the user explicitly asking for a trade to be placed.
+5. `mt5_close_order` → close a position by ticket. **Requires `confirm: true`.**
+6. `mt5_modify_order` → adjust SL/TP on an open position (no confirm needed — does not change exposure)
+
+Never place or close an MT5 order speculatively or as part of "analysis" — only when the user explicitly asks to trade.
+
 ## Context Management Rules
 
 These tools can return large payloads. Follow these rules to avoid context bloat:
@@ -124,6 +136,7 @@ These tools can return large payloads. Follow these rules to avoid context bloat
 
 ```
 Claude Code ←→ MCP Server (stdio) ←→ CDP (localhost:9222) ←→ TradingView Desktop (Electron)
+                                 └──→ HTTP (localhost:8721) ←→ mt5_bridge.py ←→ MT5 terminal (optional, Windows only)
 ```
 
 Pine graphics path: `study._graphics._primitivesCollection.dwglines.get('lines').get(false)._primitivesDataById`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Personal AI assistant for your TradingView Desktop charts. Connects Claude Code 
 > [!CAUTION]
 > This tool accesses undocumented internal TradingView APIs via the Electron debug interface. These can change or break without notice in any TradingView update. Pin your TradingView Desktop version if stability matters to you.
 
+> [!CAUTION]
+> **The optional MT5 module executes real orders.** Unlike the TradingView chart tools (read/draw/navigate only), the `mt5_place_order` / `mt5_close_order` tools send live trade requests to whatever MetaTrader 5 account the bridge (`scripts/mt5_bridge.py`) is logged into — demo or real money. It is a separate opt-in component: nothing trades until you install `MetaTrader5`, run the bridge, and explicitly call those tools with `confirm: true`. Always check `mt5_get_account`'s `is_demo` field before trading, and see [MT5 Trading (optional)](#mt5-trading-optional) below.
+
 ## How It Works (and why it's safe to run)
 
 This tool does not connect to TradingView's servers, modify any TradingView files, or intercept any network traffic. It communicates exclusively with your locally running TradingView Desktop instance via Chrome DevTools Protocol (CDP) — a standard debugging interface built into all Chromium/Electron applications by Google, including VS Code, Slack, and Discord.
@@ -28,8 +31,10 @@ The debug port is disabled by default and must be explicitly enabled by you usin
 - Store, transmit, or redistribute any market data
 - Work without a valid TradingView subscription and installed Desktop app
 - Bypass any TradingView paywall or access restriction
-- Execute real trades (chart interaction only)
+- Execute trades through TradingView itself (chart interaction only — TradingView is read/draw/navigate)
 - Work if TradingView changes their internal Electron structure
+
+The **core tool is not a trading bot** for TradingView charts. The separate, opt-in **MT5 module** (below) is the one part of this project that does execute real orders — through MetaTrader 5, not TradingView — and only when you set it up and explicitly confirm each order.
 
 ## Research Context
 
@@ -43,7 +48,7 @@ Specifically it investigates:
 - Whether natural language is an effective interface for chart navigation and Pine Script development
 - The failure modes of LLM agents operating in real-time data environments
 
-This is not a trading bot. It is an interface layer that makes a trading application legible to an LLM agent, allowing researchers and developers to study human-AI collaboration in financial workflows.
+The TradingView side of this project is not a trading bot — it is an interface layer that makes a trading application legible to an LLM agent, allowing researchers and developers to study human-AI collaboration in financial workflows. (The optional MT5 module is the exception: see [MT5 Trading (optional)](#mt5-trading-optional).)
 
 See [RESEARCH.md](RESEARCH.md) for open questions, findings, and related work.
 
@@ -53,6 +58,7 @@ See [RESEARCH.md](RESEARCH.md) for open questions, findings, and related work.
 - **Node.js 18+**
 - **Claude Code** with MCP support (for MCP tools) or any terminal (for CLI)
 - **macOS, Windows, or Linux**
+- Optional, for MT5 trading: **Windows** + **Python 3.9+** with `pip install MetaTrader5`, plus a running **MT5 terminal** — see [MT5 Trading (optional)](#mt5-trading-optional)
 
 ## What It Does
 
@@ -311,6 +317,40 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `ui_open_panel` / `ui_click` / `ui_evaluate` | UI automation |
 | `tv_launch` / `tv_health_check` / `tv_discover` | Connection management |
 
+## MT5 Trading (optional)
+
+> [!CAUTION]
+> **This module executes real orders.** `mt5_place_order` and `mt5_close_order` send live trade requests to whatever MT5 account the bridge is logged into. There is no simulation layer — a demo account behaves identically to a live one from this tool's perspective except for the money involved. Both tools require `confirm: true`, and you should check `mt5_get_account`'s `is_demo` field before trading. This is entirely separate from the TradingView chart tools above, which never place orders.
+
+Unlike TradingView (controlled via CDP on the same machine), MetaTrader 5 has no debug protocol — its Python package (`MetaTrader5`) talks to the terminal over a local IPC channel and only works on Windows. So this integration ships as a small local HTTP bridge (`scripts/mt5_bridge.py`) that the Node MCP server calls over `http://127.0.0.1:8721`.
+
+**Setup:**
+
+```bash
+# On the Windows machine running the MT5 terminal:
+pip install MetaTrader5
+python scripts/mt5_bridge.py
+# or, to auto-login:
+set MT5_LOGIN=12345678
+set MT5_PASSWORD=your-password
+set MT5_SERVER=YourBroker-Demo
+python scripts/mt5_bridge.py
+```
+
+The bridge logs which account it connected to (and prints a warning if it's live, not demo) and listens on `127.0.0.1:8721` by default. It must stay running while you use the `mt5_*` tools. Override host/port with `MT5_BRIDGE_HOST` / `MT5_BRIDGE_PORT` (bridge) and the same env vars on the Node side.
+
+| Tool | What it does |
+|------|-------------|
+| `mt5_health_check` | Verify the bridge + MT5 terminal are reachable |
+| `mt5_get_account` | Balance, equity, margin, leverage, and `is_demo` |
+| `mt5_get_positions` | List open positions, optionally filtered by symbol |
+| `mt5_get_quote` | Current bid/ask for a symbol |
+| `mt5_place_order` | Place a market buy/sell order — **requires `confirm: true`** |
+| `mt5_close_order` | Close an open position by ticket — **requires `confirm: true`** |
+| `mt5_modify_order` | Change SL/TP on an open position |
+
+CLI equivalents: `tv mt5 health`, `tv mt5 account`, `tv mt5 positions`, `tv mt5 quote <symbol>`, `tv mt5 order <buy|sell> <symbol> <volume> --confirm`, `tv mt5 close <ticket> --confirm`, `tv mt5 modify <ticket> --sl <price> --tp <price>`.
+
 ## Context Management
 
 Tools return compact output by default to minimize context usage. For a typical "analyze my chart" workflow, total context is ~5-10KB instead of ~80KB.
@@ -353,10 +393,11 @@ npm test
 Claude Code  ←→  MCP Server (stdio)  ←→  CDP (port 9222)  ←→  TradingView Desktop (Electron)
 ```
 
-- **Transport**: MCP over stdio (84 tools) + CLI (`tv` command, 30 commands with 66 subcommands)
+- **Transport**: MCP over stdio (91 tools) + CLI (`tv` command)
 - **Connection**: Chrome DevTools Protocol on localhost:9222
 - **Streaming**: Poll-and-diff loop with deduplication, JSONL output to stdout
 - **No dependencies** beyond `@modelcontextprotocol/sdk` and `chrome-remote-interface`
+- **MT5 (optional)**: Node → HTTP (`127.0.0.1:8721`) → `scripts/mt5_bridge.py` → `MetaTrader5` package → MT5 terminal (Windows only, requires a separate Python install)
 
 ## Attributions
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -110,6 +110,21 @@ npm link
 
 Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 
+## Step 7: MT5 Trading (Optional)
+
+Only do this if the user explicitly asks for MT5/MetaTrader trading support — it is a separate, opt-in module that executes real orders (demo or live, depending on which account the user logs into). Do not set it up proactively.
+
+1. Confirm the MT5 terminal runs on **Windows** (the `MetaTrader5` Python package requires it) and that Python 3.9+ is available there.
+2. Install the package: `pip install MetaTrader5`
+3. Start the bridge on that same machine, with the MT5 terminal already open (or let the bridge launch it via `MT5_TERMINAL_PATH`):
+   ```bash
+   python scripts/mt5_bridge.py
+   ```
+   For auto-login, set `MT5_LOGIN`, `MT5_PASSWORD`, `MT5_SERVER` env vars first.
+4. The bridge prints which account it connected to and whether it's demo or live — read that output back to the user so they can confirm it's the account they intended.
+5. Verify from Claude Code with the `mt5_health_check` tool, then `mt5_get_account` to confirm `is_demo`.
+6. Before ever calling `mt5_place_order` or `mt5_close_order`, tell the user which account (`is_demo`) the order will hit and get explicit confirmation — those tools also require `confirm: true` in the call itself.
+
 ## Troubleshooting
 
 | Problem | Solution |
@@ -121,6 +136,8 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 | `tv` command not found | Run `npm link` from the project directory |
 | Tools return stale data | TradingView may still be loading — wait a few seconds |
 | Pine Editor tools fail | Open the Pine Editor panel first (`ui_open_panel pine-editor open`) |
+| MT5 bridge unreachable | Confirm `python scripts/mt5_bridge.py` is running on the machine with the MT5 terminal, and that `MT5_BRIDGE_HOST`/`MT5_BRIDGE_PORT` match on both sides (default `127.0.0.1:8721`) |
+| `mt5_place_order`/`mt5_close_order` reject the call | These require `confirm: true` in the tool call — this is intentional, not a bug |
 
 ## What to Read Next
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/mt5.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/mt5.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/scripts/mt5_bridge.py
+++ b/scripts/mt5_bridge.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+MT5 bridge — a tiny local HTTP server that wraps the MetaTrader5 Python
+package so the Node.js MCP server can reach a running MT5 terminal.
+
+Must run on the same Windows machine as the MT5 terminal (the MetaTrader5
+package talks to the terminal over a local IPC channel, not a network
+socket). Listens on 127.0.0.1 only by default — do not expose this port
+publicly, it can place and close real orders.
+
+Usage:
+    pip install MetaTrader5
+    python scripts/mt5_bridge.py [--port 8721] [--path "C:\\...\\terminal64.exe"]
+
+Env vars (override CLI flags):
+    MT5_BRIDGE_PORT   default 8721
+    MT5_BRIDGE_HOST   default 127.0.0.1
+    MT5_LOGIN, MT5_PASSWORD, MT5_SERVER   optional — auto-login on startup
+    MT5_TERMINAL_PATH                     optional — path to terminal64.exe
+"""
+import argparse
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+try:
+    import MetaTrader5 as mt5
+except ImportError:
+    print("MetaTrader5 package not found. Install it with: pip install MetaTrader5", file=sys.stderr)
+    sys.exit(1)
+
+ORDER_TYPE_MAP = {
+    "buy": mt5.ORDER_TYPE_BUY,
+    "sell": mt5.ORDER_TYPE_SELL,
+}
+
+
+def _ensure_initialized(terminal_path=None, login=None, password=None, server=None):
+    if not mt5.initialize(path=terminal_path) if terminal_path else not mt5.initialize():
+        raise RuntimeError(f"MT5 initialize() failed: {mt5.last_error()}")
+    if login and password and server:
+        if not mt5.login(int(login), password=password, server=server):
+            raise RuntimeError(f"MT5 login() failed: {mt5.last_error()}")
+
+
+def _account_dict():
+    info = mt5.account_info()
+    if info is None:
+        raise RuntimeError(f"account_info() failed: {mt5.last_error()}")
+    d = info._asdict()
+    d["is_demo"] = d.get("trade_mode") == mt5.ACCOUNT_TRADE_MODE_DEMO
+    return d
+
+
+def _positions_list(symbol=None):
+    positions = mt5.positions_get(symbol=symbol) if symbol else mt5.positions_get()
+    if positions is None:
+        return []
+    return [p._asdict() for p in positions]
+
+
+def _quote_dict(symbol):
+    if not mt5.symbol_select(symbol, True):
+        raise RuntimeError(f"symbol_select({symbol}) failed: {mt5.last_error()}")
+    tick = mt5.symbol_info_tick(symbol)
+    if tick is None:
+        raise RuntimeError(f"symbol_info_tick({symbol}) failed: {mt5.last_error()}")
+    return tick._asdict()
+
+
+def _place_order(body):
+    symbol = body.get("symbol")
+    side = str(body.get("side", "")).lower()
+    volume = body.get("volume")
+    if not symbol or side not in ORDER_TYPE_MAP or not volume:
+        raise ValueError("symbol, side (buy|sell), and volume are required")
+    volume = float(volume)
+    if not (volume > 0):
+        raise ValueError("volume must be > 0")
+
+    if not mt5.symbol_select(symbol, True):
+        raise RuntimeError(f"symbol_select({symbol}) failed: {mt5.last_error()}")
+    tick = mt5.symbol_info_tick(symbol)
+    if tick is None:
+        raise RuntimeError(f"symbol_info_tick({symbol}) failed: {mt5.last_error()}")
+    price = tick.ask if side == "buy" else tick.bid
+
+    request = {
+        "action": mt5.TRADE_ACTION_DEAL,
+        "symbol": symbol,
+        "volume": volume,
+        "type": ORDER_TYPE_MAP[side],
+        "price": price,
+        "deviation": int(body.get("deviation", 20)),
+        "magic": int(body.get("magic", 990500)),
+        "comment": str(body.get("comment", "tradingview-mcp"))[:31],
+        "type_time": mt5.ORDER_TIME_GTC,
+        "type_filling": mt5.ORDER_FILLING_IOC,
+    }
+    if body.get("sl") is not None:
+        request["sl"] = float(body["sl"])
+    if body.get("tp") is not None:
+        request["tp"] = float(body["tp"])
+
+    result = mt5.order_send(request)
+    if result is None:
+        raise RuntimeError(f"order_send() returned None: {mt5.last_error()}")
+    out = result._asdict()
+    if hasattr(result, "request") and result.request is not None:
+        out["request"] = result.request._asdict()
+    return out
+
+
+def _close_position(body):
+    ticket = body.get("ticket")
+    if not ticket:
+        raise ValueError("ticket is required")
+    ticket = int(ticket)
+    positions = mt5.positions_get(ticket=ticket)
+    if not positions:
+        raise RuntimeError(f"no open position with ticket {ticket}")
+    pos = positions[0]
+    volume = float(body.get("volume") or pos.volume)
+    close_side = "sell" if pos.type == mt5.ORDER_TYPE_BUY else "buy"
+
+    tick = mt5.symbol_info_tick(pos.symbol)
+    if tick is None:
+        raise RuntimeError(f"symbol_info_tick({pos.symbol}) failed: {mt5.last_error()}")
+    price = tick.bid if close_side == "sell" else tick.ask
+
+    request = {
+        "action": mt5.TRADE_ACTION_DEAL,
+        "symbol": pos.symbol,
+        "volume": volume,
+        "type": ORDER_TYPE_MAP[close_side],
+        "position": ticket,
+        "price": price,
+        "deviation": int(body.get("deviation", 20)),
+        "magic": int(body.get("magic", 990500)),
+        "comment": "tradingview-mcp close",
+        "type_time": mt5.ORDER_TIME_GTC,
+        "type_filling": mt5.ORDER_FILLING_IOC,
+    }
+    result = mt5.order_send(request)
+    if result is None:
+        raise RuntimeError(f"order_send() returned None: {mt5.last_error()}")
+    return result._asdict()
+
+
+def _modify_position(body):
+    ticket = body.get("ticket")
+    if not ticket:
+        raise ValueError("ticket is required")
+    ticket = int(ticket)
+    positions = mt5.positions_get(ticket=ticket)
+    if not positions:
+        raise RuntimeError(f"no open position with ticket {ticket}")
+    pos = positions[0]
+
+    request = {
+        "action": mt5.TRADE_ACTION_SLTP,
+        "symbol": pos.symbol,
+        "position": ticket,
+        "sl": float(body["sl"]) if body.get("sl") is not None else pos.sl,
+        "tp": float(body["tp"]) if body.get("tp") is not None else pos.tp,
+    }
+    result = mt5.order_send(request)
+    if result is None:
+        raise RuntimeError(f"order_send() returned None: {mt5.last_error()}")
+    return result._asdict()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+    def _send_json(self, obj, status=200):
+        body = json.dumps(obj, default=str).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        if length == 0:
+            return {}
+        raw = self.rfile.read(length)
+        return json.loads(raw.decode("utf-8")) if raw else {}
+
+    def _handle(self, method):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        qs = parse_qs(parsed.query)
+        try:
+            if path == "/health" and method == "GET":
+                info = mt5.terminal_info()
+                self._send_json({"success": True, "connected": info is not None,
+                                  "terminal": info._asdict() if info else None})
+            elif path == "/account" and method == "GET":
+                self._send_json({"success": True, "account": _account_dict()})
+            elif path == "/positions" and method == "GET":
+                symbol = qs.get("symbol", [None])[0]
+                self._send_json({"success": True, "positions": _positions_list(symbol)})
+            elif path == "/quote" and method == "GET":
+                symbol = qs.get("symbol", [None])[0]
+                if not symbol:
+                    raise ValueError("symbol query param is required")
+                self._send_json({"success": True, "quote": _quote_dict(symbol)})
+            elif path == "/order" and method == "POST":
+                self._send_json({"success": True, "result": _place_order(self._read_json_body())})
+            elif path == "/order/close" and method == "POST":
+                self._send_json({"success": True, "result": _close_position(self._read_json_body())})
+            elif path == "/order/modify" and method == "POST":
+                self._send_json({"success": True, "result": _modify_position(self._read_json_body())})
+            else:
+                self._send_json({"success": False, "error": f"not found: {method} {path}"}, status=404)
+        except Exception as e:  # noqa: BLE001 — bridge must never crash on a bad request
+            self._send_json({"success": False, "error": str(e)}, status=400)
+
+    def do_GET(self):
+        self._handle("GET")
+
+    def do_POST(self):
+        self._handle("POST")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MT5 HTTP bridge for tradingview-mcp")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("MT5_BRIDGE_PORT", 8721)))
+    parser.add_argument("--host", default=os.environ.get("MT5_BRIDGE_HOST", "127.0.0.1"))
+    parser.add_argument("--path", default=os.environ.get("MT5_TERMINAL_PATH"))
+    args = parser.parse_args()
+
+    _ensure_initialized(
+        terminal_path=args.path,
+        login=os.environ.get("MT5_LOGIN"),
+        password=os.environ.get("MT5_PASSWORD"),
+        server=os.environ.get("MT5_SERVER"),
+    )
+    account = _account_dict()
+    mode = "DEMO" if account["is_demo"] else "LIVE"
+    print(f"MT5 bridge connected — account {account.get('login')} ({mode}), "
+          f"server {account.get('server')}, balance {account.get('balance')} {account.get('currency')}",
+          file=sys.stderr)
+    if mode == "LIVE":
+        print("WARNING: this is a LIVE account. Orders placed through this bridge use real money.", file=sys.stderr)
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    print(f"MT5 bridge listening on http://{args.host}:{args.port}", file=sys.stderr)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        mt5.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/commands/mt5.js
+++ b/src/cli/commands/mt5.js
@@ -1,0 +1,80 @@
+import { register } from '../router.js';
+import * as core from '../../core/mt5.js';
+
+register('mt5', {
+  description: 'MT5 live trading via the local bridge (scripts/mt5_bridge.py)',
+  subcommands: new Map([
+    ['health', {
+      description: 'Check the MT5 bridge + terminal connection',
+      handler: () => core.health(),
+    }],
+    ['account', {
+      description: 'Get account balance, equity, margin, and demo/live status',
+      handler: () => core.getAccount(),
+    }],
+    ['positions', {
+      description: 'List open positions',
+      options: {
+        symbol: { type: 'string', short: 's', description: 'Filter by symbol' },
+      },
+      handler: (opts) => core.getPositions({ symbol: opts.symbol }),
+    }],
+    ['quote', {
+      description: 'Get current bid/ask for a symbol',
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Symbol required. Usage: tv mt5 quote EURUSD');
+        return core.getQuote({ symbol: positionals[0] });
+      },
+    }],
+    ['order', {
+      description: 'Place a market order. Usage: tv mt5 order buy EURUSD 0.01 --confirm',
+      options: {
+        sl: { type: 'string', description: 'Stop loss price' },
+        tp: { type: 'string', description: 'Take profit price' },
+        comment: { type: 'string', description: 'Order comment' },
+        confirm: { type: 'boolean', description: 'Required — confirms this is a real order' },
+      },
+      handler: (opts, positionals) => {
+        const [side, symbol, volume] = positionals;
+        if (!side || !symbol || !volume) throw new Error('Usage: tv mt5 order <buy|sell> <symbol> <volume> --confirm');
+        return core.placeOrder({
+          side, symbol, volume: Number(volume),
+          sl: opts.sl ? Number(opts.sl) : undefined,
+          tp: opts.tp ? Number(opts.tp) : undefined,
+          comment: opts.comment,
+          confirm: !!opts.confirm,
+        });
+      },
+    }],
+    ['close', {
+      description: 'Close an open position by ticket. Usage: tv mt5 close <ticket> --confirm',
+      options: {
+        volume: { type: 'string', description: 'Partial close volume' },
+        confirm: { type: 'boolean', description: 'Required — confirms this closes a real position' },
+      },
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Ticket required. Usage: tv mt5 close 123456 --confirm');
+        return core.closeOrder({
+          ticket: Number(positionals[0]),
+          volume: opts.volume ? Number(opts.volume) : undefined,
+          confirm: !!opts.confirm,
+        });
+      },
+    }],
+    ['modify', {
+      description: 'Modify SL/TP on an open position. Usage: tv mt5 modify <ticket> --sl 1.05 --tp 1.10',
+      options: {
+        sl: { type: 'string', description: 'New stop loss price' },
+        tp: { type: 'string', description: 'New take profit price' },
+      },
+      handler: (opts, positionals) => {
+        if (!positionals[0]) throw new Error('Ticket required. Usage: tv mt5 modify 123456 --sl 1.05');
+        return core.modifyOrder({
+          ticket: Number(positionals[0]),
+          sl: opts.sl ? Number(opts.sl) : undefined,
+          tp: opts.tp ? Number(opts.tp) : undefined,
+        });
+      },
+    }],
+  ]),
+});

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,6 +25,7 @@ import './commands/ui.js';
 import './commands/pane.js';
 import './commands/tab.js';
 import './commands/stream.js';
+import './commands/mt5.js';
 
 // Run
 import { run } from './router.js';

--- a/src/core/mt5.js
+++ b/src/core/mt5.js
@@ -1,0 +1,118 @@
+/**
+ * Core MT5 (MetaTrader 5) trading logic.
+ * Talks to a local Python bridge (scripts/mt5_bridge.py) that wraps the
+ * MetaTrader5 package. That bridge must be running on the same machine as
+ * the MT5 terminal — see SETUP_GUIDE.md.
+ *
+ * This module can place, modify, and close real orders. It works against
+ * whatever account the bridge is logged into (demo or live) — the bridge
+ * reports which on /account via `is_demo`. Callers that care about the
+ * distinction should check getAccount().is_demo before trading.
+ */
+import { mt5Get as _mt5Get, mt5Post as _mt5Post } from '../mt5/client.js';
+
+function _resolve(deps) {
+  return {
+    mt5Get: deps?.mt5Get || _mt5Get,
+    mt5Post: deps?.mt5Post || _mt5Post,
+  };
+}
+
+function requireFinite(value, name) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw new Error(`${name} must be a finite number, got: ${value}`);
+  return n;
+}
+
+function requireSymbol(symbol) {
+  if (typeof symbol !== 'string' || !symbol.trim()) throw new Error('symbol is required');
+  return symbol.trim();
+}
+
+export async function health({ _deps } = {}) {
+  const { mt5Get } = _resolve(_deps);
+  const res = await mt5Get('/health');
+  return { success: true, connected: !!res.connected, terminal: res.terminal ?? null };
+}
+
+export async function getAccount({ _deps } = {}) {
+  const { mt5Get } = _resolve(_deps);
+  const res = await mt5Get('/account');
+  const a = res.account;
+  return {
+    success: true,
+    login: a.login,
+    server: a.server,
+    currency: a.currency,
+    balance: a.balance,
+    equity: a.equity,
+    margin: a.margin,
+    margin_free: a.margin_free,
+    margin_level: a.margin_level,
+    leverage: a.leverage,
+    is_demo: !!a.is_demo,
+  };
+}
+
+export async function getPositions({ symbol, _deps } = {}) {
+  const { mt5Get } = _resolve(_deps);
+  const qs = symbol ? `?symbol=${encodeURIComponent(requireSymbol(symbol))}` : '';
+  const res = await mt5Get(`/positions${qs}`);
+  return { success: true, count: res.positions.length, positions: res.positions };
+}
+
+export async function getQuote({ symbol, _deps }) {
+  const { mt5Get } = _resolve(_deps);
+  const sym = requireSymbol(symbol);
+  const res = await mt5Get(`/quote?symbol=${encodeURIComponent(sym)}`);
+  return { success: true, symbol: sym, ...res.quote };
+}
+
+/**
+ * Places a live market order against whatever account the bridge is
+ * logged into. `confirm: true` is mandatory — this is real order
+ * execution (demo or live depending on bridge login), not a chart drawing.
+ */
+export async function placeOrder({ symbol, side, volume, sl, tp, comment, confirm, _deps }) {
+  if (confirm !== true) {
+    throw new Error('confirm must be true to place a real MT5 order. This executes against a live account (demo or real) — set confirm: true to proceed.');
+  }
+  const sym = requireSymbol(symbol);
+  if (side !== 'buy' && side !== 'sell') throw new Error('side must be "buy" or "sell"');
+  const vol = requireFinite(volume, 'volume');
+  if (vol <= 0) throw new Error('volume must be > 0');
+
+  const body = { symbol: sym, side, volume: vol };
+  if (sl !== undefined && sl !== null) body.sl = requireFinite(sl, 'sl');
+  if (tp !== undefined && tp !== null) body.tp = requireFinite(tp, 'tp');
+  if (comment) body.comment = String(comment).slice(0, 31);
+
+  const { mt5Post } = _resolve(_deps);
+  const res = await mt5Post('/order', body);
+  return { success: true, order: res.result };
+}
+
+export async function closeOrder({ ticket, volume, confirm, _deps }) {
+  if (confirm !== true) {
+    throw new Error('confirm must be true to close a real MT5 position. Set confirm: true to proceed.');
+  }
+  const t = requireFinite(ticket, 'ticket');
+  const body = { ticket: t };
+  if (volume !== undefined && volume !== null) body.volume = requireFinite(volume, 'volume');
+
+  const { mt5Post } = _resolve(_deps);
+  const res = await mt5Post('/order/close', body);
+  return { success: true, result: res.result };
+}
+
+export async function modifyOrder({ ticket, sl, tp, _deps }) {
+  const t = requireFinite(ticket, 'ticket');
+  if (sl === undefined && tp === undefined) throw new Error('at least one of sl or tp is required');
+  const body = { ticket: t };
+  if (sl !== undefined && sl !== null) body.sl = requireFinite(sl, 'sl');
+  if (tp !== undefined && tp !== null) body.tp = requireFinite(tp, 'tp');
+
+  const { mt5Post } = _resolve(_deps);
+  const res = await mt5Post('/order/modify', body);
+  return { success: true, result: res.result };
+}

--- a/src/mt5/client.js
+++ b/src/mt5/client.js
@@ -1,0 +1,47 @@
+/**
+ * HTTP client for the MT5 bridge (scripts/mt5_bridge.py).
+ * The bridge runs on the same machine as the MT5 terminal and speaks
+ * plain JSON over HTTP — this is a thin fetch wrapper, mirroring the
+ * conventions in src/connection.js (env-overridable host/port, no retries
+ * baked in beyond a single timeout since order placement must not be
+ * silently retried).
+ */
+export const MT5_HOST = process.env.MT5_BRIDGE_HOST || '127.0.0.1';
+export const MT5_PORT = Number(process.env.MT5_BRIDGE_PORT) || 8721;
+const TIMEOUT_MS = 10_000;
+
+async function request(method, path, body) {
+  const url = `http://${MT5_HOST}:${MT5_PORT}${path}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let res;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw new Error(`MT5 bridge timed out after ${TIMEOUT_MS}ms at ${url}`);
+    }
+    throw new Error(`MT5 bridge unreachable at ${url}: ${err.message}. Is scripts/mt5_bridge.py running?`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  let json;
+  try {
+    json = await res.json();
+  } catch {
+    throw new Error(`MT5 bridge returned a non-JSON response (HTTP ${res.status})`);
+  }
+  if (!res.ok || json.success === false) {
+    throw new Error(json.error || `MT5 bridge error (HTTP ${res.status})`);
+  }
+  return json;
+}
+
+export const mt5Get = (path) => request('GET', path);
+export const mt5Post = (path, body) => request('POST', path, body);

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import { registerWatchlistTools } from './tools/watchlist.js';
 import { registerUiTools } from './tools/ui.js';
 import { registerPaneTools } from './tools/pane.js';
 import { registerTabTools } from './tools/tab.js';
+import { registerMt5Tools } from './tools/mt5.js';
 
 const server = new McpServer(
   {
@@ -22,7 +23,7 @@ const server = new McpServer(
     description: 'AI-assisted TradingView chart analysis and Pine Script development via Chrome DevTools Protocol',
   },
   {
-    instructions: `TradingView MCP — 84 tools for reading and controlling a live TradingView Desktop chart.
+    instructions: `TradingView MCP — 91 tools for reading and controlling a live TradingView Desktop chart, plus live MT5 trading via a local bridge.
 
 TOOL SELECTION GUIDE — use this to pick the right tool:
 
@@ -60,6 +61,13 @@ Launch: tv_launch → auto-detect and start TradingView with CDP on any platform
 Panes: pane_list, pane_set_layout (s, 2h, 2v, 4, 6, 8), pane_focus, pane_set_symbol
 Tabs: tab_list, tab_new, tab_close, tab_switch
 
+MT5 live trading (requires scripts/mt5_bridge.py running — see SETUP_GUIDE.md):
+- mt5_health_check → verify the bridge + terminal are reachable
+- mt5_get_account → balance, equity, margin, and is_demo (check this before trading)
+- mt5_get_positions, mt5_get_quote → read account state and prices
+- mt5_place_order, mt5_close_order → REAL order execution (demo or live account, whichever the bridge is logged into). Both require confirm: true.
+- mt5_modify_order → change SL/TP on an open position
+
 CONTEXT MANAGEMENT:
 - ALWAYS use summary=true on data_get_ohlcv
 - ALWAYS use study_filter on pine tools when you know which indicator you want
@@ -84,6 +92,7 @@ registerWatchlistTools(server);
 registerUiTools(server);
 registerPaneTools(server);
 registerTabTools(server);
+registerMt5Tools(server);
 
 // Startup notice (stderr so it doesn't interfere with MCP stdio protocol)
 process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');

--- a/src/tools/mt5.js
+++ b/src/tools/mt5.js
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/mt5.js';
+
+export function registerMt5Tools(server) {
+  server.tool('mt5_health_check', 'Check connection to the MT5 bridge (scripts/mt5_bridge.py) and the MT5 terminal it wraps', {}, async () => {
+    try { return jsonResult(await core.health()); }
+    catch (err) { return jsonResult({ success: false, error: err.message, hint: 'Start the bridge with: python scripts/mt5_bridge.py — see SETUP_GUIDE.md' }, true); }
+  });
+
+  server.tool('mt5_get_account', 'Get MT5 account info: balance, equity, margin, leverage, and whether it is a demo or live account', {}, async () => {
+    try { return jsonResult(await core.getAccount()); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('mt5_get_positions', 'Get open MT5 positions, optionally filtered by symbol', {
+    symbol: z.string().optional().describe('Filter to a single symbol, e.g. "EURUSD"'),
+  }, async ({ symbol }) => {
+    try { return jsonResult(await core.getPositions({ symbol })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('mt5_get_quote', 'Get the current bid/ask quote for an MT5 symbol', {
+    symbol: z.string().describe('MT5 symbol, e.g. "EURUSD", "XAUUSD"'),
+  }, async ({ symbol }) => {
+    try { return jsonResult(await core.getQuote({ symbol })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('mt5_place_order', 'Place a real market order on MT5 (buy or sell). Executes against whatever account the bridge is logged into — demo or live; check mt5_get_account.is_demo first if unsure. Requires confirm: true.', {
+    symbol: z.string().describe('MT5 symbol, e.g. "EURUSD"'),
+    side: z.enum(['buy', 'sell']).describe('Order direction'),
+    volume: z.coerce.number().positive().describe('Lot size, e.g. 0.01'),
+    sl: z.coerce.number().optional().describe('Stop loss price'),
+    tp: z.coerce.number().optional().describe('Take profit price'),
+    comment: z.string().max(31).optional().describe('Order comment (max 31 chars)'),
+    confirm: z.literal(true).describe('Must be true — this places a real order'),
+  }, async ({ symbol, side, volume, sl, tp, comment, confirm }) => {
+    try { return jsonResult(await core.placeOrder({ symbol, side, volume, sl, tp, comment, confirm })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('mt5_close_order', 'Close an open MT5 position by ticket (fully or partially). Requires confirm: true.', {
+    ticket: z.coerce.number().describe('Position ticket id (from mt5_get_positions)'),
+    volume: z.coerce.number().positive().optional().describe('Partial close volume; omit to close the full position'),
+    confirm: z.literal(true).describe('Must be true — this closes a real position'),
+  }, async ({ ticket, volume, confirm }) => {
+    try { return jsonResult(await core.closeOrder({ ticket, volume, confirm })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('mt5_modify_order', 'Modify stop loss / take profit on an open MT5 position by ticket', {
+    ticket: z.coerce.number().describe('Position ticket id (from mt5_get_positions)'),
+    sl: z.coerce.number().optional().describe('New stop loss price'),
+    tp: z.coerce.number().optional().describe('New take profit price'),
+  }, async ({ ticket, sl, tp }) => {
+    try { return jsonResult(await core.modifyOrder({ ticket, sl, tp })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+}

--- a/tests/mt5.test.js
+++ b/tests/mt5.test.js
@@ -1,0 +1,140 @@
+/**
+ * Tests for src/core/mt5.js — validation and request shaping against a
+ * mocked bridge client (no real MT5 bridge or terminal involved).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  health, getAccount, getPositions, getQuote,
+  placeOrder, closeOrder, modifyOrder,
+} from '../src/core/mt5.js';
+
+function mockDeps({ get = {}, post = {} } = {}) {
+  const calls = { get: [], post: [] };
+  const mt5Get = async (path) => {
+    calls.get.push(path);
+    for (const [key, val] of Object.entries(get)) {
+      if (path.includes(key)) return typeof val === 'function' ? val(path) : val;
+    }
+    throw new Error(`unmocked GET ${path}`);
+  };
+  const mt5Post = async (path, body) => {
+    calls.post.push({ path, body });
+    for (const [key, val] of Object.entries(post)) {
+      if (path.includes(key)) return typeof val === 'function' ? val(body) : val;
+    }
+    throw new Error(`unmocked POST ${path}`);
+  };
+  return { _deps: { mt5Get, mt5Post }, calls };
+}
+
+describe('health()', () => {
+  it('reports connected state from the bridge', async () => {
+    const { _deps } = mockDeps({ get: { '/health': { success: true, connected: true, terminal: { build: 1 } } } });
+    const res = await health({ _deps });
+    assert.equal(res.success, true);
+    assert.equal(res.connected, true);
+    assert.deepEqual(res.terminal, { build: 1 });
+  });
+});
+
+describe('getAccount()', () => {
+  it('maps bridge account fields and demo flag', async () => {
+    const { _deps } = mockDeps({
+      get: { '/account': { success: true, account: { login: 12345, server: 'Demo-1', currency: 'USD', balance: 10000, equity: 10000, margin: 0, margin_free: 10000, margin_level: 0, leverage: 100, is_demo: true } } },
+    });
+    const res = await getAccount({ _deps });
+    assert.equal(res.success, true);
+    assert.equal(res.login, 12345);
+    assert.equal(res.is_demo, true);
+    assert.equal(res.balance, 10000);
+  });
+});
+
+describe('getPositions()', () => {
+  it('passes symbol filter through as a query param', async () => {
+    const { _deps, calls } = mockDeps({ get: { '/positions': { success: true, positions: [] } } });
+    await getPositions({ symbol: 'EURUSD', _deps });
+    assert.ok(calls.get[0].includes('symbol=EURUSD'));
+  });
+
+  it('rejects empty symbol filter', async () => {
+    const { _deps } = mockDeps({ get: { '/positions': { success: true, positions: [] } } });
+    await assert.rejects(() => getPositions({ symbol: '  ', _deps }), /symbol is required/);
+  });
+});
+
+describe('getQuote()', () => {
+  it('requires a symbol', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(() => getQuote({ symbol: '', _deps }), /symbol is required/);
+  });
+
+  it('returns bid/ask fields from the bridge', async () => {
+    const { _deps } = mockDeps({ get: { '/quote': { success: true, quote: { bid: 1.1, ask: 1.1002 } } } });
+    const res = await getQuote({ symbol: 'EURUSD', _deps });
+    assert.equal(res.symbol, 'EURUSD');
+    assert.equal(res.bid, 1.1);
+  });
+});
+
+describe('placeOrder()', () => {
+  it('refuses to place an order without confirm: true', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => placeOrder({ symbol: 'EURUSD', side: 'buy', volume: 0.01, confirm: false, _deps }),
+      /confirm must be true/
+    );
+  });
+
+  it('rejects an invalid side', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => placeOrder({ symbol: 'EURUSD', side: 'long', volume: 0.01, confirm: true, _deps }),
+      /side must be "buy" or "sell"/
+    );
+  });
+
+  it('rejects non-positive volume', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(
+      () => placeOrder({ symbol: 'EURUSD', side: 'buy', volume: 0, confirm: true, _deps }),
+      /volume must be > 0/
+    );
+  });
+
+  it('sends a well-formed order request when confirmed', async () => {
+    const { _deps, calls } = mockDeps({ post: { '/order': { success: true, result: { retcode: 10009, order: 555 } } } });
+    const res = await placeOrder({ symbol: 'EURUSD', side: 'buy', volume: 0.01, sl: 1.05, tp: 1.15, comment: 'test', confirm: true, _deps });
+    assert.equal(res.success, true);
+    assert.equal(res.order.order, 555);
+    assert.deepEqual(calls.post[0].body, { symbol: 'EURUSD', side: 'buy', volume: 0.01, sl: 1.05, tp: 1.15, comment: 'test' });
+  });
+});
+
+describe('closeOrder()', () => {
+  it('refuses to close without confirm: true', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(() => closeOrder({ ticket: 1, confirm: false, _deps }), /confirm must be true/);
+  });
+
+  it('closes with ticket when confirmed', async () => {
+    const { _deps, calls } = mockDeps({ post: { '/order/close': { success: true, result: { retcode: 10009 } } } });
+    const res = await closeOrder({ ticket: 42, confirm: true, _deps });
+    assert.equal(res.success, true);
+    assert.deepEqual(calls.post[0].body, { ticket: 42 });
+  });
+});
+
+describe('modifyOrder()', () => {
+  it('requires at least sl or tp', async () => {
+    const { _deps } = mockDeps();
+    await assert.rejects(() => modifyOrder({ ticket: 1, _deps }), /at least one of sl or tp/);
+  });
+
+  it('sends provided sl/tp', async () => {
+    const { _deps, calls } = mockDeps({ post: { '/order/modify': { success: true, result: {} } } });
+    await modifyOrder({ ticket: 42, sl: 1.05, _deps });
+    assert.deepEqual(calls.post[0].body, { ticket: 42, sl: 1.05 });
+  });
+});


### PR DESCRIPTION
Closing — the author already has a working, separate local MT5 MCP server (`mt5-mcp/server.py`, not part of this repo) that covers the same functionality (account info, positions, quotes, order send/close/modify) and was already tested successfully against a live demo account. This PR would have introduced a duplicate implementation, so leaving it closed rather than merging redundant code.