### PR TITLE
fix(pine): interpolate pine_check error messages and annotate the source line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,17 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `chart_set_visible_range` → zoom to exact date range (unix timestamps)
 
 ### "Work on Pine Script"
+0. `pine_check` → **always start here.** Compiles against TradingView's own
+   server-side compiler without opening the editor or needing a chart. Returns
+   `errors` / `warnings` with line+column+code, plus an `annotated` view:
+
+   ```
+    139 |     risk := atrVal * slMult
+        |     ^-- Undeclared identifier "risk"
+   ```
+
+   Fix everything it reports before touching the editor. The chart is where you
+   look at an idea, not where you debug it.
 1. `pine_set_source` → inject code into editor
 2. `pine_smart_compile` → compile with auto-detection + error check
 3. `pine_get_errors` → read compilation errors
@@ -50,6 +61,10 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 6. `pine_save` → save to TradingView cloud
 7. `pine_new` → create blank indicator/strategy/library
 8. `pine_open` → load a saved script by name
+
+Steps 1-8 drive the Monaco editor through the React fiber tree, which does not
+exist on every TradingView build. `pine_check` and `pine_analyze` never touch
+the browser, so they work regardless.
 
 ### "Practice trading with replay"
 1. `replay_start` with `date: "2025-03-01"` → enter replay mode

--- a/README.md
+++ b/README.md
@@ -286,6 +286,18 @@ Read `line.new()`, `label.new()`, `table.new()`, `box.new()` output from any vis
 | `pine_analyze` | Offline static analysis (no chart needed) |
 | `pine_check` | Server-side compile check (no chart needed) |
 
+`pine_check` returns errors and warnings with an `annotated` view — the offending
+source line with a caret under the exact column, and the compiler's message with
+its `{placeholder}` values filled in:
+
+```
+ 139 |     risk := atrVal * slMult
+     |     ^-- Undeclared identifier "risk"
+```
+
+Run it before `pine_set_source` so the chart is where you look at an idea, not
+where you debug it.
+
 ### Replay Mode
 
 | Tool | Step |

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/pine_annotate.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/pine_annotate.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -183,6 +183,35 @@ export function analyze({ source }) {
   };
 }
 
+// pine-facade returns message templates with {placeholders} and a `ctx` map of
+// the real values. Substituting makes the error readable on its own.
+function fillMessage(entry) {
+  const template = entry.message || '';
+  const ctx = entry.ctx;
+  if (!ctx || typeof ctx !== 'object') return template;
+  return template.replace(/\{(\w+)\}/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(ctx, key) ? String(ctx[key]) : match
+  );
+}
+
+// Render the offending source lines with the compiler's complaint attached, so
+// the caller can fix an error without counting columns by hand.
+export function annotate(source, issues) {
+  const lines = source.split('\n');
+  return issues
+    .map((issue) => {
+      const ln = issue.line;
+      if (!Number.isInteger(ln) || ln < 1 || ln > lines.length) {
+        return `   ? | ${issue.message}`;
+      }
+      const src = lines[ln - 1];
+      const gutter = String(ln).padStart(4, ' ');
+      const pad = ' '.repeat(5) + '|' + ' '.repeat(1 + Math.max(0, (issue.column ?? 1) - 1));
+      return `${gutter} | ${src}\n${pad}^-- ${issue.message}`;
+    })
+    .join('\n');
+}
+
 export async function check({ source }) {
   const formData = new URLSearchParams();
   formData.append('source', source);
@@ -215,13 +244,14 @@ export async function check({ source }) {
         errors.push({
           line: e.start?.line, column: e.start?.column,
           end_line: e.end?.line, end_column: e.end?.column,
-          message: e.message,
+          message: fillMessage(e),
+          code: e.code,
         });
       }
     }
     if (inner.warnings2 && inner.warnings2.length > 0) {
       for (const w of inner.warnings2) {
-        warnings.push({ line: w.start?.line, column: w.start?.column, message: w.message });
+        warnings.push({ line: w.start?.line, column: w.start?.column, message: fillMessage(w), code: w.code });
       }
     }
   }
@@ -231,6 +261,7 @@ export async function check({ source }) {
   }
 
   const compiled = errors.length === 0;
+  const flagged = [...errors, ...warnings];
   return {
     success: true,
     compiled,
@@ -238,6 +269,7 @@ export async function check({ source }) {
     warning_count: warnings.length,
     errors: errors.length > 0 ? errors : undefined,
     warnings: warnings.length > 0 ? warnings : undefined,
+    annotated: flagged.length > 0 ? annotate(source, flagged) : undefined,
     note: compiled ? 'Pine Script compiled successfully.' : undefined,
   };
 }

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -197,7 +197,7 @@ function fillMessage(entry) {
 // Render the offending source lines with the compiler's complaint attached, so
 // the caller can fix an error without counting columns by hand.
 export function annotate(source, issues) {
-  const lines = source.split('\n');
+  const lines = source.split(/\r?\n/);
   return issues
     .map((issue) => {
       const ln = issue.line;
@@ -205,8 +205,13 @@ export function annotate(source, issues) {
         return `   ? | ${issue.message}`;
       }
       const src = lines[ln - 1];
+      // The caret may legitimately sit one past the last character ("end of
+      // line without line continuation"), but no further — clamp so a bad
+      // column can't allocate a huge pad.
+      const col = Number.isInteger(issue.column) ? issue.column : 1;
+      const caretAt = Math.min(Math.max(col, 1), src.length + 1);
       const gutter = String(ln).padStart(4, ' ');
-      const pad = ' '.repeat(5) + '|' + ' '.repeat(1 + Math.max(0, (issue.column ?? 1) - 1));
+      const pad = `${' '.repeat(5)}|${' '.repeat(caretAt)}`;
       return `${gutter} | ${src}\n${pad}^-- ${issue.message}`;
     })
     .join('\n');

--- a/src/tools/pine.js
+++ b/src/tools/pine.js
@@ -66,7 +66,7 @@ export function registerPineTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('pine_check', 'Compile Pine Script via TradingView\'s server API without needing the chart open. Returns compilation errors/warnings. Useful for validating code before injecting into the chart.', {
+  server.tool('pine_check', 'Compile Pine Script via TradingView\'s server API without needing the chart open. Returns compilation errors/warnings plus an `annotated` view showing each offending source line with a caret under the exact column. Useful for validating code before injecting into the chart.', {
     source: z.string().describe('Pine Script source code to compile/validate'),
   }, async ({ source }) => {
     try { return jsonResult(await core.check({ source })); }

--- a/tests/pine_annotate.test.js
+++ b/tests/pine_annotate.test.js
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for pine_check's annotated output and message interpolation.
+ * Stubs fetch — no TradingView connection or network needed.
+ *
+ * Run: node --test tests/pine_annotate.test.js
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { annotate, check } from '../src/core/pine.js';
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+function stubFacade(payload) {
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => payload,
+  });
+}
+
+describe('annotate', () => {
+  it('puts a caret under the reported column', () => {
+    const source = '//@version=5\nindicator("t")\nplot(ta.sma(clse, 20))';
+    const out = annotate(source, [{ line: 3, column: 13, message: 'Undeclared identifier "clse"' }]);
+    const [srcLine, caretLine] = out.split('\n');
+
+    assert.equal(srcLine, '   3 | plot(ta.sma(clse, 20))');
+    assert.equal(caretLine.indexOf('^'), srcLine.indexOf('clse'));
+    assert.ok(caretLine.endsWith('^-- Undeclared identifier "clse"'));
+  });
+
+  it('handles a line number outside the source without throwing', () => {
+    const out = annotate('plot(close)', [{ line: 99, column: 1, message: 'nope' }]);
+    assert.equal(out, '   ? | nope');
+  });
+
+  it('handles a missing column', () => {
+    const out = annotate('plot(close)', [{ line: 1, message: 'no column given' }]);
+    assert.ok(out.includes('^-- no column given'));
+  });
+
+  it('renders one block per issue', () => {
+    const source = 'a\nb\nc';
+    const out = annotate(source, [
+      { line: 1, column: 1, message: 'first' },
+      { line: 3, column: 1, message: 'second' },
+    ]);
+    assert.equal(out.split('\n').length, 4);
+    assert.ok(out.includes('first') && out.includes('second'));
+  });
+});
+
+describe('check — message interpolation', () => {
+  it('fills {placeholders} from the ctx map', async () => {
+    stubFacade({
+      success: true,
+      result: {
+        errors2: [{
+          code: 'CE10272',
+          ctx: { identifier: 'risk' },
+          message: 'Undeclared identifier "{identifier}"',
+          start: { line: 1, column: 5 },
+          end: { line: 1, column: 8 },
+        }],
+      },
+    });
+
+    const result = await check({ source: 'x := 1' });
+    assert.equal(result.compiled, false);
+    assert.equal(result.errors[0].message, 'Undeclared identifier "risk"');
+    assert.equal(result.errors[0].code, 'CE10272');
+    assert.ok(result.annotated.includes('^-- Undeclared identifier "risk"'));
+  });
+
+  it('leaves a placeholder alone when ctx has no value for it', async () => {
+    stubFacade({
+      success: true,
+      result: {
+        errors2: [{ ctx: { other: 'x' }, message: 'Missing {identifier}', start: { line: 1, column: 1 } }],
+      },
+    });
+
+    const result = await check({ source: 'plot(close)' });
+    assert.equal(result.errors[0].message, 'Missing {identifier}');
+  });
+
+  it('interpolates warnings too and annotates them', async () => {
+    stubFacade({
+      success: true,
+      result: {
+        warnings2: [{ ctx: { fn: 'plot' }, message: 'Slow "{fn}"', start: { line: 1, column: 1 } }],
+      },
+    });
+
+    const result = await check({ source: 'plot(close)' });
+    assert.equal(result.compiled, true, 'warnings alone still compile');
+    assert.equal(result.warning_count, 1);
+    assert.equal(result.warnings[0].message, 'Slow "plot"');
+    assert.ok(result.annotated.includes('^-- Slow "plot"'));
+  });
+
+  it('omits annotated when the script is clean', async () => {
+    stubFacade({ success: true, result: { functions2: [] } });
+
+    const result = await check({ source: 'plot(close)' });
+    assert.equal(result.compiled, true);
+    assert.equal(result.annotated, undefined);
+    assert.equal(result.note, 'Pine Script compiled successfully.');
+  });
+});

--- a/tests/pine_annotate.test.js
+++ b/tests/pine_annotate.test.js
@@ -42,6 +42,28 @@ describe('annotate', () => {
     assert.ok(out.includes('^-- no column given'));
   });
 
+  it('strips CRLF so the caret stays aligned', () => {
+    const source = '//@version=5\r\nindicator("t")\r\nplot(ta.sma(clse, 20))';
+    const out = annotate(source, [{ line: 3, column: 13, message: 'Undeclared identifier "clse"' }]);
+    const [srcLine, caretLine] = out.split('\n');
+
+    assert.ok(!srcLine.includes('\r'), 'no stray CR in the rendered line');
+    assert.equal(caretLine.indexOf('^'), srcLine.indexOf('clse'));
+  });
+
+  it('clamps an absurd column instead of allocating a huge pad', () => {
+    const out = annotate('plot(close)', [{ line: 1, column: 9_999_999, message: 'bad col' }]);
+    assert.ok(out.length < 200);
+    assert.ok(out.endsWith('^-- bad col'));
+  });
+
+  it('still allows a caret one past the last character', () => {
+    // "Syntax error at input 'end of line without line continuation'" points here.
+    const out = annotate('abc', [{ line: 1, column: 4, message: 'eol' }]);
+    const [srcLine, caretLine] = out.split('\n');
+    assert.equal(caretLine.indexOf('^'), srcLine.length);
+  });
+
   it('renders one block per issue', () => {
     const source = 'a\nb\nc';
     const out = annotate(source, [


### PR DESCRIPTION
## The bug

`pine_check` returns TradingView's message templates verbatim, so a real compile error reads:

```
Undeclared identifier "{identifier}"
```

pine-facade doesn't interpolate its own messages. It sends the values separately in a `ctx` map next to the template, and `check()` in `src/core/pine.js` was reading `e.message` while dropping `e.ctx`:

```json
{"code": "CE10272",
 "ctx": {"identifier": "risk"},
 "message": "Undeclared identifier \"{identifier}\"",
 "start": {"line": 139, "column": 5}}
```

So the one field the caller actually needs — which identifier — was being thrown away on every error.

## The fix

Fill the placeholders from `ctx`, pass the error `code` through, and add an `annotated` view showing the offending line with a caret under the reported column:

```
 139 |     risk := atrVal * slMult
     |     ^-- Undeclared identifier "risk"
```

A placeholder with no matching `ctx` key is left as-is rather than blanked, so an unrecognised template degrades to today's behaviour instead of losing text. Warnings get the same treatment. `annotated` is omitted entirely when the script is clean, so nothing changes for a passing check.

This matters most on builds where the Pine editor has no React fiber — `pine_set_source` / `pine_smart_compile` / `pine_get_errors` all fail there (several open PRs are chasing variants of this), and `pine_check` becomes the only compile path left. Its output is then the entire error report.

## What I ran

```
npm run lint       # 0 errors (4 pre-existing warnings, untouched)
npm run test:unit  # 160/160 pass
```

Against the live pine-facade endpoint, 15 real third-party Pine scripts (v5 and v6, 2.5KB–20KB) were checked end to end: 13 compiled clean, 2 had genuine errors. Both error cases printed raw `{identifier}` / `{funId}` templates before this change and read correctly after:

```
 139 |     risk := atrVal * slMult
     |     ^-- Undeclared identifier "risk"

  87 |     plot(smaFast * (1 - t) + smaSlow * t, title="Band " + str.tostring(i),
     |                                                 ^-- Cannot call "plot" with argument "title"="call "operator +" (series string)". An argument of "series string" type was used but a "const string"  is expected.
```

The second one is the case that convinced me this was worth filing — untouched, it names neither the function nor the argument.

`npm run test:e2e` was **not** run: no TradingView Desktop on this machine, and this path never opens a CDP connection. `check()` posts to pine-facade from the server process, so there is nothing browser-side for the change to affect.

## Tests

`tests/pine_annotate.test.js`, 8 tests, fetch stubbed — no network, no TradingView. Covers caret column alignment, out-of-range and missing-column input, multiple issues, `ctx` interpolation for errors and warnings, an unknown placeholder, and `annotated` being absent on a clean compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsdBoQLyPJihjuyYbPkda6