### PR TITLE
Fix lint warnings and Windows path bug in sanitization test

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -381,7 +381,7 @@ async function _getQuoteInternal({ symbol } = {}) {
   let needsRestore = false;
 
   if (requested) {
-    try { originalSymbol = await evaluate(`${CHART_API}.symbol()`); } catch (e) {}
+    try { originalSymbol = await evaluate(`${CHART_API}.symbol()`); } catch {}
     const bare = (s) => (s || '').toString().split(':').pop().toUpperCase();
     if (bare(originalSymbol) !== bare(requested)) {
       needsRestore = true;
@@ -444,7 +444,7 @@ async function _getQuoteInternal({ symbol } = {}) {
           })()
         `);
         await waitForChartReady(originalSymbol);
-      } catch (e) {}
+      } catch {}
     }
   }
 }

--- a/src/core/pane.js
+++ b/src/core/pane.js
@@ -2,7 +2,7 @@
  * Core pane/layout management logic.
  * Controls multi-chart layouts (split panes) in TradingView.
  */
-import { evaluate, evaluateAsync, getClient, safeString } from '../connection.js';
+import { evaluate, evaluateAsync, safeString } from '../connection.js';
 
 const CWC = 'window.TradingViewApi._chartWidgetCollection';
 

--- a/src/tools/watchlist.js
+++ b/src/tools/watchlist.js
@@ -19,7 +19,7 @@ export function registerWatchlistTools(server) {
         const c = await getClient();
         await c.Input.dispatchKeyEvent({ type: 'keyDown', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
         await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 });
-      } catch (_) {}
+      } catch {}
       return jsonResult({ success: false, error: err.message }, true);
     }
   });

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Summary
- Drop unused `catch` bindings in `src/core/data.js` and `src/tools/watchlist.js`, and an unused `getClient` import in `src/core/pane.js`, clearing eslint's `no-unused-vars` warnings (`npm run lint` was previously warning-only, now clean).
- Fix `tests/sanitization.test.js`'s "source audit" suite: it used `new URL(...).pathname` to get a filesystem path, which resolves to a malformed path on Windows (doubled drive letter) and was silently failing with `ENOENT` — meaning the audit of `src/core/*.js` for unsafe string interpolation never actually ran. Switched to `fileURLToPath()`.

## Test plan
- [x] `npm run lint` — 0 warnings (previously 4)
- [x] `npm run test:unit` — 159/159 passing (previously 125 passing + 1 suite silently broken on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)