### PR TITLE
fix: bound every CDP call with timeouts; guard frozen renderers + base64 screenshots

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ export default [
         fetch: 'readonly', setTimeout: 'readonly', clearTimeout: 'readonly',
         setInterval: 'readonly', clearInterval: 'readonly', console: 'readonly',
         process: 'readonly', Buffer: 'readonly', URL: 'readonly',
-        URLSearchParams: 'readonly', WebSocket: 'readonly', AbortController: 'readonly',
+        URLSearchParams: 'readonly', WebSocket: 'readonly', AbortController: 'readonly', AbortSignal: 'readonly',
         TextEncoder: 'readonly', TextDecoder: 'readonly', global: 'readonly',
         __dirname: 'readonly', structuredClone: 'readonly',
       },

--- a/src/connection.js
+++ b/src/connection.js
@@ -10,6 +10,29 @@ export const CDP_PORT = Number(process.env.TV_CDP_PORT || process.env.CDP_PORT) 
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 
+// Command timeouts (chrome-remote-interface has none by design — issue #194).
+// Layered: protocol-level Runtime.evaluate timeout kills hung in-page JS;
+// the Promise.race handles a fully dead renderer that never replies.
+const EVAL_TIMEOUT_MS = Number(process.env.TV_EVAL_TIMEOUT_MS) || 15000;
+const HTTP_TIMEOUT_MS = 5000;
+
+/** Reject with a timeout error after ms. Labels the operation for debugging. */
+export function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** Fetch a CDP HTTP endpoint (/json/*) with a hard timeout (upstream #275). */
+export async function fetchJson(pathname) {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}${pathname}`, {
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  });
+  return resp.json();
+}
+
 // Known direct API paths discovered via live probing (see PROBE_RESULTS.md)
 const KNOWN_PATHS = {
   chartApi: 'window.TradingViewApi._activeChartWidgetWV.value()',
@@ -53,8 +76,12 @@ export function requireFinite(value, name) {
 export async function getClient() {
   if (client) {
     try {
-      // Quick liveness check
-      await client.Runtime.evaluate({ expression: '1', returnByValue: true });
+      // Quick liveness check (bounded — a hung renderer must not block reconnect)
+      await withTimeout(
+        client.Runtime.evaluate({ expression: '1', returnByValue: true }),
+        EVAL_TIMEOUT_MS,
+        'liveness check',
+      );
       return client;
     } catch {
       client = null;
@@ -108,8 +135,7 @@ export async function reconnectTo(targetId) {
 }
 
 async function findChartTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
+  const targets = await fetchJson('/json/list');
   // Prefer targets with tradingview.com/chart in the URL
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
@@ -117,8 +143,7 @@ async function findChartTarget() {
 }
 
 async function findTargetById(id) {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
+  const targets = await fetchJson('/json/list');
   return targets.find(t => t.id === id) || null;
 }
 
@@ -131,12 +156,20 @@ export async function getTargetInfo() {
 
 export async function evaluate(expression, opts = {}) {
   const c = await getClient();
-  const result = await c.Runtime.evaluate({
-    expression,
-    returnByValue: true,
-    awaitPromise: opts.awaitPromise ?? false,
-    ...opts,
-  });
+  const timeoutMs = opts.timeoutMs ?? EVAL_TIMEOUT_MS;
+  // Protocol-level timeout terminates hung JS in-page; the race catches a
+  // dead renderer that never replies. (CRI #194/#512, Runtime#evaluate docs.)
+  const result = await withTimeout(
+    c.Runtime.evaluate({
+      expression,
+      returnByValue: true,
+      awaitPromise: opts.awaitPromise ?? false,
+      ...opts,
+      ...(timeoutMs > 0 ? { timeout: timeoutMs } : {}),
+    }),
+    timeoutMs > 0 ? timeoutMs + 5000 : 0,
+    'Runtime.evaluate',
+  );
   if (result.exceptionDetails) {
     const msg = result.exceptionDetails.exception?.description
       || result.exceptionDetails.text

--- a/src/core/capture.js
+++ b/src/core/capture.js
@@ -1,7 +1,7 @@
 /**
  * Core screenshot/capture logic.
  */
-import { getClient, evaluate, getChartCollection } from '../connection.js';
+import { getClient, evaluate, getChartCollection, withTimeout } from '../connection.js';
 import { waitForChartRender } from '../wait.js';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
@@ -63,12 +63,24 @@ export async function captureScreenshot({ region, filename, method, waitForRende
   const params = { format: 'png' };
   if (clip) params.clip = clip;
 
-  const { data } = await client.Page.captureScreenshot(params);
-  writeFileSync(filePath, Buffer.from(data, 'base64'));
+  // Bounded: Page.captureScreenshot hangs forever on unresponsive renderers
+  // (upstream issue #174). Race with a generous budget for big captures.
+  const { data } = await withTimeout(
+    client.Page.captureScreenshot(params),
+    60000,
+    'Page.captureScreenshot',
+  );
+  const buf = Buffer.from(data, 'base64');
+  writeFileSync(filePath, buf);
 
+  // Remote deployments (SSE over Tailscale) can't read VPS-local paths, so the
+  // image is embedded as a data URL in addition to being written to disk.
+  // Images can be large — cap embedded preview at ~2 MB.
+  const includeData = buf.length <= 2 * 1024 * 1024;
   return {
     success: true, method: 'cdp', file_path: filePath, region,
     waited_for_render: !!waitForRender,
-    size_bytes: Buffer.from(data, 'base64').length,
+    size_bytes: buf.length,
+    ...(includeData ? { image_base64: `data:image/png;base64,${data}` } : { note: 'image too large to embed (>2MB) — read file_path on the host' }),
   };
 }

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -289,6 +289,17 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   const killFirst = kill_existing !== false;
   const platform = process.platform;
 
+  // Guard: on systemd-managed deployments (headless VPS) the TV process is
+  // owned by a unit — spawning or killing it here fights the service manager
+  // (tv_launch spawns without a display → SUID sandbox crash, and kills the
+  // unit's instance). Launching on such hosts is systemd's job, always.
+  if (process.env.TV_MANAGED_BY_SYSTEMD === '1') {
+    throw new Error(
+      'tv_launch is disabled on this deployment: TradingView is managed by systemd. ' +
+      'Use: systemctl --user restart tradingview-headless (or set TV_MANAGED_BY_SYSTEMD=0 to override).'
+    );
+  }
+
   const pathMap = {
     darwin: [
       '/Applications/TradingView.app/Contents/MacOS/TradingView',
@@ -303,6 +314,9 @@ export async function launch({ port, kill_existing, _deps } = {}) {
       '/opt/TradingView/tradingview',
       '/opt/TradingView/TradingView',
       `${process.env.HOME}/.local/share/TradingView/TradingView`,
+      // Non-root install: .deb extracted with dpkg-deb -x into the home dir
+      // (common on headless VPS boxes where sudo is unavailable).
+      `${process.env.HOME}/tv-headless/app/opt/TradingView/tradingview`,
       '/usr/bin/tradingview',
       '/snap/tradingview/current/tradingview',
     ],

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -10,14 +10,25 @@
  * (Approach from issue #155 and PR #163, verified on Desktop 3.1.0.)
  */
 import CDP from 'chrome-remote-interface';
-import { getClient, reconnectTo, CDP_HOST, CDP_PORT } from '../connection.js';
+import { getClient, reconnectTo, CDP_HOST, CDP_PORT, fetchJson, withTimeout } from '../connection.js';
+
+const EVAL_TIMEOUT_MS = Number(process.env.TV_EVAL_TIMEOUT_MS) || 15000;
+
+/** Runtime.evaluate on an arbitrary target, bounded and self-cleaning. */
+async function evalOn(c, expression) {
+  const { result } = await withTimeout(
+    c.Runtime.evaluate({ expression, returnByValue: true, timeout: EVAL_TIMEOUT_MS }),
+    EVAL_TIMEOUT_MS + 5000,
+    'Runtime.evaluate',
+  );
+  return result?.value;
+}
 
 /**
  * List all open chart tabs (CDP page targets).
  */
 export async function list() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
+  const targets = await fetchJson('/json/list');
 
   // Chart tabs plus new-tab landing pages (layout picker), so every tab in the
   // top bar is listable and switchable.
@@ -41,23 +52,16 @@ export async function list() {
  * is the one whose DOM actually contains `.tabs-container .tab`.
  */
 async function withShell(fn) {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
+  const targets = await fetchJson('/json/list');
   const candidates = targets.filter(t => t.type === 'page' && /\/window\/index\.html/i.test(t.url || ''));
 
   for (const cand of candidates) {
     let c = null;
     try {
       c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: cand.id });
-      const probe = await c.Runtime.evaluate({
-        expression: `!!document.querySelector('.tabs-container .tab')`,
-        returnByValue: true,
-      });
-      if (probe.result?.value) {
-        const out = await fn(async (expression) => {
-          const { result } = await c.Runtime.evaluate({ expression, returnByValue: true });
-          return result?.value;
-        });
+      const probe = await evalOn(c, `!!document.querySelector('.tabs-container .tab')`);
+      if (probe) {
+        const out = await fn((expression) => evalOn(c, expression));
         await c.close();
         return out;
       }
@@ -74,8 +78,7 @@ async function isTargetVisible(targetId) {
   let c = null;
   try {
     c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
-    const { result } = await c.Runtime.evaluate({ expression: 'document.visibilityState', returnByValue: true });
-    return result?.value === 'visible';
+    return (await evalOn(c, 'document.visibilityState')) === 'visible';
   } catch {
     return false;
   } finally {
@@ -85,8 +88,7 @@ async function isTargetVisible(targetId) {
 
 /** Find an open new-tab landing page target (shows the layout picker). */
 async function findLandingTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
+  const targets = await fetchJson('/json/list');
   return targets.find(t => t.type === 'page' && t.title === 'New tab') || null;
 }
 
@@ -95,10 +97,7 @@ async function withTarget(targetId, fn) {
   let c = null;
   try {
     c = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
-    return await fn(async (expression) => {
-      const { result } = await c.Runtime.evaluate({ expression, returnByValue: true });
-      return result?.value;
-    });
+    return await fn((expression) => evalOn(c, expression));
   } finally {
     try { if (c) await c.close(); } catch { /* already gone */ }
   }
@@ -147,9 +146,8 @@ export async function newTab({ layout, name } = {}) {
   if (!landing) throw new Error('New tab opened but its landing page target was not found.');
 
   // Snapshot existing chart targets so we can spot the one the pick creates.
-  const beforeResp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
   const chartIdsBefore = new Set(
-    (await beforeResp.json())
+    (await fetchJson('/json/list'))
       .filter(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
       .map(t => t.id)
   );
@@ -226,8 +224,7 @@ export async function newTab({ layout, name } = {}) {
   let chartTarget = null;
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 500));
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-    const targets = await resp.json();
+    const targets = await fetchJson('/json/list');
     chartTarget = targets.find(x =>
       x.type === 'page' && /tradingview\.com\/chart/i.test(x.url) && !chartIdsBefore.has(x.id)
     ) || targets.find(x => x.id === landing.id && /tradingview\.com\/chart/i.test(x.url)) || null;
@@ -293,6 +290,13 @@ export async function switchTab({ index }) {
   }
 
   const target = tabs.tabs[idx];
+
+  // Guard: never re-attach the shared client to a non-chart target. The
+  // file:// layout-picker renderer is throttled/frozen under xvfb — every
+  // subsequent tool call would hang. Only chart tabs are drivable.
+  if (!target.is_chart) {
+    throw new Error(`Tab ${idx} is the layout picker (not a chart). CDP automation can only switch to chart tabs — pick a layout via tab_new({layout}) instead.`);
+  }
 
   if (!(await isTargetVisible(target.id))) {
     const clicked = await withShell(async (evalIn) => {


### PR DESCRIPTION
## Problem

`chrome-remote-interface` has no command timeout by design (cyrus-and/chrome-remote-interface#194). A single hung `Runtime.evaluate` — e.g. on a renderer Chromium has throttled (hidden/occluded window, `file://` landing page) — wedges the whole MCP server forever. Every subsequent tool call queues behind it.

Matches the hang class in #275 (`/json/*` fetches with no timeout) and #174 (`Page.captureScreenshot` hanging on unresponsive renderers).

## Fixes

### `src/connection.js`
- `withTimeout()` Promise.race wrapper exported for all core modules
- `evaluate()` sends the protocol-level `Runtime.evaluate({ timeout })` param (terminates hung in-page JS — cyrus-and#512) *and* races it (catches dead renderers)
- All `/json/*` HTTP fetches via `fetchJson()` with `AbortSignal.timeout(5000)`
- `getClient()` liveness check bounded

### `src/core/tab.js`
- All shell-window / landing-page evals bounded
- `tab_switch` refuses non-chart (`file://` layout-picker) targets with a clear error instead of hanging

### `src/core/capture.js`
- `Page.captureScreenshot` bounded (60s)
- Response embeds `image_base64` (data URL, ≤2MB) alongside `file_path`

### `src/core/health.js`
- `tv_launch` throws under `TV_MANAGED_BY_SYSTEMD=1`
- Added Linux path for non-root installs (`dpkg-deb -x`)

### `eslint.config.mjs`
- `AbortSignal` added to globals

Caveat: the protocol-level `timeout` param is experimental in the CDP docs; the Promise.race layer keeps behavior safe where the param is ignored.