### PR TITLE
fix(watchlist): match the right-rail button by data-name, not the English aria-label

### DIFF
--- a/src/core/watchlist.js
+++ b/src/core/watchlist.js
@@ -10,7 +10,12 @@ import { evaluate, evaluateAsync, getClient } from '../connection.js';
 // TV renamed the right-rail button: current builds use data-name="base" with
 // aria-label "Watchlist, details, and news"; older builds used
 // data-name="base-watchlist-widget-button" / aria-label "Watchlist".
+// data-name is locale-independent; the aria-label is translated (zh-CN renders
+// "自选表、详情和新闻"), so match data-name first and keep the labels as a
+// fallback for builds that lack it. The "base" lookup is scoped to the
+// widgetbar because that value is generic enough to collide elsewhere.
 const WL_BUTTON_JS = `(document.querySelector('[data-name="base-watchlist-widget-button"]')
+  || document.querySelector('[class*="widgetbar"] [data-name="base"]')
   || document.querySelector('[aria-label="Watchlist, details, and news"]')
   || document.querySelector('[aria-label^="Watchlist"]'))`;
 


### PR DESCRIPTION
## Problem

Every watchlist tool fails on a localized TradingView build:

```json
{ "success": false, "error": "Watchlist button not found" }
```

`ensureWatchlistOpen()` gates `watchlist_get` / `add` / `add_bulk` / `remove`, and its selector chain only matches the **English** label:

```js
document.querySelector('[data-name="base-watchlist-widget-button"]')   // older builds
  || document.querySelector('[aria-label="Watchlist, details, and news"]')
  || document.querySelector('[aria-label^="Watchlist"]')
```

`aria-label` is translated. On `cn.tradingview.com` the same button renders as `自选表、详情和新闻`, so none of the three match and the whole watchlist tool group is unusable. Other locales will hit this identically.

## Fix

The comment right above that chain already says *"current builds use `data-name="base"`"* — but that selector was never actually added. `data-name` is not translated, so this adds it ahead of the label lookups:

```js
|| document.querySelector('[class*="widgetbar"] [data-name="base"]')
```

Scoped to the widgetbar because `base` on its own is generic enough to collide elsewhere in the DOM. The English labels stay as fallbacks, so nothing changes for existing en-US users.

## Verification

Tested on TradingView Desktop **3.4.0** (Electron 41.7.1) with the UI language set to Chinese:

- before — `Watchlist button not found`
- after — `watchlist get` returns the full list with `list_id` / `list_name` and populated price fields

`npm run lint` → 0 errors. `npm run test:unit` → 152 passing.

## Note on the same class of bug

I grepped the rest of `src/core/` for English-hardcoded selectors while I was here. `watchlist.add` (`[data-name="add-symbol-button"]` first) and `pine.js` (`[data-name="pine-dialog-button"]` fallback) both already have locale-independent paths, so this button was the only one actually broken. Worth noting that `add-symbol-button`'s aria-label is also translated (`添加商品代码`) — the `data-name` lookup is what saves it there, which is the same reason this fix uses one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)