### PR TITLE
docs: fix MCP config path in SETUP_GUIDE (server never registers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Claude reads [`CLAUDE.md`](CLAUDE.md) automatically when working in this project
 | "Draw a level at 24500" | `draw_shape` (horizontal_line) |
 | "Take a screenshot" | `capture_screenshot` |
 
-## Tool Reference (78 MCP tools)
+## Tool Reference (84 MCP tools)
 
 ### Chart Reading
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -12,9 +12,39 @@ npm install
 
 If the user specifies a different install path, use that instead of `~/tradingview-mcp`.
 
-## Step 2: Add to MCP Config
+## Step 2: Register the MCP Server
 
-Add the server to the user's Claude Code MCP configuration. The config file is at `~/.claude/.mcp.json` (global) or `.mcp.json` (project-level).
+Register the server with Claude Code using the `claude mcp add` CLI. This writes to the config file Claude Code actually reads, so it is the reliable path.
+
+**User scope** (loads in every project — recommended):
+
+```bash
+claude mcp add tradingview -s user -- node <INSTALL_PATH>/src/server.js
+```
+
+**Project scope** (this project only, shareable via git):
+
+```bash
+claude mcp add tradingview -s project -- node <INSTALL_PATH>/src/server.js
+```
+
+Replace `<INSTALL_PATH>` with the absolute path where the repo was cloned. On Windows, pass the full native path, e.g. `C:\Users\username\tradingview-mcp\src\server.js`.
+
+Verify it registered:
+
+```bash
+claude mcp list
+```
+
+Expected output:
+
+```
+tradingview: node <INSTALL_PATH>/src/server.js - ✔ Connected
+```
+
+### Editing config by hand
+
+If you would rather edit JSON directly, the files Claude Code reads are `~/.claude.json` (user scope) or `.mcp.json` in the project root (project scope). The entry goes under an `mcpServers` object:
 
 ```json
 {
@@ -27,9 +57,9 @@ Add the server to the user's Claude Code MCP configuration. The config file is a
 }
 ```
 
-Replace `<INSTALL_PATH>` with the actual path where the repo was cloned (e.g., `/Users/username/tradingview-mcp`).
+If the file already exists and has other servers, merge the `tradingview` entry into the existing `mcpServers` object. Do not overwrite other servers.
 
-If the config file already exists and has other servers, merge the `tradingview` entry into the existing `mcpServers` object. Do not overwrite other servers.
+> **Note:** `~/.claude/.mcp.json` is **not** read by Claude Code. Earlier versions of this guide pointed there; a config at that path is silently ignored and `claude mcp list` will report no servers. If you have one, re-register with `claude mcp add` above.
 
 ## Step 3: Launch TradingView Desktop
 
@@ -117,7 +147,7 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 | `cdp_connected: false` | Launch TradingView with `--remote-debugging-port=9222` |
 | Windows: "Access is denied" launching from `WindowsApps` | Use `tv_launch` (auto copy-fallback) or the manual copy snippet in Step 3 — never `icacls` on WindowsApps |
 | `ECONNREFUSED` | TradingView isn't running or port 9222 is blocked |
-| MCP server not showing in Claude Code | Check `~/.claude/.mcp.json` syntax, restart Claude Code |
+| MCP server not showing in Claude Code | Run `claude mcp list` — if empty, the server was never registered (see Step 2). `~/.claude/.mcp.json` is not read by Claude Code. Restart Claude Code after registering. |
 | `tv` command not found | Run `npm link` from the project directory |
 | Tools return stale data | TradingView may still be loading — wait a few seconds |
 | Pine Editor tools fail | Open the Pine Editor panel first (`ui_open_panel pine-editor open`) |
@@ -125,5 +155,5 @@ Then `tv status`, `tv quote`, `tv pine compile`, etc. work from anywhere.
 ## What to Read Next
 
 - `CLAUDE.md` — Decision tree for which tool to use when (auto-loaded by Claude Code)
-- `README.md` — Full tool reference (78 MCP tools, 30 CLI commands)
+- `README.md` — Full tool reference (84 MCP tools, 30 CLI commands)
 - `RESEARCH.md` — Research context and open questions


### PR DESCRIPTION
## Problem

`SETUP_GUIDE.md` Step 2 tells you to write the server config to `~/.claude/.mcp.json`. Claude Code does not read that path.

The failure is quiet and confusing:
- the config looks correct and is valid JSON
- `claude mcp list` reports **no servers configured**
- the MCP tools never appear, and restarting Claude Code does not help
- the guide's troubleshooting row (`Check ~/.claude/.mcp.json syntax, restart Claude Code`) sends you back to the same ignored file

I hit this on a fresh Windows install. Everything else in the guide worked — deps installed, TradingView launched with CDP on 9222, `tv status` returned `cdp_connected: true` — but the server was never registered, so the tools were absent. It took a couple of pointless restarts to find that the path itself was the issue.

## Fix

**Step 2 now leads with the CLI**, which writes to the file Claude Code actually reads:

```bash
claude mcp add tradingview -s user -- node <INSTALL_PATH>/src/server.js
```

Both user and project scope are covered, followed by a `claude mcp list` verification step with expected output.

Hand-editing JSON is kept as a secondary option, but pointed at the correct files — `~/.claude.json` (user) or a project-root `.mcp.json` (project). A note records that `~/.claude/.mcp.json` is ignored, so anyone who followed the previous guide can recognise the symptom and recover.

The troubleshooting row is updated to check `claude mcp list` first.

## Also included

Two stale **"78 MCP tools"** counts that `d77ed4a` missed:
- `README.md:220` — Tool Reference heading
- `SETUP_GUIDE.md` — "What to Read Next"

`src/tools/` registers exactly **84** `server.tool()` calls, which matches `CLAUDE.md` and README's own architecture line at `README.md:356`.

## Scope

Documentation only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)