### PR TITLE
Fix pine_smart_compile button detection on non-English TradingView UI

### DIFF
--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -458,7 +458,27 @@ export async function smartCompile() {
       }
       if (addBtn) { addBtn.click(); return 'Add to chart'; }
       if (updateBtn) { updateBtn.click(); return 'Update on chart'; }
-      if (saveBtn) { saveBtn.click(); return 'Pine Save'; }
+      // Language-independent fallback: the English text match above only
+      // works when the TradingView UI language is English. On any other
+      // locale (e.g. German) the compile/add-to-chart icon button has no
+      // matching text, so we locate it structurally instead: it's the
+      // icon-only button ("noContent" class, no text) that sits immediately
+      // before the Save button inside the script toolbar row.
+      if (saveBtn) {
+        var row = saveBtn.closest('.tv-script-widget') || saveBtn.parentElement;
+        var rowBtns = row ? Array.prototype.slice.call(row.querySelectorAll('button')) : [];
+        var saveIdx = rowBtns.indexOf(saveBtn);
+        var playBtn = null;
+        for (var j = saveIdx - 1; j >= 0; j--) {
+          if (rowBtns[j].className.indexOf('noContent') !== -1 && rowBtns[j].offsetParent !== null) {
+            playBtn = rowBtns[j];
+            break;
+          }
+        }
+        if (playBtn) { playBtn.click(); return 'Add to chart (structural)'; }
+        saveBtn.click();
+        return 'Pine Save';
+      }
       return null;
     })()
   `);


### PR DESCRIPTION
## Problem
`smartCompile()` matches the compile/add-to-chart button only by English text (`/^add to chart$/i`, `/^update on chart$/i`). On a non-English TradingView UI (e.g. German), that button's text never matches those patterns, so the code falls through to clicking the **Save** button instead of the actual compile/add button. The script gets compiled and saved, but never actually added to or updated on the chart — `study_added` silently stays `false`.

## Fix
Add a language-independent structural fallback in `src/core/pine.js`: within the script toolbar row (`.tv-script-widget`), the compile/add-to-chart button is always the icon-only button (`noContent` class, no text) that sits immediately before the Save button — regardless of UI language. The existing English-text fast path is kept as the first attempt; the fallback only kicks in when it doesn't match.

## Verification
- Reproduced live against a German-language TradingView Desktop instance: before the fix, `pine_smart_compile` reported `button_clicked: "Pine Save"` and `study_added: false` even though compilation succeeded with no errors.
- After the fix, same scenario reports `button_clicked: "Add to chart (structural)"` and the chart study is actually created/updated.
- `npm run lint`: no new issues introduced.
- `npm run test:unit`: 123/125 pass, same as on `main` without this change (verified via `git stash`) — the 2 pre-existing failures (a Windows path-join bug in `sanitization.test.js`, a CLI exit-code mismatch in `cli.test.js`) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)