### PR TITLE
docs: document default TradingView layout preference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,10 @@ These tools can return large payloads. Follow these rules to avoid context bloat
 | `data_get_ohlcv` (100 bars) | ~8 KB |
 | `capture_screenshot` | ~300 bytes (returns file path, not image data) |
 
+## User Preferences
+
+- **Default chart layout: `PBNormalWeekly`** — the user's preferred saved layout. Any automated/scheduled TradingView work (scan-sync routines, etc.) should `layout_switch` to this layout before making changes, regardless of the scan's own timeframe (daily scans included — this is a fixed default, not matched to cadence).
+
 ## Tool Conventions
 
 - All tools return `{ success: true/false, ... }`


### PR DESCRIPTION
## Summary
- Adds a "User Preferences" section to CLAUDE.md recording `PBNormalWeekly` as the fixed default chart layout for automated/scheduled TradingView work.
- Any scan-sync routine (daily or weekly cadence) should `layout_switch` to this layout before touching watchlists, giving Claude a stable, known UI state to operate against instead of whatever chart happens to be open.

## Why
Local scheduled scan-sync routines (Chartink → TradingView watchlist sync) run unattended and need a predictable layout to act on. The user confirmed this should be a fixed default across all routines, not matched to each scan's own timeframe.

## Test plan
- [x] Manually verified `PBNormalWeekly` resolves via `layout_switch` and leaves the chart on the expected 1W resolution.
- [x] Applied the same convention to the three existing local scheduled-task prompts (outside this repo, in `~/.claude/scheduled-tasks/`) and confirmed a subsequent scheduled run picked it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)