### PR TITLE
fix(launch): route synchronous spawn EPERM into MSIX local-copy fallback

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -360,12 +360,25 @@ export async function launch({ port, kill_existing, _deps } = {}) {
   if (killFirst) await killExisting();
 
   const cdpArgs = [`--remote-debugging-port=${cdpPort}`];
-  let child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  const isWindowsApps = platform === 'win32' && WINDOWS_APPS_RE.test(tvPath);
+
+  // Blocked MSIX launches can surface either way: spawn throws EPERM synchronously
+  // on some builds, or emits 'error'/exits on others. Capture the sync throw so both
+  // paths reach the local-copy fallback below.
+  let child = null;
+  let spawnThrew = null;
+  try {
+    child = _spawnDetached(deps.spawn, tvPath, cdpArgs);
+  } catch (e) {
+    if (!isWindowsApps) throw e;
+    spawnThrew = e.code || e.message || 'spawn error';
+  }
+
   let info = null;
   let usedLocalCopy = false;
 
-  if (platform === 'win32' && WINDOWS_APPS_RE.test(tvPath)) {
-    const earlyFailure = await _spawnFailedEarly(child);
+  if (isWindowsApps) {
+    const earlyFailure = spawnThrew || await _spawnFailedEarly(child);
     if (!earlyFailure) {
       info = await _waitForCdp({ cdpPort, attempts: 15, delay: deps.delay, probeCdp: deps.probeCdp });
     }

--- a/tests/launch.test.js
+++ b/tests/launch.test.js
@@ -25,11 +25,12 @@ function mockChild({ failWith } = {}) {
 /**
  * Build a _deps bundle simulating a win32 MSIX environment.
  * @param {object} opts
- *   spawnFailures — spawn paths (substring) that emit EACCES
+ *   spawnFailures — spawn paths (substring) that emit EACCES asynchronously
+ *   spawnThrows   — spawn paths (substring) that throw EPERM synchronously
  *   cdpBindsFor  — spawn paths (substring) after which probeCdp starts succeeding
  *   copyExists   — local copy already present
  */
-function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } = {}) {
+function msixDeps({ spawnFailures = [], spawnThrows = [], cdpBindsFor = [], copyExists = false } = {}) {
   const state = { spawned: [], copies: [], removed: [], killed: 0, cdpUp: false };
   const deps = {
     existsSync: (p) => {
@@ -46,6 +47,9 @@ function msixDeps({ spawnFailures = [], cdpBindsFor = [], copyExists = false } =
     },
     spawn: (exe) => {
       state.spawned.push(exe);
+      if (spawnThrows.some((s) => exe.includes(s))) {
+        throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' });
+      }
       const fail = spawnFailures.some((s) => exe.includes(s));
       if (!fail && cdpBindsFor.some((s) => exe.includes(s))) state.cdpUp = true;
       return mockChild(fail ? { failWith: 'EACCES' } : {});
@@ -86,6 +90,19 @@ describe('launch() — MSIX WindowsApps handling', { skip: !onWindows }, () => {
     assert.match(state.removed[0], /3\.0\.0\.7652/);
     // the CDP-less direct instance is killed before relaunching from the copy
     assert.ok(state.killed >= 2);
+  });
+
+  // Regression: on some Windows builds spawn() throws EPERM synchronously rather
+  // than emitting 'error', which escaped launch() entirely and skipped the fallback.
+  it('synchronous EPERM throw on direct spawn falls back to local copy', async () => {
+    const { deps, state } = msixDeps({ spawnThrows: ['WindowsApps'], cdpBindsFor: ['tradingview-mcp'] });
+    const result = await launch({ _deps: deps });
+    assert.equal(result.success, true);
+    assert.equal(result.msix_local_copy, true);
+    assert.equal(result.binary, LOCAL_COPY_EXE);
+    assert.equal(result.pid, 12345);
+    assert.equal(state.copies.length, 1);
+    assert.deepEqual(state.spawned.map((e) => (e.includes('WindowsApps') ? 'msix' : 'copy')), ['msix', 'copy']);
   });
 
   it('CDP never binding on direct spawn falls back to local copy', async () => {
@@ -135,6 +152,19 @@ describe('launch() — classic install path', { skip: !onWindows }, () => {
     assert.equal(result.binary, classicExe);
     assert.equal(result.msix_local_copy, undefined);
     assert.deepEqual(state.spawned, [classicExe]);
+  });
+
+  it('propagates a synchronous spawn error instead of copying', async () => {
+    const classicExe = `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`;
+    const deps = {
+      existsSync: (p) => p === classicExe,
+      execSync: (cmd) => { if (cmd.includes('taskkill')) return ''; throw new Error(`unexpected: ${cmd}`); },
+      spawn: () => { throw Object.assign(new Error('spawn EPERM'), { code: 'EPERM' }); },
+      cpSync: () => { throw new Error('should not copy'); },
+      rmSync: () => {}, readdirSync: () => [],
+      delay: async () => {}, probeCdp: async () => null,
+    };
+    await assert.rejects(() => launch({ _deps: deps }), /spawn EPERM/);
   });
 
   it('throws a helpful error when TradingView is not found', async () => {


### PR DESCRIPTION
On some Windows builds, spawn() on a WindowsApps-packaged TradingView.exe throws EPERM synchronously instead of emitting an 'error' event. The call to _spawnDetached sat outside any try/catch, so the exception escaped launch() before the local-copy fallback could run — tv_launch failed with a bare "spawn EPERM" and the fallback was effectively dead code for that failure mode.

Wrap the initial spawn and treat a synchronous throw as an early failure, so both the sync-throw and async-'error' paths reach the same fallback. Non-MSIX installs rethrow unchanged.

The existing EACCES test only mocked the async 'error' event, which is why this went unnoticed. Adds a regression test for the synchronous throw (verified failing without the fix) plus a guard test that a classic install still propagates a spawn error rather than copying.


Claude-Session: https://claude.ai/code/session_01Pzp65QL62bkuw6xaUm7yeg