### PR TITLE
Add IHSG daily technical screener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ temp_*
 *.log
 discovery-log.json
 rules.json
+
+# Personal MCP client config (hardcoded local paths) and daily screener
+# output (real trading signals/results, regenerated every run) — neither
+# belongs in the shared repo.
+.mcp.json
+screener/results/
+~$*.xlsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "chrome-remote-interface": "^0.33.2"
+        "chrome-remote-interface": "^0.33.2",
+        "exceljs": "^4.4.0"
       },
       "bin": {
         "tv": "src/cli/index.js"
@@ -186,10 +187,39 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -318,6 +348,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -403,6 +439,75 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -410,28 +515,92 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -441,15 +610,77 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/bytes": {
@@ -498,6 +729,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -556,11 +799,25 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "license": "MIT"
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -603,6 +860,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -620,6 +883,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -633,6 +921,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -681,6 +975,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -694,6 +1027,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -953,6 +1295,26 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -1014,6 +1376,19 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1035,9 +1410,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -1140,6 +1515,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1186,6 +1589,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1224,6 +1648,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1259,9 +1689,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1303,6 +1733,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1312,6 +1762,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -1340,6 +1796,17 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1347,9 +1814,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1393,6 +1860,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1409,9 +1882,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -1457,6 +1930,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1465,6 +1980,48 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/levn": {
@@ -1480,6 +2037,21 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -1497,11 +2069,90 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -1563,13 +2214,33 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
@@ -1592,6 +2263,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -1686,6 +2366,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1716,6 +2402,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -1755,6 +2450,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1819,6 +2520,50 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1838,6 +2583,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1854,11 +2612,43 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1904,6 +2694,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2013,6 +2809,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2039,6 +2844,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2046,6 +2876,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -2062,17 +2901,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {
@@ -2084,6 +2940,54 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2092,6 +2996,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -2155,6 +3075,12 @@
         }
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2166,6 +3092,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "chrome-remote-interface": "^0.33.2"
+    "chrome-remote-interface": "^0.33.2",
+    "exceljs": "^4.4.0"
   },
   "devDependencies": {
     "eslint": "^9.39.4"

--- a/screener/backtest.js
+++ b/screener/backtest.js
@@ -1,0 +1,226 @@
+/**
+ * Historical backtest of the screening criteria.
+ *
+ * For each symbol, pulls its full available OHLCV history ONCE (same CDP
+ * call the live scanner uses), then replays the screening detectors against
+ * every historical day locally in pure JS (no further network calls) —
+ * `bars.slice(0, t+1)` simulates "what the screener would have seen if it
+ * ran as-of day t," using the exact same detector code as production so the
+ * backtest can't silently drift from what actually ships.
+ *
+ * For every historical match, walks forward up to LOOKFORWARD_BARS to see
+ * whether price hit take_profit_1 before hitting cutloss (a "win"), the
+ * reverse (a "loss"), or neither within the window ("unresolved").
+ *
+ * LIMITATIONS (read before trusting the win rate):
+ *   - Only ~500 bars (~2 years) of daily history are available per symbol —
+ *     no longer sample without manually scrolling each chart back further.
+ *   - This is a mechanical TP-vs-cutloss race, not a real trading
+ *     simulation — no transaction costs, slippage, partial fills, or
+ *     capital/position-sizing constraints.
+ *   - Small per-criterion sample sizes (N) make the win rate unreliable —
+ *     always read N alongside the percentage, not the percentage alone.
+ *   - Survivorship bias: only currently-listed symbols are tested; any
+ *     stock that got delisted during the window is invisible here.
+ *
+ * Usage:
+ *   node screener/backtest.js --limit 50
+ *   node screener/backtest.js --symbols BBCA,BBRI,TLKM
+ */
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setSymbol } from '../src/core/chart.js';
+import { getOhlcv } from '../src/core/data.js';
+import { disconnect } from '../src/connection.js';
+
+import { findPivots, avgValueTraded } from './lib/zigzag.js';
+import { findSrZones } from './lib/support_resistance.js';
+import { detectDowntrendBreak } from './lib/trendline.js';
+import { detectElliottImpulse, detectElliottWave2Support, detectPullbackReversal } from './lib/elliott.js';
+import { detectAllPatterns } from './lib/patterns.js';
+import { detectBreakoutWithVolume, detectVolumeSpikeGreenCandle, detectConfirmedUptrend } from './lib/volume.js';
+import { buildTradingPlan } from './lib/levels.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIN_AVG_VALUE_TRX_50D = 1_000_000_000;
+const MIN_HISTORY_BARS = 150; // need enough history before the first as-of day to let pivots/SMA200 etc. form
+const LOOKFORWARD_BARS = 60; // ~3 trading months to let TP/cutloss resolve
+
+function parseArgs(argv) {
+  const args = { limit: null, symbols: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--limit') args.limit = Number(argv[++i]);
+    if (argv[i] === '--symbols') args.symbols = argv[++i].split(',').map(s => s.trim().toUpperCase());
+  }
+  return args;
+}
+
+function loadSymbols({ limit, symbols }) {
+  if (symbols) return symbols;
+  const csv = readFileSync(join(__dirname, 'idx_all.csv'), 'utf8');
+  const lines = csv.trim().split('\n').slice(1);
+  let codes = lines.map(l => l.split(',')[0].trim()).filter(Boolean);
+  if (limit) codes = codes.slice(0, limit);
+  return codes;
+}
+
+function runDetectorsAsOf(asOfBars) {
+  const pivots = findPivots(asOfBars, 0.04);
+  const srZones = findSrZones(pivots);
+  const matches = [];
+
+  const tryAdd = (criterion, detail) => {
+    if (!detail) return;
+    const plan = buildTradingPlan(criterion, detail, asOfBars, srZones);
+    if (!plan) return;
+    matches.push({ criterion, plan });
+  };
+
+  tryAdd('downtrend_break', detectDowntrendBreak(asOfBars, pivots));
+  tryAdd('elliott_wave', detectElliottImpulse(asOfBars, pivots));
+  tryAdd('elliott_wave2', detectElliottWave2Support(asOfBars, pivots));
+  tryAdd('pullback_reversal', detectPullbackReversal(asOfBars, pivots));
+  for (const pattern of detectAllPatterns(asOfBars, pivots)) tryAdd(pattern.pattern, pattern);
+  tryAdd('breakout_resistance_with_volume', detectBreakoutWithVolume(asOfBars, srZones));
+  tryAdd('volume_spike_green_candle', detectVolumeSpikeGreenCandle(asOfBars));
+  tryAdd('confirmed_uptrend', detectConfirmedUptrend(asOfBars, pivots));
+
+  return matches;
+}
+
+/** Walk forward from entryIdx+1, race TP1 vs cutloss. Same-day double-touch is resolved by which side the open sat closer to (a rough tie-break, not exact intraday sequencing). */
+function resolveOutcome(bars, entryIdx, plan) {
+  const end = Math.min(bars.length, entryIdx + 1 + LOOKFORWARD_BARS);
+  for (let i = entryIdx + 1; i < end; i++) {
+    const bar = bars[i];
+    const hitCutloss = plan.cutloss != null && bar.low <= plan.cutloss;
+    const hitTp = plan.take_profit_1 != null && bar.high >= plan.take_profit_1;
+    if (hitCutloss && hitTp) {
+      const midpoint = (plan.cutloss + plan.take_profit_1) / 2;
+      return { outcome: bar.open <= midpoint ? 'loss' : 'win', resolvedIdx: i };
+    }
+    if (hitCutloss) return { outcome: 'loss', resolvedIdx: i };
+    if (hitTp) return { outcome: 'win', resolvedIdx: i };
+  }
+  return { outcome: 'unresolved', resolvedIdx: end - 1 };
+}
+
+async function backtestSymbol(code) {
+  await setSymbol({ symbol: `IDX:${code}` });
+  const { bars } = await getOhlcv({ count: 500 });
+  if (!bars || bars.length < MIN_HISTORY_BARS + LOOKFORWARD_BARS) return [];
+
+  const avgValTrx = avgValueTraded(bars, 50);
+  if (avgValTrx < MIN_AVG_VALUE_TRX_50D) return []; // same liquidity gate as live screening
+
+  const records = [];
+  const lastUsableIdx = bars.length - 1 - LOOKFORWARD_BARS;
+  // One open "position" per criterion at a time — the same underlying setup
+  // (e.g. one wave-2 pullback) re-triggers on every subsequent green-candle
+  // day until it resolves, since the pivots/pullback-low it's built on barely
+  // change day to day. Counting each of those re-triggers as an independent
+  // signal was massively inflating N and — because a losing setup keeps
+  // re-firing right up until the day it actually breaks down — was skewing
+  // the win rate down (many near-duplicate "losses" for one real trade).
+  // A new signal for a given criterion only counts once any prior one has
+  // resolved (won, lost, or expired unresolved).
+  const busyUntil = new Map(); // criterion -> bar index its last open trade resolves at
+
+  for (let t = MIN_HISTORY_BARS; t <= lastUsableIdx; t++) {
+    const asOfBars = bars.slice(0, t + 1);
+    const matches = runDetectorsAsOf(asOfBars);
+    for (const m of matches) {
+      if ((busyUntil.get(m.criterion) ?? -1) >= t) continue; // still holding a prior trade for this criterion
+      const { outcome, resolvedIdx } = resolveOutcome(bars, t, m.plan);
+      busyUntil.set(m.criterion, resolvedIdx);
+      records.push({ symbol: code, criterion: m.criterion, date: bars[t].time, outcome });
+    }
+  }
+  return records;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const codes = loadSymbols(args);
+  const startedAt = Date.now();
+
+  console.log(`Backtesting ${codes.length} symbols over up to ~${500 - MIN_HISTORY_BARS - LOOKFORWARD_BARS} historical as-of days each...`);
+
+  const allRecords = [];
+  const errors = [];
+
+  for (let i = 0; i < codes.length; i++) {
+    const code = codes[i];
+    try {
+      const records = await backtestSymbol(code);
+      allRecords.push(...records);
+    } catch (err) {
+      errors.push({ symbol: code, error: err.message });
+    }
+
+    if ((i + 1) % 10 === 0 || i === codes.length - 1) {
+      const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(0);
+      console.log(`[${i + 1}/${codes.length}] elapsed=${elapsedSec}s signals_so_far=${allRecords.length} errors_so_far=${errors.length}`);
+    }
+  }
+
+  // Aggregate per criterion.
+  const byCriterion = new Map();
+  for (const r of allRecords) {
+    if (!byCriterion.has(r.criterion)) byCriterion.set(r.criterion, { win: 0, loss: 0, unresolved: 0 });
+    byCriterion.get(r.criterion)[r.outcome]++;
+  }
+
+  const perCriterion = [...byCriterion.entries()].map(([criterion, c]) => {
+    const resolved = c.win + c.loss;
+    return {
+      criterion,
+      total_signals: c.win + c.loss + c.unresolved,
+      resolved,
+      win: c.win,
+      loss: c.loss,
+      unresolved: c.unresolved,
+      win_rate_pct: resolved > 0 ? Math.round((c.win / resolved) * 1000) / 10 : null,
+    };
+  }).sort((a, b) => b.total_signals - a.total_signals);
+
+  const totalResolved = perCriterion.reduce((s, c) => s + c.resolved, 0);
+  const totalWins = perCriterion.reduce((s, c) => s + c.win, 0);
+
+  const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+  const summary = {
+    generated_at: new Date().toISOString(),
+    symbols_tested: codes.length,
+    lookforward_bars: LOOKFORWARD_BARS,
+    min_history_bars: MIN_HISTORY_BARS,
+    total_errors: errors.length,
+    elapsed_seconds: Number(elapsedSec),
+    overall_win_rate_pct: totalResolved > 0 ? Math.round((totalWins / totalResolved) * 1000) / 10 : null,
+    overall_resolved_signals: totalResolved,
+    per_criterion: perCriterion,
+    errors,
+  };
+
+  mkdirSync(join(__dirname, 'results'), { recursive: true });
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const jsonPath = join(__dirname, 'results', `backtest-${dateStr}.json`);
+  writeFileSync(jsonPath, JSON.stringify(summary, null, 2));
+
+  console.log(`\nDone. ${allRecords.length} total historical signals across ${codes.length} symbols. Elapsed ${elapsedSec}s.`);
+  console.log(`Overall win rate: ${summary.overall_win_rate_pct}% (${totalWins}/${totalResolved} resolved signals)`);
+  console.log('\nPer criterion:');
+  for (const c of perCriterion) {
+    console.log(`  ${c.criterion}: ${c.win_rate_pct}% win rate (${c.win}W/${c.loss}L, ${c.unresolved} unresolved, ${c.total_signals} total)`);
+  }
+  console.log(`\nReport: ${jsonPath}`);
+}
+
+main()
+  .catch(err => {
+    console.error('FATAL:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    try { await disconnect(); } catch { /* already gone */ }
+  });

--- a/screener/daily.js
+++ b/screener/daily.js
@@ -1,0 +1,53 @@
+/**
+ * Daily orchestrator: ensure TradingView Desktop is up with CDP, run the
+ * full IHSG scan, and print a Markdown report + Excel path to stdout. Meant
+ * to be invoked by the "screening-ihsg" scheduled task (18:00 weekdays);
+ * also runnable by hand.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { healthCheck, launch } from '../src/core/health.js';
+import { generateReport } from './report.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function ensureTradingViewReady() {
+  try {
+    const health = await healthCheck();
+    if (health?.cdp_connected) {
+      console.log('TradingView already running with CDP — reusing existing session.');
+      return;
+    }
+  } catch { /* not connected — fall through to launch */ }
+
+  console.log('TradingView not reachable via CDP — launching it now...');
+  const result = await launch({ kill_existing: false });
+  if (!result?.success) {
+    throw new Error(`Failed to launch TradingView: ${JSON.stringify(result)}`);
+  }
+  console.log(`Launched TradingView (pid ${result.pid}), CDP on port ${result.cdp_port}. Waiting for chart to settle...`);
+  await new Promise(r => setTimeout(r, 8000));
+}
+
+async function main() {
+  await ensureTradingViewReady();
+
+  console.log('Running full IHSG scan...');
+  execFileSync(process.execPath, [join(__dirname, 'scan.js')], { stdio: 'inherit' });
+
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const jsonPath = join(__dirname, 'results', `scan-${dateStr}.json`);
+  const excelPath = join(__dirname, 'results', `scan-${dateStr}.xlsx`);
+  const scan = JSON.parse(readFileSync(jsonPath, 'utf8'));
+
+  const report = generateReport(scan);
+  console.log('\n\n' + report);
+  console.log(`\nFile Excel hasil screening: ${excelPath}`);
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exitCode = 1;
+});

--- a/screener/daily_sore.js
+++ b/screener/daily_sore.js
@@ -1,0 +1,44 @@
+/**
+ * Performance-check orchestrator: ensure TradingView Desktop is up with CDP,
+ * run the performance check against the most recent evening screening
+ * (found automatically — not necessarily today's, e.g. Friday's on a
+ * Monday), and print a text summary to stdout (no Excel for this report).
+ * Meant to be invoked by the "performa-ihsg" scheduled task (17:00
+ * weekdays); also runnable by hand.
+ */
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { healthCheck, launch } from '../src/core/health.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function ensureTradingViewReady() {
+  try {
+    const health = await healthCheck();
+    if (health?.cdp_connected) {
+      console.log('TradingView already running with CDP — reusing existing session.');
+      return;
+    }
+  } catch { /* not connected — fall through to launch */ }
+
+  console.log('TradingView not reachable via CDP — launching it now...');
+  const result = await launch({ kill_existing: false });
+  if (!result?.success) {
+    throw new Error(`Failed to launch TradingView: ${JSON.stringify(result)}`);
+  }
+  console.log(`Launched TradingView (pid ${result.pid}), CDP on port ${result.cdp_port}. Waiting for chart to settle...`);
+  await new Promise(r => setTimeout(r, 8000));
+}
+
+async function main() {
+  await ensureTradingViewReady();
+
+  console.log('Menjalankan pengecekan performa akhir hari...');
+  execFileSync(process.execPath, [join(__dirname, 'performance.js')], { stdio: 'inherit' });
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exitCode = 1;
+});

--- a/screener/excel.js
+++ b/screener/excel.js
@@ -1,0 +1,68 @@
+/**
+ * Formats a scan-YYYY-MM-DD.json result into an .xlsx workbook: one summary
+ * sheet plus one flat "Sinyal" sheet (one row per matched criterion) that's
+ * easy to sort/filter directly in Excel.
+ */
+import ExcelJS from 'exceljs';
+import { shortCriteriaLabel } from './report.js';
+
+export async function generateExcel(scan, outputPath) {
+  const wb = new ExcelJS.Workbook();
+  wb.creator = 'tradingview-mcp screener';
+  wb.created = new Date(scan.generated_at);
+
+  const summary = wb.addWorksheet('Ringkasan');
+  summary.columns = [{ width: 40 }, { width: 30 }];
+  summary.addRows([
+    ['Tanggal Screening', scan.generated_at.slice(0, 10)],
+    ['Total Saham Dipindai', scan.total_scanned],
+    ['Saham dengan Minimal 1 Sinyal', scan.total_matches],
+    ['Error', scan.total_errors],
+    ['Disaring (Tidak Likuid)', scan.total_skipped_illiquid ?? 'n/a'],
+    ['Threshold AvgValTrx 50 Hari (Rp)', scan.min_avg_value_trx_50d ?? 'n/a'],
+    ['Durasi (detik)', scan.elapsed_seconds],
+    [],
+    ['Disclaimer', 'Hasil analisis teknikal terkomputasi berbasis aturan (rule-based), bukan nasihat investasi dari penasihat keuangan berlisensi. Selalu verifikasi ulang secara manual sebelum mengambil keputusan trading.'],
+  ]);
+  summary.getRow(1).font = { bold: true };
+  summary.getColumn(1).font = { bold: true };
+  summary.getCell('B9').alignment = { wrapText: true };
+
+  const sheet = wb.addWorksheet('Sinyal');
+  sheet.columns = [
+    { header: 'Saham', key: 'symbol', width: 10 },
+    { header: 'Close', key: 'close', width: 12 },
+    { header: 'Kriteria', key: 'criterion', width: 34 },
+    { header: 'Buy Area', key: 'buy_area', width: 18 },
+    { header: 'Cutloss', key: 'cutloss', width: 12 },
+    { header: 'Take Profit 1', key: 'tp1', width: 14 },
+    { header: 'Take Profit 2', key: 'tp2', width: 14 },
+    { header: 'Extended Target', key: 'extended', width: 16 },
+    { header: 'Nearest Resistance', key: 'resistance', width: 18 },
+    { header: 'Nearest Support', key: 'support', width: 16 },
+    { header: 'Metode', key: 'method', width: 70 },
+  ];
+  sheet.getRow(1).font = { bold: true };
+  sheet.autoFilter = { from: 'A1', to: 'K1' };
+
+  for (const stock of scan.results) {
+    for (const m of stock.matches) {
+      sheet.addRow({
+        symbol: stock.symbol,
+        close: stock.last_close,
+        criterion: shortCriteriaLabel(m.criterion),
+        buy_area: m.plan?.buy_area ?? '',
+        cutloss: m.plan?.cutloss ?? '',
+        tp1: m.plan?.take_profit_1 ?? '',
+        tp2: m.plan?.take_profit_2 ?? '',
+        extended: m.plan?.extended_target ?? '',
+        resistance: stock.nearest_resistance ?? '',
+        support: stock.nearest_support ?? '',
+        method: m.plan?.method ?? '',
+      });
+    }
+  }
+
+  await wb.xlsx.writeFile(outputPath);
+  return outputPath;
+}

--- a/screener/idx_all.csv
+++ b/screener/idx_all.csv
@@ -1,0 +1,952 @@
+code,name,listingDate,shares,listingBoard
+AALI,Astra Agro Lestari Tbk.,1997-12-09T00:00:00,1924688333.0,Utama
+ABBA,Mahaka Media Tbk.,2002-04-03T00:00:00,3935892857.0,Pemantauan Khusus
+ABDA,Asuransi Bina Dana Arta Tbk.,1989-07-06T00:00:00,620806680.0,Pemantauan Khusus
+ABMM,ABM Investama Tbk.,2011-12-06T00:00:00,2753165000.0,Utama
+ACES,Aspirasi Hidup Indonesia Tbk.,2007-11-06T00:00:00,17120389700.0,Utama
+ACST,Acset Indonusa Tbk.,2013-06-24T00:00:00,12675160000.0,Pengembangan
+ADES,Akasha Wira International Tbk.,1994-06-13T00:00:00,589896800.0,Pengembangan
+ADHI,Adhi Karya (Persero) Tbk.,2004-03-18T00:00:00,8407608979.0,Utama
+ADMF,Adira Dinamika Multi Finance T,2004-03-31T00:00:00,1000000000.0,Pengembangan
+ADMG,Polychem Indonesia Tbk,1993-10-20T00:00:00,3889179559.0,Pengembangan
+ADRO,Alamtri Resources Indonesia Tb,2008-07-16T00:00:00,30758665900.0,Utama
+AGII,Samator Indo Gas Tbk.,2016-09-28T00:00:00,3066660000.0,Pengembangan
+AGRO,Bank Raya Indonesia Tbk.,2003-08-08T00:00:00,24493093216.0,Utama
+AGRS,Bank IBK Indonesia Tbk.,2014-12-22T00:00:00,47367057874.0,Pengembangan
+AHAP,Asuransi Harta Aman Pratama Tb,1990-09-14T00:00:00,4900000000.0,Pengembangan
+AIMS,Artha Mahiya Investama Tbk.,2001-07-20T00:00:00,220000000.0,Pengembangan
+AISA,FKS Food Sejahtera Tbk.,1997-06-11T00:00:00,9311800000.0,Utama
+AKKU,Anugerah Kagum Karya Utama Tbk,2004-11-01T00:00:00,6449463636.0,Pemantauan Khusus
+AKPI,Argha Karya Prima Industry Tbk,1992-12-18T00:00:00,612248000.0,Pengembangan
+AKRA,AKR Corporindo Tbk.,1994-10-03T00:00:00,20073474600.0,Utama
+AKSI,Mineral Sumberdaya Mandiri Tbk,2001-07-13T00:00:00,720000000.0,Pengembangan
+ALDO,Alkindo Naratama Tbk.,2011-07-12T00:00:00,2700713744.0,Pengembangan
+ALKA,Alakasa Industrindo Tbk,1990-07-12T00:00:00,507665055.0,Pengembangan
+ALMI,Alumindo Light Metal Industry ,1997-01-02T00:00:00,3816000000.0,Pemantauan Khusus
+ALTO,Tri Banyan Tirta Tbk.,2012-07-10T00:00:00,2191870558.0,Pemantauan Khusus
+AMAG,Asuransi Multi Artha Guna Tbk.,2005-12-23T00:00:00,5001552516.0,Pengembangan
+AMFG,Asahimas Flat Glass Tbk.,1995-11-08T00:00:00,434000000.0,Utama
+AMIN,Ateliers Mecaniques D Indonesi,2015-12-10T00:00:00,1080000000.0,Pengembangan
+AMRT,Sumber Alfaria Trijaya Tbk.,2009-01-15T00:00:00,41524501700.0,Utama
+ANJT,Austindo Nusantara Jaya Tbk.,2013-05-08T00:00:00,3354175000.0,Pengembangan
+ANTM,Aneka Tambang Tbk.,1997-11-27T00:00:00,24030764725.0,Utama
+APEX,Apexindo Pratama Duta Tbk.,2013-06-05T00:00:00,3546466661.0,Pengembangan
+APIC,Pacific Strategic Financial Tb,2002-12-18T00:00:00,11766313488.0,Pengembangan
+APII,Arita Prima Indonesia Tbk.,2013-10-29T00:00:00,1075760000.0,Pengembangan
+APLI,Asiaplast Industries Tbk.,2000-05-01T00:00:00,1362671400.0,Pengembangan
+APLN,Agung Podomoro Land Tbk.,2010-11-11T00:00:00,22699326779.0,Utama
+ARGO,Argo Pantes Tbk,1991-01-07T00:00:00,3174339029.0,Pengembangan
+ARII,Atlas Resources Tbk.,2011-11-08T00:00:00,3431000000.0,Pengembangan
+ARNA,Arwana Citramulia Tbk.,2001-07-17T00:00:00,7341430976.0,Utama
+ARTA,Arthavest Tbk,2002-11-05T00:00:00,446674175.0,Pengembangan
+ARTI,Ratu Prabu Energi Tbk,2003-04-30T00:00:00,7840000000.0,Pemantauan Khusus
+ARTO,Bank Jago Tbk.,2016-01-12T00:00:00,13722768400.0,Utama
+ASBI,Asuransi Bintang Tbk.,1989-11-29T00:00:00,348386472.0,Pengembangan
+ASDM,Asuransi Dayin Mitra Tbk.,1989-12-15T00:00:00,384000000.0,Pengembangan
+ASGR,Astra Graphia Tbk.,1989-11-15T00:00:00,1348780500.0,Utama
+ASII,Astra International Tbk.,1990-04-04T00:00:00,40483553140.0,Utama
+ASJT,Asuransi Jasa Tania Tbk.,2003-12-23T00:00:00,1400000000.0,Pengembangan
+ASMI,Asuransi Maximus Graha Persada,2014-01-16T00:00:00,8958380460.0,Pemantauan Khusus
+ASRI,Alam Sutera Realty Tbk.,2007-12-18T00:00:00,19649411888.0,Utama
+ASRM,Asuransi Ramayana Tbk.,1990-03-19T00:00:00,1217135360.0,Pengembangan
+ASSA,Adi Sarana Armada Tbk.,2012-11-12T00:00:00,3691137517.0,Utama
+ATIC,Anabatic Technologies Tbk.,2015-07-08T00:00:00,2315361355.0,Pengembangan
+AUTO,Astra Otoparts Tbk.,1998-06-15T00:00:00,4819733000.0,Utama
+BABP,Bank MNC Internasional Tbk.,2002-07-15T00:00:00,44014333126.0,Pengembangan
+BACA,Bank Capital Indonesia Tbk.,2007-10-04T00:00:00,19753494636.0,Utama
+BAJA,Saranacentral Bajatama Tbk.,2011-12-21T00:00:00,1800000000.0,Pengembangan
+BALI,Bali Towerindo Sentra Tbk.,2014-03-13T00:00:00,3934592500.0,Utama
+BAPA,Bekasi Asri Pemula Tbk.,2008-01-14T00:00:00,661784520.0,Pengembangan
+BATA,Sepatu Bata Tbk.,1982-03-24T00:00:00,1300000000.0,Pengembangan
+BAYU,Bayu Buana Tbk,1989-10-30T00:00:00,353220780.0,Pengembangan
+BBCA,Bank Central Asia Tbk.,2000-05-31T00:00:00,122042299500.0,Utama
+BBHI,Allo Bank Indonesia Tbk.,2015-08-12T00:00:00,21512953877.0,Utama
+BBKP,Bank KB Bukopin Tbk.,2006-07-10T00:00:00,185819884852.0,Utama
+BBLD,Buana Finance Tbk.,1990-05-07T00:00:00,1645796054.0,Pengembangan
+BBMD,Bank Mestika Dharma Tbk.,2013-07-08T00:00:00,4049189100.0,Pengembangan
+BBNI,Bank Negara Indonesia (Persero,1996-11-25T00:00:00,36924339786.0,Utama
+BBRI,Bank Rakyat Indonesia (Persero,2003-11-10T00:00:00,150043411587.0,Utama
+BBRM,Pelayaran Nasional Bina Buana ,2013-01-09T00:00:00,8479490328.0,Pengembangan
+BBTN,Bank Tabungan Negara (Persero),2009-12-17T00:00:00,13894099969.0,Utama
+BBYB,Bank Neo Commerce Tbk.,2015-01-13T00:00:00,13216977523.0,Utama
+BCAP,MNC Kapital Indonesia Tbk.,2001-06-08T00:00:00,42618850927.0,Utama
+BCIC,Bank JTrust Indonesia Tbk.,1997-06-25T00:00:00,17926071041.0,Pengembangan
+BCIP,Bumi Citra Permai Tbk.,2009-12-11T00:00:00,1429915525.0,Pengembangan
+BDMN,Bank Danamon Indonesia Tbk.,1989-12-06T00:00:00,9675817341.0,Utama
+BEKS,Bank Pembangunan Daerah Banten,2001-07-13T00:00:00,51351733883.0,Pemantauan Khusus
+BEST,Bekasi Fajar Industrial Estate,2012-04-10T00:00:00,9647311150.0,Utama
+BFIN,BFI Finance  Indonesia Tbk.,1990-05-16T00:00:00,15967115620.0,Utama
+BGTG,Bank Ganesha Tbk.,2016-05-12T00:00:00,23731287132.0,Pengembangan
+BHIT,MNC Asia Holding Tbk.,1997-11-24T00:00:00,86068156705.0,Pemantauan Khusus
+BIKA,Binakarya Jaya Abadi Tbk.,2015-07-14T00:00:00,592280000.0,Pemantauan Khusus
+BIMA,Primarindo Asia Infrastructure,1994-08-30T00:00:00,608175716.0,Pengembangan
+BINA,Bank Ina Perdana Tbk.,2014-01-16T00:00:00,6073369498.0,Utama
+BIPI,Astrindo Nusantara Infrastrukt,2010-02-11T00:00:00,63710196917.0,Pengembangan
+BIPP,Bhuwanatala Indah Permai Tbk.,1995-10-23T00:00:00,5028669376.0,Pemantauan Khusus
+BIRD,Blue Bird Tbk.,2014-11-05T00:00:00,2502100000.0,Utama
+BISI,BISI International Tbk.,2007-05-28T00:00:00,3000000000.0,Utama
+BJBR,Bank Pembangunan Daerah Jawa B,2010-07-08T00:00:00,10416229249.0,Utama
+BJTM,Bank Pembangunan Daerah Jawa T,2012-07-12T00:00:00,14865343101.0,Utama
+BKDP,Bukit Darmo Property Tbk,2007-06-15T00:00:00,7513992252.0,Pemantauan Khusus
+BKSL,Sentul City Tbk.,1997-07-28T00:00:00,167708902705.0,Pemantauan Khusus
+BKSW,Bank QNB Indonesia Tbk.,2002-11-21T00:00:00,34806467881.0,Pengembangan
+BLTA,Berlian Laju Tanker Tbk,1990-03-26T00:00:00,25940187103.0,Pemantauan Khusus
+BLTZ,Graha Layar Prima Tbk.,2014-04-10T00:00:00,873937142.0,Pemantauan Khusus
+BMAS,Bank Maspion Indonesia Tbk.,2013-07-11T00:00:00,17921635680.0,Pemantauan Khusus
+BMRI,Bank Mandiri (Persero) Tbk.,2003-07-14T00:00:00,92399999996.0,Utama
+BMSR,Bintang Mitra Semestaraya Tbk,1999-12-29T00:00:00,1159200024.0,Pengembangan
+BMTR,Global Mediacom Tbk.,1995-07-17T00:00:00,16583997586.0,Utama
+BNBA,Bank Bumi Arta Tbk.,2006-06-01T00:00:00,3354120000.0,Pengembangan
+BNBR,Bakrie & Brothers Tbk,1989-08-28T00:00:00,173416832509.0,Pemantauan Khusus
+BNGA,Bank CIMB Niaga Tbk.,1989-11-29T00:00:00,24890783784.0,Utama
+BNII,Bank Maybank Indonesia Tbk.,1989-11-21T00:00:00,75357433911.0,Utama
+BNLI,Bank Permata Tbk.,1990-01-15T00:00:00,35819545925.0,Pengembangan
+BOLT,Garuda Metalindo Tbk.,2015-07-07T00:00:00,2343750000.0,Pengembangan
+BPFI,Woori Finance Indonesia Tbk.,2009-06-01T00:00:00,2673995362.0,Pengembangan
+BPII,Batavia Prosperindo Internasio,2014-07-08T00:00:00,10309973240.0,Pengembangan
+BRAM,Indo Kordsa Tbk.,1990-09-05T00:00:00,450056980.0,Pengembangan
+BRMS,Bumi Resources Minerals Tbk.,2010-12-09T00:00:00,141784040338.0,Utama
+BRNA,Berlina Tbk.,1989-11-06T00:00:00,979110000.0,Pengembangan
+BRPT,Barito Pacific Tbk.,1993-10-01T00:00:00,93747218044.0,Utama
+BSDE,Bumi Serpong Damai Tbk.,2008-06-06T00:00:00,21171365812.0,Utama
+BSIM,Bank Sinarmas Tbk.,2010-12-13T00:00:00,19517921842.0,Utama
+BSSR,Baramulti Suksessarana Tbk.,2012-11-08T00:00:00,2616500000.0,Pengembangan
+BSWD,Bank Of India Indonesia Tbk.,2002-05-01T00:00:00,3651978177.0,Pengembangan
+BTEK,Bumi Teknokultura Unggul Tbk,2004-05-14T00:00:00,46277496376.0,Pemantauan Khusus
+BTEL,Bakrie Telecom Tbk.,2006-02-03T00:00:00,36822665755.0,Pemantauan Khusus
+BTON,Betonjaya Manunggal Tbk.,2001-07-18T00:00:00,720000000.0,Pemantauan Khusus
+BTPN,Bank SMBC Indonesia Tbk.,2008-03-12T00:00:00,10536203690.0,Utama
+BUDI,Budi Starch & Sweetener Tbk.,1995-05-08T00:00:00,4498997362.0,Utama
+BUKK,Bukaka Teknik Utama Tbk.,2015-06-29T00:00:00,2640452000.0,Pengembangan
+BULL,Buana Lintas Lautan Tbk.,2011-05-23T00:00:00,14117801449.0,Pengembangan
+BUMI,Bumi Resources Tbk.,1990-07-30T00:00:00,371335392068.0,Utama
+BUVA,Bukit Uluwatu Villa Tbk.,2010-07-12T00:00:00,20590473213.0,Pengembangan
+BVIC,Bank Victoria International Tb,1999-06-30T00:00:00,15690056585.0,Utama
+BWPT,Eagle High Plantations Tbk.,2009-10-27T00:00:00,31525291000.0,Utama
+BYAN,Bayan Resources Tbk.,2008-08-12T00:00:00,33333335000.0,Utama
+CANI,Capitol Nusantara Indonesia Tb,2014-01-16T00:00:00,833440000.0,Pemantauan Khusus
+CASS,Cardig Aero Services Tbk.,2011-12-05T00:00:00,2086950000.0,Utama
+CEKA,Wilmar Cahaya Indonesia Tbk.,1996-07-09T00:00:00,595000000.0,Pengembangan
+CENT,Centratama Telekomunikasi Indo,2001-11-01T00:00:00,31183464900.0,Pemantauan Khusus
+CFIN,Clipan Finance Indonesia Tbk.,1990-08-27T00:00:00,3984520457.0,Utama
+CINT,Chitose Internasional Tbk.,2014-06-27T00:00:00,1000000000.0,Pengembangan
+CITA,Cita Mineral Investindo Tbk.,2002-03-20T00:00:00,3960361250.0,Pengembangan
+CLPI,Colorpak Indonesia Tbk.,2001-11-30T00:00:00,306338500.0,Pengembangan
+CMNP,Citra Marga Nusaphala Persada ,1995-01-10T00:00:00,6020165828.0,Utama
+CMPP,AirAsia Indonesia Tbk.,1994-12-08T00:00:00,10685124441.0,Pemantauan Khusus
+CNKO,Exploitasi Energi Indonesia Tb,2001-11-20T00:00:00,8956361206.0,Pemantauan Khusus
+CNTX,Century Textile Industry Tbk.,1979-05-22T00:00:00,70000000.0,Pemantauan Khusus
+COWL,Cowell Development Tbk.,2007-12-19T00:00:00,4871214021.0,Pemantauan Khusus
+CPIN,Charoen Pokphand Indonesia Tbk,1991-03-18T00:00:00,16398000000.0,Utama
+CPRO,Central Proteina Prima Tbk.,2006-11-28T00:00:00,59572382787.0,Pengembangan
+CSAP,Catur Sentosa Adiprana Tbk.,2007-12-12T00:00:00,5683175151.0,Pengembangan
+CTBN,Citra Tubindo Tbk.,1989-11-28T00:00:00,800371500.0,Pemantauan Khusus
+CTRA,Ciputra Development Tbk.,1994-03-28T00:00:00,18535695255.0,Utama
+CTTH,Citatah Tbk.,1996-07-03T00:00:00,1230839821.0,Pemantauan Khusus
+DART,Duta Anggada Realty Tbk.,1990-05-08T00:00:00,3141390962.0,Pengembangan
+DEFI,Danasupra Erapacific Tbk.,2001-07-06T00:00:00,687266666.0,Pemantauan Khusus
+DEWA,Darma Henwa Tbk,2007-09-26T00:00:00,21853733792.0,Utama
+DGIK,Nusa Konstruksi Enjiniring Tbk,2007-12-19T00:00:00,5541165000.0,Pengembangan
+DILD,Intiland Development Tbk.,1991-09-04T00:00:00,10365854185.0,Utama
+DKFT,Central Omega Resources Tbk.,1997-11-21T00:00:00,5638246600.0,Pengembangan
+DLTA,Delta Djakarta Tbk.,1984-02-27T00:00:00,800659050.0,Utama
+DMAS,Puradelta Lestari Tbk.,2015-05-29T00:00:00,48198111100.0,Utama
+DNAR,Bank Oke Indonesia Tbk.,2014-07-11T00:00:00,16867292274.0,Pengembangan
+DNET,Indoritel Makmur Internasional,2000-12-11T00:00:00,14184000000.0,Pengembangan
+DOID,Delta Dunia Makmur Tbk.,2001-06-15T00:00:00,7651007132.0,Utama
+DPNS,Duta Pertiwi Nusantara Tbk.,1990-08-08T00:00:00,331129952.0,Pengembangan
+DSFI,Dharma Samudera Fishing Indust,2000-03-24T00:00:00,1857135500.0,Pengembangan
+DSNG,Dharma Satya Nusantara Tbk.,2013-06-14T00:00:00,10599842400.0,Utama
+DSSA,Dian Swastatika Sentosa Tbk,2009-12-10T00:00:00,7705523200.0,Utama
+DUTI,Duta Pertiwi Tbk,1994-11-02T00:00:00,1850000000.0,Pemantauan Khusus
+DVLA,Darya-Varia Laboratoria Tbk.,1994-11-11T00:00:00,1120000000.0,Pengembangan
+DYAN,Dyandra Media International Tb,2013-03-25T00:00:00,4272964279.0,Pengembangan
+ECII,Electronic City Indonesia Tbk.,2013-07-03T00:00:00,1334333000.0,Pengembangan
+EKAD,Ekadharma International Tbk.,1990-08-14T00:00:00,3493875000.0,Pengembangan
+ELSA,Elnusa Tbk.,2008-02-06T00:00:00,7298500000.0,Utama
+ELTY,Bakrieland Development Tbk.,1995-10-30T00:00:00,43521913019.0,Pemantauan Khusus
+EMDE,Megapolitan Developments Tbk.,2011-01-12T00:00:00,3350000000.0,Pengembangan
+EMTK,Elang Mahkota Teknologi Tbk.,2010-01-12T00:00:00,61391751483.0,Utama
+ENRG,Energi Mega Persada Tbk.,2004-06-07T00:00:00,24821230250.0,Utama
+EPMT,Enseval Putera Megatrading Tbk,1994-08-01T00:00:00,2708640000.0,Pengembangan
+ERAA,Erajaya Swasembada Tbk.,2011-12-14T00:00:00,15950000000.0,Utama
+ERTX,Eratex Djaja Tbk.,1990-08-21T00:00:00,1286539792.0,Pengembangan
+ESSA,ESSA Industries Indonesia Tbk.,2012-02-01T00:00:00,17226975700.0,Utama
+ESTI,Ever Shine Tex Tbk.,1992-10-13T00:00:00,2015208720.0,Pemantauan Khusus
+ETWA,Eterindo Wahanatama Tbk,1997-05-16T00:00:00,4668671400.0,Pemantauan Khusus
+EXCL,XL Axiata Tbk.,2005-09-29T00:00:00,13128430665.0,Utama
+FAST,Fast Food Indonesia Tbk.,1993-05-11T00:00:00,3990277158.0,Pengembangan
+FASW,Fajar Surya Wisesa Tbk.,1994-12-19T00:00:00,2477888787.0,Pemantauan Khusus
+FISH,FKS Multi Agro Tbk.,2002-01-18T00:00:00,480000000.0,Pemantauan Khusus
+FMII,Fortune Mate Indonesia Tbk,2000-06-30T00:00:00,6400000000.0,Pengembangan
+FORU,Fortune Indonesia Tbk,2002-01-17T00:00:00,465224000.0,Pengembangan
+FPNI,Lotte Chemical Titan Tbk.,2002-03-21T00:00:00,5566414000.0,Pengembangan
+FREN,Smartfren Telecom Tbk.,2006-11-29T00:00:00,476704062619.0,Pemantauan Khusus
+GAMA,Aksara Global Development Tbk.,2012-07-11T00:00:00,10011027656.0,Pemantauan Khusus
+GDST,Gunawan Dianjaya Steel Tbk.,2009-12-23T00:00:00,9242500000.0,Pemantauan Khusus
+GDYR,Goodyear Indonesia Tbk.,1980-12-22T00:00:00,410000000.0,Pengembangan
+GEMA,Gema Grahasarana Tbk.,2002-08-12T00:00:00,1600000000.0,Pengembangan
+GEMS,Golden Energy Mines Tbk.,2011-11-17T00:00:00,5882353000.0,Utama
+GGRM,Gudang Garam Tbk.,1990-08-27T00:00:00,1924088000.0,Utama
+GIAA,Garuda Indonesia (Persero) Tbk,2011-02-11T00:00:00,91480783837.0,Pemantauan Khusus
+GJTL,Gajah Tunggal Tbk.,1990-05-08T00:00:00,3484800000.0,Utama
+GLOB,Globe Kita Terang Tbk.,2012-07-10T00:00:00,1111112000.0,Pemantauan Khusus
+GMTD,Gowa Makassar Tourism Developm,2000-12-11T00:00:00,1015380000.0,Pengembangan
+GOLD,Visi Telekomunikasi Infrastruk,2010-07-07T00:00:00,1277276000.0,Pengembangan
+GOLL,Golden Plantation Tbk.,2014-12-23T00:00:00,3665000759.0,Pemantauan Khusus
+GPRA,Perdana Gapuraprima Tbk.,2007-10-10T00:00:00,4276655336.0,Pengembangan
+GSMF,Equity Development Investment ,1989-10-23T00:00:00,14230399705.0,Pengembangan
+GTBO,Garda Tujuh Buana Tbk,2009-07-09T00:00:00,2500000000.0,Pengembangan
+GWSA,Greenwood Sejahtera Tbk.,2011-12-23T00:00:00,7800760000.0,Pengembangan
+GZCO,Gozco Plantations Tbk.,2008-05-15T00:00:00,6000000000.0,Pengembangan
+HADE,Himalaya Energi Perkasa Tbk.,2004-04-12T00:00:00,2120000000.0,Pemantauan Khusus
+HDFA,Radana Bhaskara Finance Tbk.,2011-05-10T00:00:00,6542445783.0,Pengembangan
+HDTX,Panasia Indo Resources Tbk.,1990-06-06T00:00:00,3601462800.0,Pemantauan Khusus
+HERO,DFI Retail Nusantara Tbk.,1989-08-21T00:00:00,4183634000.0,Pengembangan
+HEXA,Hexindo Adiperkasa Tbk.,1995-02-13T00:00:00,840000000.0,Utama
+HITS,Humpuss Intermoda Transportasi,1997-12-15T00:00:00,7101084801.0,Utama
+HMSP,H.M. Sampoerna Tbk.,1990-08-15T00:00:00,116318076900.0,Pengembangan
+HOME,Hotel Mandarine Regency Tbk.,2008-07-17T00:00:00,22212194782.0,Pemantauan Khusus
+HOTL,Saraswati Griya Lestari Tbk.,2013-01-10T00:00:00,3550001452.0,Pemantauan Khusus
+HRUM,Harum Energy Tbk.,2010-10-06T00:00:00,13518100000.0,Utama
+IATA,MNC Energy Investments Tbk.,2006-09-13T00:00:00,25238245556.0,Pemantauan Khusus
+IBFN,Intan Baru Prana Tbk.,2014-12-22T00:00:00,1517332349.0,Pemantauan Khusus
+IBST,Inti Bangun Sejahtera Tbk.,2012-08-31T00:00:00,1350904927.0,Pemantauan Khusus
+ICBP,Indofood CBP Sukses Makmur Tbk,2010-10-07T00:00:00,11661908000.0,Utama
+ICON,Island Concepts Indonesia Tbk.,2005-07-08T00:00:00,1089750000.0,Pemantauan Khusus
+IGAR,Champion Pacific Indonesia Tbk,1990-11-05T00:00:00,972204500.0,Pengembangan
+IIKP,Inti Agri Resources Tbk,2002-10-14T00:00:00,33600000000.0,Pemantauan Khusus
+IKAI,Intikeramik Alamasri Industri ,1997-06-04T00:00:00,13305799387.0,Pemantauan Khusus
+IKBI,Sumi Indo Kabel Tbk.,1991-01-21T00:00:00,1224000000.0,Pengembangan
+IMAS,Indomobil Sukses Internasional,1993-11-15T00:00:00,3994291039.0,Utama
+IMJS,Indomobil Multi Jasa Tbk.,2013-12-10T00:00:00,8654325000.0,Pengembangan
+IMPC,Impack Pratama Industri Tbk.,2014-12-17T00:00:00,54268500000.0,Utama
+INAF,Indofarma Tbk.,2001-04-17T00:00:00,3099267500.0,Pemantauan Khusus
+INAI,Indal Aluminium Industry Tbk.,1994-12-05T00:00:00,633600000.0,Pengembangan
+INCI,Intanwijaya Internasional Tbk,1990-07-24T00:00:00,207656617.0,Pengembangan
+INCO,Vale Indonesia Tbk.,1990-05-16T00:00:00,10539784534.0,Utama
+INDF,Indofood Sukses Makmur Tbk.,1994-07-14T00:00:00,8780426500.0,Utama
+INDR,Indo-Rama Synthetics Tbk.,1990-08-03T00:00:00,654351707.0,Pengembangan
+INDS,Indospring Tbk.,1990-08-10T00:00:00,6562497100.0,Pengembangan
+INDX,Tanah Laut Tbk,2001-05-17T00:00:00,437913588.0,Pengembangan
+INDY,Indika Energy Tbk.,2008-06-11T00:00:00,5210192000.0,Utama
+INKP,Indah Kiat Pulp & Paper Tbk.,1990-07-16T00:00:00,5470982941.0,Utama
+INPC,Bank Artha Graha Internasional,1990-08-23T00:00:00,20021178779.0,Utama
+INPP,Indonesian Paradise Property T,2004-01-12T00:00:00,11181971732.0,Pengembangan
+INRU,Toba Pulp Lestari Tbk.,1990-06-18T00:00:00,1388883283.0,Pengembangan
+INTA,Intraco Penta Tbk.,1993-08-23T00:00:00,3343935022.0,Pemantauan Khusus
+INTD,Inter Delta Tbk,1989-12-18T00:00:00,591828000.0,Pengembangan
+INTP,Indocement Tunggal Prakarsa Tb,1989-12-05T00:00:00,3681231699.0,Utama
+IPOL,Indopoly Swakarsa Industry Tbk,2010-07-09T00:00:00,6443379509.0,Pengembangan
+ISAT,Indosat Tbk.,1994-10-19T00:00:00,32250810957.0,Utama
+ISSP,Steel Pipe Industry of Indones,2013-02-22T00:00:00,7185992035.0,Utama
+ITMA,Sumber Energi Andalan Tbk.,1990-12-10T00:00:00,999053167.0,Pengembangan
+ITMG,Indo Tambangraya Megah Tbk.,2007-12-18T00:00:00,1129925000.0,Utama
+JAWA,Jaya Agra Wattie Tbk.,2011-05-30T00:00:00,16232951842.0,Pengembangan
+JECC,Jembo Cable Company Tbk.,1992-11-18T00:00:00,756000000.0,Pengembangan
+JIHD,Jakarta International Hotels &,1984-02-29T00:00:00,2329040482.0,Pengembangan
+JKON,Jaya Konstruksi Manggala Prata,2007-12-04T00:00:00,16308519860.0,Utama
+JKSW,Jakarta Kyoei Steel Works Tbk.,1997-08-06T00:00:00,150000000.0,Pemantauan Khusus
+JPFA,Japfa Comfeed Indonesia Tbk.,1989-10-23T00:00:00,11726575201.0,Utama
+JRPT,Jaya Real Property Tbk.,1994-06-29T00:00:00,13750000000.0,Pengembangan
+JSMR,Jasa Marga (Persero) Tbk.,2007-11-12T00:00:00,7257871200.0,Utama
+JSPT,Jakarta Setiabudi Internasiona,1998-01-12T00:00:00,2318736000.0,Pengembangan
+JTPE,Jasuindo Tiga Perkasa Tbk.,2002-04-16T00:00:00,6852050000.0,Utama
+KAEF,Kimia Farma Tbk.,2001-07-04T00:00:00,5566588407.0,Pengembangan
+KARW,Meratus Jasa Prima Tbk.,1994-12-20T00:00:00,587152700.0,Pemantauan Khusus
+KBLI,KMI Wire & Cable Tbk.,1992-07-06T00:00:00,4007235107.0,Utama
+KBLM,Kabelindo Murni Tbk.,1992-06-01T00:00:00,1120000000.0,Pengembangan
+KBLV,First Media Tbk.,2000-02-25T00:00:00,1742167907.0,Pemantauan Khusus
+KBRI,Kertas Basuki Rachmat Indonesi,2008-07-11T00:00:00,8687995734.0,Pemantauan Khusus
+KDSI,Kedawung Setia Industrial Tbk.,1996-07-29T00:00:00,1620000000.0,Pengembangan
+KIAS,Keramika Indonesia Assosiasi T,1994-12-08T00:00:00,14929100000.0,Pemantauan Khusus
+KICI,Kedaung Indah Can Tbk,1993-10-28T00:00:00,276000000.0,Pengembangan
+KIJA,Kawasan Industri Jababeka Tbk.,1995-01-10T00:00:00,20824888369.0,Utama
+KKGI,Resource Alam Indonesia Tbk.,1991-07-01T00:00:00,5000000000.0,Utama
+KLBF,Kalbe Farma Tbk.,1991-07-30T00:00:00,46875122110.0,Utama
+KOBX,Kobexindo Tractors Tbk.,2012-07-05T00:00:00,2272500000.0,Pengembangan
+KOIN,Kokoh Inti Arebama Tbk,2008-04-09T00:00:00,980843732.0,Pemantauan Khusus
+KONI,Perdana Bangun Pusaka Tbk,1995-08-22T00:00:00,312000000.0,Pengembangan
+KOPI,Mitra Energi Persada Tbk.,2015-05-04T00:00:00,697266668.0,Pengembangan
+KPIG,MNC Land Tbk.,2000-03-30T00:00:00,97557129263.0,Pengembangan
+KRAH,Grand Kartech Tbk.,2013-11-08T00:00:00,971190000.0,Pemantauan Khusus
+KRAS,Krakatau Steel (Persero) Tbk.,2010-11-10T00:00:00,19346396900.0,Pengembangan
+KREN,Quantum Clovera Investama Tbk.,2002-06-28T00:00:00,18208470100.0,Pemantauan Khusus
+LAPD,Leyand International Tbk.,2001-07-17T00:00:00,3966350139.0,Pemantauan Khusus
+LCGP,Eureka Prima Jakarta Tbk.,2007-07-13T00:00:00,5630000914.0,Pemantauan Khusus
+LEAD,Logindo Samudramakmur Tbk.,2013-12-11T00:00:00,5799616328.0,Pengembangan
+LINK,Link Net Tbk.,2014-06-02T00:00:00,2863195484.0,Pemantauan Khusus
+LION,Lion Metal Works Tbk.,1993-08-20T00:00:00,520160000.0,Utama
+LMAS,Limas Indonesia Makmur Tbk,2001-12-28T00:00:00,787851525.0,Pemantauan Khusus
+LMPI,Langgeng Makmur Industri Tbk.,1994-10-17T00:00:00,1008517669.0,Pengembangan
+LMSH,Lionmesh Prima Tbk.,1990-06-04T00:00:00,96000000.0,Pemantauan Khusus
+LPCK,Lippo Cikarang Tbk,1997-07-24T00:00:00,2679600000.0,Utama
+LPGI,Lippo General Insurance Tbk.,1997-07-22T00:00:00,3000000000.0,Pemantauan Khusus
+LPIN,Multi Prima Sejahtera Tbk,1990-02-05T00:00:00,425000000.0,Pengembangan
+LPKR,Lippo Karawaci Tbk.,1996-06-28T00:00:00,70898018369.0,Utama
+LPLI,Star Pacific Tbk,1989-10-23T00:00:00,1170432803.0,Pengembangan
+LPPF,Matahari Department Store Tbk.,1989-10-09T00:00:00,2259292880.0,Utama
+LPPS,Lenox Pasifik Investama Tbk.,1994-03-28T00:00:00,2588250000.0,Pengembangan
+LRNA,Eka Sari Lorena Transport Tbk.,2014-04-15T00:00:00,350000022.0,Pengembangan
+LSIP,PP London Sumatra Indonesia Tb,1996-07-05T00:00:00,6819963965.0,Utama
+LTLS,Lautan Luas Tbk.,1997-07-21T00:00:00,1560000000.0,Utama
+MAGP,Multi Agro Gemilang Plantation,2013-01-16T00:00:00,9000000004.0,Pemantauan Khusus
+MAIN,Malindo Feedmill Tbk.,2006-02-10T00:00:00,2238750000.0,Utama
+MAMI,Mas Murni Indonesia Tbk,1994-02-09T00:00:00,12299317590.0,Pemantauan Khusus
+MAPI,Mitra Adiperkasa Tbk.,2004-11-10T00:00:00,16600000000.0,Utama
+MASA,Multistrada Arah Sarana Tbk.,2005-06-09T00:00:00,9182946945.0,Pengembangan
+MAYA,Bank Mayapada Internasional Tb,1997-08-29T00:00:00,25906179152.0,Utama
+MBAP,Mitrabara Adiperdana Tbk.,2014-07-10T00:00:00,1227271952.0,Pengembangan
+MBSS,Mitrabahtera Segara Sejati Tbk,2011-04-06T00:00:00,1750026639.0,Utama
+MBTO,Martina Berto Tbk.,2011-01-13T00:00:00,1070000000.0,Pengembangan
+MCOR,Bank China Construction Bank I,2007-07-03T00:00:00,37540533209.0,Utama
+MDIA,Intermedia Capital Tbk.,2014-04-11T00:00:00,39215538400.0,Pemantauan Khusus
+MDKA,Merdeka Copper Gold Tbk.,2015-06-19T00:00:00,24472983771.0,Utama
+MDLN,Modernland Realty Tbk.,1993-01-18T00:00:00,12533067322.0,Utama
+MDRN,Modern Internasional Tbk.,1991-07-16T00:00:00,7632167798.0,Pemantauan Khusus
+MEDC,Medco Energi Internasional Tbk,1994-10-12T00:00:00,25136231252.0,Utama
+MEGA,Bank Mega Tbk.,2000-04-17T00:00:00,11623514905.0,Utama
+MERK,Merck Tbk.,1981-07-23T00:00:00,448000000.0,Pengembangan
+META,Nusantara Infrastructure Tbk.,2001-07-18T00:00:00,17710708194.0,Pemantauan Khusus
+MFIN,Mandala Multifinance Tbk.,2005-09-06T00:00:00,2676887872.0,Utama
+MFMI,Multifiling Mitra Indonesia Tb,2010-12-29T00:00:00,757581000.0,Pemantauan Khusus
+MGNA,Magna Investama Mandiri Tbk.,2014-07-08T00:00:00,3410477164.0,Pemantauan Khusus
+MICE,Multi Indocitra Tbk.,2005-12-21T00:00:00,600000000.0,Pengembangan
+MIDI,Midi Utama Indonesia Tbk.,2010-11-30T00:00:00,33435294800.0,Pengembangan
+MIKA,Mitra Keluarga Karyasehat Tbk.,2015-03-24T00:00:00,13907481500.0,Utama
+MIRA,Mitra International Resources ,1997-01-30T00:00:00,3961452039.0,Pemantauan Khusus
+MITI,Mitra Investindo Tbk.,1997-07-16T00:00:00,3540735503.0,Pengembangan
+MKPI,Metropolitan Kentjana Tbk.,2009-07-10T00:00:00,948194000.0,Pengembangan
+MLBI,Multi Bintang Indonesia Tbk.,1981-12-15T00:00:00,2107000000.0,Utama
+MLIA,Mulia Industrindo Tbk,1994-01-17T00:00:00,6615000000.0,Utama
+MLPL,Multipolar Tbk.,1989-11-06T00:00:00,15682323987.0,Utama
+MLPT,Multipolar Technology Tbk.,2013-07-08T00:00:00,1875000000.0,Pengembangan
+MMLP,Mega Manunggal Property Tbk.,2015-06-12T00:00:00,6889134608.0,Utama
+MNCN,Media Nusantara Citra Tbk.,2007-06-22T00:00:00,15049787710.0,Utama
+MPMX,Mitra Pinasthika Mustika Tbk.,2013-05-29T00:00:00,4462963276.0,Utama
+MPPA,Matahari Putra Prima Tbk.,1992-12-21T00:00:00,12966640084.0,Utama
+MRAT,Mustika Ratu Tbk.,1995-07-27T00:00:00,428000000.0,Pengembangan
+MREI,Maskapai Reasuransi Indonesia ,1989-09-04T00:00:00,517791681.0,Pengembangan
+MSKY,MNC Sky Vision Tbk.,2012-07-09T00:00:00,1994370480.0,Pengembangan
+MTDL,Metrodata Electronics Tbk.,1990-04-09T00:00:00,12276884585.0,Utama
+MTFN,Capitalinc Investment Tbk.,1990-04-16T00:00:00,31842082852.0,Pemantauan Khusus
+MTLA,Metropolitan Land Tbk.,2011-06-20T00:00:00,7655126330.0,Utama
+MTSM,Metro Realty Tbk.,1992-01-08T00:00:00,232848000.0,Pemantauan Khusus
+MYOH,Samindo Resources Tbk.,2000-07-27T00:00:00,2206312500.0,Utama
+MYOR,Mayora Indah Tbk.,1990-07-04T00:00:00,22358699725.0,Utama
+MYRX,Hanson International Tbk.,1990-10-31T00:00:00,86703220792.0,Pemantauan Khusus
+MYTX,Asia Pacific Investama Tbk.,1989-10-10T00:00:00,7747281949.0,Pemantauan Khusus
+NELY,Pelayaran Nelly Dwi Putri Tbk.,2012-10-11T00:00:00,2350000000.0,Pengembangan
+NIKL,Pelat Timah Nusantara Tbk.,2009-12-14T00:00:00,2523350000.0,Pengembangan
+NIPS,Nipress Tbk.,1991-07-24T00:00:00,1635333332.0,Pemantauan Khusus
+NIRO,City Retail Developments Tbk.,2012-09-13T00:00:00,22198871804.0,Pengembangan
+NISP,Bank OCBC NISP Tbk.,1994-10-20T00:00:00,22715776032.0,Utama
+NOBU,Bank Nationalnobu Tbk.,2013-05-20T00:00:00,7403659460.0,Pengembangan
+NRCA,Nusa Raya Cipta Tbk.,2013-06-27T00:00:00,2496258344.0,Pengembangan
+OCAP,Onix Capital Tbk.,2003-10-10T00:00:00,273200000.0,Pemantauan Khusus
+OKAS,Ancora Indonesia Resources Tbk,2006-03-29T00:00:00,2373449165.0,Pengembangan
+OMRE,Indonesia Prima Property Tbk,1994-08-22T00:00:00,2945211000.0,Pemantauan Khusus
+PADI,Minna Padi Investama Sekuritas,2012-01-09T00:00:00,11307246524.0,Pemantauan Khusus
+PALM,Provident Investasi Bersama Tb,2012-10-08T00:00:00,15773797158.0,Pengembangan
+PANR,Panorama Sentrawisata Tbk.,2001-09-18T00:00:00,1387500000.0,Utama
+PANS,Panin Sekuritas Tbk.,2000-05-31T00:00:00,720000000.0,Utama
+PBRX,Pan Brothers Tbk.,1990-08-16T00:00:00,21482028246.0,Pemantauan Khusus
+PDES,Destinasi Tirta Nusantara Tbk,2008-07-08T00:00:00,715000000.0,Pengembangan
+PEGE,Panca Global Kapital Tbk.,2005-06-24T00:00:00,2833417056.0,Pengembangan
+PGAS,Perusahaan Gas Negara Tbk.,2003-12-15T00:00:00,24241508196.0,Utama
+PGLI,Pembangunan Graha Lestari Inda,2000-04-05T00:00:00,488000000.0,Pengembangan
+PICO,Pelangi Indah Canindo Tbk,1996-09-23T00:00:00,568375000.0,Pengembangan
+PJAA,Pembangunan Jaya Ancol Tbk.,2004-07-02T00:00:00,1599999996.0,Pengembangan
+PKPK,Perdana Karya Perkasa Tbk,2007-07-11T00:00:00,1200000000.0,Pengembangan
+PLAS,Polaris Investama Tbk,2001-03-16T00:00:00,1184200000.0,Pemantauan Khusus
+PLIN,Plaza Indonesia Realty Tbk.,1992-06-15T00:00:00,3550000000.0,Pemantauan Khusus
+PNBN,Bank Pan Indonesia Tbk,1982-12-29T00:00:00,23837645998.0,Utama
+PNBS,Bank Panin Dubai Syariah Tbk.,2014-01-15T00:00:00,38425504906.0,Pengembangan
+PNIN,Paninvest Tbk.,1983-09-20T00:00:00,4068323920.0,Utama
+PNLF,Panin Financial Tbk.,1983-06-14T00:00:00,32022073293.0,Utama
+PNSE,Pudjiadi & Sons Tbk.,1990-05-01T00:00:00,797813496.0,Pengembangan
+POLY,Asia Pacific Fibers Tbk,1991-03-12T00:00:00,2495753334.0,Pemantauan Khusus
+POOL,Pool Advista Indonesia Tbk.,1991-05-20T00:00:00,2341366264.0,Pemantauan Khusus
+PPRO,PP Properti Tbk.,2015-05-19T00:00:00,61675671883.0,Pemantauan Khusus
+PRAS,Prima Alloy Steel Universal Tb,1990-07-12T00:00:00,701043478.0,Pemantauan Khusus
+PSAB,J Resources Asia Pasifik Tbk.,2003-04-22T00:00:00,26460000000.0,Pengembangan
+PSDN,Prasidha Aneka Niaga Tbk,1994-10-18T00:00:00,1440000000.0,Pengembangan
+PSKT,Red Planet Indonesia Tbk.,1995-09-19T00:00:00,10351231636.0,Pemantauan Khusus
+PTBA,Bukit Asam Tbk.,2002-12-23T00:00:00,11520659250.0,Utama
+PTIS,Indo Straits Tbk.,2011-07-12T00:00:00,550165300.0,Pengembangan
+PTPP,PP (Persero) Tbk.,2010-02-09T00:00:00,6199897354.0,Utama
+PTRO,Petrosea Tbk.,1990-05-21T00:00:00,10086050000.0,Utama
+PTSN,Sat Nusapersada Tbk,2007-11-08T00:00:00,5314344000.0,Pengembangan
+PTSP,Pioneerindo Gourmet Internatio,1994-05-30T00:00:00,220808000.0,Pengembangan
+PUDP,Pudjiadi Prestige Tbk.,1994-11-18T00:00:00,659120000.0,Utama
+PWON,Pakuwon Jati Tbk.,1989-10-09T00:00:00,48159602400.0,Utama
+PYFA,Pyridam Farma Tbk,2001-10-16T00:00:00,11236683094.0,Pengembangan
+RAJA,Rukun Raharja Tbk.,2006-04-19T00:00:00,4227082500.0,Utama
+RALS,Ramayana Lestari Sentosa Tbk.,1996-07-24T00:00:00,7096000000.0,Utama
+RANC,Supra Boga Lestari Tbk.,2012-06-07T00:00:00,1564487500.0,Pengembangan
+RBMS,Ristia Bintang Mahkotasejati T,1997-12-19T00:00:00,2656212826.0,Pemantauan Khusus
+RDTX,Roda Vivatex Tbk,1990-05-14T00:00:00,268800000.0,Pengembangan
+RELI,Reliance Sekuritas Indonesia T,2005-07-13T00:00:00,1800000000.0,Pengembangan
+RICY,Ricky Putra Globalindo Tbk,1998-01-22T00:00:00,641717510.0,Pengembangan
+RIGS,Rig Tenders Indonesia Tbk.,1990-03-05T00:00:00,609130000.0,Pengembangan
+RIMO,Rimo International Lestari Tbk,2000-11-10T00:00:00,45080600000.0,Pemantauan Khusus
+RODA,Pikko Land Development Tbk.,2001-10-22T00:00:00,13592128209.0,Pemantauan Khusus
+ROTI,Nippon Indosari Corpindo Tbk.,2010-06-28T00:00:00,6186488888.0,Pengembangan
+RUIS,Radiant Utama Interinsco Tbk.,2006-07-12T00:00:00,770000000.0,Pengembangan
+SAFE,Steady Safe Tbk,1994-08-15T00:00:00,615145012.0,Pengembangan
+SAME,Sarana Meditama Metropolitan T,2013-01-11T00:00:00,17147132545.0,Utama
+SCCO,Supreme Cable Manufacturing & ,1982-07-20T00:00:00,822333600.0,Pengembangan
+SCMA,Surya Citra Media Tbk.,2002-07-16T00:00:00,73970569505.0,Utama
+SCPI,Organon Pharma Indonesia Tbk.,1990-06-08T00:00:00,3600000.0,Pemantauan Khusus
+SDMU,Sidomulyo Selaras Tbk.,2011-07-12T00:00:00,1135225000.0,Pemantauan Khusus
+SDPC,Millennium Pharmacon Internati,1990-05-07T00:00:00,1274000000.0,Pengembangan
+SDRA,Bank Woori Saudara Indonesia 1,2006-12-15T00:00:00,14545267990.0,Utama
+SGRO,Sampoerna Agro Tbk.,2007-06-18T00:00:00,1818622000.0,Utama
+SHID,Hotel Sahid Jaya International,1990-05-08T00:00:00,1119326168.0,Pengembangan
+SIDO,Industri Jamu dan Farmasi Sido,2013-12-18T00:00:00,30000000000.0,Utama
+SILO,Siloam International Hospitals,2013-09-12T00:00:00,13006125000.0,Utama
+SIMA,Siwani Makmur Tbk,1994-06-03T00:00:00,442589871.0,Pemantauan Khusus
+SIMP,Salim Ivomas Pratama Tbk.,2011-06-09T00:00:00,15501310000.0,Utama
+SIPD,Sreeya Sewu Indonesia Tbk.,1996-12-27T00:00:00,1839102056.0,Pengembangan
+SKBM,Sekar Bumi Tbk.,2012-09-28T00:00:00,1730103217.0,Pengembangan
+SKLT,Sekar Laut Tbk.,1993-09-08T00:00:00,6907405000.0,Pengembangan
+SKYB,Northcliff Citranusa Indonesia,2010-07-07T00:00:00,585000000.0,Pemantauan Khusus
+SMAR,Smart Tbk.,1992-11-20T00:00:00,2872193366.0,Pengembangan
+SMBR,Semen Baturaja Tbk.,2013-06-28T00:00:00,9932534336.0,Utama
+SMCB,Solusi Bangun Indonesia Tbk.,1977-08-10T00:00:00,9019381973.0,Pemantauan Khusus
+SMDM,Suryamas Dutamakmur Tbk.,1995-10-12T00:00:00,4772138237.0,Pengembangan
+SMDR,Samudera Indonesia  Tbk.,1999-07-05T00:00:00,16375600000.0,Utama
+SMGR,Semen Indonesia (Persero) Tbk.,1991-07-08T00:00:00,6751540089.0,Utama
+SMMA,Sinarmas Multiartha Tbk.,1995-07-05T00:00:00,6367664717.0,Utama
+SMMT,Golden Eagle Energy Tbk.,1997-12-01T00:00:00,3150000000.0,Pemantauan Khusus
+SMRA,Summarecon Agung Tbk.,1990-05-07T00:00:00,16508568358.0,Utama
+SMRU,SMR Utama Tbk.,2011-10-10T00:00:00,12499385782.0,Pemantauan Khusus
+SMSM,Selamat Sempurna Tbk.,1996-09-09T00:00:00,5758675440.0,Utama
+SOCI,Soechi Lines Tbk.,2014-12-03T00:00:00,7059000000.0,Utama
+SONA,Sona Topas Tourism Industry Tb,1992-07-21T00:00:00,662400000.0,Pengembangan
+SPMA,Suparma Tbk.,1994-11-16T00:00:00,3154092216.0,Pengembangan
+SQMI,Wilton Makmur Indonesia Tbk.,2004-07-15T00:00:00,15537591429.0,Pemantauan Khusus
+SRAJ,Sejahteraraya Anugrahjaya Tbk.,2011-04-11T00:00:00,12000705445.0,Utama
+SRIL,Sri Rejeki Isman Tbk.,2013-06-17T00:00:00,20452176844.0,Pemantauan Khusus
+SRSN,Indo Acidatama Tbk,1993-01-11T00:00:00,6020000000.0,Pengembangan
+SRTG,Saratoga Investama Sedaya Tbk.,2013-06-26T00:00:00,13564835000.0,Utama
+SSIA,Surya Semesta Internusa Tbk.,1997-03-27T00:00:00,4705249440.0,Utama
+SSMS,Sawit Sumbermas Sarana Tbk.,2013-12-12T00:00:00,9525000000.0,Utama
+SSTM,Sunson Textile Manufacture Tbk,1997-08-20T00:00:00,1170909181.0,Pengembangan
+STAR,Buana Artha Anugerah Tbk.,2011-07-13T00:00:00,4800000602.0,Pengembangan
+STTP,Siantar Top Tbk.,1996-12-16T00:00:00,1310000000.0,Pengembangan
+SUGI,Sugih Energy Tbk.,2002-06-19T00:00:00,24811541414.0,Pemantauan Khusus
+SULI,SLJ Global Tbk.,1994-03-21T00:00:00,6320776836.0,Pengembangan
+SUPR,Solusi Tunas Pratama Tbk.,2011-10-11T00:00:00,1137579698.0,Pemantauan Khusus
+TALF,Tunas Alfin Tbk.,2014-01-17T00:00:00,1353435000.0,Pengembangan
+TARA,Agung Semesta Sejahtera Tbk.,2014-07-11T00:00:00,10069645750.0,Pemantauan Khusus
+TAXI,Express Transindo Utama Tbk.,2012-11-02T00:00:00,10223647156.0,Pemantauan Khusus
+TBIG,Tower Bersama Infrastructure T,2010-10-26T00:00:00,22656999445.0,Utama
+TBLA,Tunas Baru Lampung Tbk.,2000-02-14T00:00:00,6025373372.0,Utama
+TBMS,Tembaga Mulia Semanan Tbk.,1990-05-23T00:00:00,734680000.0,Pengembangan
+TCID,Mandom Indonesia Tbk.,1993-09-30T00:00:00,402133334.0,Pengembangan
+TELE,Omni Inovasi Indonesia Tbk.,2012-01-12T00:00:00,7310929389.0,Pemantauan Khusus
+TFCO,Tifico Fiber Indonesia Tbk.,1980-02-26T00:00:00,4823076400.0,Pemantauan Khusus
+TGKA,Tigaraksa Satria Tbk.,1990-06-11T00:00:00,918492750.0,Pengembangan
+TIFA,KDB Tifa Finance Tbk.,2011-07-08T00:00:00,3552213000.0,Pemantauan Khusus
+TINS,Timah Tbk.,1995-10-19T00:00:00,7447753454.0,Utama
+TIRA,Tira Austenite Tbk,1993-07-27T00:00:00,588000000.0,Pengembangan
+TIRT,Tirta Mahakam Resources Tbk,1999-12-13T00:00:00,1011774750.0,Pemantauan Khusus
+TKIM,Pabrik Kertas Tjiwi Kimia Tbk.,1990-04-03T00:00:00,3113223570.0,Utama
+TLKM,Telkom Indonesia (Persero) Tbk,1995-11-14T00:00:00,99062216600.0,Utama
+TMAS,Temas Tbk.,2003-07-09T00:00:00,57051500000.0,Utama
+TMPO,Tempo Intimedia Tbk.,2001-01-08T00:00:00,1058333250.0,Pengembangan
+TOBA,TBS Energi Utama Tbk.,2012-07-06T00:00:00,8167826970.0,Utama
+TOTL,Total Bangun Persada Tbk.,2006-07-25T00:00:00,3410000000.0,Utama
+TOTO,Surya Toto Indonesia Tbk.,1990-10-30T00:00:00,10320000000.0,Pengembangan
+TOWR,Sarana Menara Nusantara Tbk.,2010-03-08T00:00:00,51014625000.0,Utama
+TPIA,Chandra Asri Pacific Tbk.,2008-05-26T00:00:00,86511545092.0,Pengembangan
+TPMA,Trans Power Marine Tbk.,2013-02-20T00:00:00,3507420034.0,Utama
+TRAM,Trada Alam Minera Tbk.,2008-09-10T00:00:00,49643627934.0,Pemantauan Khusus
+TRIL,Triwira Insanlestari Tbk.,2008-01-28T00:00:00,1200000000.0,Pemantauan Khusus
+TRIM,Trimegah Sekuritas Indonesia T,2000-01-31T00:00:00,7109300000.0,Utama
+TRIO,Trikomsel Oke Tbk.,2009-04-14T00:00:00,26007494645.0,Pemantauan Khusus
+TRIS,Trisula International Tbk.,2012-06-28T00:00:00,3141443831.0,Pengembangan
+TRST,Trias Sentosa Tbk.,1990-07-02T00:00:00,2808000000.0,Pengembangan
+TRUS,Trust Finance Indonesia Tbk,2002-11-28T00:00:00,800000000.0,Pengembangan
+TSPC,Tempo Scan Pacific Tbk.,1994-06-17T00:00:00,4509864300.0,Utama
+ULTJ,Ultrajaya Milk Industry & Trad,1990-07-02T00:00:00,11553528000.0,Utama
+UNIC,Unggul Indah Cahaya Tbk.,1989-11-06T00:00:00,383331363.0,Utama
+UNIT,Nusantara Inti Corpora Tbk,2002-04-18T00:00:00,75422200.0,Pengembangan
+UNSP,Bakrie Sumatera Plantations Tb,1990-03-06T00:00:00,2500162344.0,Pemantauan Khusus
+UNTR,United Tractors Tbk.,1989-09-19T00:00:00,3730135136.0,Utama
+UNVR,Unilever Indonesia Tbk.,1982-01-11T00:00:00,38150000000.0,Utama
+VICO,Victoria Investama Tbk.,2013-07-08T00:00:00,15217075658.0,Pengembangan
+VINS,Victoria Insurance Tbk.,2015-09-28T00:00:00,1460573616.0,Pengembangan
+VIVA,Visi Media Asia Tbk.,2011-11-21T00:00:00,16464270400.0,Pemantauan Khusus
+VOKS,Voksel Electric Tbk.,1990-12-20T00:00:00,4155602595.0,Pengembangan
+VRNA,Mizuho Leasing Indonesia Tbk.,2008-06-25T00:00:00,5687353997.0,Pengembangan
+WAPO,Wahana Pronatural Tbk.,2001-06-22T00:00:00,1240923111.0,Pengembangan
+WEHA,WEHA Transportasi Indonesia Tb,2007-05-31T00:00:00,1460554819.0,Pengembangan
+WICO,Wicaksana Overseas Internation,1994-08-08T00:00:00,2393710348.0,Pemantauan Khusus
+WIIM,Wismilak Inti Makmur Tbk.,2012-12-18T00:00:00,2099873760.0,Utama
+WIKA,Wijaya Karya (Persero) Tbk.,2007-10-29T00:00:00,39873063858.0,Pengembangan
+WINS,Wintermar Offshore Marine Tbk.,2010-11-29T00:00:00,4364837057.0,Utama
+WOMF,Wahana Ottomitra Multiartha Tb,2004-12-13T00:00:00,3481481480.0,Pengembangan
+WSKT,Waskita Karya (Persero) Tbk.,2012-12-19T00:00:00,28806807016.0,Pemantauan Khusus
+WTON,Wijaya Karya Beton Tbk.,2014-04-08T00:00:00,8715466600.0,Utama
+YPAS,Yanaprima Hastapersada Tbk,2008-03-05T00:00:00,668000089.0,Pemantauan Khusus
+YULE,Yulie Sekuritas Indonesia Tbk.,2004-12-10T00:00:00,1785000000.0,Pengembangan
+ZBRA,Dosni Roha Indonesia Tbk.,1991-08-01T00:00:00,2510706263.0,Pengembangan
+SHIP,Sillo Maritime Perdana Tbk.,2016-06-16T00:00:00,2719790000.0,Utama
+CASA,Capital Financial Indonesia Tb,2016-07-19T00:00:00,54476269803.0,Pengembangan
+DAYA,Duta Intidaya Tbk.,2016-06-28T00:00:00,2420547025.0,Pengembangan
+DPUM,Dua Putra Utama Makmur Tbk.,2015-12-08T00:00:00,4175000000.0,Pengembangan
+IDPR,Indonesia Pondasi Raya Tbk.,2015-12-10T00:00:00,2003000000.0,Pengembangan
+JGLE,Graha Andrasentra Propertindo ,2016-06-29T00:00:00,22581909405.0,Pemantauan Khusus
+KINO,Kino Indonesia Tbk.,2015-12-11T00:00:00,1428571500.0,Pengembangan
+MARI,Mahaka Radio Integra Tbk.,2016-02-11T00:00:00,5252644000.0,Pengembangan
+MKNT,Mitra Komunikasi Nusantara Tbk,2015-10-26T00:00:00,5500000000.0,Pemantauan Khusus
+MTRA,Mitra Pemuda Tbk.,2016-02-10T00:00:00,770000000.0,Pemantauan Khusus
+OASA,Maharaksa Biru Energi Tbk.,2016-07-18T00:00:00,6347220000.0,Pengembangan
+POWR,Cikarang Listrindo Tbk.,2016-06-14T00:00:00,16087156000.0,Utama
+INCF,Indo Komoditi Korpora Tbk.,2016-09-06T00:00:00,1438370465.0,Pemantauan Khusus
+WSBP,Waskita Beton Precast Tbk.,2016-09-20T00:00:00,55085048699.0,Pemantauan Khusus
+PBSA,Paramita Bangun Sarana Tbk.,2016-09-28T00:00:00,3000000000.0,Pengembangan
+PRDA,Prodia Widyahusada Tbk.,2016-12-07T00:00:00,937500000.0,Utama
+BOGA,Bintang Oto Global Tbk.,2016-12-19T00:00:00,3803526210.0,Pengembangan
+BRIS,Bank Syariah Indonesia Tbk.,2018-05-09T00:00:00,45667877639.0,Utama
+PORT,Nusantara Pelabuhan Handal Tbk,2017-03-16T00:00:00,2813941985.0,Pengembangan
+CARS,Industri dan Perdagangan Bintr,2017-04-10T00:00:00,15000000000.0,Utama
+MINA,Sanurhasta Mitra Tbk.,2017-04-28T00:00:00,6562500000.0,Pemantauan Khusus
+FORZ,Forza Land Indonesia Tbk.,2017-04-28T00:00:00,1984009887.0,Pemantauan Khusus
+CLEO,Sariguna Primatirta Tbk.,2017-05-05T00:00:00,12000000000.0,Utama
+TAMU,Pelayaran Tamarin Samudra Tbk.,2017-05-10T00:00:00,37500000000.0,Pemantauan Khusus
+CSIS,Cahayasakti Investindo Sukses ,2017-05-10T00:00:00,1307000000.0,Pemantauan Khusus
+TGRA,Terregra Asia Energy Tbk.,2017-05-16T00:00:00,2750000000.0,Pemantauan Khusus
+FIRE,Alfa Energi Investama Tbk.,2017-06-09T00:00:00,1475363179.0,Pengembangan
+TOPS,Totalindo Eka Persada Tbk.,2017-06-16T00:00:00,33330000000.0,Pemantauan Khusus
+KMTR,Kirana Megatara Tbk.,2017-06-19T00:00:00,8215366379.0,Pengembangan
+ARMY,Armidian Karyatama Tbk.,2017-06-21T00:00:00,9006250000.0,Pemantauan Khusus
+MAPB,MAP Boga Adiperkasa Tbk.,2017-06-21T00:00:00,2387922900.0,Pemantauan Khusus
+WOOD,Integra Indocabinet Tbk.,2017-06-21T00:00:00,6437500000.0,Utama
+HRTA,Hartadinata Abadi Tbk.,2017-06-21T00:00:00,4605262400.0,Utama
+MABA,Marga Abhinaya Abadi Tbk.,2017-06-22T00:00:00,15365229912.0,Pemantauan Khusus
+HOKI,Buyung Poetra Sembada Tbk.,2017-06-22T00:00:00,9677752680.0,Utama
+MPOW,Megapower Makmur Tbk.,2017-07-05T00:00:00,816997053.0,Pengembangan
+MARK,Mark Dynamics Indonesia Tbk.,2017-07-12T00:00:00,3800000310.0,Utama
+NASA,Andalan Perkasa Abadi Tbk.,2017-08-07T00:00:00,11004929322.0,Pemantauan Khusus
+MDKI,Emdeki Utama Tbk.,2017-09-25T00:00:00,2530150002.0,Pengembangan
+BELL,Trisula Textile Industries Tbk,2017-10-03T00:00:00,7250000000.0,Pemantauan Khusus
+KIOS,Kioson Komersial Indonesia Tbk,2017-10-05T00:00:00,1075862960.0,Pengembangan
+GMFI,Garuda Maintenance Facility Ae,2017-10-10T00:00:00,37565978976.0,Pemantauan Khusus
+MTWI,Malacca Trust Wuwungan Insuran,2017-10-12T00:00:00,2924486639.0,Pengembangan
+ZINC,Kapuas Prima Coal Tbk.,2017-10-16T00:00:00,25250000000.0,Pemantauan Khusus
+MCAS,M Cash Integrasi Tbk.,2017-11-01T00:00:00,867933300.0,Utama
+PPRE,PP Presisi Tbk.,2017-11-24T00:00:00,10224271000.0,Pengembangan
+WEGE,Wijaya Karya Bangunan Gedung T,2017-11-30T00:00:00,9572000000.0,Utama
+PSSI,IMC Pelita Logistik Tbk.,2017-12-05T00:00:00,5417063153.0,Utama
+MORA,Mora Telematika Indonesia Tbk.,2022-08-08T00:00:00,23646668691.0,Utama
+DWGL,Dwi Guna Laksana Tbk.,2017-12-13T00:00:00,9252820991.0,Pengembangan
+PBID,Panca Budi Idaman Tbk.,2017-12-13T00:00:00,7500000000.0,Utama
+JMAS,Asuransi Jiwa Syariah Jasa Mit,2017-12-18T00:00:00,1000000000.0,Pengembangan
+CAMP,Campina Ice Cream Industry Tbk,2017-12-19T00:00:00,5885000000.0,Pengembangan
+IPCM,Jasa Armada Indonesia Tbk.,2017-12-22T00:00:00,5284811100.0,Pengembangan
+PCAR,Prima Cakrawala Abadi Tbk.,2017-12-29T00:00:00,1166666700.0,Pengembangan
+LCKM,LCK Global Kedaton Tbk.,2018-01-16T00:00:00,1000000000.0,Pengembangan
+BOSS,Borneo Olah Sarana Sukses Tbk.,2018-02-15T00:00:00,1400000000.0,Pemantauan Khusus
+HELI,Jaya Trishindo Tbk.,2018-03-27T00:00:00,832862387.0,Pengembangan
+JSKY,Sky Energy Indonesia Tbk.,2018-03-28T00:00:00,2032540000.0,Pemantauan Khusus
+INPS,Indah Prakasa Sentosa Tbk.,2018-04-06T00:00:00,650000000.0,Pengembangan
+GHON,Gihon Telekomunikasi Indonesia,2018-04-09T00:00:00,550000000.0,Pengembangan
+TDPM,Tianrong Chemicals Industry Tb,2018-04-09T00:00:00,10485050500.0,Pemantauan Khusus
+DFAM,Dafam Property Indonesia Tbk.,2018-04-27T00:00:00,1899852850.0,Pengembangan
+NICK,Charnic Capital Tbk.,2018-05-02T00:00:00,651150000.0,Pengembangan
+BTPS,Bank BTPN Syariah Tbk.,2018-05-08T00:00:00,7626663000.0,Utama
+SPTO,Surya Pertiwi Tbk.,2018-05-14T00:00:00,2700000000.0,Utama
+PRIM,Royal Prima Tbk.,2018-05-15T00:00:00,3393434905.0,Pengembangan
+HEAL,Medikaloka Hermina Tbk.,2018-05-16T00:00:00,15365950000.0,Utama
+TRUK,Guna Timur Raya Tbk.,2018-05-23T00:00:00,435000000.0,Pengembangan
+PZZA,Sarimelati Kencana Tbk.,2018-05-23T00:00:00,3021875000.0,Pengembangan
+TUGU,Asuransi Tugu Pratama Indonesi,2018-05-28T00:00:00,3555575600.0,Utama
+MSIN,MNC Digital Entertainment Tbk.,2018-06-08T00:00:00,60676178205.0,Utama
+SWAT,Sriwahana Adityakarta Tbk.,2018-06-08T00:00:00,3019200000.0,Pemantauan Khusus
+KPAL,Steadfast Marine Tbk.,2018-06-08T00:00:00,1069009400.0,Pemantauan Khusus
+TNCA,Trimuda Nuansa Citra Tbk.,2018-06-28T00:00:00,421640000.0,Pengembangan
+MAPA,Map Aktif Adiperkasa Tbk.,2018-07-05T00:00:00,28504000000.0,Utama
+TCPI,Transcoal Pacific Tbk.,2018-07-06T00:00:00,5000000000.0,Pengembangan
+IPCC,Indonesia Kendaraan Terminal T,2018-07-09T00:00:00,1818384820.0,Utama
+RISE,Jaya Sukses Makmur Sentosa Tbk,2018-07-09T00:00:00,10945000000.0,Pengembangan
+BPTR,Batavia Prosperindo Trans Tbk.,2018-07-09T00:00:00,3534000000.0,Pengembangan
+POLL,Pollux Properties Indonesia Tb,2018-07-11T00:00:00,8318823600.0,Pemantauan Khusus
+NFCX,NFC Indonesia Tbk.,2018-07-12T00:00:00,666667500.0,Pengembangan
+MGRO,Mahkota Group Tbk.,2018-07-12T00:00:00,3554445700.0,Pengembangan
+NUSA,Sinergi Megah Internusa Tbk.,2018-07-12T00:00:00,7700000148.0,Pemantauan Khusus
+FILM,MD Entertainment Tbk.,2018-08-07T00:00:00,9897787962.0,Utama
+ANDI,Andira Agro Tbk.,2018-08-16T00:00:00,9350000000.0,Pemantauan Khusus
+LAND,Trimitra Propertindo Tbk.,2018-08-23T00:00:00,2792620000.0,Pemantauan Khusus
+MOLI,Madusari Murni Indah Tbk.,2018-08-30T00:00:00,2724036581.0,Pengembangan
+PANI,Pantai Indah Kapuk Dua Tbk.,2018-09-18T00:00:00,16883595500.0,Pengembangan
+DIGI,Arkadia Digital Media Tbk.,2018-09-18T00:00:00,1625000000.0,Pemantauan Khusus
+CITY,Natura City Developments Tbk.,2018-09-28T00:00:00,5405188966.0,Pengembangan
+SAPX,Satria Antaran Prima Tbk.,2018-10-03T00:00:00,833333300.0,Pengembangan
+KPAS,Cottonindo Ariesta Tbk.,2018-10-05T00:00:00,768043253.0,Pemantauan Khusus
+SURE,Super Energy Tbk.,2018-10-05T00:00:00,1497576771.0,Pengembangan
+HKMU,HK Metals Utama Tbk.,2018-10-09T00:00:00,3221750000.0,Pemantauan Khusus
+MPRO,Maha Properti Indonesia Tbk.,2018-10-09T00:00:00,9942500000.0,Pengembangan
+DUCK,Jaya Bersama Indo Tbk.,2018-10-10T00:00:00,1283330000.0,Pemantauan Khusus
+GOOD,Garudafood Putra Putri Jaya Tb,2018-10-10T00:00:00,36897901455.0,Utama
+SKRN,Superkrane Mitra Utama Tbk.,2018-10-11T00:00:00,7500000000.0,Pengembangan
+YELO,Yelooo Integra Datanet Tbk.,2018-10-29T00:00:00,1912774405.0,Pemantauan Khusus
+CAKK,Cahayaputra Asa Keramik Tbk.,2018-10-31T00:00:00,1203300219.0,Pengembangan
+SATU,Kota Satu Properti Tbk.,2018-11-05T00:00:00,1375000000.0,Pengembangan
+ZONE,Mega Perintis Tbk.,2018-12-12T00:00:00,870171478.0,Pengembangan
+PEHA,Phapros Tbk.,2018-12-26T00:00:00,840000000.0,Pengembangan
+FOOD,Sentra Food Indonesia Tbk.,2019-01-08T00:00:00,650000000.0,Pengembangan
+BEEF,Estika Tata Tiara Tbk.,2019-01-10T00:00:00,7186061591.0,Pengembangan
+POLI,Pollux Hotels Group Tbk.,2019-01-10T00:00:00,2010526400.0,Pemantauan Khusus
+CLAY,Citra Putra Realty Tbk.,2019-01-18T00:00:00,2570000000.0,Pemantauan Khusus
+NATO,Surya Permata Andalan Tbk.,2019-01-18T00:00:00,8001111504.0,Pengembangan
+JAYA,Armada Berjaya Trans Tbk.,2019-02-21T00:00:00,798499394.0,Pengembangan
+COCO,Wahana Interfood Nusantara Tbk,2019-03-20T00:00:00,889863981.0,Pengembangan
+MTPS,Meta Epsi Tbk.,2019-04-10T00:00:00,2084850829.0,Pemantauan Khusus
+CPRI,Capri Nusa Satu Properti Tbk.,2019-04-11T00:00:00,2433379958.0,Pemantauan Khusus
+HRME,Menteng Heritage Realty Tbk.,2019-04-12T00:00:00,5958750000.0,Pemantauan Khusus
+POSA,Bliss Properti Indonesia Tbk.,2019-05-10T00:00:00,8388870206.0,Pemantauan Khusus
+JAST,Jasnita Telekomindo Tbk.,2019-05-16T00:00:00,1082575738.0,Pengembangan
+FITT,Hotel Fitra International Tbk.,2019-06-11T00:00:00,1304272051.0,Pengembangan
+BOLA,Bali Bintang Sejahtera Tbk.,2019-06-17T00:00:00,6000000000.0,Utama
+CCSI,Communication Cable Systems In,2019-06-18T00:00:00,1319038405.0,Pengembangan
+SFAN,Surya Fajar Capital Tbk.,2019-06-19T00:00:00,1359934021.0,Pengembangan
+POLU,Golden Flower Tbk.,2019-06-26T00:00:00,750000000.0,Pengembangan
+KJEN,Krida Jaringan Nusantara Tbk.,2019-07-01T00:00:00,500000000.0,Pengembangan
+KAYU,Darmi Bersaudara Tbk.,2019-07-04T00:00:00,665000000.0,Pemantauan Khusus
+ITIC,Indonesian Tobacco Tbk.,2019-07-04T00:00:00,940720000.0,Pengembangan
+PAMG,Bima Sakti Pertiwi Tbk.,2019-07-05T00:00:00,3125000000.0,Pengembangan
+IPTV,MNC Vision Networks Tbk.,2019-07-08T00:00:00,42197950841.0,Pemantauan Khusus
+BLUE,Berkah Prima Perkasa Tbk.,2019-07-08T00:00:00,418000000.0,Pengembangan
+ENVY,Envy Technologies Indonesia Tb,2019-07-08T00:00:00,1800000000.0,Pemantauan Khusus
+EAST,Eastparc Hotel Tbk.,2019-07-09T00:00:00,4126405336.0,Pengembangan
+LIFE,MSIG Life Insurance Indonesia ,2019-07-09T00:00:00,2100000000.0,Pengembangan
+FUJI,Fuji Finance Indonesia Tbk.,2019-07-09T00:00:00,1300000000.0,Pengembangan
+KOTA,DMS Propertindo Tbk.,2019-07-09T00:00:00,10546185701.0,Pemantauan Khusus
+INOV,Inocycle Technology Group Tbk.,2019-07-10T00:00:00,1808221900.0,Pengembangan
+ARKA,Arkha Jayanti Persada Tbk.,2019-07-10T00:00:00,2000000000.0,Pemantauan Khusus
+SMKL,Satyamitra Kemas Lestari Tbk.,2019-07-11T00:00:00,3418085290.0,Pengembangan
+HDIT,Hensel Davest Indonesia Tbk.,2019-07-12T00:00:00,1524680000.0,Pemantauan Khusus
+KEEN,Kencana Energi Lestari Tbk.,2019-09-02T00:00:00,3666312500.0,Utama
+BAPI,Bhakti Agung Propertindo Tbk.,2019-09-16T00:00:00,5591980103.0,Pemantauan Khusus
+TFAS,Telefast Indonesia Tbk.,2019-09-17T00:00:00,1666666500.0,Pengembangan
+GGRP,Gunung Raja Paksi Tbk.,2019-09-19T00:00:00,12111376157.0,Pemantauan Khusus
+OPMS,Optima Prima Metal Sinergi Tbk,2019-09-23T00:00:00,1000000000.0,Pengembangan
+NZIA,Nusantara Almazia Tbk.,2019-09-25T00:00:00,2197540705.0,Pengembangan
+SLIS,Gaya Abadi Sempurna Tbk.,2019-10-07T00:00:00,2463336650.0,Pengembangan
+PURE,Trinitan Metals and Minerals T,2019-10-09T00:00:00,1375181505.0,Pemantauan Khusus
+IRRA,Itama Ranoraya Tbk.,2019-10-15T00:00:00,1600000000.0,Pengembangan
+DMMX,Digital Mediatama Maxima Tbk.,2019-10-21T00:00:00,7692307700.0,Pengembangan
+SINI,Singaraja Putra Tbk.,2019-11-08T00:00:00,481000000.0,Pemantauan Khusus
+WOWS,Ginting Jaya Energi Tbk.,2019-11-08T00:00:00,2475720000.0,Pemantauan Khusus
+ESIP,Sinergi Inti Plastindo Tbk.,2019-11-14T00:00:00,1109953847.0,Pemantauan Khusus
+TEBE,Dana Brata Luhur Tbk.,2019-11-18T00:00:00,1285000000.0,Utama
+KEJU,Mulia Boga Raya Tbk.,2019-11-25T00:00:00,5624999999.0,Pengembangan
+PSGO,Palma Serasih Tbk.,2019-11-25T00:00:00,18850000000.0,Utama
+AGAR,Asia Sejahtera Mina Tbk.,2019-12-02T00:00:00,1000000000.0,Pengembangan
+IFSH,Ifishdeco Tbk.,2019-12-05T00:00:00,2125000000.0,Pengembangan
+REAL,Repower Asia Indonesia Tbk.,2019-12-06T00:00:00,6633610151.0,Pemantauan Khusus
+IFII,Indonesia Fibreboard Industry ,2019-12-10T00:00:00,9412000000.0,Pengembangan
+PMJS,Putra Mandiri Jembar Tbk.,2019-12-18T00:00:00,13755600000.0,Pengembangan
+UCID,Uni-Charm Indonesia Tbk.,2019-12-20T00:00:00,4156572300.0,Utama
+GLVA,Galva Technologies Tbk.,2019-12-23T00:00:00,1500000000.0,Pengembangan
+PGJO,Tourindo Guide Indonesia Tbk.,2020-01-08T00:00:00,795859095.0,Akselerasi
+AMAR,Bank Amar Indonesia Tbk.,2020-01-09T00:00:00,18197283760.0,Pengembangan
+CSRA,Cisadane Sawit Raya Tbk.,2020-01-09T00:00:00,2050000000.0,Pengembangan
+INDO,Royalindo Investa Wijaya Tbk.,2020-01-13T00:00:00,4480741638.0,Pengembangan
+AMOR,Ashmore Asset Management Indon,2020-01-14T00:00:00,2222222400.0,Pengembangan
+TRIN,Perintis Triniti Properti Tbk.,2020-01-15T00:00:00,4551457346.0,Pengembangan
+DMND,Diamond Food Indonesia Tbk.,2020-01-22T00:00:00,9468359000.0,Pemantauan Khusus
+PURA,Putra Rajawali Kencana Tbk.,2020-01-29T00:00:00,6301930902.0,Pemantauan Khusus
+PTPW,Pratama Widya Tbk.,2020-02-07T00:00:00,878187500.0,Pengembangan
+TAMA,Lancartama Sejati Tbk.,2020-02-10T00:00:00,1200000696.0,Pemantauan Khusus
+IKAN,Era Mandiri Cemerlang Tbk.,2020-02-12T00:00:00,833333000.0,Pemantauan Khusus
+AYLS,Agro Yasa Lestari Tbk.,2020-02-12T00:00:00,853423236.0,Pengembangan
+DADA,Diamond Citra Propertindo Tbk.,2020-02-14T00:00:00,7431530800.0,Pemantauan Khusus
+ASPI,Andalan Sakti Primaindo Tbk.,2020-02-17T00:00:00,681823317.0,Pengembangan
+ESTA,Esta Multi Usaha Tbk.,2020-03-09T00:00:00,2425354179.0,Pengembangan
+BESS,Batulicin Nusantara Maritim Tb,2020-03-09T00:00:00,3440455528.0,Pengembangan
+CSMI,Cipta Selera Murni Tbk.,2020-04-09T00:00:00,816061500.0,Pemantauan Khusus
+BBSS,Bumi Benowo Sukses Sejahtera T,2020-04-15T00:00:00,4800016020.0,Pengembangan
+BHAT,Bhakti Multi Artha Tbk.,2020-04-15T00:00:00,5000000000.0,Pengembangan
+CASH,Cashlez Worldwide Indonesia Tb,2020-05-04T00:00:00,1431125517.0,Akselerasi
+TECH,Indosterling Technomedia Tbk.,2020-06-04T00:00:00,1256300000.0,Pengembangan
+EPAC,Megalestari Epack Sentosaraya ,2020-07-01T00:00:00,3303400000.0,Pemantauan Khusus
+UANG,Pakuan Tbk.,2020-07-06T00:00:00,1210000000.0,Pengembangan
+PGUN,Pradiksi Gunatama Tbk.,2020-07-07T00:00:00,5737848882.0,Pemantauan Khusus
+SOFA,Boston Furniture Industries Tb,2020-07-07T00:00:00,1653574499.0,Akselerasi
+PPGL,Prima Globalindo Logistik Tbk.,2020-07-20T00:00:00,771178020.0,Akselerasi
+TOYS,Sunindo Adipersada Tbk.,2020-08-06T00:00:00,1435000712.0,Pemantauan Khusus
+SGER,Sumber Global Energy Tbk.,2020-08-10T00:00:00,15586909438.0,Pengembangan
+TRJA,Transkon Jaya Tbk.,2020-08-27T00:00:00,1510200000.0,Pengembangan
+PNGO,Pinago Utama Tbk.,2020-08-31T00:00:00,781250000.0,Pengembangan
+SCNP,Selaras Citra Nusantara Perkas,2020-09-07T00:00:00,2500000000.0,Pengembangan
+BBSI,Krom Bank Indonesia Tbk.,2020-09-07T00:00:00,3637976068.0,Pengembangan
+KMDS,Kurniamitra Duta Sentosa Tbk.,2020-09-07T00:00:00,800000000.0,Pengembangan
+PURI,Puri Global Sukses Tbk.,2020-09-08T00:00:00,1000000000.0,Pengembangan
+SOHO,Soho Global Health Tbk.,2020-09-08T00:00:00,12691682390.0,Pengembangan
+HOMI,Grand House Mulia Tbk.,2020-09-10T00:00:00,1575000000.0,Pengembangan
+ROCK,Rockfields Properti Indonesia ,2020-09-10T00:00:00,1435185100.0,Pemantauan Khusus
+ENZO,Morenzo Abadi Perkasa Tbk.,2020-09-14T00:00:00,2162547122.0,Pemantauan Khusus
+PLAN,Planet Properindo Jaya Tbk.,2020-09-15T00:00:00,896709596.0,Akselerasi
+PTDU,Djasa Ubersakti Tbk.,2020-12-08T00:00:00,1500000000.0,Pemantauan Khusus
+ATAP,Trimitra Prawara Goldland Tbk.,2020-12-11T00:00:00,1250000000.0,Pemantauan Khusus
+VICI,Victoria Care Indonesia Tbk.,2020-12-17T00:00:00,6708000000.0,Utama
+PMMP,Panca Mitra Multiperdana Tbk.,2020-12-18T00:00:00,2588300000.0,Pengembangan
+WIFI,Solusi Sinergi Digital Tbk.,2020-12-30T00:00:00,2359355118.0,Pengembangan
+FAPA,FAP Agri Tbk.,2021-01-04T00:00:00,3629411800.0,Pengembangan
+DCII,DCI Indonesia Tbk.,2021-01-06T00:00:00,2383745900.0,Pengembangan
+KETR,Ketrosden Triasmitra Tbk.,2021-01-11T00:00:00,2841262838.0,Pengembangan
+DGNS,Diagnos Laboratorium Utama Tbk,2021-01-15T00:00:00,1250000000.0,Pengembangan
+UFOE,Damai Sejahtera Abadi Tbk.,2021-02-01T00:00:00,2898261693.0,Pengembangan
+BANK,Bank Aladin Syariah Tbk.,2021-02-01T00:00:00,14621942188.0,Utama
+WMUU,Widodo Makmur Unggas Tbk.,2021-02-02T00:00:00,12941176500.0,Pemantauan Khusus
+EDGE,Indointernet Tbk.,2021-02-08T00:00:00,2020250000.0,Pengembangan
+UNIQ,Ulima Nitra Tbk.,2021-03-08T00:00:00,3138983000.0,Utama
+BEBS,Berkah Beton Sadaya Tbk.,2021-03-10T00:00:00,45000000000.0,Pemantauan Khusus
+SNLK,Sunter Lakeside Hotel Tbk.,2021-03-29T00:00:00,450000000.0,Pengembangan
+ZYRX,Zyrexindo Mandiri Buana Tbk.,2021-03-30T00:00:00,1333334556.0,Pengembangan
+LFLO,Imago Mulia Persada Tbk.,2021-04-07T00:00:00,1307734937.0,Akselerasi
+FIMP,Fimperkasa Utama Tbk.,2021-04-09T00:00:00,400000975.0,Pemantauan Khusus
+TAPG,Triputra Agro Persada Tbk.,2021-04-12T00:00:00,19852540000.0,Utama
+NPGF,Nusa Palapa Gemilang Tbk.,2021-04-14T00:00:00,3240235840.0,Pemantauan Khusus
+LUCY,Lima Dua Lima Tiga Tbk.,2021-05-05T00:00:00,1514773893.0,Akselerasi
+ADCP,Adhi Commuter Properti Tbk.,2021-05-21T00:00:00,22222222200.0,Pengembangan
+HOPE,Harapan Duta Pertiwi Tbk.,2021-05-24T00:00:00,2130360203.0,Pemantauan Khusus
+MGLV,Panca Anugrah Wisesa Tbk.,2021-06-08T00:00:00,1904883411.0,Akselerasi
+TRUE,Triniti Dinamik Tbk.,2021-06-10T00:00:00,7571107860.0,Pemantauan Khusus
+LABA,Green Power Group Tbk.,2021-06-10T00:00:00,1103402553.0,Pengembangan
+ARCI,Archi Indonesia Tbk.,2021-06-28T00:00:00,24835000000.0,Pengembangan
+IPAC,Era Graharealty Tbk.,2021-06-30T00:00:00,949868500.0,Akselerasi
+MASB,Bank Multiarta Sentosa Tbk.,2021-06-30T00:00:00,1387737233.0,Pengembangan
+BMHS,Bundamedik Tbk.,2021-07-06T00:00:00,8603416176.0,Utama
+FLMC,Falmaco Nonwoven Industri Tbk.,2021-07-08T00:00:00,781250000.0,Akselerasi
+NICL,PAM Mineral Tbk.,2021-07-09T00:00:00,10635644907.0,Pengembangan
+UVCR,Trimegah Karya Pratama Tbk.,2021-07-27T00:00:00,2000144838.0,Pengembangan
+BUKA,Bukalapak.com Tbk.,2021-08-06T00:00:00,103121636167.0,Ekonomi Baru
+HAIS,Hasnur Internasional Shipping ,2021-09-01T00:00:00,2626250000.0,Pengembangan
+OILS,Indo Oil Perkasa Tbk.,2021-09-06T00:00:00,454056563.0,Pengembangan
+GPSO,Geoprima Solusi Tbk.,2021-09-06T00:00:00,666741103.0,Pengembangan
+MCOL,Prima Andalan Mandiri Tbk.,2021-09-07T00:00:00,3555560000.0,Utama
+RSGK,Kedoya Adyaraya Tbk.,2021-09-08T00:00:00,929675000.0,Utama
+RUNS,Global Sukses Solusi Tbk.,2021-09-08T00:00:00,983557875.0,Akselerasi
+SBMA,Surya Biru Murni Acetylene Tbk,2021-09-08T00:00:00,929926282.0,Pengembangan
+CMNT,Cemindo Gemilang Tbk.,2021-09-08T00:00:00,17125504000.0,Pengembangan
+GTSI,GTS Internasional Tbk.,2021-09-08T00:00:00,15819142767.0,Pemantauan Khusus
+IDEA,Idea Indonesia Akademi Tbk.,2021-09-09T00:00:00,1062437500.0,Akselerasi
+KUAS,Ace Oldfields Tbk.,2021-10-25T00:00:00,1292808150.0,Pengembangan
+BOBA,Formosa Ingredient Factory Tbk,2021-11-01T00:00:00,1155750000.0,Pengembangan
+MTEL,Dayamitra Telekomunikasi Tbk.,2021-11-22T00:00:00,83559636344.0,Utama
+DEPO,Caturkarda Depo Bangunan Tbk.,2021-11-25T00:00:00,6790000000.0,Pengembangan
+BINO,Perma Plasindo Tbk.,2021-11-25T00:00:00,2275316111.0,Pengembangan
+CMRY,Cisarua Mountain Dairy Tbk.,2021-12-06T00:00:00,7934683000.0,Utama
+WGSH,Wira Global Solusi Tbk.,2021-12-06T00:00:00,1042500000.0,Akselerasi
+TAYS,Jaya Swarasa Agung Tbk.,2021-12-06T00:00:00,1098920000.0,Pengembangan
+WMPP,Widodo Makmur Perkasa Tbk.,2021-12-06T00:00:00,29419000000.0,Pemantauan Khusus
+RMKE,RMK Energy Tbk.,2021-12-07T00:00:00,4375000000.0,Utama
+OBMD,OBM Drilchem Tbk.,2021-12-08T00:00:00,805992931.0,Pengembangan
+AVIA,Avia Avian Tbk.,2021-12-08T00:00:00,61953555600.0,Utama
+IPPE,Indo Pureco Pratama Tbk.,2021-12-09T00:00:00,4600000000.0,Pemantauan Khusus
+NASI,Wahana Inti Makmur Tbk.,2021-12-13T00:00:00,807400000.0,Pengembangan
+BSML,Bintang Samudera Mandiri Lines,2021-12-16T00:00:00,1850225000.0,Pengembangan
+DRMA,Dharma Polimetal Tbk.,2021-12-20T00:00:00,4705882300.0,Utama
+ADMR,Adaro Minerals Indonesia Tbk.,2022-01-03T00:00:00,40882331500.0,Utama
+SEMA,Semacom Integrated Tbk.,2022-01-10T00:00:00,1347258842.0,Pengembangan
+ASLC,Autopedia Sukses Lestari Tbk.,2022-01-25T00:00:00,12746354780.0,Pengembangan
+NETV,MDTV Media Technologies Tbk.,2022-01-26T00:00:00,41360517722.0,Pemantauan Khusus
+BAUT,Mitra Angkasa Sejahtera Tbk.,2022-01-28T00:00:00,4800182969.0,Pemantauan Khusus
+ENAK,Champ Resto Indonesia Tbk.,2022-02-08T00:00:00,2166666800.0,Pengembangan
+NTBK,Nusatama Berkah Tbk.,2022-02-09T00:00:00,2700064877.0,Pengembangan
+SMKM,Sumber Mas Konstruksi Tbk.,2022-03-09T00:00:00,1253000000.0,Akselerasi
+STAA,Sumber Tani Agung Resources Tb,2022-03-10T00:00:00,10903372600.0,Utama
+NANO,Nanotech Indonesia Global Tbk.,2022-03-10T00:00:00,4285255666.0,Akselerasi
+BIKE,Sepeda Bersama Indonesia Tbk.,2022-03-21T00:00:00,1293916404.0,Pengembangan
+WIRG,WIR ASIA Tbk.,2022-04-04T00:00:00,11938622394.0,Pengembangan
+SICO,Sigma Energy Compressindo Tbk.,2022-04-08T00:00:00,910057234.0,Pengembangan
+GOTO,GoTo Gojek Tokopedia Tbk.,2022-04-11T00:00:00,1140573267220.0,Ekonomi Baru
+TLDN,Teladan Prima Agro Tbk.,2022-04-12T00:00:00,12946530200.0,Pengembangan
+MTMH,Murni Sadar Tbk.,2022-04-20T00:00:00,2068526950.0,Utama
+WINR,Winner Nusantara Jaya Tbk.,2022-04-25T00:00:00,5235307783.0,Pemantauan Khusus
+IBOS,Indo Boga Sukses Tbk.,2022-04-25T00:00:00,8065789529.0,Akselerasi
+OLIV,Oscar Mitra Sukses Sejahtera T,2022-05-17T00:00:00,1900073314.0,Akselerasi
+ASHA,Cilacap Samudera Fishing Indus,2022-05-27T00:00:00,5000000000.0,Pemantauan Khusus
+SWID,Saraswanti Indoland Developmen,2022-07-07T00:00:00,5385019201.0,Pengembangan
+TRGU,Cerestar Indonesia Tbk.,2022-07-08T00:00:00,7945412700.0,Utama
+ARKO,Arkora Hydro Tbk.,2022-07-08T00:00:00,2928495000.0,Pengembangan
+CHEM,Chemstar Indonesia Tbk.,2022-07-08T00:00:00,1700014594.0,Pengembangan
+DEWI,Dewi Shri Farmindo Tbk.,2022-07-18T00:00:00,2000000000.0,Pengembangan
+AXIO,Tera Data Indonusa Tbk.,2022-07-20T00:00:00,5840126500.0,Utama
+KRYA,Bangun Karya Perkasa Jaya Tbk.,2022-07-25T00:00:00,1663943474.0,Pengembangan
+HATM,Habco Trans Maritima Tbk.,2022-07-26T00:00:00,7000000000.0,Utama
+RCCC,Utama Radar Cahaya Tbk.,2022-08-02T00:00:00,787500000.0,Akselerasi
+GULA,Aman Agrindo Tbk.,2022-08-03T00:00:00,1070362500.0,Pengembangan
+JARR,Jhonlin Agro Raya Tbk.,2022-08-04T00:00:00,9230665050.0,Utama
+AMMS,Agung Menjangan Mas Tbk.,2022-08-04T00:00:00,1200061336.0,Akselerasi
+RAFI,Sari Kreasi Boga Tbk.,2022-08-05T00:00:00,3128140475.0,Pemantauan Khusus
+KKES,Kusuma Kemindo Sentosa Tbk.,2022-08-08T00:00:00,1500000000.0,Pemantauan Khusus
+ELPI,Pelayaran Nasional Ekalya Purn,2022-08-08T00:00:00,7412000000.0,Utama
+EURO,Estee Gold Feet Tbk.,2022-08-08T00:00:00,2548826428.0,Akselerasi
+KLIN,Klinko Karya Imaji Tbk.,2022-08-09T00:00:00,1307530330.0,Akselerasi
+TOOL,Rohartindo Nusantara Luas Tbk.,2022-08-09T00:00:00,2050020320.0,Pengembangan
+BUAH,Segar Kumala Indonesia Tbk.,2022-08-09T00:00:00,1000000000.0,Pengembangan
+CRAB,Toba Surimi Industries Tbk.,2022-08-10T00:00:00,1950000000.0,Pengembangan
+MEDS,Hetzer Medical Indonesia Tbk.,2022-08-10T00:00:00,1562500000.0,Pengembangan
+COAL,Black Diamond Resources Tbk.,2022-09-07T00:00:00,6250000000.0,Pemantauan Khusus
+PRAY,Famon Awal Bros Sedaya Tbk.,2022-11-08T00:00:00,13959422300.0,Pengembangan
+CBUT,Citra Borneo Utama Tbk.,2022-11-08T00:00:00,3125000000.0,Pemantauan Khusus
+BELI,Global Digital Niaga Tbk.,2022-11-08T00:00:00,131000399381.0,Ekonomi Baru
+MKTR,Menthobi Karyatama Raya Tbk.,2022-11-08T00:00:00,12052398122.0,Utama
+OMED,Jayamas Medica Industri Tbk.,2022-11-08T00:00:00,27058850000.0,Utama
+BSBK,Wulandari Bangun Laksana Tbk.,2022-11-08T00:00:00,25091882375.0,Utama
+PDPP,Primadaya Plastisindo Tbk.,2022-11-09T00:00:00,3061341438.0,Pengembangan
+KDTN,Puri Sentul Permai Tbk.,2022-11-09T00:00:00,1250023298.0,Pengembangan
+ZATA,Bersama Zatta Jaya Tbk.,2022-11-10T00:00:00,8496000000.0,Pemantauan Khusus
+NINE,Techno9 Indonesia Tbk.,2022-12-05T00:00:00,2157000000.0,Akselerasi
+MMIX,Multi Medika Internasional Tbk,2022-12-06T00:00:00,2400212690.0,Pengembangan
+PADA,Personel Alih Daya Tbk.,2022-12-08T00:00:00,3150000000.0,Pemantauan Khusus
+ISAP,Isra Presisi Indonesia Tbk.,2022-12-09T00:00:00,4020096305.0,Akselerasi
+VTNY,Venteny Fortuna International ,2022-12-15T00:00:00,6265193445.0,Utama
+SOUL,Mitra Tirta Buwana Tbk.,2023-01-06T00:00:00,1082526223.0,Akselerasi
+ELIT,Data Sinergitama Jaya Tbk.,2023-01-06T00:00:00,2031643057.0,Pengembangan
+BEER,Jobubu Jarum Minahasa Tbk.,2023-01-06T00:00:00,4000000000.0,Pengembangan
+CBPE,Citra Buana Prasida Tbk.,2023-01-06T00:00:00,1356250000.0,Pengembangan
+SUNI,Sunindo Pratama Tbk.,2023-01-09T00:00:00,2500000000.0,Utama
+CBRE,Cakra Buana Resources Energi T,2023-01-09T00:00:00,4538067441.0,Pemantauan Khusus
+WINE,Hatten Bali Tbk.,2023-01-10T00:00:00,2710000000.0,Pengembangan
+BMBL,Lavender Bina Cendikia Tbk.,2023-01-11T00:00:00,1030080995.0,Akselerasi
+PEVE,Penta Valent Tbk.,2023-01-24T00:00:00,1765625000.0,Pengembangan
+LAJU,Jasa Berdikari Logistics Tbk.,2023-01-27T00:00:00,2149942974.0,Pengembangan
+FWCT,Wijaya Cahaya Timber Tbk.,2023-02-01T00:00:00,1875000000.0,Pengembangan
+NAYZ,Hassana Boga Sejahtera Tbk.,2023-02-06T00:00:00,2550011472.0,Akselerasi
+IRSX,Aviana Sinar Abadi Tbk.,2023-02-07T00:00:00,5000356706.0,Pemantauan Khusus
+PACK,Abadi Nusantara Hijau Investam,2023-02-08T00:00:00,1597398988.0,Akselerasi
+VAST,Vastland Indonesia Tbk.,2023-02-08T00:00:00,3055715621.0,Pengembangan
+CHIP,Pelita Teknologi Global Tbk.,2023-02-08T00:00:00,806000000.0,Akselerasi
+HALO,Haloni Jane Tbk.,2023-02-08T00:00:00,5650018332.0,Pengembangan
+KING,Hoffmen Cleanindo Tbk.,2023-02-16T00:00:00,2600361227.0,Akselerasi
+PGEO,Pertamina Geothermal Energy Tb,2023-02-24T00:00:00,41508024149.0,Utama
+FUTR,Lini Imaji Kreasi Ekosistem Tb,2023-02-27T00:00:00,6451294579.0,Pengembangan
+HILL,Hillcon Tbk.,2023-03-01T00:00:00,2948300000.0,Utama
+BDKR,Berdikari Pondasi Perkasa Tbk.,2023-03-03T00:00:00,4725101522.0,Utama
+PTMP,Mitra Pack Tbk.,2023-03-06T00:00:00,3169200000.0,Pengembangan
+SAGE,Saptausaha Gemilangindah Tbk.,2023-03-08T00:00:00,8033274759.0,Pemantauan Khusus
+TRON,Teknologi Karya Digital Nusa T,2023-03-08T00:00:00,2951301462.0,Pengembangan
+CUAN,Petrindo Jaya Kreasi Tbk.,2023-03-08T00:00:00,11241890000.0,Utama
+NSSS,Nusantara Sawit Sejahtera Tbk.,2023-03-10T00:00:00,23801568645.0,Pengembangan
+GTRA,Grahaprima Suksesmandiri Tbk.,2023-03-30T00:00:00,1894375000.0,Pengembangan
+HAJJ,Arsy Buana Travelindo Tbk.,2023-04-05T00:00:00,2290541340.0,Akselerasi
+PIPA,Multi Makmur Lemindo Tbk.,2023-04-10T00:00:00,3425040452.0,Pemantauan Khusus
+NCKL,Trimegah Bangun Persada Tbk.,2023-04-12T00:00:00,63098600000.0,Utama
+MENN,Menn Teknologi Indonesia Tbk.,2023-04-18T00:00:00,1434052006.0,Akselerasi
+AWAN,Era Digital Media Tbk.,2023-04-18T00:00:00,3435000000.0,Pengembangan
+MBMA,Merdeka Battery Materials Tbk.,2023-04-18T00:00:00,107995419900.0,Pengembangan
+RAAM,Tripar Multivision Plus Tbk.,2023-05-08T00:00:00,6813620000.0,Utama
+DOOH,Era Media Sejahtera Tbk.,2023-05-08T00:00:00,7737582423.0,Pengembangan
+JATI,Informasi Teknologi Indonesia ,2023-05-08T00:00:00,3262520106.0,Pengembangan
+TYRE,King Tire Indonesia Tbk.,2023-05-08T00:00:00,3478050807.0,Pengembangan
+MPXL,MPX Logistics International Tb,2023-05-09T00:00:00,2000014587.0,Pengembangan
+SMIL,Sarana Mitra Luas Tbk.,2023-05-12T00:00:00,8750173838.0,Utama
+KLAS,Pelayaran Kurnia Lautan Semest,2023-06-12T00:00:00,3644415975.0,Pengembangan
+MAXI,Maxindo Karya Anugerah Tbk.,2023-06-12T00:00:00,9610083060.0,Pengembangan
+VKTR,VKTR Teknologi Mobilitas Tbk.,2023-06-19T00:00:00,43750000000.0,Pengembangan
+RELF,Graha Mitra Asia Tbk.,2023-06-22T00:00:00,5727832195.0,Akselerasi
+AMMN,Amman Mineral Internasional Tb,2023-07-07T00:00:00,72518217656.0,Utama
+CRSN,Carsurin Tbk.,2023-07-10T00:00:00,2892000000.0,Pengembangan
+GRPM,Graha Prima Mentari Tbk.,2023-07-10T00:00:00,1545063268.0,Akselerasi
+WIDI,Widiant Jaya Krenindo Tbk.,2023-07-10T00:00:00,1600031683.0,Akselerasi
+TGUK,Platinum Wahab Nusantara Tbk.,2023-07-10T00:00:00,3571451815.0,Pengembangan
+INET,Sinergi Inti Andalan Prima Tbk,2023-07-24T00:00:00,7567356578.0,Pengembangan
+MAHA,Mandiri Herindo Adiperkasa Tbk,2023-07-25T00:00:00,16666000000.0,Utama
+RMKO,Royaltama Mulia Kontraktorindo,2023-07-31T00:00:00,1250000000.0,Pengembangan
+CNMA,Nusantara Sejahtera Raya Tbk.,2023-08-02T00:00:00,83345000000.0,Utama
+FOLK,Multi Garam Utama Tbk.,2023-08-07T00:00:00,3948141464.0,Pengembangan
+HBAT,Minahasa Membangun Hebat Tbk.,2023-08-07T00:00:00,1040740800.0,Akselerasi
+GRIA,Ingria Pratama Capitalindo Tbk,2023-08-08T00:00:00,7375720674.0,Pengembangan
+PPRI,Paperocks Indonesia Tbk.,2023-08-08T00:00:00,1075027288.0,Pengembangan
+ERAL,Sinar Eka Selaras Tbk.,2023-08-08T00:00:00,5187500000.0,Utama
+CYBR,ITSEC Asia Tbk.,2023-08-08T00:00:00,6526951798.0,Pengembangan
+MUTU,Mutuagung Lestari Tbk.,2023-08-09T00:00:00,3142892746.0,Pengembangan
+LMAX,Lupromax Pelumas Indonesia Tbk,2023-08-09T00:00:00,650008775.0,Akselerasi
+HUMI,Humpuss Maritim Internasional ,2023-08-09T00:00:00,18046516702.0,Pengembangan
+MSIE,Multisarana Intan Eduka Tbk.,2023-08-10T00:00:00,1460007754.0,Akselerasi
+RSCH,Charlie Hospital Semarang Tbk.,2023-08-28T00:00:00,2650000000.0,Pengembangan
+BABY,Multitrend Indo Tbk.,2023-09-07T00:00:00,2616226706.0,Pengembangan
+AEGS,Anugerah Spareparts Sejahtera ,2023-09-11T00:00:00,1006080721.0,Pemantauan Khusus
+IOTF,Sumber Sinergi Makmur Tbk.,2023-10-06T00:00:00,5290298067.0,Pengembangan
+KOCI,Kokoh Exa Nusantara Tbk.,2023-10-07T00:00:00,4415593100.0,Pengembangan
+PTPS,Pulau Subur Tbk.,2023-10-09T00:00:00,2167514856.0,Pengembangan
+BREN,Barito Renewables Energy Tbk.,2023-10-09T00:00:00,133786220000.0,Utama
+STRK,Lovina Beach Brewery Tbk.,2023-10-10T00:00:00,10721835562.0,Pengembangan
+KOKA,Koka Indonesia Tbk.,2023-10-11T00:00:00,2861333000.0,Pemantauan Khusus
+LOPI,Logisticsplus International Tb,2023-10-11T00:00:00,1100011289.0,Akselerasi
+UDNG,Agro Bahari Nusantara Tbk.,2023-10-31T00:00:00,1750040072.0,Akselerasi
+RGAS,Kian Santang Muliatama Tbk.,2023-11-08T00:00:00,1459234110.0,Pengembangan
+MSTI,Mastersystem Infotama Tbk.,2023-11-08T00:00:00,3139416200.0,Utama
+IKPM,Ikapharmindo Putramas Tbk.,2023-11-08T00:00:00,1684662500.0,Pengembangan
+AYAM,Janu Putra Sejahtera Tbk.,2023-11-30T00:00:00,4000000000.0,Pengembangan
+SURI,Maja Agung Latexindo Tbk.,2023-12-07T00:00:00,6334375000.0,Pengembangan
+ASLI,Asri Karya Lestari Tbk.,2024-01-05T00:00:00,6250000000.0,Pengembangan
+CGAS,Citra Nusantara Gemilang Tbk.,2024-01-08T00:00:00,1771499039.0,Pengembangan
+NICE,Adhi Kartiko Pratama Tbk.,2024-01-09T00:00:00,6082020000.0,Pengembangan
+MSJA,Multi Spunindo Jaya Tbk.,2024-01-10T00:00:00,5882352900.0,Utama
+SMLE,Sinergi Multi Lestarindo Tbk.,2024-01-10T00:00:00,2328153048.0,Pengembangan
+ACRO,Samcro Hyosung Adilestari Tbk.,2024-01-11T00:00:00,3469167472.0,Pengembangan
+MANG,Manggung Polahraya Tbk.,2024-01-11T00:00:00,3812502885.0,Akselerasi
+GRPH,Griptha Putra Persada Tbk.,2024-01-17T00:00:00,1000000000.0,Pengembangan
+SMGA,Sumber Mineral Global Abadi Tb,2024-01-30T00:00:00,8750000000.0,Pengembangan
+UNTD,Terang Dunia Internusa Tbk.,2024-02-07T00:00:00,6666666700.0,Pengembangan
+TOSK,Topindo Solusi Komunika Tbk.,2024-02-07T00:00:00,4375277300.0,Pengembangan
+MPIX,Mitra Pedagang Indonesia Tbk.,2024-02-07T00:00:00,1562500000.0,Pengembangan
+ALII,Ancara Logistics Indonesia Tbk,2024-02-07T00:00:00,15825800000.0,Utama
+MKAP,Multikarya Asia Pasifik Raya T,2024-02-12T00:00:00,3250000000.0,Pengembangan
+MEJA,Harta Djaya Karya Tbk.,2024-02-12T00:00:00,1917500000.0,Akselerasi
+LIVE,Homeco Victoria Makmur Tbk.,2024-02-12T00:00:00,4593005014.0,Pengembangan
+HYGN,Ecocare Indo Pasifik Tbk.,2024-02-13T00:00:00,2525000000.0,Pengembangan
+BAIK,Bersama Mencapai Puncak Tbk.,2024-02-15T00:00:00,1125000000.0,Pengembangan
+VISI,Satu Visi Putra Tbk.,2024-02-27T00:00:00,3075000000.0,Pengembangan
+AREA,Dunia Virtual Online Tbk.,2024-04-01T00:00:00,2539601000.0,Pengembangan
+MHKI,Multi Hanna Kreasindo Tbk.,2024-04-16T00:00:00,3750000000.0,Pengembangan
+ATLA,Atlantis Subsea Indonesia Tbk.,2024-04-16T00:00:00,6199560766.0,Pengembangan
+DATA,Remala Abadi Tbk.,2024-05-07T00:00:00,1375000000.0,Pengembangan
+SOLA,Xolare RCR Energy Tbk.,2024-05-08T00:00:00,3283812500.0,Pengembangan
+BATR,Benteng Api Technic Tbk.,2024-06-10T00:00:00,3025027385.0,Pengembangan
+SPRE,Soraya Berjaya Indonesia Tbk.,2024-07-03T00:00:00,800000000.0,Akselerasi
+PART,Cipta Perdana Lancar Tbk.,2024-07-05T00:00:00,2720000000.0,Pengembangan
+GOLF,Intra Golflink Resorts Tbk.,2024-07-08T00:00:00,19486760000.0,Utama
+ISEA,Indo American Seafoods Tbk.,2024-07-08T00:00:00,1390005198.0,Pengembangan
+BLES,Superior Prima Sukses Tbk.,2024-07-08T00:00:00,8890206400.0,Utama
+GUNA,Gunanusa Eramandiri Tbk.,2024-07-09T00:00:00,2500000000.0,Pengembangan
+LABS,UBC Medical Indonesia Tbk.,2024-07-10T00:00:00,3950000000.0,Pengembangan
+DOSS,Global Sukses Digital Tbk.,2024-08-07T00:00:00,1725000000.0,Pengembangan
+NEST,Esta Indonesia Tbk.,2024-08-08T00:00:00,4112500000.0,Pengembangan
+PTMR,Master Print Tbk.,2024-10-08T00:00:00,1907000000.0,Pengembangan
+VERN,Verona Indah Pictures Tbk.,2024-10-08T00:00:00,4765525000.0,Pengembangan
+DAAZ,Daaz Bara Lestari Tbk.,2024-11-11T00:00:00,1997000000.0,Utama
+BOAT,Newport Marine Services Tbk.,2024-11-12T00:00:00,3501680000.0,Pengembangan
+NAIK,Adiwarna Anugerah Abadi Tbk.,2024-11-13T00:00:00,3250000000.0,Pengembangan
+AADI,Adaro Andalan Indonesia Tbk.,2024-12-05T00:00:00,7786891760.0,Utama
+MDIY,Daya Intiguna Yasa Tbk.,2024-12-19T00:00:00,25190392000.0,Utama
+KSIX,Kentanix Supra International T,2025-01-08T00:00:00,2137831800.0,Utama
+RATU,Raharja Energi Cepu Tbk.,2025-01-08T00:00:00,2715053800.0,Pengembangan
+YOII,Asuransi Digital Bersama Tbk.,2025-01-08T00:00:00,3424687500.0,Pengembangan
+HGII,Hero Global Investment Tbk.,2025-01-09T00:00:00,6500000000.0,Pengembangan
+BRRC,Raja Roti Cemerlang Tbk.,2025-01-09T00:00:00,971500000.0,Pengembangan
+DGWG,Delta Giri Wacana Tbk.,2025-01-13T00:00:00,5882353000.0,Utama
+CBDK,Bangun Kosambi Sukses Tbk.,2025-01-13T00:00:00,5668944500.0,Utama
+OBAT,Brigit Biofarmaka Teknologi Tb,2025-01-13T00:00:00,600000000.0,Pengembangan
+SOSS,Shield On Service Tbk.,2018-11-06T00:00:00,799414231.0,Pemantauan Khusus
+DEAL,Dewata Freightinternational Tb,2018-11-11T00:00:00,1146170959.0,Pemantauan Khusus
+POLA,Pool Advista Finance Tbk.,2018-11-16T00:00:00,3351075600.0,Pemantauan Khusus
+DIVA,Distribusi Voucher Nusantara T,2018-11-27T00:00:00,1428571400.0,Pengembangan
+LUCK,Sentral Mitra Informatika Tbk.,2018-11-28T00:00:00,715749640.0,Pengembangan
+URBN,Urban Jakarta Propertindo Tbk.,2018-12-10T00:00:00,3232122640.0,Pengembangan
+SOTS,Satria Mega Kencana Tbk.,2018-12-10T00:00:00,1000003979.0,Pengembangan
+AMAN,Makmur Berkah Amanda Tbk.,2020-03-13T00:00:00,3873500000.0,Pengembangan
+CARE,Metro Healthcare Indonesia Tbk,2020-03-13T00:00:00,33250000000.0,Pengembangan
+SAMF,Saraswanti Anugerah Makmur Tbk,2020-03-31T00:00:00,10250000000.0,Utama
+SBAT,Sejahtera Bintang Abadi Textil,2020-04-08T00:00:00,4752982378.0,Pemantauan Khusus
+KBAG,Karya Bersama Anugerah Tbk.,2020-04-08T00:00:00,7150002603.0,Pemantauan Khusus
+CBMF,Cahaya Bintang Medan Tbk.,2020-04-09T00:00:00,1875000000.0,Pemantauan Khusus
+RONY,Aesler Grup Internasional Tbk.,2020-04-09T00:00:00,1250000000.0,Pengembangan

--- a/screener/lib/elliott.js
+++ b/screener/lib/elliott.js
@@ -1,0 +1,277 @@
+/**
+ * Elliott Wave (5-wave impulse, bullish) detection using Fibonacci confluence.
+ *
+ * This is a rule-based HEURISTIC, not a certified wave count. Real Elliott
+ * Wave analysis is subjective even between professional analysts — this
+ * checks the textbook Fibonacci/structure rules (Frost & Prechter,
+ * "Elliott Wave Principle") mechanically against zigzag pivots:
+ *
+ *   Rule (hard, must hold):
+ *     - Wave 2 never retraces more than 100% of wave 1.
+ *     - Wave 3 is never the shortest of waves 1/3/5.
+ *     - Wave 4 does not enter wave 1's price territory.
+ *   Guideline (soft, used for confidence/Fibonacci confirmation):
+ *     - Wave 2 typically retraces 50%-78.6% of wave 1.
+ *     - Wave 3 is often 1.618x wave 1 (allow 1.0x-2.618x).
+ *     - Wave 4 typically retraces 23.6%-38.2% of wave 3.
+ *     - Wave 5 projects 0.618x-1.618x of wave 1's length from the wave 4 low.
+ */
+
+const FIB = { w2min: 0.382, w2max: 0.786, w4min: 0.236, w4max: 0.5, w3minMult: 1.0 };
+
+// A wave count is only a live, actionable signal if it topped/broke out
+// recently. Over a long lookback, an old-but-structurally-valid impulse can
+// sit far behind current price with a "target" already left behind —
+// bounding how many bars ago the count's most recent point occurred keeps
+// matches fresh.
+const MAX_WAVE_AGE_BARS = 20;
+
+export function detectElliottImpulse(bars, pivots) {
+  if (pivots.length < 6) return null;
+  const lastBar = bars[bars.length - 1];
+  const lastClose = lastBar.close;
+  if (!(lastBar.close > lastBar.open)) return null; // require today's candle to close green — a live bounce, not a stale/declining read
+
+  // Look at the most recent 6 alternating pivots: 0(low) 1(high) 2(low) 3(high) 4(low) 5(high)
+  const last6 = pivots.slice(-6);
+  const types = last6.map(p => p.type);
+  const expected = ['low', 'high', 'low', 'high', 'low', 'high'];
+  if (types.join(',') !== expected.join(',')) return null;
+
+  const [w0, w1, w2, w3, w4, w5] = last6;
+  if (bars.length - 1 - w5.index > MAX_WAVE_AGE_BARS) return null; // wave 5 topped too long ago — stale
+
+  const wave1Len = w1.price - w0.price;
+  const wave2Len = w1.price - w2.price;
+  const wave3Len = w3.price - w2.price;
+  const wave4Len = w3.price - w4.price;
+  const wave5Len = w5.price - w4.price;
+
+  if (wave1Len <= 0 || wave3Len <= 0 || wave5Len <= 0) return null;
+
+  // Hard rules
+  const w2RetraceRatio = wave2Len / wave1Len;
+  if (w2RetraceRatio >= 1) return null; // wave2 retraced 100%+ of wave1 — invalid
+  if (w4.price <= w1.price) return null; // wave4 overlapped wave1 territory — invalid
+  const lengths = [wave1Len, wave3Len, wave5Len];
+  if (wave3Len === Math.min(...lengths)) return null; // wave3 is the shortest — invalid
+
+  // Fibonacci confluence checks — previously scored as an informational
+  // "N/3" confidence label that never actually filtered anything, so a
+  // count that failed every guideline still matched just as readily as a
+  // textbook-perfect one. Now required in full: all three must hold or the
+  // count is rejected outright, not flagged "low confidence" and shown anyway.
+  const w4RetraceRatio = wave4Len / wave3Len;
+  const w3Multiple = wave3Len / wave1Len;
+  const w2FibOk = w2RetraceRatio >= FIB.w2min && w2RetraceRatio <= FIB.w2max;
+  const w3FibOk = w3Multiple >= FIB.w3minMult;
+  const w4FibOk = w4RetraceRatio >= FIB.w4min && w4RetraceRatio <= FIB.w4max;
+  if (!w2FibOk || !w3FibOk || !w4FibOk) return null;
+
+  const uptrendConfirmed = lastClose > w4.price && w5.price > w3.price;
+  if (!uptrendConfirmed) return null;
+
+  const wave5TargetsFromWave1 = {
+    tp1_0618: Math.round((w4.price + 0.618 * wave1Len) * 1e6) / 1e6,
+    tp2_1000: Math.round((w4.price + 1.0 * wave1Len) * 1e6) / 1e6,
+    extended_1618: Math.round((w4.price + 1.618 * wave1Len) * 1e6) / 1e6,
+  };
+
+  return {
+    matched: true,
+    confirmed_uptrend: true,
+    confidence: '3/3 fib checks (wave2/wave3/wave4 semua dalam zona ideal)',
+    wave_points: { w0, w1, w2, w3, w4, w5 },
+    wave2_retrace_pct: Math.round(w2RetraceRatio * 1000) / 10,
+    wave3_multiple_of_wave1: Math.round(w3Multiple * 100) / 100,
+    wave4_retrace_pct: Math.round(w4RetraceRatio * 1000) / 10,
+    invalidation_level: w4.price, // wave 4 low — a close below this breaks the count
+    wave5_targets: wave5TargetsFromWave1,
+  };
+}
+
+/**
+ * Wave 2 defended — the earliest, most aggressive entry of the three Elliott
+ * screens. Wave 1 (impulse up) is confirmed; price has pulled back since
+ * without ever exceeding wave 1's high (the pullback prints a structural
+ * "lower high" against wave 1); and today's candle closes green — the first
+ * sign buyers are defending the correction and the uptrend character is
+ * being preserved rather than reversing into a new downtrend.
+ *
+ * This is the LEAST confirmed of the three reads: wave 2 may not have
+ * finished falling yet, so the pullback low used for cutloss/targets is
+ * "the lowest point so far," not a guaranteed final bottom.
+ *
+ *   Hard rule: wave 2 must not retrace 100%+ of wave 1 (else it's a trend
+ *              reversal, not a correction).
+ *   Trigger:   pullback hasn't exceeded wave 1's high, AND today's candle
+ *              closed green (close > open).
+ *   Guideline: wave 2 retracing 38.2%-78.6% of wave 1 is the classic zone;
+ *              tracked as a confidence flag, not a hard filter.
+ */
+export function detectElliottWave2Support(bars, pivots) {
+  const highs = pivots.filter(p => p.type === 'high');
+  const lows = pivots.filter(p => p.type === 'low');
+  if (highs.length < 1 || lows.length < 1) return null;
+
+  const w1 = highs[highs.length - 1]; // most recent confirmed high = wave 1 top candidate
+  const w0 = [...lows].reverse().find(l => l.index < w1.index); // the low before it = wave 1 start
+  if (!w0) return null;
+  if (bars.length - 1 - w1.index > MAX_WAVE_AGE_BARS) return null; // wave 1 top happened too long ago — stale
+
+  const wave1Len = w1.price - w0.price;
+  if (wave1Len <= 0) return null;
+
+  const afterW1 = bars.slice(w1.index + 1);
+  if (afterW1.length < 2) return null; // need at least a little pullback to read anything
+
+  const maxHighAfter = Math.max(...afterW1.map(b => b.high));
+  if (maxHighAfter > w1.price) return null; // already broke above wave 1 — that's wave 3 territory, not wave 2
+
+  const lastBar = bars[bars.length - 1];
+  if (!(lastBar.close > lastBar.open)) return null; // need today's candle actively defending the pullback
+
+  const pullbackLow = Math.min(...afterW1.map(b => b.low));
+  const wave2Len = w1.price - pullbackLow;
+  const w2RetraceRatio = wave2Len / wave1Len;
+  if (w2RetraceRatio >= 1) return null; // retraced 100%+ of wave1 — invalid, this is a reversal not a correction
+
+  // Previously a soft "confidence" label that still returned a match even
+  // outside the classic zone ("waspada" but shown anyway). Now required —
+  // a retrace outside 38.2%-78.6% doesn't fit the textbook wave 2 profile
+  // closely enough to surface as a signal.
+  const fibOk = w2RetraceRatio >= FIB.w2min && w2RetraceRatio <= FIB.w2max;
+  if (!fibOk) return null;
+
+  return {
+    matched: true,
+    confirmed_uptrend: true,
+    confidence: 'wave2 retrace dalam zona fib 38.2%-78.6%',
+    wave_points: { w0, w1 },
+    pullback_low: pullbackLow,
+    wave2_retrace_pct: Math.round(w2RetraceRatio * 1000) / 10,
+    invalidation_level: pullbackLow, // a close back below the pullback-so-far low breaks the "defended" read
+    wave3_targets: {
+      // Backtest (100 symbols, N=252) showed only a 25.6% win rate against
+      // the tight stop below — 1.618x wave 1 as TP1 was too far to reach
+      // before the stop typically got hit, even when the eventual direction
+      // was right. Nearer first target (0.618x), the old TP1/TP2 shifted out
+      // to TP2/extended.
+      tp0_0618: Math.round((pullbackLow + 0.618 * wave1Len) * 1e6) / 1e6,
+      tp1_1618: Math.round((pullbackLow + 1.618 * wave1Len) * 1e6) / 1e6,
+      tp2_2618: Math.round((pullbackLow + 2.618 * wave1Len) * 1e6) / 1e6,
+      extended_4236: Math.round((pullbackLow + 4.236 * wave1Len) * 1e6) / 1e6,
+    },
+  };
+}
+
+// Named Fibonacci retracement zones for classifying how deep a wave 2
+// pullback went, per the four categories requested: shallow (strong trend),
+// deep pullback, the wide golden zone, and the tight golden pocket right at
+// 61.8%. Bands are non-overlapping; a retracement outside all four (too
+// shallow to be a real pullback, or beyond ~65%) doesn't qualify for THIS
+// criterion — it may still qualify for the broader detectElliottWave2Support
+// above, which tolerates up to 78.6%.
+const FIB_ZONES = [
+  { min: 0.236, max: 0.382, label: 'Retracement Dangkal 23.6%-38.2% (trend kuat)' },
+  { min: 0.382, max: 0.5, label: 'Retracement Dalam 38.2%+ (deep pullback)' },
+  { min: 0.5, max: 0.618, label: 'Golden Zone Lebar 50%-61.8%' },
+  { min: 0.618, max: 0.65, label: 'Golden Pocket 61.8%' },
+];
+
+function classifyFibZone(ratio) {
+  return FIB_ZONES.find(z => ratio >= z.min && ratio <= z.max) ?? null;
+}
+
+/**
+ * Uptrend pullback reversal — wave 1 confirmed, a wave 2 correction landed in
+ * one of the four named Fibonacci retracement zones, and today's candle
+ * closes green, confirming buyers stepped back in. Reports which Elliott
+ * wave the move sits in (always "wave 2" here by construction — if price
+ * already broke above wave 1's high that's wave 3+ territory and this
+ * detector intentionally does not fire; there is no wave 5 case to report
+ * since this only looks at the wave 1->2 stage).
+ *
+ * Confirmation is Fibonacci-only — an earlier version also accepted a
+ * retracement landing near a known horizontal support zone as an
+ * alternative trigger with no depth limit of its own, which let a ~95-96%
+ * retracement (barely short of fully invalidating wave 1) through as a
+ * "wave 2." That's outside where Elliott Wave theory still calls it a
+ * correction rather than a failed count, so the support-zone path was
+ * dropped; the classify-by-fib-zone path already implicitly caps depth at
+ * 65% (the widest zone, Golden Pocket).
+ *
+ *   Hard rule:  wave 2 must not retrace 100%+ of wave 1.
+ *   Trigger:    pullback hasn't exceeded wave 1's high, AND today's candle
+ *               closed green, AND the pullback lands in a named fib zone.
+ */
+export function detectPullbackReversal(bars, pivots) {
+  const highs = pivots.filter(p => p.type === 'high');
+  const lows = pivots.filter(p => p.type === 'low');
+  if (highs.length < 1 || lows.length < 1) return null;
+
+  const w1 = highs[highs.length - 1];
+  const w0 = [...lows].reverse().find(l => l.index < w1.index);
+  if (!w0) return null;
+  if (bars.length - 1 - w1.index > MAX_WAVE_AGE_BARS) return null;
+
+  const wave1Len = w1.price - w0.price;
+  if (wave1Len <= 0) return null;
+
+  const afterW1 = bars.slice(w1.index + 1);
+  if (afterW1.length < 2) return null;
+
+  const maxHighAfter = Math.max(...afterW1.map(b => b.high));
+  if (maxHighAfter > w1.price) return null; // already in wave 3+ territory, not a fresh wave 2 pullback
+
+  const lastBar = bars[bars.length - 1];
+  if (!(lastBar.close > lastBar.open)) return null; // must be a green reversal candle
+
+  const pullbackLow = Math.min(...afterW1.map(b => b.low));
+  const wave2Len = w1.price - pullbackLow;
+  const retraceRatio = wave2Len / wave1Len;
+  if (retraceRatio >= 1) return null;
+
+  const fibZone = classifyFibZone(retraceRatio);
+  if (!fibZone) return null; // must land in one of the four named zones
+
+  return {
+    matched: true,
+    elliott_wave_position: 'Wave 2 (koreksi setelah impuls wave 1)',
+    wave_points: { w0, w1 },
+    pullback_low: pullbackLow,
+    retrace_pct: Math.round(retraceRatio * 1000) / 10,
+    fib_zone: fibZone.label,
+    invalidation_level: pullbackLow,
+    targets: (() => {
+      // #1/#2: standard Fibonacci expansion off the pullback low, as
+      // multiples of wave 1's length.
+      const wave3Target = pullbackLow + 1.618 * wave1Len;
+      const wave3Length = wave3Target - pullbackLow; // == 1.618 * wave1Len, kept explicit for readability below
+
+      // #4: wave 5 target — necessarily a rough, early ballpark since waves
+      // 3 and 4 haven't happened yet. Assumes a textbook-typical wave 4
+      // retrace (38.2% of wave 3's length) as a stand-in for wave 4's
+      // (unknown) low, then applies the "wave 5 = wave 1" equality rule from
+      // there. This is a directional guess, not a level to plan an exit
+      // around — it moves once wave 3/4 actually print.
+      const estimatedWave4Low = wave3Target - 0.382 * wave3Length;
+      const wave5TargetRough = estimatedWave4Low + 1.0 * wave1Len;
+
+      return {
+        // Backtest (100 symbols, N=195) showed only a 21.4% win rate with
+        // 161.8% as the near target against a tight stop — too far to reach
+        // before the stop hit. 61.8% added as a nearer, more reachable first
+        // target; the rest shift out to become TP2/wave3/extended.
+        expansion_0618: Math.round((pullbackLow + 0.618 * wave1Len) * 1e6) / 1e6,
+        expansion_1618: Math.round(wave3Target * 1e6) / 1e6,
+        expansion_2618: Math.round((pullbackLow + 2.618 * wave1Len) * 1e6) / 1e6,
+        // #3: wave 3 target — identical figure to the 161.8% expansion above
+        // (that IS the standard wave 3 projection); kept as a separate named
+        // field only because it was asked for by name.
+        wave3_target: Math.round(wave3Target * 1e6) / 1e6,
+        wave5_target_rough: Math.round(wave5TargetRough * 1e6) / 1e6,
+      };
+    })(),
+  };
+}

--- a/screener/lib/levels.js
+++ b/screener/lib/levels.js
@@ -1,0 +1,180 @@
+/**
+ * Converts a raw detector match into a standard trading-plan shape:
+ * Buy Area / Cutloss (or trailing stop) / TP1 / TP2.
+ *
+ * Formulas follow each setup's own textbook measured-move math — this is
+ * NOT personalized financial advice, it is a mechanical application of
+ * standard technical-analysis levels. Always re-verify manually before
+ * acting; these are reference levels, not certainties.
+ */
+import { nearestResistanceAbove, nearestSupportBelow } from './support_resistance.js';
+
+function atr(bars, period = 14) {
+  const slice = bars.slice(-period - 1);
+  if (slice.length < 2) return 0;
+  let sum = 0;
+  for (let i = 1; i < slice.length; i++) {
+    const cur = slice[i], prev = slice[i - 1];
+    const tr = Math.max(cur.high - cur.low, Math.abs(cur.high - prev.close), Math.abs(cur.low - prev.close));
+    sum += tr;
+  }
+  return sum / (slice.length - 1);
+}
+
+// IDX stocks trade in whole Rupiah — round to the nearest integer for a
+// readable report instead of leaving float noise like "6316.785714".
+const round = (v) => (v == null ? null : Math.round(v));
+
+// Backtest (100 symbols) showed the wave-2-based criteria's original 0.5x
+// ATR cutloss buffer was too tight — normal day-to-day noise stopped trades
+// out before the (correctly-directioned) move had room to develop. Widened
+// to 1.5x ATR, floored at a straight 3% below the level so thin-ATR names
+// still get a meaningful buffer.
+function wideCutloss(level, bars) {
+  const a = atr(bars, 14);
+  return Math.min(level - a * 1.5, level * 0.97);
+}
+
+export function buildTradingPlan(criterion, match, bars, srZones) {
+  const plan = buildTradingPlanRaw(criterion, match, bars, srZones);
+  if (!plan) return plan;
+
+  // TP1 must be the nearer/easier target and TP2 the further one — some
+  // formulas (e.g. breakout_resistance_with_volume mixing a measured-move
+  // projection with "next resistance zone") can produce them out of order.
+  if (plan.take_profit_1 != null && plan.take_profit_2 != null && plan.take_profit_1 > plan.take_profit_2) {
+    [plan.take_profit_1, plan.take_profit_2] = [plan.take_profit_2, plan.take_profit_1];
+  }
+
+  const last = bars[bars.length - 1];
+
+  // A take-profit at or below today's close means the underlying setup's
+  // target was already reached before the pattern was even detected — the
+  // signal is stale, not a live opportunity. Reject the whole plan rather
+  // than hand back a target that's behind the current price.
+  if (plan.take_profit_1 != null && plan.take_profit_1 <= last.close) return null;
+
+  // Buy area's lower bound is the setup's actual reference point (breakout
+  // level, wave pivot, SMA50). If that's already far below today's close, the
+  // stock isn't "about to move" — it already ran. This is REJECTED outright,
+  // not clamped for display: the goal is catching names still near their base
+  // (accumulation, early breakout), not ones that already flew and are being
+  // chased. 10% is the ceiling for how extended a live setup is allowed to be.
+  const buyLow = Number(plan.buy_area.split(' - ')[0]);
+  if (buyLow < last.close * 0.90) return null;
+
+  // Cutloss must sit strictly below the buy area —
+  // a stop level at or inside the entry range protects nothing.
+  if (plan.cutloss != null && plan.cutloss >= buyLow) {
+    plan.cutloss = Math.round(buyLow * 0.97);
+  }
+
+  return plan;
+}
+
+function buildTradingPlanRaw(criterion, match, bars, srZones) {
+  const last = bars[bars.length - 1];
+  const a = atr(bars, 14);
+
+  switch (criterion) {
+    case 'elliott_wave': {
+      const buyLow = match.wave_points.w4.price;
+      const buyHigh = last.close;
+      return {
+        buy_area: `${round(buyLow)} - ${round(buyHigh)}`,
+        cutloss: round(match.invalidation_level - a * 0.5),
+        take_profit_1: round(match.wave5_targets.tp1_0618),
+        take_profit_2: round(match.wave5_targets.tp2_1000),
+        extended_target: round(match.wave5_targets.extended_1618),
+        method: 'Elliott Wave — TP di proyeksi wave 5 dari wave 4 (fib 0.618x / 1.0x panjang wave 1). Cutloss di bawah invalidation wave 4.',
+      };
+    }
+    case 'elliott_wave2': {
+      const buyLow = match.pullback_low;
+      const buyHigh = last.close;
+      return {
+        buy_area: `${round(buyLow)} - ${round(buyHigh)}`,
+        cutloss: round(wideCutloss(match.invalidation_level, bars)),
+        take_profit_1: round(match.wave3_targets.tp0_0618),
+        take_profit_2: round(match.wave3_targets.tp1_1618),
+        extended_target: round(match.wave3_targets.tp2_2618),
+        method: 'Elliott Wave 2 (entry paling awal, risiko lebih tinggi) — lower high vs wave 1 + candle hijau menandakan wave 2 sedang dipertahankan pembeli. TP1 di proyeksi 61.8% (target terdekat), TP2 di 161.8% panjang wave 1 dari titik terendah wave 2. Cutloss dilebarkan (1.5x ATR / min 3%) di bawah titik terendah itu — wave 2 masih mungkin melanjutkan turun sebelum benar-benar berbalik.',
+      };
+    }
+    case 'pullback_reversal': {
+      const buyLow = match.pullback_low;
+      const buyHigh = last.close;
+      return {
+        buy_area: `${round(buyLow)} - ${round(buyHigh)}`,
+        cutloss: round(wideCutloss(match.invalidation_level, bars)),
+        take_profit_1: round(match.targets.expansion_0618),
+        take_profit_2: round(match.targets.expansion_1618),
+        extended_target: round(match.targets.expansion_2618),
+        method: `Reversal dari pullback wave 2 — retrace ${match.retrace_pct}% dari wave 1 (${match.fib_zone}), dikonfirmasi candle hijau. TP1 = ekspansi fib 61.8% (target terdekat), TP2 = ekspansi 161.8% (= target wave 3). Extended target = ekspansi 261.8%. Cutloss dilebarkan (1.5x ATR / min 3%) di bawah titik terendah pullback.`,
+      };
+    }
+    case 'double_bottom':
+    case 'inverse_head_and_shoulders':
+    case 'cup_and_handle':
+    case 'bullish_flag':
+    case 'bullish_pennant': {
+      const breakoutLevel = match.rim_level ?? match.neckline ?? match.breakout_level;
+      return {
+        buy_area: `${round(breakoutLevel)} - ${round(last.close)}`,
+        cutloss: round(match.invalidation_level - a * 0.3),
+        take_profit_1: round((breakoutLevel + (match.measured_move_target - breakoutLevel) * 0.5)),
+        take_profit_2: round(match.measured_move_target),
+        method: `Measured move ${match.pattern} — TP2 = breakout + kedalaman pola (rumus baku pattern ini). TP1 = 50% jalan menuju target.`,
+      };
+    }
+    case 'breakout_resistance_with_volume': {
+      const res = match.resistance_level;
+      const nextRes = nearestResistanceAbove(srZones, res * 1.001);
+      // retest_low (the actual bottom of the multi-day pullback that tested
+      // the broken resistance) is a more precise invalidation point than a
+      // generic ATR buffer below the resistance level itself.
+      const cutlossBase = match.retest_low ?? res;
+      return {
+        buy_area: `${round(res)} - ${round(last.close)}`,
+        cutloss: round(cutlossBase - a * 0.3),
+        take_profit_1: round(res + (res - (nearestSupportBelow(srZones, res)?.price ?? res * 0.95))),
+        take_profit_2: nextRes ? round(nextRes.price) : round(res * 1.08),
+        method: `Breakout resistance + volume — resistance ${round(res)} ditembus, pullback ${match.pullback_days ?? '?'} hari (aksi take profit) turun retest ke ${round(cutlossBase)}, lalu bounce candle hijau mengonfirmasi level ini jadi support baru. Cutloss di bawah titik retest. TP mengacu ke resistance berikutnya.`,
+      };
+    }
+    case 'volume_spike_green_candle': {
+      const res = nearestResistanceAbove(srZones, last.close);
+      const sup = nearestSupportBelow(srZones, last.close);
+      return {
+        buy_area: `${round(last.open)} - ${round(last.close)}`,
+        cutloss: round((sup?.price ?? last.low) - a * 0.3),
+        take_profit_1: res ? round(res.price) : round(last.close * 1.05),
+        take_profit_2: round(last.close + (last.close - (sup?.price ?? last.low)) * 1.5),
+        method: 'Volume spike + candle hijau — cutloss di bawah support terdekat, TP1 ke resistance terdekat.',
+      };
+    }
+    case 'downtrend_break': {
+      const res = nearestResistanceAbove(srZones, last.close);
+      return {
+        buy_area: `${round(match.line_value_now)} - ${round(last.close)}`,
+        cutloss: round(match.line_value_now - a * 0.6),
+        take_profit_1: res ? round(res.price) : round(last.close * 1.06),
+        take_profit_2: round(last.close + (last.close - match.line_value_now) * 2),
+        method: 'Breakout downtrend line — cutloss di bawah garis trendline yang ditembus, TP mengacu resistance/measured move dari lebar breakout.',
+      };
+    }
+    case 'confirmed_uptrend': {
+      const res = nearestResistanceAbove(srZones, last.close);
+      const sup = nearestSupportBelow(srZones, last.close);
+      return {
+        buy_area: `${round(match.sma50)} - ${round(last.close)}`,
+        cutloss: round((sup?.price ?? match.sma50) - a * 0.5),
+        take_profit_1: res ? round(res.price) : round(last.close * 1.05),
+        take_profit_2: round(last.close * 1.10),
+        method: 'Trend following — trailing stop di bawah SMA50/support terdekat, TP ke resistance berikutnya.',
+      };
+    }
+    default:
+      return null;
+  }
+}

--- a/screener/lib/patterns.js
+++ b/screener/lib/patterns.js
@@ -1,0 +1,235 @@
+/**
+ * Heuristic bullish chart-pattern detectors over zigzag pivots + raw bars.
+ * These are geometric approximations with tolerance bands, NOT guaranteed
+ * pattern recognition — every match reports which textbook rule it satisfied
+ * so a human can sanity-check it before acting.
+ *
+ * Each detector requires the textbook volume signature for its pattern (not
+ * just the price shape) — a breakout with no volume confirmation is a much
+ * weaker signal and is deliberately excluded.
+ */
+import { avgVolume } from './zigzag.js';
+
+const near = (a, b, tolPct) => Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) <= tolPct;
+
+// A breakout above some historical level is only a live, actionable signal if
+// it just happened. Over a 500-bar (~2yr) lookback, price will have crossed
+// above almost any old resistance/neckline eventually — checking only
+// "is price above it now" without a recency bound turns any long-surpassed
+// level into a false "breakout today", with stale measured-move targets that
+// can sit BELOW the current price. Require the actual crossing to have
+// happened within the last `maxAgeBars`.
+const MAX_PATTERN_BREAKOUT_AGE_BARS = 20;
+function brokeOutRecently(bars, level, maxAgeBars = MAX_PATTERN_BREAKOUT_AGE_BARS) {
+  const last = bars[bars.length - 1];
+  if (last.close <= level) return false;
+  const windowStart = Math.max(0, bars.length - 1 - maxAgeBars);
+  for (let i = bars.length - 1; i >= windowStart; i--) {
+    if (bars[i].close <= level) return true; // found the crossing inside the recent window
+  }
+  return false; // price has been above `level` for the entire recent window — stale breakout
+}
+
+/** Double bottom: low - high(neckline) - low(similar), breakout above neckline on volume. */
+export function detectDoubleBottom(bars, pivots) {
+  const lows = pivots.filter(p => p.type === 'low');
+  const highs = pivots.filter(p => p.type === 'high');
+  if (lows.length < 2 || highs.length < 1) return null;
+
+  const breakoutBar = bars[bars.length - 1];
+  if (!(breakoutBar.close > breakoutBar.open)) return null; // breakout day itself must close green
+  const avgVol = avgVolume(bars.slice(0, -1), 20);
+
+  // Search every adjacent pair, most recent first — not just the last two —
+  // so a stray minor pivot between two genuine bottoms doesn't hide the pattern.
+  for (let i = lows.length - 1; i >= 1; i--) {
+    const l1 = lows[i], l2 = lows[i - 1];
+    if (!near(l1.price, l2.price, 0.04)) continue;
+
+    const neckline = highs.find(h => h.index > l2.index && h.index < l1.index);
+    if (!neckline) continue;
+    if (neckline.price - Math.max(l1.price, l2.price) < 0.03 * neckline.price) continue;
+    if (!brokeOutRecently(bars, neckline.price)) continue;
+    if (avgVol > 0 && breakoutBar.volume < avgVol * 1.2) continue; // breakout needs volume confirmation
+
+    const depth = neckline.price - (l1.price + l2.price) / 2;
+    return {
+      matched: true,
+      pattern: 'double_bottom',
+      neckline: Math.round(neckline.price * 1e6) / 1e6,
+      bottom_avg: Math.round(((l1.price + l2.price) / 2) * 1e6) / 1e6,
+      measured_move_target: Math.round((neckline.price + depth) * 1e6) / 1e6,
+      invalidation_level: Math.min(l1.price, l2.price),
+      breakout_volume_ratio: avgVol > 0 ? Math.round((breakoutBar.volume / avgVol) * 100) / 100 : null,
+    };
+  }
+  return null;
+}
+
+/** Inverted head & shoulders: low(shoulder) - high - low(head, lowest) - high - low(shoulder), breakout on volume. */
+export function detectInverseHeadAndShoulders(bars, pivots) {
+  const lows = pivots.filter(p => p.type === 'low');
+  const highs = pivots.filter(p => p.type === 'high');
+  if (lows.length < 3 || highs.length < 2) return null;
+
+  const breakoutBar = bars[bars.length - 1];
+  if (!(breakoutBar.close > breakoutBar.open)) return null; // breakout day itself must close green
+  const avgVol = avgVolume(bars.slice(0, -1), 20);
+
+  // Search every consecutive triple of lows, most recent first.
+  for (let i = lows.length - 1; i >= 2; i--) {
+    const rShoulder = lows[i], head = lows[i - 1], lShoulder = lows[i - 2];
+    if (!(head.price < lShoulder.price && head.price < rShoulder.price)) continue;
+    if (!near(lShoulder.price, rShoulder.price, 0.06)) continue;
+
+    const neck1 = highs.find(h => h.index > lShoulder.index && h.index < head.index);
+    const neck2 = highs.find(h => h.index > head.index && h.index < rShoulder.index);
+    if (!neck1 || !neck2) continue;
+
+    const neckline = (neck1.price + neck2.price) / 2;
+    if (!brokeOutRecently(bars, neckline)) continue;
+    if (avgVol > 0 && breakoutBar.volume < avgVol * 1.2) continue;
+
+    const depth = neckline - head.price;
+    return {
+      matched: true,
+      pattern: 'inverse_head_and_shoulders',
+      neckline: Math.round(neckline * 1e6) / 1e6,
+      head_low: head.price,
+      measured_move_target: Math.round((neckline + depth) * 1e6) / 1e6,
+      invalidation_level: head.price,
+      breakout_volume_ratio: avgVol > 0 ? Math.round((breakoutBar.volume / avgVol) * 100) / 100 : null,
+    };
+  }
+  return null;
+}
+
+/**
+ * Cup and handle: a ROUNDED decline+recovery back near the prior high (cup —
+ * not a sharp V, real cups spend time near the bottom), then a shallow
+ * pullback (handle), then a volume-confirmed breakout.
+ */
+export function detectCupAndHandle(bars, pivots) {
+  if (bars.length < 40) return null;
+  const highs = pivots.filter(p => p.type === 'high');
+  const lows = pivots.filter(p => p.type === 'low');
+  if (highs.length < 2 || lows.length < 1) return null;
+
+  const rimRight = highs[highs.length - 1];
+  const cupLow = [...lows].reverse().find(l => l.index < rimRight.index);
+  if (!cupLow) return null;
+  const rimLeft = [...highs].reverse().find(h => h.index < cupLow.index);
+  if (!rimLeft) return null;
+
+  if (!near(rimLeft.price, rimRight.price, 0.08)) return null; // rims roughly level
+  const cupDepth = ((rimLeft.price + rimRight.price) / 2) - cupLow.price;
+  if (cupDepth < 0.12 * rimRight.price) return null; // cup should be a meaningful pullback, not noise
+
+  // Roundedness: a true cup lingers near its low across several bars. A sharp
+  // single-bar V-spike and immediate recovery is a different pattern (a V
+  // bottom / double bottom), not a cup and handle.
+  const cupSpan = bars.slice(rimLeft.index, rimRight.index + 1);
+  const nearBottomBand = cupLow.price * 1.08;
+  const barsNearBottom = cupSpan.filter(b => b.low <= nearBottomBand).length;
+  if (barsNearBottom < Math.max(3, Math.round(cupSpan.length * 0.1))) return null;
+
+  // Handle: a shallow pullback after the right rim, retracing well under the
+  // cup's full depth, and short in duration — handles run days-to-weeks, not
+  // months. An uncapped "all bars since the rim" window let a rim from ages
+  // ago pass as a "handle" spanning most of the lookback.
+  const afterRim = bars.slice(rimRight.index + 1);
+  if (afterRim.length < 3 || afterRim.length > 40) return null;
+  const handleLow = Math.min(...afterRim.map(b => b.low));
+  const handleRetrace = (rimRight.price - handleLow) / cupDepth;
+  if (handleRetrace > 0.5) return null; // handle deeper than half the cup — not a handle anymore
+
+  const breakoutLevel = Math.max(rimLeft.price, rimRight.price);
+  if (!brokeOutRecently(bars, breakoutLevel)) return null;
+
+  // Volume should generally dry up through the cup and pick back up on breakout.
+  const breakoutBar = bars[bars.length - 1];
+  if (!(breakoutBar.close > breakoutBar.open)) return null; // breakout day itself must close green
+  const cupAvgVol = avgVolume(cupSpan, cupSpan.length);
+  if (cupAvgVol > 0 && breakoutBar.volume < cupAvgVol * 1.2) return null;
+
+  return {
+    matched: true,
+    pattern: 'cup_and_handle',
+    rim_level: Math.round(breakoutLevel * 1e6) / 1e6,
+    cup_depth: Math.round(cupDepth * 1e6) / 1e6,
+    measured_move_target: Math.round((breakoutLevel + cupDepth) * 1e6) / 1e6,
+    invalidation_level: Math.round(handleLow * 1e6) / 1e6,
+    breakout_volume_ratio: cupAvgVol > 0 ? Math.round((breakoutBar.volume / cupAvgVol) * 100) / 100 : null,
+  };
+}
+
+/**
+ * Bullish flag/pennant: sharp impulsive rally (flagpole), a tight
+ * consolidation on CONTRACTING volume (the defining characteristic — without
+ * it this is just a random sideways chop, not a flag/pennant), then a
+ * volume-confirmed breakout that resumes the trend.
+ */
+export function detectBullishFlagOrPennant(bars, pivots) {
+  if (bars.length < 20) return null;
+  const highs = pivots.filter(p => p.type === 'high');
+  const lows = pivots.filter(p => p.type === 'low');
+  if (highs.length < 1 || lows.length < 1) return null;
+
+  const poleTop = highs[highs.length - 1];
+  const poleBase = [...lows].reverse().find(l => l.index < poleTop.index);
+  if (!poleBase) return null;
+
+  const poleHeight = poleTop.price - poleBase.price;
+  const poleBars = poleTop.index - poleBase.index;
+  if (poleHeight <= 0 || poleBars <= 0 || poleBars > 15) return null; // pole must be a sharp, short move
+  const poleMovePct = poleHeight / poleBase.price;
+  if (poleMovePct < 0.08) return null; // needs to be a real impulsive rally
+
+  const consolidation = bars.slice(poleTop.index + 1);
+  if (consolidation.length < 3 || consolidation.length > 25) return null;
+
+  const conHigh = Math.max(...consolidation.map(b => b.high));
+  const conLow = Math.min(...consolidation.map(b => b.low));
+  const conRange = conHigh - conLow;
+  if (conRange > poleHeight * 0.6) return null; // consolidation should be much tighter than the pole
+  if (conHigh > poleTop.price * 1.02) return null; // shouldn't make a big new high mid-consolidation
+
+  const poleVol = avgVolume(bars.slice(poleBase.index, poleTop.index + 1), poleBars || 1);
+  const conVol = avgVolume(consolidation.slice(0, -1), consolidation.length - 1 || 1);
+  if (!(conVol < poleVol)) return null; // volume MUST contract during consolidation — the pattern's defining trait
+
+  const lastClose = bars[bars.length - 1].close;
+  const breakoutBar = bars[bars.length - 1];
+  if (!(breakoutBar.close > breakoutBar.open)) return null; // breakout day itself must close green
+  const breakout = lastClose > conHigh;
+  if (!breakout) return null;
+  if (breakoutBar.volume < conVol * 1.2) return null; // and pick back up on the breakout itself
+
+  // Contracting range (pennant) vs roughly parallel channel (flag) — first half vs second half range.
+  const half = Math.floor(consolidation.length / 2) || 1;
+  const firstRange = Math.max(...consolidation.slice(0, half).map(b => b.high)) - Math.min(...consolidation.slice(0, half).map(b => b.low));
+  const secondRange = Math.max(...consolidation.slice(half).map(b => b.high)) - Math.min(...consolidation.slice(half).map(b => b.low));
+  const isPennant = secondRange < firstRange * 0.7;
+
+  return {
+    matched: true,
+    pattern: isPennant ? 'bullish_pennant' : 'bullish_flag',
+    flagpole_height: Math.round(poleHeight * 1e6) / 1e6,
+    breakout_level: Math.round(conHigh * 1e6) / 1e6,
+    measured_move_target: Math.round((conHigh + poleHeight) * 1e6) / 1e6,
+    invalidation_level: Math.round(conLow * 1e6) / 1e6,
+    breakout_volume_ratio: conVol > 0 ? Math.round((breakoutBar.volume / conVol) * 100) / 100 : null,
+  };
+}
+
+export function detectAllPatterns(bars, pivots) {
+  const detectors = [detectDoubleBottom, detectInverseHeadAndShoulders, detectCupAndHandle, detectBullishFlagOrPennant];
+  const matches = [];
+  for (const fn of detectors) {
+    try {
+      const result = fn(bars, pivots);
+      if (result) matches.push(result);
+    } catch { /* pattern didn't apply to this bar set — skip */ }
+  }
+  return matches;
+}

--- a/screener/lib/support_resistance.js
+++ b/screener/lib/support_resistance.js
@@ -1,0 +1,44 @@
+/**
+ * Support/resistance zone detection by clustering zigzag pivots.
+ * A zone needs >=2 touches within `tolerancePct` of each other to count —
+ * a single untested swing point is not a level, it's noise.
+ */
+export function findSrZones(pivots, tolerancePct = 0.015) {
+  const zones = [];
+
+  for (const p of pivots) {
+    let zone = zones.find(z => Math.abs(z.price - p.price) / z.price <= tolerancePct);
+    if (zone) {
+      zone.touches += 1;
+      zone.price = (zone.price * (zone.touches - 1) + p.price) / zone.touches; // running average
+      zone.lastIndex = Math.max(zone.lastIndex, p.index);
+      if (p.type === 'high') zone.highTouches++; else zone.lowTouches++;
+    } else {
+      zones.push({
+        price: p.price,
+        touches: 1,
+        highTouches: p.type === 'high' ? 1 : 0,
+        lowTouches: p.type === 'low' ? 1 : 0,
+        firstIndex: p.index,
+        lastIndex: p.index,
+      });
+    }
+  }
+
+  return zones
+    .filter(z => z.touches >= 2)
+    .map(z => ({ ...z, type: z.highTouches >= z.lowTouches ? 'resistance' : 'support' }))
+    .sort((a, b) => b.touches - a.touches);
+}
+
+/** Nearest resistance zone strictly above `price`, or null. */
+export function nearestResistanceAbove(zones, price) {
+  const above = zones.filter(z => z.price > price).sort((a, b) => a.price - b.price);
+  return above[0] || null;
+}
+
+/** Nearest support zone strictly below `price`, or null. */
+export function nearestSupportBelow(zones, price) {
+  const below = zones.filter(z => z.price < price).sort((a, b) => b.price - a.price);
+  return below[0] || null;
+}

--- a/screener/lib/trendline.js
+++ b/screener/lib/trendline.js
@@ -1,0 +1,60 @@
+/**
+ * Downtrend-line break detection.
+ *
+ * A downtrend line is fit through the last two (or more) descending pivot
+ * highs. A "break" is a close above the line's projected value on the
+ * current bar. "Confirmed uptrend" additionally requires the market to have
+ * printed at least one higher-high and one higher-low after the break —
+ * a single breakout candle alone can be a fakeout.
+ */
+export function detectDowntrendBreak(bars, pivots) {
+  const highs = pivots.filter(p => p.type === 'high');
+  if (highs.length < 2) return null;
+
+  // Anchor the line on the MOST RECENT pivot high, then walk backward for the
+  // nearest earlier high that's still above it — i.e. the current, still-
+  // intact descending line an analyst would actually draw right now. (The
+  // previous version tried every pair in a nested loop and just kept
+  // whichever happened to be checked last, which wasn't a deliberate choice
+  // of "most relevant descending pair" — it was an accident of loop order.)
+  const recentHighs = highs.slice(-5);
+  const b = recentHighs[recentHighs.length - 1];
+  let a = null;
+  for (let i = recentHighs.length - 2; i >= 0; i--) {
+    if (recentHighs[i].price > b.price) { a = recentHighs[i]; break; }
+  }
+  if (!a) return null;
+  const line = { x1: a.index, y1: a.price, x2: b.index, y2: b.price };
+
+  const slope = (line.y2 - line.y1) / (line.x2 - line.x1);
+  const lastIndex = bars.length - 1;
+  const lineValueAtLast = line.y1 + slope * (lastIndex - line.x1);
+  const lastClose = bars[lastIndex].close;
+
+  const brokenOut = lastClose > lineValueAtLast;
+  if (!brokenOut) return null;
+
+  const lastBar = bars[lastIndex];
+  if (!(lastBar.close > lastBar.open)) return null; // breakout day itself must close green
+
+  // Confirm uptrend structure after the line's second anchor point. This used
+  // to be returned as a `confirmed_uptrend` boolean that the caller (scan.js)
+  // checked before accepting the match — functionally equivalent, but it
+  // meant the raw function could hand back "matched: true" for an
+  // unconfirmed breakout to anyone who called it directly. Rejecting here
+  // makes the guarantee part of the function's own contract.
+  const afterBreak = pivots.filter(p => p.index > line.x2);
+  const higherHighs = afterBreak.filter(p => p.type === 'high' && p.price > line.y2);
+  const lowsAfter = afterBreak.filter(p => p.type === 'low');
+  const priorLow = pivots.filter(p => p.type === 'low' && p.index <= line.x2).slice(-1)[0];
+  const higherLowConfirmed = priorLow && lowsAfter.some(p => p.price > priorLow.price);
+  if (higherHighs.length < 1 || !higherLowConfirmed) return null;
+
+  return {
+    matched: true,
+    line_start: { index: line.x1, price: line.y1 },
+    line_end: { index: line.x2, price: line.y2 },
+    line_value_now: Math.round(lineValueAtLast * 1e6) / 1e6,
+    breakout_close: lastClose,
+  };
+}

--- a/screener/lib/volume.js
+++ b/screener/lib/volume.js
@@ -1,0 +1,116 @@
+import { avgVolume, sma } from './zigzag.js';
+
+/**
+ * Breakout-pullback-retest-bounce: price breaks above a known resistance,
+ * pulls back for several days on profit-taking (red candles), the pullback
+ * comes back down to actually retest the broken level (now support), and
+ * today closes green confirming the bounce held. This is a materially
+ * stronger confirmation than "just crossed above with volume today" — it
+ * proves the old resistance has flipped to real support rather than price
+ * merely poking above it once.
+ */
+export function detectBreakoutWithVolume(bars, srZones, opts = {}) {
+  const { maxLookback = 30, minPullbackDays = 2, retestTolerancePct = 0.02, volMultiple = 1.3 } = opts;
+  const n = bars.length;
+  const today = bars[n - 1];
+  if (!(today.close > today.open)) return null; // today must be the bounce candle, closing green
+
+  const baseAvgVol = avgVolume(bars.slice(0, -1), 20);
+  const resistances = srZones.filter(z => z.type === 'resistance');
+
+  for (const res of resistances) {
+    // 1. Find the most recent bar (within the lookback window, excluding
+    //    today) whose close crossed from at/below the resistance to above it.
+    let breakoutIdx = -1;
+    const start = Math.max(1, n - 1 - maxLookback);
+    for (let i = start; i < n - 1; i++) {
+      if (bars[i - 1].close <= res.price && bars[i].close > res.price) breakoutIdx = i;
+    }
+    if (breakoutIdx === -1) continue; // no breakout of this level found in the window
+
+    // 2. Several days of pullback (red candles) must follow the breakout —
+    //    profit-taking, not an uninterrupted run.
+    const afterBreakout = bars.slice(breakoutIdx + 1, n - 1);
+    if (afterBreakout.length < minPullbackDays) continue;
+    const redDays = afterBreakout.filter(b => b.close < b.open).length;
+    if (redDays < minPullbackDays) continue;
+
+    // 3. The pullback must actually come back down to retest the broken
+    //    level — not just drift sideways well above it.
+    const pullbackLow = Math.min(...afterBreakout.map(b => b.low), today.low);
+    if (Math.abs(pullbackLow - res.price) / res.price > retestTolerancePct) continue;
+
+    // 4. Today's bounce must hold above the resistance-turned-support, with
+    //    at least some volume pickup confirming buyers stepped back in.
+    if (today.close <= res.price) continue;
+    if (baseAvgVol > 0 && today.volume < baseAvgVol * volMultiple) continue;
+
+    return {
+      matched: true,
+      pattern: 'breakout_resistance_with_volume',
+      resistance_level: Math.round(res.price * 1e6) / 1e6,
+      pullback_days: redDays,
+      retest_low: Math.round(pullbackLow * 1e6) / 1e6,
+      breakout_volume: today.volume,
+      avg_volume_20: Math.round(baseAvgVol),
+      volume_ratio: baseAvgVol > 0 ? Math.round((today.volume / baseAvgVol) * 100) / 100 : null,
+    };
+  }
+  return null;
+}
+
+/**
+ * Volume spike on a green (bullish) candle, WITHIN an uptrend context.
+ * A volume+green spike on its own has no idea where it's happening — the
+ * same candle inside a downtrend is just as easily a dead-cat bounce as it
+ * is real accumulation. Requiring price above its SMA20 rules out flagging
+ * spikes that show up while the stock is still trending down.
+ */
+export function detectVolumeSpikeGreenCandle(bars, volMultiple = 2) {
+  const last = bars[bars.length - 1];
+  const baseAvgVol = avgVolume(bars.slice(0, -1), 20);
+  if (baseAvgVol <= 0) return null;
+  const isGreen = last.close > last.open;
+  const isSpike = last.volume >= baseAvgVol * volMultiple;
+  if (!isGreen || !isSpike) return null;
+
+  const sma20 = sma(bars, 20);
+  if (!sma20 || last.close <= sma20) return null; // must be trading above its own short-term average, not bouncing inside a downtrend
+
+  return {
+    matched: true,
+    pattern: 'volume_spike_green_candle',
+    volume: last.volume,
+    avg_volume_20: Math.round(baseAvgVol),
+    volume_ratio: Math.round((last.volume / baseAvgVol) * 100) / 100,
+    sma20: Math.round(sma20 * 1e6) / 1e6,
+  };
+}
+
+/** General trend-following filter: price above both SMA50 and SMA200, with a higher-high/higher-low pivot structure. */
+export function detectConfirmedUptrend(bars, pivots) {
+  const last = bars[bars.length - 1];
+  const sma50 = sma(bars, 50);
+  // Only compute SMA200 when there's actually 200 bars of history — a stock
+  // with, say, 80 bars (recent IPO) would otherwise get an SMA80 silently
+  // mislabeled "sma200" in the report.
+  const sma200 = bars.length >= 200 ? sma(bars, 200) : null;
+  if (!sma50) return null;
+
+  const aboveSma = last.close > sma50 && (sma200 == null || last.close > sma200);
+  if (!aboveSma) return null;
+
+  const highs = pivots.filter(p => p.type === 'high').slice(-3);
+  const lows = pivots.filter(p => p.type === 'low').slice(-3);
+  const higherHighs = highs.length >= 2 && highs[highs.length - 1].price > highs[highs.length - 2].price;
+  const higherLows = lows.length >= 2 && lows[lows.length - 1].price > lows[lows.length - 2].price;
+  if (!higherHighs || !higherLows) return null;
+
+  return {
+    matched: true,
+    pattern: 'confirmed_uptrend',
+    close: last.close,
+    sma50: Math.round(sma50 * 1e6) / 1e6,
+    sma200: sma200 ? Math.round(sma200 * 1e6) / 1e6 : null,
+  };
+}

--- a/screener/lib/zigzag.js
+++ b/screener/lib/zigzag.js
@@ -1,0 +1,91 @@
+/**
+ * Zigzag pivot detection over an OHLCV bar array.
+ * A pivot high/low is confirmed once price reverses by >= thresholdPct from
+ * the running extreme. This is the standard "swing" building block that every
+ * other detector (S/R, trendlines, Elliott Wave, chart patterns) is built on.
+ *
+ * IMPORTANT: only fully-reversed (confirmed) pivots are returned. The
+ * in-progress extreme at the tail of the data — wherever price currently
+ * sits, which may not have reversed by thresholdPct yet — is deliberately
+ * NOT included. Earlier versions pushed that unconfirmed point as a normal
+ * pivot, which let detectors (Elliott Wave impulse/wave3, chart patterns)
+ * treat "today's price" as if it were a completed wave/swing point — a
+ * recency bias that over-flagged setups that hadn't actually completed.
+ * Callers that need "where is price right now relative to the last
+ * confirmed swing" should read the bars array directly (e.g.
+ * bars[bars.length-1].close), not expect it from this pivot list.
+ */
+
+/**
+ * @param {Array<{time:number, open:number, high:number, low:number, close:number, volume:number}>} bars
+ * @param {number} thresholdPct e.g. 0.04 = 4% reversal required to confirm a pivot
+ * @returns {Array<{index:number, time:number, price:number, type:'high'|'low'}>}
+ */
+export function findPivots(bars, thresholdPct = 0.04) {
+  if (!bars || bars.length < 3) return [];
+
+  const pivots = [];
+  let direction = 0; // 1 = looking for a high, -1 = looking for a low, 0 = undetermined
+  let extremeIndex = 0;
+  let extremePrice = bars[0].close;
+
+  for (let i = 1; i < bars.length; i++) {
+    const bar = bars[i];
+
+    if (direction >= 0 && bar.high >= extremePrice) {
+      extremePrice = bar.high;
+      extremeIndex = i;
+      direction = 1;
+      continue;
+    }
+    if (direction <= 0 && bar.low <= extremePrice) {
+      extremePrice = bar.low;
+      extremeIndex = i;
+      direction = -1;
+      continue;
+    }
+
+    if (direction === 1) {
+      const drawdown = (extremePrice - bar.low) / extremePrice;
+      if (drawdown >= thresholdPct) {
+        pivots.push({ index: extremeIndex, time: bars[extremeIndex].time, price: extremePrice, type: 'high' });
+        direction = -1;
+        extremePrice = bar.low;
+        extremeIndex = i;
+      }
+    } else if (direction === -1) {
+      const rally = (bar.high - extremePrice) / extremePrice;
+      if (rally >= thresholdPct) {
+        pivots.push({ index: extremeIndex, time: bars[extremeIndex].time, price: extremePrice, type: 'low' });
+        direction = 1;
+        extremePrice = bar.high;
+        extremeIndex = i;
+      }
+    }
+  }
+
+  // The current running extreme (extremePrice/extremeIndex) is deliberately
+  // NOT pushed here — it hasn't reversed by thresholdPct yet, so it isn't a
+  // confirmed pivot. See the confirmed-only note in the file header.
+
+  return pivots;
+}
+
+export function avgVolume(bars, lookback = 20) {
+  const slice = bars.slice(-lookback);
+  if (slice.length === 0) return 0;
+  return slice.reduce((sum, b) => sum + (b.volume || 0), 0) / slice.length;
+}
+
+/** Average daily transaction VALUE (price * volume, in Rupiah) — a liquidity gate. */
+export function avgValueTraded(bars, lookback = 50) {
+  const slice = bars.slice(-lookback);
+  if (slice.length === 0) return 0;
+  return slice.reduce((sum, b) => sum + b.close * (b.volume || 0), 0) / slice.length;
+}
+
+export function sma(bars, period) {
+  if (bars.length < period) return null;
+  const slice = bars.slice(-period);
+  return slice.reduce((sum, b) => sum + b.close, 0) / period;
+}

--- a/screener/performance.js
+++ b/screener/performance.js
@@ -1,0 +1,171 @@
+/**
+ * Performance check for the most recent evening screening: finds the latest
+ * scan-YYYY-MM-DD.json under ./results (NOT necessarily today's — the
+ * screening runs in the evening and this check runs the next trading day,
+ * so on a Monday the most recent scan is Friday's), pulls each matched
+ * stock's current price, and reports plus/minus % versus the price at
+ * signal time, plus whether the plan's TP1/TP2/cutloss was touched.
+ *
+ * Uses a lighter, faster symbol-switch-and-read path than the full scanner:
+ * this only needs one OHLC bar (not 500 bars of history for pattern
+ * detection), so the generic setSymbol()/waitForChartReady() helpers'
+ * conservative waits (500ms fixed delay + 200ms poll needing 2 consecutive
+ * stable reads, up to 10s) are overkill here and were the dominant cost
+ * per symbol.
+ *
+ * Usage: node screener/performance.js
+ * Requires at least one prior screening run (screener/results/scan-*.json)
+ * to already exist — run scan.js/daily.js first.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { evaluateAsync, KNOWN_PATHS, safeString, disconnect } from '../src/connection.js';
+import { generatePerformanceReport } from './report.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHART_API = KNOWN_PATHS.chartApi;
+const BARS_PATH = KNOWN_PATHS.mainSeriesBars;
+
+/**
+ * Switch symbol and read just today's bar — one single evaluateAsync call,
+ * with the poll loop living inside the page's own JS. Each Node<->CDP round
+ * trip has its own latency, so driving the poll from Node (await evaluate()
+ * in a loop) paid that latency on every single check; polling in-page costs
+ * only a setTimeout tick.
+ *
+ * The readiness check and the data read happen in the SAME tick before
+ * resolving — an earlier version split them into two round trips (resolve
+ * once "ready", then a separate evaluate() to read the bar), which left a
+ * race window: by the time the second call landed, bars.valueAt(lastIndex())
+ * could momentarily return null even though size()>0 and the symbol already
+ * matched (a transient state while the series finished swapping in new
+ * data). Resolving only once the actual bar value is in hand closes that gap.
+ */
+async function fastReadTodayBar(symbol) {
+  const ticker = symbol.includes(':') ? symbol.slice(symbol.lastIndexOf(':') + 1) : symbol;
+
+  const bar = await evaluateAsync(`
+    (function() {
+      var chart = ${CHART_API};
+      chart.setSymbol(${safeString(symbol)}, {});
+      return new Promise(function(resolve, reject) {
+        var tries = 0;
+        (function check() {
+          tries++;
+          var sym = '';
+          try { sym = chart.symbol(); } catch (e) {}
+          // Re-fetch bars fresh each poll — don't trust a reference captured
+          // before the symbol switch in case TradingView swaps the series
+          // object on symbol change rather than mutating it in place.
+          var bars = ${BARS_PATH};
+          var hasBars = !!(bars && typeof bars.lastIndex === 'function' && bars.size() > 0);
+          var v = null;
+          if (hasBars) { try { v = bars.valueAt(bars.lastIndex()); } catch (e) {} }
+          if (v && sym && sym.toUpperCase().indexOf(${safeString(ticker.toUpperCase())}) !== -1) {
+            resolve({ time: v[0], open: v[1], high: v[2], low: v[3], close: v[4], volume: v[5] || 0 });
+          } else if (tries > 60) {
+            reject(new Error('timeout waiting for symbol'));
+          } else {
+            setTimeout(check, 50);
+          }
+        })();
+      });
+    })()
+  `);
+  if (!bar) throw new Error(`Tidak bisa membaca bar hari ini untuk ${symbol}.`);
+  return bar;
+}
+
+function statusFor(plan, high, low) {
+  if (!plan) return 'n/a';
+  if (plan.take_profit_2 != null && high >= plan.take_profit_2) return 'TP2 Tercapai';
+  if (plan.take_profit_1 != null && high >= plan.take_profit_1) return 'TP1 Tercapai';
+  if (plan.cutloss != null && low <= plan.cutloss) return 'Kena Cutloss';
+  return 'Berjalan';
+}
+
+function findLatestScanFile() {
+  const resultsDir = join(__dirname, 'results');
+  const files = readdirSync(resultsDir)
+    .filter(f => /^scan-\d{4}-\d{2}-\d{2}\.json$/.test(f))
+    .sort() // ISO dates sort lexicographically in chronological order
+    .reverse();
+  if (files.length === 0) return null;
+  return { path: join(resultsDir, files[0]), dateStr: files[0].slice(5, 15) };
+}
+
+async function main() {
+  const latest = findLatestScanFile();
+  if (!latest) {
+    throw new Error(`Tidak ada hasil screening sebelumnya di ${join(__dirname, 'results')}. Jalankan daily.js/scan.js dulu sebelum cek performa.`);
+  }
+
+  const scan = JSON.parse(readFileSync(latest.path, 'utf8'));
+  const jsonPath = latest.path;
+  const scanDateStr = latest.dateStr;
+
+  console.log(`Mengecek performa ${scan.results.length} saham dari screening tanggal ${scanDateStr}...`);
+
+  const rows = [];
+  const errors = [];
+  const startedAt = Date.now();
+
+  for (let i = 0; i < scan.results.length; i++) {
+    const stock = scan.results[i];
+    try {
+      const todayBar = await fastReadTodayBar(`IDX:${stock.symbol}`);
+
+      const signalPrice = stock.last_close;
+      const changeRp = todayBar.close - signalPrice;
+      const changePct = Math.round((changeRp / signalPrice) * 10000) / 100;
+
+      for (const m of stock.matches) {
+        rows.push({
+          symbol: stock.symbol,
+          criterion: m.criterion,
+          signal_price: signalPrice,
+          open: todayBar.open,
+          high: todayBar.high,
+          low: todayBar.low,
+          close: todayBar.close,
+          change_rp: Math.round(changeRp),
+          change_pct: changePct,
+          status: statusFor(m.plan, todayBar.high, todayBar.low),
+        });
+      }
+    } catch (err) {
+      errors.push({ symbol: stock.symbol, error: err.message });
+    }
+
+    if ((i + 1) % 25 === 0 || i === scan.results.length - 1) {
+      const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(0);
+      console.log(`[${i + 1}/${scan.results.length}] elapsed=${elapsedSec}s errors_so_far=${errors.length}`);
+    }
+  }
+
+  const perf = {
+    generated_at: new Date().toISOString(),
+    scan_date: scanDateStr,
+    source_scan: jsonPath,
+    rows,
+    errors,
+  };
+
+  const won = rows.filter(r => r.status.includes('TP')).length;
+  const lost = rows.filter(r => r.status === 'Kena Cutloss').length;
+  const running = rows.filter(r => r.status === 'Berjalan').length;
+  const elapsedTotal = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+  console.log(`\nDone. ${rows.length} sinyal dicek. TP tercapai: ${won}. Kena cutloss: ${lost}. Masih berjalan: ${running}. Error: ${errors.length}. Elapsed ${elapsedTotal}s.`);
+  console.log('\n\n' + generatePerformanceReport(perf));
+}
+
+main()
+  .catch(err => {
+    console.error('FATAL:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    try { await disconnect(); } catch { /* already gone */ }
+  });

--- a/screener/report.js
+++ b/screener/report.js
@@ -1,0 +1,122 @@
+/**
+ * Formats a scan-YYYY-MM-DD.json result into a Markdown report grouped by
+ * the 7 screening criteria, in Indonesian, with trading-plan levels and a
+ * standing disclaimer (this is rule-based TA output, not licensed
+ * financial advice).
+ */
+// Single source of truth for criterion display names — excel.js reuses this
+// (via shortCriteriaLabel) instead of keeping its own separate label map, so
+// the two report formats can't drift out of sync with each other.
+export const CRITERIA_ORDER = [
+  { key: 'downtrend_break', title: '2. Breakout Downtrend Line (Uptrend Terkonfirmasi)' },
+  { key: 'elliott_wave2', title: '3a. Elliott Wave 2 Dipertahankan (Entry Paling Awal, Fibonacci)' },
+  { key: 'elliott_wave', title: '3b. Elliott Wave 5 Selesai/Berjalan (Uptrend Terkonfirmasi, Fibonacci)' },
+  { key: 'pullback_reversal', title: '3c. Reversal dari Pullback Wave 2 (Zona Fibonacci)' },
+  { key: 'double_bottom', title: '4a. Pattern: Double Bottom' },
+  { key: 'inverse_head_and_shoulders', title: '4b. Pattern: Inverted Head & Shoulders' },
+  { key: 'cup_and_handle', title: '4c. Pattern: Cup and Handle' },
+  { key: 'bullish_flag', title: '4d. Pattern: Bullish Flag' },
+  { key: 'bullish_pennant', title: '4e. Pattern: Bullish Pennant' },
+  { key: 'breakout_resistance_with_volume', title: '5. Breakout Resistance + Volume' },
+  { key: 'volume_spike_green_candle', title: '6. Volume Spike + Candle Hijau' },
+  { key: 'confirmed_uptrend', title: '7. Confirmed Uptrend (Follow the Trend)' },
+];
+
+/** Criterion title without the report's numbering prefix ("3a. ", "4b. ") — for contexts like Excel columns that don't use that numbering. */
+export function shortCriteriaLabel(key) {
+  const entry = CRITERIA_ORDER.find(c => c.key === key);
+  if (!entry) return key;
+  return entry.title.replace(/^\d+[a-z]?\.\s*/, '');
+}
+
+function formatPlan(plan) {
+  if (!plan) return '';
+  const lines = [
+    `  - Buy Area: ${plan.buy_area}`,
+    `  - Cutloss: ${plan.cutloss}`,
+    `  - Take Profit 1: ${plan.take_profit_1}`,
+    `  - Take Profit 2: ${plan.take_profit_2}`,
+  ];
+  if (plan.extended_target) lines.push(`  - Extended Target: ${plan.extended_target}`);
+  lines.push(`  - Metode: ${plan.method}`);
+  return lines.join('\n');
+}
+
+export function generateReport(scan) {
+  const dateStr = scan.generated_at.slice(0, 10);
+  const buckets = new Map(CRITERIA_ORDER.map(c => [c.key, []]));
+
+  for (const stock of scan.results) {
+    for (const m of stock.matches) {
+      if (!buckets.has(m.criterion)) continue;
+      buckets.get(m.criterion).push({ symbol: stock.symbol, last_close: stock.last_close, ...m });
+    }
+  }
+
+  const lines = [];
+  lines.push(`# Screening Teknikal IHSG — ${dateStr}`);
+  lines.push('');
+  lines.push('> **Disclaimer:** Ini adalah hasil analisis teknikal terkomputasi berbasis aturan (rule-based),');
+  lines.push('> bukan nasihat investasi dari penasihat keuangan berlisensi. Elliott Wave dan pola chart di sini');
+  lines.push('> dideteksi lewat heuristik pivot/Fibonacci, bukan penilaian visual pasti — selalu verifikasi ulang');
+  lines.push('> secara manual sebelum mengambil keputusan trading. Kriteria "Support & Resistance" digunakan');
+  lines.push('> sebagai konteks pendukung di setiap kandidat (kolom S/R terdekat), bukan filter tersendiri.');
+  lines.push('');
+  lines.push(`Total saham dipindai: **${scan.total_scanned}** | Saham dengan minimal 1 sinyal: **${scan.total_matches}** | Error: ${scan.total_errors} | Durasi: ${scan.elapsed_seconds}s`);
+  if (scan.total_skipped_illiquid != null) {
+    const minRp = (scan.min_avg_value_trx_50d / 1e9).toFixed(1);
+    lines.push(`Disaring karena tidak likuid (AvgValTrx 50 hari < Rp ${minRp} miliar): **${scan.total_skipped_illiquid}** saham`);
+  }
+  lines.push('');
+
+  for (const { key, title } of CRITERIA_ORDER) {
+    const hits = buckets.get(key);
+    if (hits.length === 0) continue;
+    lines.push(`## ${title} — ${hits.length} saham`);
+    lines.push('');
+    for (const hit of hits) {
+      lines.push(`### ${hit.symbol} (close: ${hit.last_close})`);
+      lines.push(formatPlan(hit.plan));
+      lines.push('');
+    }
+  }
+
+  const anyMatches = CRITERIA_ORDER.some(c => buckets.get(c.key).length > 0);
+  if (!anyMatches) {
+    lines.push('Tidak ada saham yang memenuhi kriteria screening hari ini.');
+  }
+
+  return lines.join('\n');
+}
+
+const CRITERIA_LABEL_BY_KEY = new Map(CRITERIA_ORDER.map(c => [c.key, c.title]));
+
+export function generatePerformanceReport(perf) {
+  const checkDateStr = perf.generated_at.slice(0, 10);
+  const scanDateStr = perf.scan_date ?? checkDateStr;
+  const won = perf.rows.filter(r => r.status.includes('TP')).length;
+  const lost = perf.rows.filter(r => r.status === 'Kena Cutloss').length;
+  const running = perf.rows.filter(r => r.status === 'Berjalan').length;
+
+  const lines = [];
+  lines.push(`# Performa Screening IHSG Tanggal ${scanDateStr} (Dicek ${checkDateStr})`);
+  lines.push('');
+  lines.push(`> Perbandingan harga saat screening tanggal ${scanDateStr} dibuat vs harga saat ini (${checkDateStr}).`);
+  lines.push('> Bukan simulasi hasil trading riil — belum memperhitungkan biaya transaksi, slippage, atau eksekusi order aktual.');
+  lines.push('');
+  lines.push(`Total sinyal dicek: **${perf.rows.length}** | TP tercapai: **${won}** | Kena cutloss: **${lost}** | Masih berjalan: **${running}** | Error: ${perf.errors.length}`);
+  lines.push('');
+
+  const sorted = [...perf.rows].sort((a, b) => b.change_pct - a.change_pct);
+  for (const r of sorted) {
+    const label = CRITERIA_LABEL_BY_KEY.get(r.criterion) ?? r.criterion;
+    const sign = r.change_pct >= 0 ? '+' : '';
+    lines.push(`- **${r.symbol}** (${label}): ${r.signal_price} → ${r.close} (${sign}${r.change_pct}%) — ${r.status}`);
+  }
+
+  if (perf.rows.length === 0) {
+    lines.push('Tidak ada sinyal pagi untuk dicek hari ini.');
+  }
+
+  return lines.join('\n');
+}

--- a/screener/scan.js
+++ b/screener/scan.js
@@ -1,0 +1,178 @@
+/**
+ * IHSG technical screener.
+ *
+ * Connects once to the already-running TradingView Desktop (via the same
+ * CDP connection the tv CLI / MCP server uses), loops through every symbol
+ * in idx_all.csv, pulls daily OHLCV, and runs it through the detectors in
+ * ./lib. Symbols with at least one match are written to a JSON + Markdown
+ * report under ./results.
+ *
+ * Usage:
+ *   node screener/scan.js                # full IHSG universe
+ *   node screener/scan.js --limit 10      # first 10 symbols only (smoke test)
+ *   node screener/scan.js --symbols BBCA,BBRI,TLKM
+ */
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setSymbol } from '../src/core/chart.js';
+import { getOhlcv } from '../src/core/data.js';
+import { disconnect } from '../src/connection.js';
+
+import { findPivots, avgValueTraded } from './lib/zigzag.js';
+import { findSrZones, nearestResistanceAbove, nearestSupportBelow } from './lib/support_resistance.js';
+import { detectDowntrendBreak } from './lib/trendline.js';
+import { detectElliottImpulse, detectElliottWave2Support, detectPullbackReversal } from './lib/elliott.js';
+import { detectAllPatterns } from './lib/patterns.js';
+import { detectBreakoutWithVolume, detectVolumeSpikeGreenCandle, detectConfirmedUptrend } from './lib/volume.js';
+import { buildTradingPlan } from './lib/levels.js';
+import { generateExcel } from './excel.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Liquidity gate: skip anything whose average daily transaction value over
+// the last 50 trading days is too thin. Sized off a Rp 20 juta order — a
+// position that size should stay at ~2% of average daily value or less, so
+// it doesn't move the price against itself or get stuck unable to exit.
+// Rp 20.000.000 / 0.02 = Rp 1.000.000.000.
+const MIN_AVG_VALUE_TRX_50D = 1_000_000_000; // Rp 1 miliar
+
+function parseArgs(argv) {
+  const args = { limit: null, symbols: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--limit') args.limit = Number(argv[++i]);
+    if (argv[i] === '--symbols') args.symbols = argv[++i].split(',').map(s => s.trim().toUpperCase());
+  }
+  return args;
+}
+
+function loadSymbols({ limit, symbols }) {
+  if (symbols) return symbols;
+  const csv = readFileSync(join(__dirname, 'idx_all.csv'), 'utf8');
+  const lines = csv.trim().split('\n').slice(1); // skip header
+  let codes = lines.map(l => l.split(',')[0].trim()).filter(Boolean);
+  if (limit) codes = codes.slice(0, limit);
+  return codes;
+}
+
+async function analyzeSymbol(code) {
+  const symbol = `IDX:${code}`;
+  await setSymbol({ symbol });
+  const { bars } = await getOhlcv({ count: 500 });
+  if (!bars || bars.length < 60) {
+    return { symbol: code, skipped: true, reason: 'not_enough_bars' };
+  }
+
+  const avgValTrx = avgValueTraded(bars, 50);
+  if (avgValTrx < MIN_AVG_VALUE_TRX_50D) {
+    return { symbol: code, skipped: true, reason: 'illiquid', avg_value_trx_50d: Math.round(avgValTrx) };
+  }
+
+  const pivots = findPivots(bars, 0.04);
+  const srZones = findSrZones(pivots);
+  const lastClose = bars[bars.length - 1].close;
+
+  const matches = [];
+  // buildTradingPlan() returns null for a stale/already-extended setup (target
+  // already behind price, or the entry reference too far below it) — only
+  // push a match when a valid, actionable plan actually comes back.
+  const tryAdd = (criterion, detail) => {
+    if (!detail) return;
+    const plan = buildTradingPlan(criterion, detail, bars, srZones);
+    if (!plan) return;
+    matches.push({ criterion, detail, plan });
+  };
+
+  tryAdd('downtrend_break', detectDowntrendBreak(bars, pivots));
+
+  tryAdd('elliott_wave', detectElliottImpulse(bars, pivots));
+  tryAdd('elliott_wave2', detectElliottWave2Support(bars, pivots));
+  tryAdd('pullback_reversal', detectPullbackReversal(bars, pivots));
+
+  for (const pattern of detectAllPatterns(bars, pivots)) {
+    tryAdd(pattern.pattern, pattern);
+  }
+
+  tryAdd('breakout_resistance_with_volume', detectBreakoutWithVolume(bars, srZones));
+  tryAdd('volume_spike_green_candle', detectVolumeSpikeGreenCandle(bars));
+  tryAdd('confirmed_uptrend', detectConfirmedUptrend(bars, pivots));
+
+  if (matches.length === 0) return { symbol: code, skipped: false, matches: [] };
+
+  return {
+    symbol: code,
+    skipped: false,
+    last_close: lastClose,
+    nearest_resistance: nearestResistanceAbove(srZones, lastClose)?.price ?? null,
+    nearest_support: nearestSupportBelow(srZones, lastClose)?.price ?? null,
+    matches,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const codes = loadSymbols(args);
+  const startedAt = Date.now();
+
+  console.log(`Screening ${codes.length} IHSG symbols...`);
+
+  const results = [];
+  const errors = [];
+  let skippedIlliquid = 0;
+
+  for (let i = 0; i < codes.length; i++) {
+    const code = codes[i];
+    try {
+      const result = await analyzeSymbol(code);
+      if (result.skipped && result.reason === 'illiquid') skippedIlliquid++;
+      if (!result.skipped && result.matches.length > 0) results.push(result);
+    } catch (err) {
+      errors.push({ symbol: code, error: err.message });
+    }
+
+    if ((i + 1) % 25 === 0 || i === codes.length - 1) {
+      const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(0);
+      console.log(`[${i + 1}/${codes.length}] elapsed=${elapsedSec}s matches_so_far=${results.length} errors_so_far=${errors.length}`);
+    }
+  }
+
+  const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+  const summary = {
+    generated_at: new Date().toISOString(),
+    total_scanned: codes.length,
+    total_matches: results.length,
+    total_errors: errors.length,
+    total_skipped_illiquid: skippedIlliquid,
+    min_avg_value_trx_50d: MIN_AVG_VALUE_TRX_50D,
+    elapsed_seconds: Number(elapsedSec),
+    results,
+    errors,
+  };
+
+  mkdirSync(join(__dirname, 'results'), { recursive: true });
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const jsonPath = join(__dirname, 'results', `scan-${dateStr}.json`);
+  writeFileSync(jsonPath, JSON.stringify(summary, null, 2));
+
+  const excelPath = join(__dirname, 'results', `scan-${dateStr}.xlsx`);
+  await generateExcel(summary, excelPath);
+
+  console.log(`\nDone. ${results.length}/${codes.length} symbols matched at least one criterion. ${errors.length} errors. Elapsed ${elapsedSec}s.`);
+  console.log(`Report (JSON): ${jsonPath}`);
+  console.log(`Report (Excel): ${excelPath}`);
+}
+
+main()
+  .catch(err => {
+    console.error('FATAL:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    // The CDP WebSocket (chrome-remote-interface) keeps its own connection
+    // alive and never unrefs it, so without an explicit disconnect() the
+    // event loop never empties and this process hangs forever after
+    // printing "Done" — fine when run by hand (Ctrl+C ends it), but fatal
+    // for the scheduled daily run: execFileSync in daily.js would block
+    // waiting for a child that never exits.
+    try { await disconnect(); } catch { /* already gone */ }
+});

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -132,7 +132,11 @@ async function execute(handler, values, positionals) {
   try {
     const result = await handler(values, positionals);
     console.log(JSON.stringify(result, null, 2));
-    process.exit(0);
+    // Setting exitCode and letting Node exit naturally (rather than calling
+    // process.exit()) avoids a Windows-only libuv crash — "Assertion failed:
+    // !(handle->flags & UV_HANDLE_CLOSING)" — that a forced exit can trigger
+    // right after a fetch() call's handles are still being torn down.
+    process.exitCode = 0;
   } catch (err) {
     handleError(err);
   }

--- a/src/wait.js
+++ b/src/wait.js
@@ -45,8 +45,15 @@ export async function waitForChartReady(expectedSymbol = null, expectedTf = null
       continue;
     }
 
-    // Check symbol match if expected
-    if (expectedSymbol && state.currentSymbol && !state.currentSymbol.toUpperCase().includes(expectedSymbol.toUpperCase())) {
+    // Check symbol match if expected. The legend only ever shows the ticker
+    // (e.g. "ANTM"), never the exchange-qualified form (e.g. "IDX:ANTM"), so
+    // strip any "EXCHANGE:" prefix before comparing — otherwise this never
+    // matches for exchange-qualified symbols and every call burns the full
+    // timeout.
+    const expectedTicker = expectedSymbol && expectedSymbol.includes(':')
+      ? expectedSymbol.slice(expectedSymbol.lastIndexOf(':') + 1)
+      : expectedSymbol;
+    if (expectedTicker && state.currentSymbol && !state.currentSymbol.toUpperCase().includes(expectedTicker.toUpperCase())) {
       stableCount = 0;
       await new Promise(r => setTimeout(r, POLL_INTERVAL));
       continue;

--- a/tests/sanitization.test.js
+++ b/tests/sanitization.test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { safeString, requireFinite } from '../src/connection.js';
 import { setSymbol, setTimeframe, setType, manageIndicator, setVisibleRange } from '../src/core/chart.js';
 import { drawShape } from '../src/core/drawing.js';
@@ -287,7 +288,7 @@ describe('drawing.js — sanitized evaluate calls', () => {
 // ── Source-level audit ───────────────────────────────────────────────────
 
 describe('source audit — no unsafe interpolation patterns', () => {
-  const CORE_DIR = new URL('../src/core/', import.meta.url).pathname;
+  const CORE_DIR = fileURLToPath(new URL('../src/core/', import.meta.url));
   const coreFiles = readdirSync(CORE_DIR).filter(f => f.endsWith('.js'));
 
   for (const file of coreFiles) {


### PR DESCRIPTION
## Summary
- Screens the full IHSG universe (~950 symbols) for common bullish setups (Elliott Wave 2/5, pullback reversals, chart patterns, breakout+volume, trend following) via the existing CDP-driven TradingView connection
- Emits a Markdown report and an Excel workbook with buy/cutloss/TP levels per candidate
- Includes a historical backtest tool (backtest.js) and a next-day performance checker (performance.js) for the signals it produces
- Small supporting fixes surfaced while building this: process.exit() -> exitCode to dodge a Windows-only libuv assertion crash, exchange-qualified symbol matching (IDX:ANTM) in waitForChartReady, and a Windows-safe path in the sanitization test's source audit

screener/results/ (daily scan output) and .mcp.json (machine-local config) are gitignored.

## Test plan
- [x] `node --test tests/sanitization.test.js` — 68/68 passing
- [x] Ran the full scan end-to-end against live TradingView Desktop (951 symbols, 51 matches)