### PR TITLE
Fix Pine editor open path for current TradingView builds

### DIFF
--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -48,14 +48,20 @@ export async function ensurePineEditorOpen() {
   `);
   if (already) return true;
 
-  await evaluate(`
+  // 'scripteditor' is the widget's registered name; activateScriptEditorTab()
+  // silently no-ops while the widget is missing from the bar's enabled list
+  // (the state after the user closes the panel), so enable + show come first.
+  const OPEN_EDITOR = `
     (function() {
       var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
-      if (!bwb) return;
+      if (!bwb) return false;
+      if (typeof bwb.setWidgetAvailability === 'function') bwb.setWidgetAvailability('scripteditor', true);
+      if (typeof bwb.showWidget === 'function') bwb.showWidget('scripteditor');
       if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab();
-      else if (typeof bwb.showWidget === 'function') bwb.showWidget('pine-editor');
+      return true;
     })()
-  `);
+  `;
+  await evaluate(OPEN_EDITOR);
 
   await evaluate(`
     (function() {
@@ -65,10 +71,30 @@ export async function ensurePineEditorOpen() {
     })()
   `);
 
+  let remounted = false;
   for (let i = 0; i < 50; i++) {
     await new Promise(r => setTimeout(r, 200));
     const ready = await evaluate(`(function() { return ${FIND_MONACO} !== null; })()`);
     if (ready) return true;
+    // Stale mount: Monaco DOM is present but its subtree carries no React
+    // fiber keys, so FIND_MONACO can never succeed against it. Hide the bar
+    // and reopen once to force a fresh React-attached mount.
+    if (!remounted && i >= 15) {
+      const zombie = await evaluate(`!!document.querySelector('.monaco-editor.pine-editor-monaco')`);
+      if (zombie) {
+        await evaluate(`
+          (function() {
+            var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
+            if (bwb && typeof bwb.hide === 'function') bwb.hide();
+          })()
+        `);
+        await new Promise(r => setTimeout(r, 400));
+        await evaluate(OPEN_EDITOR);
+        // Consume the one-shot only on an actual remount attempt, so a
+        // slow first mount that turns out fiber-less can still be recovered.
+        remounted = true;
+      }
+    }
   }
   return false;
 }

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -31,7 +31,10 @@ export async function click({ by, value }) {
 export async function openPanel({ panel, action }) {
   const isBottomPanel = panel === 'pine-editor' || panel === 'strategy-tester';
   if (isBottomPanel) {
-    const widgetName = panel === 'pine-editor' ? 'pine-editor' : 'backtesting';
+    // The bottom bar's registered widget name for the Pine editor is
+    // 'scripteditor' (see bwb._getWidgetConfigByNames) — 'pine-editor' is
+    // only the public tool-facing panel name and is unknown to showWidget().
+    const widgetName = panel === 'pine-editor' ? 'scripteditor' : 'backtesting';
     const result = await evaluate(`
       (function() {
         var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
@@ -45,7 +48,10 @@ export async function openPanel({ panel, action }) {
         if (panel === 'strategy-tester') { var stratPanel = document.querySelector('[data-name="backtesting"]') || document.querySelector('[class*="strategyReport"]'); isOpen = isOpen && !!(stratPanel && stratPanel.offsetParent); }
         var performed = 'none';
         if (action === 'open' || (action === 'toggle' && !isOpen)) {
-          if (panel === 'pine-editor') { if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab(); else if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); }
+          // activateScriptEditorTab() silently no-ops while the widget is not
+          // in the bar's enabled list (the state after the user closes the
+          // panel), so enable + show first and only then activate the tab.
+          if (panel === 'pine-editor') { if (typeof bwb.setWidgetAvailability === 'function') bwb.setWidgetAvailability(widgetName, true); if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab(); }
           else { if (typeof bwb.showWidget === 'function') bwb.showWidget(widgetName); }
           performed = 'opened';
         } else if (action === 'close' || (action === 'toggle' && isOpen)) {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -673,7 +673,7 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
     after(async () => {
       // Restore editor state
       if (!editorWasOpen) {
-        await evaluate(`try { ${CLOSE_BOTTOM('pine-editor')} } catch(e) {}`);
+        await evaluate(`try { ${CLOSE_BOTTOM('scripteditor')} } catch(e) {}`);
         await sleep(300);
       }
     });
@@ -684,8 +684,10 @@ describe('TradingView MCP — Full E2E (70 tools)', () => {
       await evaluate(`
         (function() {
           var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
-          if (bwb && typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab();
-          else if (bwb && typeof bwb.showWidget === 'function') bwb.showWidget('pine-editor');
+          if (!bwb) return;
+          if (typeof bwb.setWidgetAvailability === 'function') bwb.setWidgetAvailability('scripteditor', true);
+          if (typeof bwb.showWidget === 'function') bwb.showWidget('scripteditor');
+          if (typeof bwb.activateScriptEditorTab === 'function') bwb.activateScriptEditorTab();
         })()
       `);
       for (let i = 0; i < 50; i++) {


### PR DESCRIPTION
## Problem

Every `pine_*` tool (`pine_new`, `pine_set_source`, `pine_get_source`, `pine_smart_compile`, ...) failed with `Could not open Pine Editor` / `Monaco not found in React fiber tree` whenever the Pine editor panel was closed in current TradingView Desktop builds.

## Root cause

Two defects in the panel-open path (`ensurePineEditorOpen` in `src/core/pine.js`, `openPanel` in `src/core/ui.js`):

1. `bottomWidgetBar.activateScriptEditorTab()` silently no-ops while the script editor widget is missing from the bar's enabled-widgets list — which is exactly the state after a user closes the panel.
2. The fallback `showWidget('pine-editor')` uses a name unknown to the widget registry; the registered name is `scripteditor` (confirmed empirically via `bwb._getWidgetConfigByNames` on a live app).

A secondary failure mode: a stale editor mount whose Monaco DOM is present but carries no React fiber keys, so the `FIND_MONACO` fiber-walk probe polls uselessly for 10s.

## Fix

- Open sequence is now `setWidgetAvailability('scripteditor', true)` → `showWidget('scripteditor')` → `activateScriptEditorTab()`, in both the core pine path and `ui_open_panel`.
- The poll loop gains a one-shot recovery: if Monaco DOM exists but the probe still fails after ~3s, hide the bar and reopen to force a fresh React-attached mount. The one-shot is consumed only when a remount is actually attempted, so a slow fiber-less first mount can still be recovered.
- `tests/e2e.test.js` editor helper updated to the same sequence and correct widget name.

## Verification

- Reproduced the broken state live (hidden bar, empty enabled list, zombie Monaco DOM) and confirmed `tv pine get` succeeds through the new path over CDP.
- Unit suite: 152/152 pass.
- Diff passed an independent adversarial review; its two confirmed findings (remount one-shot consumed too early, stale widget name in the e2e helper) are fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)