### PR TITLE
fix: connect to CDP over 127.0.0.1 instead of localhost (fixes #14, #42)

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -42,7 +42,7 @@ echo Waiting for CDP to become available...
 timeout /t 5 /nobreak >nul
 
 :check
-curl -s http://localhost:%PORT%/json/version >nul 2>&1
+curl -s http://127.0.0.1:%PORT%/json/version >nul 2>&1
 if %errorlevel% neq 0 (
     echo Still waiting...
     timeout /t 2 /nobreak >nul
@@ -50,6 +50,6 @@ if %errorlevel% neq 0 (
 )
 
 echo.
-echo CDP ready at http://localhost:%PORT%
-curl -s http://localhost:%PORT%/json/version
+echo CDP ready at http://127.0.0.1:%PORT%
+curl -s http://127.0.0.1:%PORT%/json/version
 echo.

--- a/scripts/launch_tv_debug_linux.sh
+++ b/scripts/launch_tv_debug_linux.sh
@@ -56,9 +56,9 @@ echo "PID: $TV_PID"
 # Wait for CDP to be ready
 echo "Waiting for CDP..."
 for i in $(seq 1 15); do
-  if curl -s "http://localhost:$PORT/json/version" > /dev/null 2>&1; then
-    echo "CDP ready at http://localhost:$PORT"
-    curl -s "http://localhost:$PORT/json/version" | python3 -m json.tool 2>/dev/null || curl -s "http://localhost:$PORT/json/version"
+  if curl -s "http://127.0.0.1:$PORT/json/version" > /dev/null 2>&1; then
+    echo "CDP ready at http://127.0.0.1:$PORT"
+    curl -s "http://127.0.0.1:$PORT/json/version" | python3 -m json.tool 2>/dev/null || curl -s "http://127.0.0.1:$PORT/json/version"
     exit 0
   fi
   sleep 1

--- a/scripts/launch_tv_debug_mac.sh
+++ b/scripts/launch_tv_debug_mac.sh
@@ -56,13 +56,13 @@ echo "PID: $TV_PID"
 # Wait for CDP to be ready
 echo "Waiting for CDP..."
 for i in $(seq 1 15); do
-  if curl -s "http://localhost:$PORT/json/version" > /dev/null 2>&1; then
-    echo "CDP ready at http://localhost:$PORT"
-    curl -s "http://localhost:$PORT/json/version" | python3 -m json.tool 2>/dev/null || curl -s "http://localhost:$PORT/json/version"
+  if curl -s "http://127.0.0.1:$PORT/json/version" > /dev/null 2>&1; then
+    echo "CDP ready at http://127.0.0.1:$PORT"
+    curl -s "http://127.0.0.1:$PORT/json/version" | python3 -m json.tool 2>/dev/null || curl -s "http://127.0.0.1:$PORT/json/version"
     exit 0
   fi
   sleep 1
 done
 
 echo "Warning: CDP not responding after 15s. TradingView may still be loading."
-echo "Check manually: curl http://localhost:$PORT/json/version"
+echo "Check manually: curl http://127.0.0.1:$PORT/json/version"

--- a/scripts/pine_pull.js
+++ b/scripts/pine_pull.js
@@ -3,10 +3,10 @@
 import CDP from 'chrome-remote-interface';
 import { writeFileSync } from 'fs';
 
-const targets = await (await fetch('http://localhost:9222/json/list')).json();
+const targets = await (await fetch('http://127.0.0.1:9222/json/list')).json();
 const t = targets.find(t => t.url?.includes('tradingview.com'));
 if (!t) { console.error('No TradingView target'); process.exit(1); }
-const c = await CDP({ host: 'localhost', port: 9222, target: t.id });
+const c = await CDP({ host: '127.0.0.1', port: 9222, target: t.id });
 await c.Runtime.enable();
 
 const src = (await c.Runtime.evaluate({

--- a/scripts/pine_push.js
+++ b/scripts/pine_push.js
@@ -6,10 +6,10 @@ import { readFileSync } from 'fs';
 const srcPath = new URL('../scripts/current.pine', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
 const src = readFileSync(srcPath, 'utf-8');
 
-const targets = await (await fetch('http://localhost:9222/json/list')).json();
+const targets = await (await fetch('http://127.0.0.1:9222/json/list')).json();
 const t = targets.find(t => t.url?.includes('tradingview.com'));
 if (!t) { console.error('No TradingView target'); process.exit(1); }
-const c = await CDP({ host: 'localhost', port: 9222, target: t.id });
+const c = await CDP({ host: '127.0.0.1', port: 9222, target: t.id });
 await c.Runtime.enable();
 
 // Inject source

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,8 +2,8 @@ import CDP from 'chrome-remote-interface';
 
 let client = null;
 let targetInfo = null;
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+const CDP_HOST = process.env.TV_CDP_HOST || '127.0.0.1';
+const CDP_PORT = Number(process.env.TV_CDP_PORT) || 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
 
@@ -26,7 +26,7 @@ const KNOWN_PATHS = {
   pineFacadeApi: 'https://pine-facade.tradingview.com/pine-facade',
 };
 
-export { KNOWN_PATHS };
+export { KNOWN_PATHS, CDP_HOST, CDP_PORT };
 
 /**
  * Sanitize a string for safe interpolation into JavaScript code evaluated via CDP.

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -1,7 +1,7 @@
 /**
  * Core health/discovery/launch logic.
  */
-import { getClient, getTargetInfo, evaluate } from '../connection.js';
+import { getClient, getTargetInfo, evaluate, CDP_HOST } from '../connection.js';
 import { existsSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 
@@ -227,7 +227,7 @@ export async function launch({ port, kill_existing } = {}) {
     try {
       const http = await import('http');
       const ready = await new Promise((resolve) => {
-        http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+        http.get(`http://${CDP_HOST}:${cdpPort}/json/version`, (res) => {
           let data = '';
           res.on('data', (chunk) => data += chunk);
           res.on('end', () => resolve(data));
@@ -237,7 +237,7 @@ export async function launch({ port, kill_existing } = {}) {
         const info = JSON.parse(ready);
         return {
           success: true, platform, binary: tvPath, pid: child.pid,
-          cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
+          cdp_port: cdpPort, cdp_url: `http://${CDP_HOST}:${cdpPort}`,
           browser: info.Browser, user_agent: info['User-Agent'],
         };
       }

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,10 +2,8 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
+import { getClient, evaluate, CDP_HOST, CDP_PORT } from '../connection.js';
 
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
 
 /**
  * List all open chart tabs (CDP page targets).


### PR DESCRIPTION
TradingView binds the DevTools port to IPv4 127.0.0.1 only. On Windows
`localhost` resolves to ::1 first, and Node stopped preferring IPv4 in v17
when the default DNS result order became `verbatim`. Every CDP request
therefore fails with ECONNREFUSED against a port that is open and listening.

This is the real cause behind #14 and #42, both of which conclude that the
MSIX sandbox blocks CDP. It does not.

Verified on TradingView Desktop 3.3.0.7992 installed from the Microsoft Store:

```
pid 23780: "...\WindowsApps\TradingView.Desktop_3.3.0.7992_x64__n534cwy3pjxzj\TradingView.exe" --remote-debugging-port=9222
TCP    127.0.0.1:9222    0.0.0.0:0    LISTENING    23780
```

The flag is honoured and the port is open. `http://localhost:9222/json/version`
is refused; `http://127.0.0.1:9222/json/version` succeeds. Every tool works
once the client stops asking for localhost.

Changes:

- `connection.js`: `CDP_HOST` defaults to `127.0.0.1`, overridable via
  `TV_CDP_HOST`, and is exported alongside `CDP_PORT` (`TV_CDP_PORT`)
- `core/tab.js`: use the shared constants instead of a duplicate `localhost`
- `core/health.js`: use `CDP_HOST` for the readiness probe and reported URL
- `scripts/`: same change in the bat/sh launchers and the pine helpers

Fixes #14
Fixes #42
