### PR TITLE
Fix tv_launch on Microsoft Store (MSIX) TradingView installs

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -227,8 +227,17 @@ async function _probeCdp(cdpPort) {
   });
 }
 
-function _spawnDetached(spawnFn, exe, args) {
-  const child = spawnFn(exe, args, { detached: true, stdio: 'ignore' });
+function _spawnDetached(spawnFn, exe, args, { tolerateSyncFailure = false } = {}) {
+  let child;
+  try {
+    child = spawnFn(exe, args, { detached: true, stdio: 'ignore' });
+  } catch (e) {
+    // Windows rejects a WindowsApps binary with a synchronous EPERM throw
+    // rather than the async 'error' event the caller waits on. Hand back a stub
+    // carrying the failure so the local-copy fallback still gets its turn.
+    if (!tolerateSyncFailure) throw e;
+    return { pid: null, spawnError: e.code || e.message, unref() {}, on() {}, off() {} };
+  }
   child.unref();
   return child;
 }
@@ -236,6 +245,7 @@ function _spawnDetached(spawnFn, exe, args) {
 // Resolves once with an error string if the process fails/exits within graceMs,
 // or with null if it survives that long.
 function _spawnFailedEarly(child, graceMs = 1500) {
+  if (child.spawnError) return Promise.resolve(child.spawnError);
   return new Promise((resolve) => {
     const timer = setTimeout(() => { cleanup(); resolve(null); }, graceMs);
     const onError = (e) => { cleanup(); resolve(e.code || e.message || 'spawn error'); };
@@ -273,7 +283,10 @@ function _copyMsixPackageLocal(tvPath, { cpSync, rmSync, readdirSync, existsSync
   if (!existsSync(dstExe)) {
     try {
       for (const entry of readdirSync(cacheRoot)) {
-        if (entry !== pkgName && /^TradingView\./i.test(entry)) {
+        // Match anywhere, not just a leading "TradingView.": Store packages are
+        // publisher-prefixed (31178TradingViewInc.TradingView_...), and stale
+        // copies would otherwise pile up at ~330MB each.
+        if (entry !== pkgName && /TradingView/i.test(entry)) {
           rmSync(join(cacheRoot, entry), { recursive: true, force: true });
         }
       }
@@ -318,7 +331,9 @@ export async function launch({ port, kill_existing, _deps } = {}) {
     // MSIX/Windows Store install — InstallLocation is in WindowsApps, which is ACL-restricted
     // for normal `dir` enumeration but readable via Get-AppxPackage without elevation.
     try {
-      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'TradingView.Desktop\' -ErrorAction SilentlyContinue).InstallLocation"';
+      // Match on a wildcard: the published package name is publisher-prefixed
+      // (e.g. 31178TradingViewInc.TradingView), not a fixed literal.
+      const ps = 'powershell -NoProfile -Command "(Get-AppxPackage -Name \'*TradingView*\' -ErrorAction SilentlyContinue | Select-Object -First 1).InstallLocation"';
       const installDir = deps.execSync(ps, { timeout: 5000 }).toString().trim();
       if (installDir) {
         const candidate = `${installDir}\\TradingView.exe`;
@@ -360,11 +375,12 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  const fromWindowsApps = platform === 'win32' && WINDOWS_APPS_RE.test(tvPath);
+  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs, { tolerateSyncFailure: fromWindowsApps });
   let info = null;
   let usedLocalCopy = false;
 
-  if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
+  if (fromWindowsApps) {
     const earlyFailure = await _spawnFailedEarly(child);
     if (!earlyFailure) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -148,3 +148,95 @@ describe('launch() — classic install path', { skip: !onWindows }, () => {
     await assert.rejects(() => launch({ _deps: deps }), /TradingView not found/);
   });
 });
+
+// Store packages are publisher-prefixed, so neither the Get-AppxPackage -Name
+// filter nor the stale-copy cleanup may assume a bare "TradingView." prefix.
+describe('launch() — publisher-prefixed MSIX package', { skip: !onWindows }, () => {
+  const PKG = '31178TradingViewInc.TradingView_3.3.0.0_x64__q4jpyh43s5mv6';
+  const PREFIXED_EXE = `C:\\Program Files\\WindowsApps\\${PKG}\\TradingView.exe`;
+
+  function prefixedDeps() {
+    const state = { spawned: [], copies: [], removed: [], queries: [], cdpUp: false };
+    const deps = {
+      existsSync: (p) => {
+        if (p === PREFIXED_EXE) return true;
+        if (p.includes('tradingview-mcp')) return state.copies.length > 0;
+        return false;
+      },
+      execSync: (cmd) => {
+        if (cmd.includes('Get-AppxPackage')) {
+          state.queries.push(cmd);
+          // Mimic PowerShell: a -Name filter that does not match returns nothing.
+          const m = cmd.match(/-Name '([^']+)'/);
+          const filter = m ? m[1] : '';
+          const re = new RegExp(`^${filter.replace(/\*/g, '.*')}$`, 'i');
+          return re.test('31178TradingViewInc.TradingView')
+            ? `C:\\Program Files\\WindowsApps\\${PKG}\n`
+            : '\n';
+        }
+        if (cmd.includes('taskkill')) return '';
+        throw new Error(`unexpected execSync: ${cmd}`);
+      },
+      spawn: (exe) => {
+        state.spawned.push(exe);
+        if (exe.includes('tradingview-mcp')) state.cdpUp = true;
+        return mockChild(exe.includes('WindowsApps') ? { failWith: 'EACCES' } : {});
+      },
+      cpSync: (src, dst) => { state.copies.push({ src, dst }); },
+      rmSync: (p) => { state.removed.push(p); },
+      readdirSync: () => ['31178TradingViewInc.TradingView_3.2.0.0_x64__q4jpyh43s5mv6'],
+      delay: async () => {},
+      probeCdp: async () => (state.cdpUp ? CDP_VERSION : null),
+    };
+    return { deps, state };
+  }
+
+  it('resolves the install via a wildcard -Name filter', async () => {
+    const { deps, state } = prefixedDeps();
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.match(state.queries[0], /-Name '\*TradingView\*'/);
+    assert.match(state.spawned[0], /WindowsApps/);
+  });
+
+  it('cleans up a stale copy of a publisher-prefixed package', async () => {
+    const { deps, state } = prefixedDeps();
+    await launch({ _deps: deps });
+    assert.equal(state.removed.length, 1);
+    assert.match(state.removed[0], /3\.2\.0\.0/);
+    assert.equal(state.copies.length, 1);
+  });
+
+  // Windows throws EPERM out of spawn() itself for WindowsApps binaries; the
+  // fallback must still run instead of the throw escaping launch().
+  it('synchronous EPERM on spawn still falls back to the local copy', async () => {
+    const { deps, state } = prefixedDeps();
+    deps.spawn = (exe) => {
+      state.spawned.push(exe);
+      if (exe.includes('WindowsApps')) {
+        const err = new Error('spawn EPERM');
+        err.code = 'EPERM';
+        throw err;
+      }
+      state.cdpUp = true;
+      return mockChild();
+    };
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.match(state.spawned[0], /WindowsApps/);
+    assert.match(state.spawned[1], /tradingview-mcp/);
+  });
+
+  it('propagates a synchronous spawn failure on a classic install', async () => {
+    const classicExe = `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`;
+    const deps = {
+      existsSync: (p) => p === classicExe,
+      execSync: (cmd) => { if (cmd.includes('taskkill')) return ''; throw new Error(`unexpected: ${cmd}`); },
+      spawn: () => { const e = new Error('spawn EPERM'); e.code = 'EPERM'; throw e; },
+      cpSync: () => {}, rmSync: () => {}, readdirSync: () => [],
+      delay: async () => {}, probeCdp: async () => null,
+    };
+    await assert.rejects(() => launch({ _deps: deps }), /EPERM/);
+  });
+});


### PR DESCRIPTION
## Summary
- `tv_launch` always failed with "TradingView not found on win32" against a Microsoft Store (MSIX) install
- Three chained bugs, all from assuming the package is literally named `TradingView.Desktop` instead of publisher-prefixed (e.g. `31178TradingViewInc.TradingView`):
  1. `Get-AppxPackage -Name 'TradingView.Desktop'` never matches, so resolution falls through to `where TradingView.exe`, which also misses (Store app execution aliases aren't on a non-shell process PATH). Now matches on `-Name '*TradingView*'`.
  2. Stale local-copy cleanup used `/^TradingView\./`, which never matches a publisher-prefixed folder name, so superseded ~330MB copies piled up in `%LOCALAPPDATA%\tradingview-mcp`.
  3. Windows throws `EPERM` synchronously out of `spawn()` for a WindowsApps binary, not as the async `'error'` event `_spawnFailedEarly` was waiting on, so the throw escaped `launch()` entirely and the local-copy fallback never ran.

## Test plan
- [x] `node --test tests/launch.test.js` - 11/11 pass (4 new regression tests added, covering the wildcard name match, stale-copy cleanup, and the synchronous-EPERM fallback path)
- [x] `npm run test:unit` - 127/129 pass (2 pre-existing failures in `sanitization.test.js`, unrelated to this change - a Windows path-with-spaces bug in that test file)
- [x] `npm run lint` - clean on `src/core/health.js`
- [x] Verified end-to-end against a real Store install (package version 3.3.0.0): `launch()` resolves the path via the wildcard query, falls back to the local copy, spawns it, and binds CDP on 9222; `tv_health_check` then connects successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)