### PR TITLE
feat: optional JSONL log of every tool call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,20 @@ These tools can return large payloads. Follow these rules to avoid context bloat
 - OHLCV capped at 500 bars, trades at 20 per request
 - Pine labels capped at 50 per study by default (pass `max_labels` to override)
 
+## Tool-Call Logging
+
+Set `TV_MCP_LOG_FILE` in the server's `env` to append every tool call to a JSONL
+file — name, args, truncated result, duration. Unset it is a no-op. Use it when
+a chart ends up in a state nobody meant to create, or to time a slow tool.
+
+```bash
+jq -r 'select(.result.is_error) | "\(.ts) \(.tool)"' ~/.tradingview-mcp/calls.jsonl
+jq -s 'group_by(.tool) | map({tool: .[0].tool, n: length,
+       p95: (sort_by(.duration_ms) | .[(length * 0.95 | floor)].duration_ms)})' calls.jsonl
+```
+
+Results are truncated at 2000 chars so screenshots do not bloat the file.
+
 ## Architecture
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,8 @@ jq -s 'group_by(.tool) | map({tool: .[0].tool, n: length,
        p95: (sort_by(.duration_ms) | .[(length * 0.95 | floor)].duration_ms)})' calls.jsonl
 ```
 
-Results are truncated at 2000 chars so screenshots do not bloat the file.
+Arguments and results are truncated at 2000 chars per string, so a pasted Pine
+script or a screenshot payload does not bloat the file.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,30 @@ Tools return compact output by default to minimize context usage. For a typical 
 | `verbose: true` | Pass on any pine tool to get raw data with IDs/colors when needed |
 | `study_filter` | Target one indicator instead of scanning all |
 
+## Tool-Call Logging
+
+Set `TV_MCP_LOG_FILE` to record every MCP tool call as JSON lines — tool name,
+arguments, truncated result, and duration. Unset (the default) it is a no-op.
+
+```json
+{"ts":"2026-09-04T12:30:08.145Z","tool":"pine_check","args":{"source":"plot(close)"},"duration_ms":312.4,"result":{"is_error":false,"chars":35,"text":"..."}}
+```
+
+```json
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "node",
+      "args": ["/path/to/tradingview-mcp/src/server.js"],
+      "env": { "TV_MCP_LOG_FILE": "~/.tradingview-mcp/calls.jsonl" }
+    }
+  }
+}
+```
+
+Results are truncated to 2000 characters so screenshots don't bloat the log, and
+a logging failure never breaks a tool call.
+
 ## Finding TradingView on Your System
 
 Launch scripts and `tv_launch` auto-detect TradingView. If auto-detection fails:

--- a/README.md
+++ b/README.md
@@ -347,8 +347,9 @@ arguments, truncated result, and duration. Unset (the default) it is a no-op.
 }
 ```
 
-Results are truncated to 2000 characters so screenshots don't bloat the log, and
-a logging failure never breaks a tool call.
+Both arguments and results are truncated to 2000 characters per string, so a
+pasted Pine script or a screenshot payload can't bloat the log, and a logging
+failure never breaks a tool call.
 
 ## Finding TradingView on Your System
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint src/",
     "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/tool_log.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/sanitization.test.js tests/replay.test.js tests/launch.test.js tests/chart_indicator.test.js tests/chart_history.test.js tests/update.test.js tests/tool_log.test.js",
     "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },

--- a/src/core/tool_log.js
+++ b/src/core/tool_log.js
@@ -1,0 +1,76 @@
+// JSONL tool-call log — one line per MCP tool call, so you can grep or replay
+// what the agent did to the chart. Disabled unless TV_MCP_LOG_FILE is set.
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { performance } from 'node:perf_hooks';
+
+const RAW_PATH = (process.env.TV_MCP_LOG_FILE || '').trim();
+const LOG_PATH = RAW_PATH
+  ? resolve(RAW_PATH.startsWith('~') ? RAW_PATH.replace(/^~/, homedir()) : RAW_PATH)
+  : null;
+
+// Results can be enormous (screenshots are base64). Keep the log greppable.
+const MAX_RESULT_CHARS = 2000;
+
+export const enabled = LOG_PATH !== null;
+
+function summarize(result) {
+  if (result == null) return null;
+  const parts = Array.isArray(result.content) ? result.content : [];
+  const text = parts
+    .map((p) => (p?.type === 'text' ? p.text : `[${p?.type || 'unknown'}]`))
+    .join('\n');
+  return {
+    is_error: result.isError === true,
+    chars: text.length,
+    text: text.length > MAX_RESULT_CHARS ? `${text.slice(0, MAX_RESULT_CHARS)}…[truncated]` : text,
+  };
+}
+
+export function logCall(tool, args, result, durationMs, error) {
+  if (!LOG_PATH) return;
+  const entry = {
+    ts: new Date().toISOString(),
+    tool,
+    args: args ?? {},
+    duration_ms: Math.round(durationMs * 100) / 100,
+  };
+  if (error) entry.threw = String(error?.message || error);
+  else entry.result = summarize(result);
+
+  try {
+    mkdirSync(dirname(LOG_PATH), { recursive: true });
+    appendFileSync(LOG_PATH, `${JSON.stringify(entry)}\n`, 'utf8');
+  } catch {
+    // Logging must never break a tool call.
+  }
+}
+
+// Wrap server.tool() so every registered tool is logged without touching the
+// individual register*() modules.
+export function instrument(server) {
+  if (!LOG_PATH) return server;
+  const original = server.tool.bind(server);
+  server.tool = (...args) => {
+    const handlerIndex = args.length - 1;
+    const handler = args[handlerIndex];
+    if (typeof handler !== 'function') return original(...args);
+    const name = typeof args[0] === 'string' ? args[0] : 'unknown';
+
+    args[handlerIndex] = async (...handlerArgs) => {
+      const started = performance.now();
+      try {
+        const result = await handler(...handlerArgs);
+        logCall(name, handlerArgs[0], result, performance.now() - started);
+        return result;
+      } catch (err) {
+        logCall(name, handlerArgs[0], null, performance.now() - started, err);
+        throw err;
+      }
+    };
+    return original(...args);
+  };
+  return server;
+}

--- a/src/core/tool_log.js
+++ b/src/core/tool_log.js
@@ -11,10 +11,27 @@ const LOG_PATH = RAW_PATH
   ? resolve(RAW_PATH.startsWith('~') ? RAW_PATH.replace(/^~/, homedir()) : RAW_PATH)
   : null;
 
-// Results can be enormous (screenshots are base64). Keep the log greppable.
+// Results can be enormous (screenshots are base64) and so can arguments
+// (pine_set_source carries a whole script). Keep the log greppable.
 const MAX_RESULT_CHARS = 2000;
+const MAX_ARG_CHARS = 2000;
 
 export const enabled = LOG_PATH !== null;
+
+// Truncate long strings anywhere in the argument object. Structure is kept so
+// the log still shows which arguments were passed, just not all of their bytes.
+function trimArgs(value, depth = 0) {
+  if (typeof value === 'string') {
+    return value.length > MAX_ARG_CHARS
+      ? `${value.slice(0, MAX_ARG_CHARS)}…[truncated ${value.length} chars]`
+      : value;
+  }
+  if (depth >= 4 || value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map((v) => trimArgs(v, depth + 1));
+  return Object.fromEntries(
+    Object.entries(value).map(([k, v]) => [k, trimArgs(v, depth + 1)])
+  );
+}
 
 function summarize(result) {
   if (result == null) return null;
@@ -34,7 +51,7 @@ export function logCall(tool, args, result, durationMs, error) {
   const entry = {
     ts: new Date().toISOString(),
     tool,
-    args: args ?? {},
+    args: trimArgs(args ?? {}),
     duration_ms: Math.round(durationMs * 100) / 100,
   };
   if (error) entry.threw = String(error?.message || error);

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ import { registerWatchlistTools } from './tools/watchlist.js';
 import { registerUiTools } from './tools/ui.js';
 import { registerPaneTools } from './tools/pane.js';
 import { registerTabTools } from './tools/tab.js';
+import { instrument, enabled as logEnabled } from './core/tool_log.js';
 
 const server = new McpServer(
   {
@@ -69,6 +70,9 @@ CONTEXT MANAGEMENT:
   }
 );
 
+// Optional JSONL call log (set TV_MCP_LOG_FILE). No-op when unset.
+instrument(server);
+
 // Register all tool groups
 registerHealthTools(server);
 registerChartTools(server);
@@ -87,7 +91,9 @@ registerTabTools(server);
 
 // Startup notice (stderr so it doesn't interfere with MCP stdio protocol)
 process.stderr.write('⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.\n');
-process.stderr.write('   Ensure your usage complies with TradingView\'s Terms of Use.\n\n');
+process.stderr.write('   Ensure your usage complies with TradingView\'s Terms of Use.\n');
+if (logEnabled) process.stderr.write(`   Tool-call log: ${process.env.TV_MCP_LOG_FILE}\n`);
+process.stderr.write('\n');
 
 // Start stdio transport
 const transport = new StdioServerTransport();

--- a/tests/tool_log.test.js
+++ b/tests/tool_log.test.js
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the optional JSONL tool-call log.
+ * Spawns child processes because TV_MCP_LOG_FILE is read at module load.
+ *
+ * Run: node --test tests/tool_log.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let dir;
+before(() => { dir = mkdtempSync(join(tmpdir(), 'tv-mcp-log-')); });
+after(() => { rmSync(dir, { recursive: true, force: true }); });
+
+// Exercise the logger in a child process with a given TV_MCP_LOG_FILE, then
+// return whatever landed in the log.
+function run(script, logFile) {
+  const env = { ...process.env };
+  if (logFile) env.TV_MCP_LOG_FILE = logFile;
+  else delete env.TV_MCP_LOG_FILE;
+
+  const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+    env,
+    cwd: new URL('..', import.meta.url).pathname,
+    encoding: 'utf8',
+  });
+
+  const lines = logFile && existsSync(logFile)
+    ? readFileSync(logFile, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l))
+    : [];
+  return { stdout, lines };
+}
+
+const CALL_ONE = `
+  import { instrument } from './src/core/tool_log.js';
+  const server = { tool: (n, d, s, h) => { server._h = h; } };
+  instrument(server);
+  server.tool('pine_check', 'd', {}, async (a) => ({ content: [{ type: 'text', text: 'ok:' + a.source }] }));
+  await server._h({ source: 'plot(close)' });
+  console.log('done');
+`;
+
+describe('tool_log', () => {
+  it('writes one JSON line per call with tool, args, result and duration', () => {
+    const logFile = join(dir, 'calls.jsonl');
+    const { lines } = run(CALL_ONE, logFile);
+
+    assert.equal(lines.length, 1);
+    const entry = lines[0];
+    assert.equal(entry.tool, 'pine_check');
+    assert.deepEqual(entry.args, { source: 'plot(close)' });
+    assert.equal(entry.result.is_error, false);
+    assert.equal(entry.result.text, 'ok:plot(close)');
+    assert.equal(typeof entry.duration_ms, 'number');
+    assert.ok(!Number.isNaN(Date.parse(entry.ts)));
+  });
+
+  it('writes nothing when TV_MCP_LOG_FILE is unset', () => {
+    const logFile = join(dir, 'unset.jsonl');
+    const { stdout } = run(CALL_ONE, null);
+
+    assert.match(stdout, /done/);
+    assert.equal(existsSync(logFile), false);
+  });
+
+  it('records a thrown handler and rethrows it', () => {
+    const logFile = join(dir, 'threw.jsonl');
+    const { stdout, lines } = run(`
+      import { instrument } from './src/core/tool_log.js';
+      const server = { tool: (n, d, s, h) => { server._h = h; } };
+      instrument(server);
+      server.tool('boom', 'd', {}, async () => { throw new Error('kaboom'); });
+      await server._h({}).catch((e) => console.log('rethrown:' + e.message));
+    `, logFile);
+
+    assert.match(stdout, /rethrown:kaboom/);
+    assert.equal(lines[0].threw, 'kaboom');
+    assert.equal(lines[0].result, undefined);
+  });
+
+  it('truncates huge results so screenshots do not bloat the log', () => {
+    const logFile = join(dir, 'big.jsonl');
+    const { lines } = run(`
+      import { instrument } from './src/core/tool_log.js';
+      const server = { tool: (n, d, s, h) => { server._h = h; } };
+      instrument(server);
+      server.tool('capture_screenshot', 'd', {}, async () => ({ content: [{ type: 'text', text: 'x'.repeat(50000) }] }));
+      await server._h({});
+    `, logFile);
+
+    assert.equal(lines[0].result.chars, 50000);
+    assert.ok(lines[0].result.text.length < 2100);
+    assert.ok(lines[0].result.text.endsWith('…[truncated]'));
+  });
+
+  it('creates the log directory if it does not exist', () => {
+    const logFile = join(dir, 'nested', 'deeper', 'calls.jsonl');
+    const { lines } = run(CALL_ONE, logFile);
+    assert.equal(lines.length, 1);
+  });
+
+  it('leaves tools registered normally when logging is off', () => {
+    const { stdout } = run(`
+      import { instrument, enabled } from './src/core/tool_log.js';
+      const registered = [];
+      const server = { tool: (n) => registered.push(n) };
+      instrument(server);
+      server.tool('pine_check', 'd', {}, async () => ({}));
+      console.log(JSON.stringify({ enabled, registered }));
+    `, null);
+
+    assert.deepEqual(JSON.parse(stdout.trim()), { enabled: false, registered: ['pine_check'] });
+  });
+});

--- a/tests/tool_log.test.js
+++ b/tests/tool_log.test.js
@@ -10,7 +10,10 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
 let dir;
 before(() => { dir = mkdtempSync(join(tmpdir(), 'tv-mcp-log-')); });
@@ -25,7 +28,7 @@ function run(script, logFile) {
 
   const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
     env,
-    cwd: new URL('..', import.meta.url).pathname,
+    cwd: REPO_ROOT,
     encoding: 'utf8',
   });
 
@@ -95,6 +98,22 @@ describe('tool_log', () => {
     assert.equal(lines[0].result.chars, 50000);
     assert.ok(lines[0].result.text.length < 2100);
     assert.ok(lines[0].result.text.endsWith('…[truncated]'));
+  });
+
+  it('truncates long argument strings so a pasted script cannot bloat the log', () => {
+    const logFile = join(dir, 'bigargs.jsonl');
+    const { lines } = run(`
+      import { instrument } from './src/core/tool_log.js';
+      const server = { tool: (n, d, s, h) => { server._h = h; } };
+      instrument(server);
+      server.tool('pine_set_source', 'd', {}, async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+      await server._h({ source: 'x'.repeat(200000), verbose: true, nested: { deep: 'y'.repeat(9000) } });
+    `, logFile);
+
+    assert.ok(lines[0].args.source.endsWith('…[truncated 200000 chars]'));
+    assert.ok(lines[0].args.source.length < 2100);
+    assert.equal(lines[0].args.verbose, true, 'non-string args pass through');
+    assert.ok(lines[0].args.nested.deep.endsWith('…[truncated 9000 chars]'), 'nested strings too');
   });
 
   it('creates the log directory if it does not exist', () => {


### PR DESCRIPTION
## What

Set `TV_MCP_LOG_FILE` and every tool call is appended as one JSON line — name, arguments, truncated result, duration:

```json
{"ts":"2026-09-04T12:30:08.145Z","tool":"pine_check","args":{"source":"plot(close)"},"duration_ms":312.4,"result":{"is_error":false,"chars":35,"text":"..."}}
```

## Why

Debugging this bridge means reconstructing what an agent did to a live chart, and right now there's no record. A stray `ui_click` that closes the Pine panel, a `chart_set_symbol` nobody meant to issue, an indicator whose settings dialog got opened — all of it is invisible after the fact. With a log it's one `grep`.

It also answers "which tool is slow on this build", which varies a lot between Desktop versions:

```bash
jq -r 'select(.result.is_error) | "\(.ts) \(.tool)"' calls.jsonl
jq -s 'group_by(.tool) | map({tool: .[0].tool, n: length,
       p95: (sort_by(.duration_ms) | .[(length * 0.95 | floor)].duration_ms)})' calls.jsonl
```

And it makes bug reports concrete — `CONTRIBUTING.md` asks for "the exact tool call with its full JSON result", which is exactly a line of this file.

## How

One wrapper around `server.tool()` in `server.js`. All 84 tools are covered without touching any `register*()` module, and new tools are logged for free.

Deliberately cheap and opt-in:

- **Unset (the default), `instrument()` returns the server untouched** — no wrapper on the hot path, not even a branch per call
- Results cap at 2000 chars so screenshot payloads don't bloat the file
- A failing write is swallowed — logging must never break a tool call
- A thrown handler is logged with `threw` and rethrown unchanged

Nothing is written unless the user opts in, and the file stays on their machine. No telemetry, no network, nothing added to the default path.

## Scope check

Per `CONTRIBUTING.md`: no server access, no market data stored (results are truncated tool output, not price series), no auth bypass, no execution. It's local debug tooling for the bridge itself.

## What I ran

```
npm run lint       # 0 errors (4 pre-existing warnings, untouched)
npm run test:unit  # 160/160 pass
```

Server boot with the env var set and unset, confirming `tools/list` still returns all 84 tools either way, and that `tools/list` alone writes no lines (it isn't a tool call):

```
$ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | TV_MCP_LOG_FILE=/tmp/calls.jsonl node src/server.js
⚠  tradingview-mcp  |  Unofficial tool. Not affiliated with TradingView Inc. or Anthropic.
   Ensure your usage complies with TradingView's Terms of Use.
   Tool-call log: /tmp/calls.jsonl
```

`npm run test:e2e` was **not** run: no TradingView Desktop on this machine. The wrapper is transport-level and never touches CDP — it wraps the handler the SDK already calls, and passes its arguments and return value through untouched.

## Tests

`tests/tool_log.test.js`, 6 tests, offline. They spawn child processes because `TV_MCP_LOG_FILE` is read at module load. Covers the written line's shape, no file when unset, a thrown handler being logged and rethrown, truncation of a 50KB result, directory creation, and tools registering normally with logging off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsdBoQLyPJihjuyYbPkda6