### PR TITLE
Fix Windows path resolution and CLI exit crash

### DIFF
--- a/scripts/pine_pull.js
+++ b/scripts/pine_pull.js
@@ -2,6 +2,7 @@
 // Pull current Pine Script source from TradingView editor → scripts/current.pine
 import CDP from 'chrome-remote-interface';
 import { writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 
 const targets = await (await fetch('http://localhost:9222/json/list')).json();
 const t = targets.find(t => t.url?.includes('tradingview.com'));
@@ -16,7 +17,7 @@ const src = (await c.Runtime.evaluate({
 
 if (!src) { console.error('Could not read Pine editor'); await c.close(); process.exit(1); }
 
-const outPath = new URL('../scripts/current.pine', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const outPath = fileURLToPath(new URL('../scripts/current.pine', import.meta.url));
 writeFileSync(outPath, src);
 console.log(`Pulled ${src.split('\n').length} lines → scripts/current.pine`);
 await c.close();

--- a/scripts/pine_push.js
+++ b/scripts/pine_push.js
@@ -2,8 +2,9 @@
 // Push scripts/current.pine → TradingView editor, then compile
 import CDP from 'chrome-remote-interface';
 import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 
-const srcPath = new URL('../scripts/current.pine', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const srcPath = fileURLToPath(new URL('../scripts/current.pine', import.meta.url));
 const src = readFileSync(srcPath, 'utf-8');
 
 const targets = await (await fetch('http://localhost:9222/json/list')).json();

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -3,6 +3,26 @@
  * Zero dependencies — uses only Node.js built-ins.
  */
 import { parseArgs } from 'node:util';
+import { disconnect } from '../connection.js';
+
+/**
+ * End the process with `code` without calling process.exit().
+ *
+ * On Windows, process.exit() while undici (global fetch) is still tearing down
+ * its sockets trips a libuv assertion — `!(handle->flags & UV_HANDLE_CLOSING)`
+ * in src/win/async.c — and the process dies with 0xC0000409 instead of `code`.
+ * Setting exitCode and letting the loop drain also guarantees piped stdout is
+ * flushed, which process.exit() does not.
+ *
+ * The CDP WebSocket is the one handle that would otherwise keep the loop alive
+ * forever, so close it here. The unref'd timer is a backstop for any handle we
+ * failed to release; it never delays a process that drains on its own.
+ */
+function finish(code) {
+  process.exitCode = code;
+  disconnect().catch(() => { /* nothing open, or already gone */ });
+  setTimeout(() => process.exit(code), 2000).unref();
+}
 
 /** @type {Map<string, { description: string, options?: object, handler: Function, subcommands?: Map<string, object> }>} */
 const commands = new Map();
@@ -55,7 +75,7 @@ export async function run(argv) {
 
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     printHelp();
-    process.exit(0);
+    return finish(0);
   }
 
   const cmdName = args[0];
@@ -64,7 +84,7 @@ export async function run(argv) {
   if (!cmd) {
     console.error(`Unknown command: ${cmdName}`);
     console.error('Run "tv --help" for a list of commands.');
-    process.exit(1);
+    return finish(1);
   }
 
   // Handle subcommands (e.g., tv pine get)
@@ -73,13 +93,13 @@ export async function run(argv) {
     const subName = args[1];
     if (!subName || subName === '--help' || subName === '-h') {
       printCommandHelp(cmdName, cmd);
-      process.exit(0);
+      return finish(0);
     }
     const sub = cmd.subcommands.get(subName);
     if (!sub) {
       console.error(`Unknown subcommand: ${cmdName} ${subName}`);
       printCommandHelp(cmdName, cmd);
-      process.exit(1);
+      return finish(1);
     }
     handler = sub.handler;
     options = sub.options || {};
@@ -101,7 +121,7 @@ export async function run(argv) {
             console.log(`  ${flag.padEnd(20)}${v.description || ''}`);
           }
         }
-        process.exit(0);
+        return finish(0);
       }
       await execute(handler, values, positionals);
     } catch (err) {
@@ -119,7 +139,7 @@ export async function run(argv) {
       });
       if (values.help) {
         printCommandHelp(cmdName, cmd);
-        process.exit(0);
+        return finish(0);
       }
       await execute(handler, values, positionals);
     } catch (err) {
@@ -132,7 +152,7 @@ async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
     console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    return finish(0);
   } catch (err) {
     handleError(err);
   }
@@ -143,8 +163,8 @@ function handleError(err) {
   // Connection failures get exit code 2
   if (/CDP|connection|ECONNREFUSED|not running/i.test(message)) {
     console.error(JSON.stringify({ success: false, error: message }, null, 2));
-    process.exit(2);
+    return finish(2);
   }
   console.error(JSON.stringify({ success: false, error: message }, null, 2));
-  process.exit(1);
+  return finish(1);
 }

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
Three Windows-only defects found setting up on Windows 10 / Node 24.19.0. Unit suite goes from **125 tests / 2 failures** to **159 / 0**.

### 1. `new URL(...).pathname` is not a filesystem path

It returns a URL path (`/C:/Users/...`). `tests/sanitization.test.js` joined that into `C:\C:\Users\...` and threw `ENOENT` at suite construction — and since that `describe` builds its cases by reading `src/core/`, the crash silently suppressed all 34 source-audit tests. That's most of the 125 → 159 jump.

`scripts/pine_pull.js` and `scripts/pine_push.js` patched around the same issue with `.replace(/^\/([A-Z]:)/, '$1')`, which leaves percent-escapes encoded, so any clone path with a space in it fails to resolve (`space%20test` → `ENOENT`). It also only matched uppercase drive letters.

All three now use `fileURLToPath()` — a no-op on POSIX, so no change on Mac/Linux.

### 2. CLI crashes on exit after any `fetch()`

`tv pine check` printed correct JSON, then died with `0xC0000409` and:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
```

Not a bug in the pine code — it reduces to one `fetch()` followed by `process.exit(0)`. On Windows, exiting while undici is still tearing down its sockets trips a libuv assert and the real exit code is lost. `router.js` now sets `process.exitCode` and lets the loop drain (~0.5s; undici's keep-alive socket is unref'd). Side benefit: `process.exit()` can truncate piped stdout on Windows.

**Worth a review:** `process.exit()` was also the only thing terminating CDP commands, since nothing in the CLI path closes the WebSocket `connect()` opens — a bare removal would hang every chart command. So `finish()` closes it and arms an unref'd 2s backstop timer for any handle left behind. Unref'd, so it never delays a process that drains on its own. Someone who knows the CDP lifecycle may want this done differently. The deliberate exits in `commands/stream.js` are untouched.

### Testing

`npm run test:unit` 159/159; `npm run lint` clean (4 pre-existing warnings, other files). Exit codes checked by hand; path fix verified from a directory with a space in its name.

**Not verified:** e2e (needs TradingView Desktop on :9222), the two scripts against a live editor, and anything non-Windows.
