### PR TITLE
docs: state the real Node floor (20+), not 18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [RESEARCH.md](RESEARCH.md) for open questions, findings, and related work.
 ## Prerequisites
 
 - **TradingView Desktop app** (paid subscription required for real-time data)
-- **Node.js 18+**
+- **Node.js 20+**
 - **Claude Code** with MCP support (for MCP tools) or any terminal (for CLI)
 - **macOS, Windows, or Linux**
 


### PR DESCRIPTION
One line in `README.md`. Splitting it out of #457, which I closed in favor of #445.

## The claim isn't backed by anything

`README.md:53` says **`Node.js 18+`**. That is the *only* place the supported Node version is written down anywhere in the repo — `package.json` has no `engines` field, so nothing enforces or contradicts it in code.

Meanwhile CI has only ever tested `[20.x, 22.x]`:

```yaml
# .github/workflows/ci.yml
matrix:
  node-version: [20.x, 22.x]
```

So Node 18 is advertised and never exercised. It also left maintenance in April 2025.

## #445 makes it outright false

#445 resolves `@hono/node-server` from `1.19.14` to `2.1.0`, and that bump carries an engines change:

```
main   @hono/node-server=1.19.14  engines={"node":">=18.14.1"}
#445   @hono/node-server=2.1.0    engines={"node":">=20"}
```

#445 touches `package-lock.json` only, so nothing there updates this line — it goes stale the moment that PR merges. I'd rather send the correction than let it rot.

**No ordering requirement.** This is correct on `main` as it stands today (Node 18 is untested either way) and stays correct after #445. Merge it whenever, in either order.

## Verification

- `README.md:53` is the sole prose statement of a Node version — I grepped every `.md`, `.json`, `.yml`, and `.yaml` tracked on `main`
- `package.json` `engines` → `null`
- `ci.yml` matrix → `[20.x, 22.x]`
- engines figures above read directly out of each lockfile, not from the advisory text
- diff is 1 file, 1 insertion, 1 deletion — no source, test, or dependency changes

## On CI

Upstream CI won't run here — like every external PR on this repo since 2026-07-24, the run will sit at `action_required` (context in #474). For a one-word docs change there is nothing a green run would tell you that the diff doesn't.
