### PR TITLE
fix: quote_get must not label chart data with the requested symbol

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -242,12 +242,22 @@ export async function getEquity() {
   return { success: true, data_points: equity?.data?.length || 0, source: equity?.source, data: equity?.data || [], equity_summary: equity?.equity_summary, note: equity?.note, error: equity?.error };
 }
 
+/**
+ * Normalize a symbol for comparison: drop any exchange prefix and upper-case.
+ * "BATS:TSLA" and "tsla" both become "TSLA".
+ */
+function normalizeSymbol(s) {
+  if (!s) return '';
+  const parts = String(s).trim().toUpperCase().split(':');
+  return parts[parts.length - 1];
+}
+
 export async function getQuote({ symbol } = {}) {
   const data = await evaluate(`
     (function() {
       var api = ${CHART_API};
-      var sym = ${safeString(symbol || '')};
-      if (!sym) { try { sym = api.symbol(); } catch(e) {} }
+      var sym = '';
+      try { sym = api.symbol(); } catch(e) {}
       if (!sym) { try { sym = api.symbolExt().symbol; } catch(e) {} }
       var ext = {};
       try { ext = api.symbolExt() || {}; } catch(e) {}
@@ -274,7 +284,19 @@ export async function getQuote({ symbol } = {}) {
     })()
   `);
   if (!data || (!data.last && !data.close)) throw new Error('Could not retrieve quote. The chart may still be loading.');
-  return { success: true, ...data };
+
+  // getQuote reads the chart's main series, so it can only report the symbol on the chart.
+  // Refuse rather than return the chart's prices labelled with the caller's symbol.
+  if (symbol && normalizeSymbol(symbol) !== normalizeSymbol(data.symbol)) {
+    throw new Error(
+      `quote_get reads the symbol currently on the chart. You asked for "${symbol}" but the chart shows ` +
+      `"${data.symbol}". Call chart_set_symbol with "${symbol}" first, then call quote_get.`
+    );
+  }
+
+  const result = { success: true, ...data };
+  if (symbol) result.requested_symbol = symbol;
+  return result;
 }
 
 export async function getDepth() {

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -35,8 +35,8 @@ export function registerDataTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('quote_get', 'Get real-time quote data for a symbol (price, OHLC, volume)', {
-    symbol: z.string().optional().describe('Symbol to quote (blank = current chart symbol)'),
+  server.tool('quote_get', 'Get real-time quote data for the symbol currently on the chart (price, OHLC, volume). To quote a different symbol, call chart_set_symbol first.', {
+    symbol: z.string().optional().describe('Optional guard. If given it must match the symbol on the chart, otherwise the call fails instead of returning the wrong instrument. Omit to quote whatever is on the chart.'),
   }, async ({ symbol }) => {
     try { return jsonResult(await core.getQuote({ symbol })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }


### PR DESCRIPTION
`getQuote` accepted a `symbol` argument, used it only as a label, and read
OHLCV from the chart main series plus description/exchange/type from
`api.symbolExt()`. Requesting a symbol that is not on the chart returns the
chart prices under the requested symbol name, with no error and no warning.

Reproduced with GOOGL on the chart:

```js
quote_get({ symbol: 'TSLA' })
// { symbol: 'TSLA', last: 344.82, description: 'Alphabet Inc. Class A' }
```

The real TSLA last at that moment was 362.86. Only the `description` field
revealed the mismatch. Silently returning the wrong instrument price is a
dangerous failure mode in a tool built for traders.

Changes:

- The injected JS no longer receives the caller symbol, so it cannot mislabel.
- The argument becomes a guard: if it does not match the chart symbol
  (exchange prefix ignored, case-insensitive) the call throws and points the
  caller at `chart_set_symbol`.
- On success the response echoes `requested_symbol`.
- Tool description and schema now describe the actual behaviour.
